### PR TITLE
Add e2e coverage for XP score debug modes

### DIFF
--- a/tests/e2e/xp-score-awards.spec.js
+++ b/tests/e2e/xp-score-awards.spec.js
@@ -191,12 +191,15 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('XP score awards debug modes', () => {
   test('score mode includes debug scoreXp and gating blocks insufficient input', async ({ page }) => {
+    const info = test.info();
+    const keyNamespace = `e2e:score:${info.title.replace(/\s+/g, '-')}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
     const xpScoreToXp = 3;
     const handler = await loadAwardHandler({
       XP_USE_SCORE: '1',
       XP_DEBUG: '1',
       XP_SCORE_TO_XP: String(xpScoreToXp),
       XP_MAX_XP_PER_WINDOW: '100',
+      XP_KEY_NS: keyNamespace,
     });
 
     await setupPostWindowHandler(page, handler, { userId: 'xp-score-mode-user' });
@@ -229,9 +232,12 @@ test.describe('XP score awards debug modes', () => {
   });
 
   test('time mode reports debug mode time and still blocks insufficient activity', async ({ page }) => {
+    const info = test.info();
+    const keyNamespace = `e2e:score:${info.title.replace(/\s+/g, '-')}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
     const handler = await loadAwardHandler({
       XP_USE_SCORE: '0',
       XP_DEBUG: '1',
+      XP_KEY_NS: keyNamespace,
     });
 
     await setupPostWindowHandler(page, handler, { userId: 'xp-time-mode-user' });


### PR DESCRIPTION
## Summary
- add a Playwright harness that records XPClient payloads and responses for the score award flow
- verify debug payload differences when XP_USE_SCORE is toggled and confirm gating continues to suppress idle windows

## Testing
- `npx playwright test tests/e2e/xp-score-awards.spec.js` *(fails: browsers not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd6dcb70083238f8acba97ffdd423)