### PR TITLE
feat: route client XP awards through Netlify function

### DIFF
--- a/about/licenses.html
+++ b/about/licenses.html
@@ -12,6 +12,7 @@
   <script src="../js/analytics.js" defer></script>
   <script src="../js/i18n.js" defer></script>
   <script src="../js/topbar.js" defer></script>
+  <script src="../js/xpClient.js" defer></script>
   <script src="../js/points.js" defer></script>
   <script src="../js/sidebar.js" defer></script>
   <style>

--- a/game.html
+++ b/game.html
@@ -135,6 +135,7 @@
   </footer>
 
   <script src="js/topbar.js" defer></script>
+  <script src="js/xpClient.js" defer></script>
   <script src="js/points.js" defer></script>
   <script src="js/sidebar.js" defer></script>
   <script src="js/core/catalog.js" defer></script>

--- a/game_cats.html
+++ b/game_cats.html
@@ -12,6 +12,7 @@
   <script src="js/analytics.js" defer></script>
   <script src="js/i18n.js" defer></script>
   <script src="js/topbar.js" defer></script>
+  <script src="js/xpClient.js" defer></script>
   <script src="js/points.js" defer></script>
 </head>
 <body data-game-slug="cats">

--- a/game_trex.html
+++ b/game_trex.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/game.css">
   <script src="js/i18n.js" defer></script>
   <script src="js/topbar.js" defer></script>
+  <script src="js/xpClient.js" defer></script>
   <script src="js/points.js" defer></script>
   <style>
     .stats .stat strong{ font-family:'Courier New', Courier, monospace; }

--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="style.css" />
     <script src="../../js/i18n.js" defer></script>
     <script src="../../js/topbar.js" defer></script>
+    <script src="../../js/xpClient.js" defer></script>
     <script src="../../js/points.js" defer></script>
   </head>
   <body data-game-slug="2048" data-game-id="2048">

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="style.css" />
     <script src="../../js/i18n.js" defer></script>
     <script src="../../js/topbar.js" defer></script>
+    <script src="../../js/xpClient.js" defer></script>
     <script src="../../js/points.js" defer></script>
   </head>
   <body data-game-slug="pacman" data-game-id="pacman">

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="style.css" />
     <script src="../../js/i18n.js" defer></script>
     <script src="../../js/topbar.js" defer></script>
+    <script src="../../js/xpClient.js" defer></script>
     <script src="../../js/points.js" defer></script>
   </head>
   <body data-game-slug="tetris" data-game-id="tetris">

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
     </div>
   </footer>
   <script src="js/topbar.js" defer></script>
+  <script src="js/xpClient.js" defer></script>
   <script src="js/points.js" defer></script>
   <script src="js/core/catalog.js" defer></script>
   <script src="js/core/game-utils.js" defer></script>


### PR DESCRIPTION
## Summary
- refactor the in-browser points service to queue play windows and apply XP deltas returned by the Netlify award-xp function
- update the shared activity tracker and game shells to emit rich window payloads for the server instead of local XP math
- ensure the XP client script is loaded on XP-enabled pages so badge updates use server responses

## Testing
- `npm test` *(fails: Playwright browsers cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690463f35eb48323aae721451a094f20