### PR TITLE
Guard XP accrual behind engagement

### DIFF
--- a/tests/e2e-xp-engagement.spec.ts
+++ b/tests/e2e-xp-engagement.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+async function totalXp(page) {
+  return await page.evaluate(() => (window as any).XP?.getSnapshot?.().totalXp ?? 0);
+}
+
+test('idle tab earns no XP', async ({ page }) => {
+  await page.goto('/game.html', { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(12000);
+  const xp = await totalXp(page);
+  expect(xp).toBe(0);
+});
+
+test('inputs extend engagement and earn XP', async ({ page }) => {
+  await page.goto('/game.html', { waitUntil: 'domcontentloaded' });
+  const xp0 = await totalXp(page);
+  for (let i = 0; i < 6; i++) {
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(1500);
+  }
+  await page.waitForTimeout(1000);
+  const xp1 = await totalXp(page);
+  expect(xp1).toBeGreaterThanOrEqual(xp0 + 1);
+});
+
+test('single input grace window only', async ({ page }) => {
+  await page.goto('/game.html', { waitUntil: 'domcontentloaded' });
+  const xp0 = await totalXp(page);
+  await page.keyboard.press('ArrowLeft'); // one nudge
+  await page.waitForTimeout(3000);
+  const xp1 = await totalXp(page); // might increase slightly
+  await page.waitForTimeout(9000); // past ACTIVE_WINDOW_MS
+  const xp2 = await totalXp(page);
+  expect(xp2).toBe(xp1); // no further growth after grace window
+});


### PR DESCRIPTION
## Summary
- tighten the XP active window to 8s and gate window uploads on active engagement
- stop non-control UI from nudging XP while adding filtered input listeners
- cover engagement behaviour with a new Playwright spec

## Testing
- node scripts/check-lifecycle.js
- node scripts/check-xpbadge.js
- npm run lint:games

------
https://chatgpt.com/codex/tasks/task_e_690b91da1f3483238bc38a667fdbc623