### PR TITLE
Reset XP counters when document hidden

### DIFF
--- a/js/xp.js
+++ b/js/xp.js
@@ -26,6 +26,15 @@
     snapshot: null,
   };
 
+  function resetActivityCounters(now) {
+    const ts = typeof now === "number" ? now : Date.now();
+    state.windowStart = ts;
+    state.visibilitySeconds = 0;
+    state.inputEvents = 0;
+    state.activeMs = 0;
+    state.activeUntil = 0;
+  }
+
   function isDocumentVisible() {
     if (typeof document === "undefined") return false;
     if (typeof document.hidden === "boolean") {
@@ -210,7 +219,10 @@
     state.lastTick = now;
     if (!state.running) return;
     const visible = isDocumentVisible();
-    if (!visible) return;
+    if (!visible) {
+      resetActivityCounters(now);
+      return;
+    }
 
     state.visibilitySeconds += delta / 1000;
     if (now <= state.activeUntil) {
@@ -320,7 +332,11 @@
       attachBadge();
     }
     document.addEventListener("visibilitychange", () => {
-      state.lastTick = Date.now();
+      const now = Date.now();
+      state.lastTick = now;
+      if (!isDocumentVisible()) {
+        resetActivityCounters(now);
+      }
     }, { passive: true });
   }
 


### PR DESCRIPTION
## Summary
- add a helper to reset XP activity counters when the document becomes hidden
- call the reset from the visibilitychange handler and from tick before early exit when not visible
- ensure activity counters clear without disturbing lastTick when visibility is lost

## Testing
- npm run syntax

------
https://chatgpt.com/codex/tasks/task_e_690cfaeeb15883238bdf0d5c253ee469