### PR TITLE
Guard XP tick against hidden document

### DIFF
--- a/js/xp.js
+++ b/js/xp.js
@@ -198,12 +198,12 @@
     const delta = state.lastTick ? Math.max(0, now - state.lastTick) : 0;
     state.lastTick = now;
     if (!state.running) return;
-    const visible = !document.hidden;
-    if (visible) {
-      state.visibilitySeconds += delta / 1000;
-      if (now <= state.activeUntil) {
-        state.activeMs += delta;
-      }
+    const visible = typeof document !== "undefined" && !document.hidden;
+    if (!visible) return;
+
+    state.visibilitySeconds += delta / 1000;
+    if (now <= state.activeUntil) {
+      state.activeMs += delta;
     }
     if (state.activeMs >= CHUNK_MS) {
       sendWindow(false);


### PR DESCRIPTION
## Summary
- guard the XP tick loop against missing document instances when running off-DOM
- short-circuit tick work when the document is hidden before updating timers

## Testing
- npm run syntax

------
https://chatgpt.com/codex/tasks/task_e_690ce3444be483238c105599d964c176