### PR TITLE
Fix personal best awards to grant XP

### DIFF
--- a/js/points.js
+++ b/js/points.js
@@ -553,9 +553,16 @@
       this.state.games[slug] = record;
       if (!this.state.bestByGame) this.state.bestByGame = {};
       this.state.bestByGame[slug] = Math.max(Number(this.state.bestByGame[slug]) || 0, rawScore);
-      this._persist();
-      this._emitUpdate();
-      return 0;
+      return this._applyServerAward(amount, {
+        reason: 'personalBest',
+        metadata: {
+          gameId: slug,
+          score: rawScore,
+          previousBest: baseline,
+          delta,
+          suggestedAmount: Number(details && details.amount) || null
+        }
+      });
     }
 
     recordScore(gameId, score){


### PR DESCRIPTION
## Summary
- route personal-best awards through the shared XP application path
- restore XP grants and event emissions when a player sets a personal best

## Testing
- not run (Playwright browsers are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_6904833b462c832382889c5c3e86ced2