### PR TITLE
Adjust XP window visibility threshold handling

### DIFF
--- a/js/xp.js
+++ b/js/xp.js
@@ -154,7 +154,8 @@
     const now = Date.now();
     const elapsed = now - state.windowStart;
     if (!force && elapsed < CHUNK_MS) return;
-    const visibility = Math.round(state.visibilitySeconds);
+    const visibilitySecondsRaw = state.visibilitySeconds;
+    const visibility = Math.round(visibilitySecondsRaw);
     const inputs = state.inputEvents;
     /* xp idle guard */
     if (typeof document !== "undefined" && document.hidden) {
@@ -165,7 +166,7 @@
       return;
     }
     const _minInputsGate = Math.max(2, Math.ceil(CHUNK_MS / 4000));
-    if (visibility <= 1 || inputs < _minInputsGate) {
+    if (visibilitySecondsRaw <= 1 || inputs < _minInputsGate) {
       state.windowStart = now;
       state.activeMs = 0;
       state.visibilitySeconds = 0;


### PR DESCRIPTION
## Summary
- retain rounded visibility value for XP payloads while gating on the raw seconds of visibility
- ensure the guard keeps clearing window counters when submissions are blocked

## Testing
- npm run syntax

------
https://chatgpt.com/codex/tasks/task_e_690cdfae5738832389c475b4a2e1a7d5