### PR TITLE
fix: enforce exclusive redis lock for award-xp

### DIFF
--- a/netlify/functions/award-xp.mjs
+++ b/netlify/functions/award-xp.mjs
@@ -100,8 +100,9 @@ export async function handler(event) {
     local lastTtl = tonumber(ARGV[7])
     local lockTtl = tonumber(ARGV[8])
 
-    local locked = redis.call('SET', lockk, tostring(now), 'NX', 'PX', lockTtl)
-    if not locked then
+    -- Acquire lock with NX so only one invocation enters the critical section.
+    local locked = redis.call('SET', lockk, tostring(now), 'PX', lockTtl, 'NX')
+    if locked ~= 'OK' then
       local current = tonumber(redis.call('GET', daily) or '0')
       return {0, current, 4}  -- someone else holds the lock
     end


### PR DESCRIPTION
## Summary
- acquire the award-xp Redis lock with SET ... NX so only one invocation enters the critical section
- treat a failed lock acquisition as a concurrent request and skip XP award

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904904678b08323bf9db13fdec14106