### PR TITLE
Add SVG thumbnails for classic games

### DIFF
--- a/img/games/2048-tile.svg
+++ b/img/games/2048-tile.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">2048 puzzle thumbnail</title>
+  <desc id="desc">Rounded tile with 2048 number and merging arrows.</desc>
+  <defs>
+    <linearGradient id="tile" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8e29a" />
+      <stop offset="100%" stop-color="#f0c419" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="28" fill="#fdf6e3" />
+  <rect x="28" y="28" width="104" height="104" rx="24" fill="url(#tile)" stroke="#d4a200" stroke-width="6" />
+  <text x="80" y="100" text-anchor="middle" font-family="'Fira Sans', 'Arial', sans-serif" font-size="48" font-weight="700" fill="#5c4b51">2048</text>
+  <path d="M80 36 L92 24 L104 36" fill="none" stroke="#8d5524" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M56 132 L44 144 L32 132" fill="none" stroke="#8d5524" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M116 88 h12 m0 0 l-8 -8 m8 8 l-8 8" fill="none" stroke="#8d5524" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M32 72 H20 m0 0 l8 -8 m-8 8 l8 8" fill="none" stroke="#8d5524" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/img/games/catch-the-cats.svg
+++ b/img/games/catch-the-cats.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Catch the Cats thumbnail</title>
+  <desc id="desc">Stylized cat face with playful stars.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffce54" />
+      <stop offset="100%" stop-color="#f6a623" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="160" height="160" rx="24" fill="url(#bg)" />
+  <path d="M40 64 L28 28 Q58 42 64 24 Q70 42 100 28 L88 64" fill="#5c4b51" />
+  <path d="M120 64 L132 28 Q102 42 96 24 Q90 42 60 28 L72 64" fill="#5c4b51" />
+  <path d="M40 64 Q80 40 120 64 Q128 120 80 132 Q32 120 40 64" fill="#6e5961" />
+  <circle cx="56" cy="92" r="10" fill="#2f2f2f" />
+  <circle cx="104" cy="92" r="10" fill="#2f2f2f" />
+  <path d="M80 108 L76 116 L84 116 Z" fill="#2f2f2f" />
+  <path d="M80 116 Q90 124 100 116" stroke="#2f2f2f" stroke-width="6" stroke-linecap="round" fill="none" />
+  <path d="M80 116 Q70 124 60 116" stroke="#2f2f2f" stroke-width="6" stroke-linecap="round" fill="none" />
+  <circle cx="36" cy="112" r="6" fill="#fff" opacity="0.8" />
+  <circle cx="126" cy="70" r="5" fill="#fff" opacity="0.8" />
+  <circle cx="110" cy="126" r="7" fill="#fff" opacity="0.6" />
+</svg>

--- a/img/games/pacman-maze.svg
+++ b/img/games/pacman-maze.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Pacman arcade thumbnail</title>
+  <desc id="desc">Pacman chasing pellets with a ghost.</desc>
+  <rect width="160" height="160" rx="22" fill="#0a0f2d" />
+  <rect x="24" y="24" width="112" height="112" rx="16" fill="none" stroke="#1f7cff" stroke-width="10" />
+  <path d="M80 64 a24 24 0 1 0 0 48 l24 -24 z" fill="#ffd54f" />
+  <circle cx="90" cy="92" r="5" fill="#0a0f2d" />
+  <circle cx="52" cy="88" r="6" fill="#ffd54f" opacity="0.4" />
+  <circle cx="40" cy="88" r="6" fill="#ffd54f" opacity="0.25" />
+  <g transform="translate(96 56)">
+    <rect width="36" height="44" rx="14" ry="14" fill="#ff5c8d" />
+    <path d="M0 40 L6 46 L12 40 L18 46 L24 40 L30 46 L36 40" fill="#ff5c8d" />
+    <circle cx="11" cy="22" r="5" fill="#fff" />
+    <circle cx="25" cy="22" r="5" fill="#fff" />
+    <circle cx="13" cy="22" r="2.5" fill="#0a0f2d" />
+    <circle cx="27" cy="22" r="2.5" fill="#0a0f2d" />
+  </g>
+</svg>

--- a/img/games/tetris-blocks.svg
+++ b/img/games/tetris-blocks.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title id="title">Tetris puzzle thumbnail</title>
+  <desc id="desc">Colorful falling tetromino blocks.</desc>
+  <rect width="160" height="160" rx="20" fill="#101b37" />
+  <g stroke="#0b1320" stroke-width="4" stroke-linejoin="round">
+    <rect x="28" y="24" width="40" height="40" fill="#ff6f61" rx="6" />
+    <rect x="28" y="64" width="40" height="40" fill="#ff6f61" rx="6" />
+    <rect x="28" y="104" width="40" height="40" fill="#ff6f61" rx="6" />
+    <rect x="68" y="104" width="40" height="40" fill="#ffd15c" rx="6" />
+    <rect x="108" y="104" width="40" height="40" fill="#1abc9c" rx="6" />
+    <rect x="68" y="24" width="40" height="40" fill="#4a89dc" rx="6" />
+    <rect x="108" y="24" width="40" height="40" fill="#ac92ec" rx="6" />
+    <rect x="108" y="64" width="40" height="40" fill="#ac92ec" rx="6" />
+  </g>
+  <path d="M112 68 l12 -12 l12 12" fill="none" stroke="#ffe082" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/js/games.json
+++ b/js/games.json
@@ -16,7 +16,7 @@
       "title": { "en": "Catch the Cats", "pl": "Złap koty" },
       "description": { "en": "Catch the falling cats!", "pl": "Złap spadające koty!" },
       "category": ["Puzzle"],
-      "thumbnail": "img/games/placeholder.svg",
+      "thumbnail": "img/games/catch-the-cats.svg",
       "tags": ["reflex", "casual"],
       "source": { "type": "self", "page": "game_cats.html" }
     },
@@ -26,7 +26,7 @@
       "title": { "en": "2048", "pl": "2048" },
       "description": { "en": "Join tiles to reach 2048.", "pl": "Łącz kafelki, aby osiągnąć 2048." },
       "category": ["Puzzle"],
-      "thumbnail": "img/games/placeholder.svg",
+      "thumbnail": "img/games/2048-tile.svg",
       "tags": ["puzzle", "logic", "classic"],
       "source": { "type": "self", "page": "games-open/2048/index.html" }
     },
@@ -36,7 +36,7 @@
       "title": { "en": "Tetris", "pl": "Tetris" },
       "description": { "en": "Stack falling blocks to clear lines.", "pl": "Układaj spadające klocki i czyść linie." },
       "category": ["Puzzle"],
-      "thumbnail": "img/games/placeholder.svg",
+      "thumbnail": "img/games/tetris-blocks.svg",
       "tags": ["puzzle", "retro", "classic"],
       "source": { "type": "self", "page": "games-open/tetris/index.html" }
     },
@@ -46,7 +46,7 @@
       "title": { "en": "Pacman", "pl": "Pacman" },
       "description": { "en": "Eat dots, avoid ghosts, clear the maze.", "pl": "Zjadaj kropki, unikaj duchów, wyczyść labirynt." },
       "category": ["Arcade"],
-      "thumbnail": "img/games/placeholder.svg",
+      "thumbnail": "img/games/pacman-maze.svg",
       "tags": ["arcade", "retro", "classic"],
       "source": { "type": "self", "page": "games-open/pacman/index.html" }
     }


### PR DESCRIPTION
## Summary
- add bespoke SVG thumbnails for Catch the Cats, 2048, Tetris, and Pacman
- update the games catalog to reference the new artwork instead of the placeholder icon

## Testing
- no automated tests were run (asset update only)


------
https://chatgpt.com/codex/tasks/task_e_6900ab1a17a083239f8a8312df3a4d68