### PR TITLE
Document score-driven XP awards configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Score-driven XP awards are currently experimental and disabled by default to sup
 When score-driven awards are enabled:
 
 - `XP_USE_SCORE` (default `0`) toggles whether `scoreDelta` is considered when calculating XP.
-- `XP_SCORE_TO_XP` (default `100`) controls the conversion rate: XP gained per request is `scoreDelta / XP_SCORE_TO_XP`, rounded
-  down, before clamping. Negative values are ignored by the server-side guardrails.
+- `XP_SCORE_TO_XP` (default `1`) controls the conversion rate: XP gained per request is `scoreDelta * XP_SCORE_TO_XP`, rounded and
+  clamped. Negative values are ignored by the server-side guardrails.
 - `XP_MAX_XP_PER_WINDOW` (default `15`) caps the XP converted from a single window regardless of the incoming score.
 
 If a window is submitted without a `scoreDelta` value (including zero) or the feature is disabled, XP awards continue to use the


### PR DESCRIPTION
## Summary
- add documentation for enabling score-driven XP awards in README
- describe relevant environment variables, defaults, and fallbacks

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dcfe19ee083238da76736d6e73af8)