### PR TITLE
Add navigation chrome to classic game pages

### DIFF
--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -3,56 +3,117 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b1020" />
     <title>2048 — Arcade Hub</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../../css/game.css" />
     <link rel="stylesheet" href="../game-shell.css" />
     <link rel="stylesheet" href="style.css" />
+    <script src="../../js/i18n.js" defer></script>
   </head>
   <body>
-    <main class="game-shell">
-      <header class="hud">
-        <div class="hud-title">
-          <h1>2048</h1>
-          <p>Join identical tiles to reach the 2048 tile.</p>
-        </div>
-        <div class="scoreboard">
-          <div class="score-card">
-            <span>Score</span>
-            <strong id="score">0</strong>
-          </div>
-          <div class="score-card">
-            <span>Best</span>
-            <strong id="best">0</strong>
-          </div>
-        </div>
-        <div class="primary-actions">
-          <button class="button" type="button" id="new-game">New game</button>
-        </div>
-      </header>
+    <div class="topbar">
+      <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <div class="brand"><div class="logo" aria-hidden="true"></div><h1>Arcade Hub</h1></div>
+      <div class="search">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M21 21l-3.9-3.9M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="#86e1e1" stroke-width="2" stroke-linecap="round"/></svg>
+        <input type="search" data-i18n-aria="searchAria" data-i18n-placeholder="searchPlaceholder" aria-label="Search games" placeholder="Search games (inactive in MVP)" />
+      </div>
+      <span class="chip">MVP</span>
+    </div>
 
-      <section class="board-wrap">
-        <div class="board" id="board" role="grid" aria-label="2048 board"></div>
-        <div class="mobile-hint">Swipe or use the controls to move tiles.</div>
+    <div class="layout">
+      <aside class="sidebar collapsed" id="sidebar" aria-label="Main navigation">
+        <nav class="sb-nav">
+          <ul class="sb-list">
+            <li class="sb-item">
+              <a href="../../index.html" class="sb-link sb-home" aria-label="Home" tabindex="0">
+                <span class="sb-ico" aria-hidden="true">
+                  <svg class="sb-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1v-9.5Z"/></svg>
+                </span>
+                <span class="sb-label">Home</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+      <section class="center">
+        <div class="gameWrap game-shell-host">
+          <main class="game-shell">
+            <header class="hud">
+              <div class="hud-title">
+                <h1>2048</h1>
+                <p>Join identical tiles to reach the 2048 tile.</p>
+              </div>
+              <div class="scoreboard">
+                <div class="score-card">
+                  <span>Score</span>
+                  <strong id="score">0</strong>
+                </div>
+                <div class="score-card">
+                  <span>Best</span>
+                  <strong id="best">0</strong>
+                </div>
+              </div>
+              <div class="primary-actions">
+                <button class="button" type="button" id="new-game">New game</button>
+              </div>
+            </header>
+
+            <section class="board-wrap">
+              <div class="board" id="board" role="grid" aria-label="2048 board"></div>
+              <div class="mobile-hint">Swipe or use the controls to move tiles.</div>
+            </section>
+
+            <section class="controls">
+              <div class="dpad" aria-hidden="false">
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="up" aria-label="Move up">↑</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="left" aria-label="Move left">←</button>
+                <button type="button" data-dir="down" aria-label="Move down">↓</button>
+                <button type="button" data-dir="right" aria-label="Move right">→</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+              </div>
+            </section>
+
+            <p class="notice">Tip: combine tiles quickly to build momentum. The board is optimised for touch, keyboard, and screen readers.</p>
+          </main>
+        </div>
       </section>
 
-      <section class="controls">
-        <div class="dpad" aria-hidden="false">
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="up" aria-label="Move up">↑</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="left" aria-label="Move left">←</button>
-          <button type="button" data-dir="down" aria-label="Move down">↓</button>
-          <button type="button" data-dir="right" aria-label="Move right">→</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-        </div>
-      </section>
+      <aside class="right"></aside>
+    </div>
 
-      <p class="notice">Tip: combine tiles quickly to build momentum. The board is optimised for touch, keyboard, and screen readers.</p>
-    </main>
+    <footer class="site-footer" role="contentinfo">
+      <nav class="footer-nav" aria-label="Footer">
+        <a class="ft-link" data-i18n="about" data-href-en="../../about.en.html" data-href-pl="../../about.pl.html" href="../../about.en.html">About</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="licenses" data-href-en="../../about/licenses.html" data-href-pl="../../about/licenses.html" href="../../about/licenses.html">Licenses</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="terms" data-href-en="../../legal/terms.en.html" data-href-pl="../../legal/terms.pl.html" href="../../legal/terms.en.html">Terms</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="privacy" data-href-en="../../legal/privacy.en.html" data-href-pl="../../legal/privacy.pl.html" href="../../legal/privacy.en.html">Privacy</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+        <span class="sep">•</span>
+        <a class="ft-link manage-cookies" data-i18n="manageCookies" href="#">Manage cookies</a>
+      </nav>
+      <div class="lang-switch" aria-label="Language">
+        <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+        <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+      </div>
+    </footer>
+
+    <script src="../../js/sidebar.js" defer></script>
     <script src="script.js"></script>
+    <script src="../../js/loadThirdParty.js"></script>
   </body>
 </html>

--- a/games-open/game-shell.css
+++ b/games-open/game-shell.css
@@ -21,27 +21,14 @@
   box-sizing: border-box;
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  display: grid;
-  place-items: center;
-  padding: clamp(1.5rem, 3vw, 3rem);
-  background: radial-gradient(circle at top, #131d43 0%, var(--bg-start) 45%, var(--bg-end) 100%);
-  color: var(--text-soft);
-  font-family: inherit;
-  overscroll-behavior: contain;
+.game-shell-host {
+  background: transparent;
+  border: none;
+  padding: 12px;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(140% 180% at 0% 0%, rgba(110, 231, 231, 0.05), transparent),
-    radial-gradient(120% 150% at 100% 0%, rgba(167, 139, 250, 0.06), transparent);
-  opacity: 0.9;
+.game-shell-host .game-shell {
+  margin: 0 auto;
 }
 
 .game-shell {
@@ -55,6 +42,7 @@ body::before {
   gap: clamp(1rem, 2vw, 1.75rem);
   position: relative;
   z-index: 1;
+  color: var(--text-soft);
 }
 
 .hud {
@@ -225,9 +213,6 @@ body::before {
 }
 
 @media (max-width: 680px) {
-  body {
-    padding: 1.2rem;
-  }
   .hud {
     flex-direction: column;
     align-items: stretch;

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -3,61 +3,122 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b1020" />
     <title>Pacman — Arcade Hub</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../../css/game.css" />
     <link rel="stylesheet" href="../game-shell.css" />
     <link rel="stylesheet" href="style.css" />
+    <script src="../../js/i18n.js" defer></script>
   </head>
   <body>
-    <main class="game-shell">
-      <header class="hud">
-        <div class="hud-title">
-          <h1>Pacman</h1>
-          <p>Eat all dots, avoid ghosts, and chase high scores.</p>
-        </div>
-        <div class="scoreboard">
-          <div class="score-card">
-            <span>Score</span>
-            <strong id="score">0</strong>
-          </div>
-          <div class="score-card">
-            <span>Lives</span>
-            <strong id="lives">3</strong>
-          </div>
-        </div>
-        <div class="primary-actions">
-          <button class="button" type="button" id="start">Start</button>
-          <button class="button secondary" type="button" id="pause">Pause</button>
-          <button class="button secondary" type="button" id="reset">Reset</button>
-        </div>
-      </header>
+    <div class="topbar">
+      <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <div class="brand"><div class="logo" aria-hidden="true"></div><h1>Arcade Hub</h1></div>
+      <div class="search">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M21 21l-3.9-3.9M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="#86e1e1" stroke-width="2" stroke-linecap="round"/></svg>
+        <input type="search" data-i18n-aria="searchAria" data-i18n-placeholder="searchPlaceholder" aria-label="Search games" placeholder="Search games (inactive in MVP)" />
+      </div>
+      <span class="chip">MVP</span>
+    </div>
 
-      <section class="playfield">
-        <div class="canvas-frame">
-          <canvas id="board" width="448" height="416" role="img" aria-label="Pacman maze"></canvas>
-          <div class="overlay-banner" id="gameOverlay" hidden></div>
+    <div class="layout">
+      <aside class="sidebar collapsed" id="sidebar" aria-label="Main navigation">
+        <nav class="sb-nav">
+          <ul class="sb-list">
+            <li class="sb-item">
+              <a href="../../index.html" class="sb-link sb-home" aria-label="Home" tabindex="0">
+                <span class="sb-ico" aria-hidden="true">
+                  <svg class="sb-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1v-9.5Z"/></svg>
+                </span>
+                <span class="sb-label">Home</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+      <section class="center">
+        <div class="gameWrap game-shell-host">
+          <main class="game-shell">
+            <header class="hud">
+              <div class="hud-title">
+                <h1>Pacman</h1>
+                <p>Eat all dots, avoid ghosts, and chase high scores.</p>
+              </div>
+              <div class="scoreboard">
+                <div class="score-card">
+                  <span>Score</span>
+                  <strong id="score">0</strong>
+                </div>
+                <div class="score-card">
+                  <span>Lives</span>
+                  <strong id="lives">3</strong>
+                </div>
+              </div>
+              <div class="primary-actions">
+                <button class="button" type="button" id="start">Start</button>
+                <button class="button secondary" type="button" id="pause">Pause</button>
+                <button class="button secondary" type="button" id="reset">Reset</button>
+              </div>
+            </header>
+
+            <section class="playfield">
+              <div class="canvas-frame">
+                <canvas id="board" width="448" height="416" role="img" aria-label="Pacman maze"></canvas>
+                <div class="overlay-banner" id="gameOverlay" hidden></div>
+              </div>
+              <p class="mobile-hint">Swipe or use the D-pad to guide Pacman.</p>
+            </section>
+
+            <section class="controls">
+              <div class="dpad" id="pacpad">
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="up" aria-label="Move up">↑</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="left" aria-label="Move left">←</button>
+                <button type="button" data-dir="down" aria-label="Move down">↓</button>
+                <button type="button" data-dir="right" aria-label="Move right">→</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+              </div>
+            </section>
+
+            <p class="notice">Keyboard: arrows or WASD. Eat energizers to turn the chase around.</p>
+          </main>
         </div>
-        <p class="mobile-hint">Swipe or use the D-pad to guide Pacman.</p>
       </section>
 
-      <section class="controls">
-        <div class="dpad" id="pacpad">
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="up" aria-label="Move up">↑</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="left" aria-label="Move left">←</button>
-          <button type="button" data-dir="down" aria-label="Move down">↓</button>
-          <button type="button" data-dir="right" aria-label="Move right">→</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-        </div>
-      </section>
+      <aside class="right"></aside>
+    </div>
 
-      <p class="notice">Keyboard: arrows or WASD. Eat energizers to turn the chase around.</p>
-    </main>
+    <footer class="site-footer" role="contentinfo">
+      <nav class="footer-nav" aria-label="Footer">
+        <a class="ft-link" data-i18n="about" data-href-en="../../about.en.html" data-href-pl="../../about.pl.html" href="../../about.en.html">About</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="licenses" data-href-en="../../about/licenses.html" data-href-pl="../../about/licenses.html" href="../../about/licenses.html">Licenses</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="terms" data-href-en="../../legal/terms.en.html" data-href-pl="../../legal/terms.pl.html" href="../../legal/terms.en.html">Terms</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="privacy" data-href-en="../../legal/privacy.en.html" data-href-pl="../../legal/privacy.pl.html" href="../../legal/privacy.en.html">Privacy</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+        <span class="sep">•</span>
+        <a class="ft-link manage-cookies" data-i18n="manageCookies" href="#">Manage cookies</a>
+      </nav>
+      <div class="lang-switch" aria-label="Language">
+        <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+        <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+      </div>
+    </footer>
+
+    <script src="../../js/sidebar.js" defer></script>
     <script src="script.js"></script>
+    <script src="../../js/loadThirdParty.js"></script>
   </body>
 </html>

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -3,68 +3,129 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#0b1020" />
     <title>Tetris — Arcade Hub</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../../css/game.css" />
     <link rel="stylesheet" href="../game-shell.css" />
     <link rel="stylesheet" href="style.css" />
+    <script src="../../js/i18n.js" defer></script>
   </head>
   <body>
-    <main class="game-shell">
-      <header class="hud">
-        <div class="hud-title">
-          <h1>Tetris</h1>
-          <p>Stack tetrominoes to complete lines and climb the leaderboard.</p>
-        </div>
-        <div class="scoreboard">
-          <div class="score-card">
-            <span>Score</span>
-            <strong id="score">0</strong>
-          </div>
-          <div class="score-card">
-            <span>Lines</span>
-            <strong id="lines">0</strong>
-          </div>
-          <div class="score-card">
-            <span>Level</span>
-            <strong id="level">1</strong>
-          </div>
-        </div>
-        <div class="primary-actions">
-          <button class="button" type="button" id="play">Play</button>
-          <button class="button secondary" type="button" id="pause">Pause</button>
-          <button class="button secondary" type="button" id="reset">Reset</button>
-        </div>
-      </header>
+    <div class="topbar">
+      <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+      <div class="brand"><div class="logo" aria-hidden="true"></div><h1>Arcade Hub</h1></div>
+      <div class="search">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M21 21l-3.9-3.9M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="#86e1e1" stroke-width="2" stroke-linecap="round"/></svg>
+        <input type="search" data-i18n-aria="searchAria" data-i18n-placeholder="searchPlaceholder" aria-label="Search games" placeholder="Search games (inactive in MVP)" />
+      </div>
+      <span class="chip">MVP</span>
+    </div>
 
-      <section class="playfield">
-        <div class="canvas-frame">
-          <canvas id="board" width="300" height="600" role="img" aria-label="Tetris board"></canvas>
-          <div class="overlay-banner" id="stateOverlay" hidden>
-            <div>Paused</div>
-            <div style="font-size:1rem; margin-top:0.4rem; color: rgba(203,213,255,0.7);">Tap play to resume</div>
-          </div>
+    <div class="layout">
+      <aside class="sidebar collapsed" id="sidebar" aria-label="Main navigation">
+        <nav class="sb-nav">
+          <ul class="sb-list">
+            <li class="sb-item">
+              <a href="../../index.html" class="sb-link sb-home" aria-label="Home" tabindex="0">
+                <span class="sb-ico" aria-hidden="true">
+                  <svg class="sb-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 10.5 12 4l9 6.5V20a1 1 0 0 1-1 1h-5v-6H9v6H4a1 1 0 0 1-1-1v-9.5Z"/></svg>
+                </span>
+                <span class="sb-label">Home</span>
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+
+      <section class="center">
+        <div class="gameWrap game-shell-host">
+          <main class="game-shell">
+            <header class="hud">
+              <div class="hud-title">
+                <h1>Tetris</h1>
+                <p>Stack tetrominoes to complete lines and climb the leaderboard.</p>
+              </div>
+              <div class="scoreboard">
+                <div class="score-card">
+                  <span>Score</span>
+                  <strong id="score">0</strong>
+                </div>
+                <div class="score-card">
+                  <span>Lines</span>
+                  <strong id="lines">0</strong>
+                </div>
+                <div class="score-card">
+                  <span>Level</span>
+                  <strong id="level">1</strong>
+                </div>
+              </div>
+              <div class="primary-actions">
+                <button class="button" type="button" id="play">Play</button>
+                <button class="button secondary" type="button" id="pause">Pause</button>
+                <button class="button secondary" type="button" id="reset">Reset</button>
+              </div>
+            </header>
+
+            <section class="playfield">
+              <div class="canvas-frame">
+                <canvas id="board" width="300" height="600" role="img" aria-label="Tetris board"></canvas>
+                <div class="overlay-banner" id="stateOverlay" hidden>
+                  <div>Paused</div>
+                  <div style="font-size:1rem; margin-top:0.4rem; color: rgba(203,213,255,0.7);">Tap play to resume</div>
+                </div>
+              </div>
+              <p class="mobile-hint">Use the D-pad or swipe down to drop faster.</p>
+            </section>
+
+            <section class="controls">
+              <div class="dpad" id="dpad">
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-action="rotate" aria-label="Rotate">⤾</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-action="left" aria-label="Move left">←</button>
+                <button type="button" data-action="soft" aria-label="Soft drop">↓</button>
+                <button type="button" data-action="right" aria-label="Move right">→</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+                <button type="button" data-action="hard" aria-label="Hard drop">⤓</button>
+                <button type="button" data-dir="" aria-hidden="true"></button>
+              </div>
+            </section>
+
+            <p class="notice">Controls: ← → move, ↑ rotate, ↓ soft drop, space for hard drop. Tap play to start the action.</p>
+          </main>
         </div>
-        <p class="mobile-hint">Use the D-pad or swipe down to drop faster.</p>
       </section>
 
-      <section class="controls">
-        <div class="dpad" id="dpad">
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-action="rotate" aria-label="Rotate">⤾</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-action="left" aria-label="Move left">←</button>
-          <button type="button" data-action="soft" aria-label="Soft drop">↓</button>
-          <button type="button" data-action="right" aria-label="Move right">→</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-          <button type="button" data-action="hard" aria-label="Hard drop">⤓</button>
-          <button type="button" data-dir="" aria-hidden="true"></button>
-        </div>
-      </section>
+      <aside class="right"></aside>
+    </div>
 
-      <p class="notice">Controls: ← → move, ↑ rotate, ↓ soft drop, space for hard drop. Tap play to start the action.</p>
-    </main>
+    <footer class="site-footer" role="contentinfo">
+      <nav class="footer-nav" aria-label="Footer">
+        <a class="ft-link" data-i18n="about" data-href-en="../../about.en.html" data-href-pl="../../about.pl.html" href="../../about.en.html">About</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="licenses" data-href-en="../../about/licenses.html" data-href-pl="../../about/licenses.html" href="../../about/licenses.html">Licenses</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="terms" data-href-en="../../legal/terms.en.html" data-href-pl="../../legal/terms.pl.html" href="../../legal/terms.en.html">Terms</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="privacy" data-href-en="../../legal/privacy.en.html" data-href-pl="../../legal/privacy.pl.html" href="../../legal/privacy.en.html">Privacy</a>
+        <span class="sep">•</span>
+        <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+        <span class="sep">•</span>
+        <a class="ft-link manage-cookies" data-i18n="manageCookies" href="#">Manage cookies</a>
+      </nav>
+      <div class="lang-switch" aria-label="Language">
+        <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+        <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+      </div>
+    </footer>
+
+    <script src="../../js/sidebar.js" defer></script>
     <script src="script.js"></script>
+    <script src="../../js/loadThirdParty.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add the portal top bar, sidebar trigger, and footer to the open-source Tetris, Pacman, and 2048 pages
- hook the pages into the shared layout styles and language toggle script
- tune the shared game-shell stylesheet so the standalone games nest cleanly inside the portal chrome

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_6900a3dab8688323917f30d2b1299fe9