### PR TITLE
fix: allow xp auto bootstrap to restart sessions

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  Permissions-Policy: clipboard-write=(self)
+

--- a/about.en.html
+++ b/about.en.html
@@ -23,6 +23,7 @@
     gtag('config', 'G-JRP62LCXYK');
   </script>
   <script src="js/analytics.js" defer></script>
+  <script src="js/debug.js" defer></script>
 </head>
 <body style="padding:16px; font-family:Poppins, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color:#e8eeff; background:#0b1020;">
   <main>
@@ -31,6 +32,8 @@
         <span class="xp-badge__label">Syncing XP…</span>
       </a>
     </div>
+    <button id="debugDumpButton" class="debug-dump-button" type="button" hidden>Dump diagnostics</button>
+    <div id="debugToast" class="debug-toast" role="status" aria-live="polite"></div>
     <h1>About</h1>
     <p>This is a simple arcade portal (MVP). More games and features are coming soon.</p>
     <p>Contact: <a href="#" class="ft-link">email</a></p>
@@ -38,12 +41,149 @@
     <p><a id="backLink" href="index.html?lang=en" class="ft-link">Back to portal</a></p>
   </main>
   <script>
-    const params = new URLSearchParams(window.location.search);
-    const origin = params.get('origin');
-    const backLink = document.getElementById('backLink');
-    if (origin === 'landing') {
-      backLink.href = 'https://kcswh.pl/';
-    }
+    (function () {
+      const TAP_WINDOW_MS = 3000;
+      const TAP_COUNT = 5;
+
+      function onReady() {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          const origin = params.get('origin');
+          const backLink = document.getElementById('backLink');
+          if (origin === 'landing' && backLink) {
+            backLink.href = 'https://kcswh.pl/';
+          }
+        } catch (_) {}
+
+        const dumpButton = document.getElementById('debugDumpButton');
+        const toast = document.getElementById('debugToast');
+        let toastTimer = null;
+
+        function showToast(message) {
+          if (!toast) return;
+          toast.textContent = message;
+          toast.classList.add('is-visible');
+          if (toastTimer) {
+            clearTimeout(toastTimer);
+          }
+          toastTimer = window.setTimeout(() => {
+            toast.classList.remove('is-visible');
+          }, 2400);
+        }
+
+        function isAdmin() {
+          try {
+            return !!(window.KLog && typeof window.KLog.isAdmin === 'function' && window.KLog.isAdmin());
+          } catch (_) {
+            return false;
+          }
+        }
+
+        function ensureRecorder() {
+          if (!isAdmin()) return;
+          try {
+            if (!window.KLog || typeof window.KLog.start !== 'function') return;
+            const status = typeof window.KLog.status === 'function' ? window.KLog.status() : null;
+            const level = status && typeof status.level === 'number' ? status.level : 0;
+            const startedAt = status && typeof status.startedAt === 'number' ? status.startedAt : 0;
+            if (!status || level <= 0 || !startedAt) {
+              window.KLog.start(1);
+            }
+          } catch (_) {}
+        }
+
+        function updateVisibility() {
+          if (!dumpButton) return;
+          if (!window.KLog || typeof window.KLog.isAdmin !== 'function') {
+            dumpButton.hidden = true;
+            return;
+          }
+          const active = isAdmin();
+          dumpButton.hidden = !active;
+          if (active) {
+            ensureRecorder();
+          }
+        }
+
+        if (dumpButton) {
+          dumpButton.addEventListener('click', () => {
+            if (!window.KLog) return;
+            ensureRecorder();
+            const attempt = window.KLog.dumpToClipboard ? window.KLog.dumpToClipboard() : false;
+            Promise.resolve(attempt)
+              .then((opened) => {
+                if (opened) {
+                  showToast('Opened diagnostics in a new tab');
+                  return;
+                }
+                const downloaded = window.KLog.downloadFile ? window.KLog.downloadFile() : false;
+                if (downloaded) {
+                  showToast('Downloaded file');
+                } else {
+                  showToast('Diagnostics unavailable');
+                }
+              })
+              .catch(() => {
+                const downloaded = window.KLog && window.KLog.downloadFile ? window.KLog.downloadFile() : false;
+                if (downloaded) {
+                  showToast('Downloaded file');
+                } else {
+                  showToast('Diagnostics unavailable');
+                }
+              });
+          });
+        }
+
+        function unlockAdmin() {
+          if (!window.KLog || typeof window.KLog.enableAdmin !== 'function') return false;
+          const enabled = window.KLog.enableAdmin(24 * 60 * 60 * 1000);
+          if (enabled) {
+            showToast('Debug unlocked for 24h');
+            updateVisibility();
+            ensureRecorder();
+          }
+          return enabled;
+        }
+
+        const title = document.querySelector('main h1');
+        if (title) {
+          let taps = [];
+          function recordTap() {
+            const now = Date.now();
+            taps = taps.filter((ts) => (now - ts) <= TAP_WINDOW_MS);
+            taps.push(now);
+            if (taps.length >= TAP_COUNT) {
+              taps = [];
+              unlockAdmin();
+            }
+          }
+          title.addEventListener('pointerdown', recordTap, { passive: true });
+          if (!window.PointerEvent) {
+            title.addEventListener('click', recordTap);
+            title.addEventListener('touchstart', recordTap, { passive: true });
+          }
+          title.addEventListener('keydown', (event) => {
+            if (!event) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+              recordTap();
+            }
+          });
+          if (!title.hasAttribute('tabindex')) {
+            title.setAttribute('tabindex', '0');
+          }
+        }
+
+        window.addEventListener('klog:admin', updateVisibility);
+        updateVisibility();
+        window.setTimeout(updateVisibility, 250);
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', onReady, { once: true });
+      } else {
+        onReady();
+      }
+    })();
   </script>
   <script src="js/cookiebot-manager.js" defer></script>
 </body>

--- a/about.pl.html
+++ b/about.pl.html
@@ -23,6 +23,7 @@
     gtag('config', 'G-JRP62LCXYK');
   </script>
   <script src="js/analytics.js" defer></script>
+  <script src="js/debug.js" defer></script>
 </head>
 <body style="padding:16px; font-family:Poppins, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color:#e8eeff; background:#0b1020;">
   <main>
@@ -31,6 +32,8 @@
         <span class="xp-badge__label">Synchronizuję XP…</span>
       </a>
     </div>
+    <button id="debugDumpButton" class="debug-dump-button" type="button" hidden>Dump diagnostics</button>
+    <div id="debugToast" class="debug-toast" role="status" aria-live="polite"></div>
     <h1>O serwisie</h1>
     <p>To prosty portal arcade (MVP). Więcej gier i funkcji już wkrótce.</p>
     <p>Kontakt: <a href="#" class="ft-link">email</a></p>
@@ -38,12 +41,149 @@
     <p><a id="backLink" href="index.html?lang=pl" class="ft-link">Wróć do portalu</a></p>
   </main>
   <script>
-    const params = new URLSearchParams(window.location.search);
-    const origin = params.get('origin');
-    const backLink = document.getElementById('backLink');
-    if (origin === 'landing') {
-      backLink.href = 'https://kcswh.pl/';
-    }
+    (function () {
+      const TAP_WINDOW_MS = 3000;
+      const TAP_COUNT = 5;
+
+      function onReady() {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          const origin = params.get('origin');
+          const backLink = document.getElementById('backLink');
+          if (origin === 'landing' && backLink) {
+            backLink.href = 'https://kcswh.pl/';
+          }
+        } catch (_) {}
+
+        const dumpButton = document.getElementById('debugDumpButton');
+        const toast = document.getElementById('debugToast');
+        let toastTimer = null;
+
+        function showToast(message) {
+          if (!toast) return;
+          toast.textContent = message;
+          toast.classList.add('is-visible');
+          if (toastTimer) {
+            clearTimeout(toastTimer);
+          }
+          toastTimer = window.setTimeout(() => {
+            toast.classList.remove('is-visible');
+          }, 2400);
+        }
+
+        function isAdmin() {
+          try {
+            return !!(window.KLog && typeof window.KLog.isAdmin === 'function' && window.KLog.isAdmin());
+          } catch (_) {
+            return false;
+          }
+        }
+
+        function ensureRecorder() {
+          if (!isAdmin()) return;
+          try {
+            if (!window.KLog || typeof window.KLog.start !== 'function') return;
+            const status = typeof window.KLog.status === 'function' ? window.KLog.status() : null;
+            const level = status && typeof status.level === 'number' ? status.level : 0;
+            const startedAt = status && typeof status.startedAt === 'number' ? status.startedAt : 0;
+            if (!status || level <= 0 || !startedAt) {
+              window.KLog.start(1);
+            }
+          } catch (_) {}
+        }
+
+        function updateVisibility() {
+          if (!dumpButton) return;
+          if (!window.KLog || typeof window.KLog.isAdmin !== 'function') {
+            dumpButton.hidden = true;
+            return;
+          }
+          const active = isAdmin();
+          dumpButton.hidden = !active;
+          if (active) {
+            ensureRecorder();
+          }
+        }
+
+        if (dumpButton) {
+          dumpButton.addEventListener('click', () => {
+            if (!window.KLog) return;
+            ensureRecorder();
+            const attempt = window.KLog.dumpToClipboard ? window.KLog.dumpToClipboard() : false;
+            Promise.resolve(attempt)
+              .then((opened) => {
+                if (opened) {
+                  showToast('Opened diagnostics in a new tab');
+                  return;
+                }
+                const downloaded = window.KLog.downloadFile ? window.KLog.downloadFile() : false;
+                if (downloaded) {
+                  showToast('Downloaded file');
+                } else {
+                  showToast('Diagnostics unavailable');
+                }
+              })
+              .catch(() => {
+                const downloaded = window.KLog && window.KLog.downloadFile ? window.KLog.downloadFile() : false;
+                if (downloaded) {
+                  showToast('Downloaded file');
+                } else {
+                  showToast('Diagnostics unavailable');
+                }
+              });
+          });
+        }
+
+        function unlockAdmin() {
+          if (!window.KLog || typeof window.KLog.enableAdmin !== 'function') return false;
+          const enabled = window.KLog.enableAdmin(24 * 60 * 60 * 1000);
+          if (enabled) {
+            showToast('Debug unlocked for 24h');
+            updateVisibility();
+            ensureRecorder();
+          }
+          return enabled;
+        }
+
+        const title = document.querySelector('main h1');
+        if (title) {
+          let taps = [];
+          function recordTap() {
+            const now = Date.now();
+            taps = taps.filter((ts) => (now - ts) <= TAP_WINDOW_MS);
+            taps.push(now);
+            if (taps.length >= TAP_COUNT) {
+              taps = [];
+              unlockAdmin();
+            }
+          }
+          title.addEventListener('pointerdown', recordTap, { passive: true });
+          if (!window.PointerEvent) {
+            title.addEventListener('click', recordTap);
+            title.addEventListener('touchstart', recordTap, { passive: true });
+          }
+          title.addEventListener('keydown', (event) => {
+            if (!event) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+              recordTap();
+            }
+          });
+          if (!title.hasAttribute('tabindex')) {
+            title.setAttribute('tabindex', '0');
+          }
+        }
+
+        window.addEventListener('klog:admin', updateVisibility);
+        updateVisibility();
+        window.setTimeout(updateVisibility, 250);
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', onReady, { once: true });
+      } else {
+        onReady();
+      }
+    })();
   </script>
   <script src="js/cookiebot-manager.js" defer></script>
 </body>

--- a/about/licenses.html
+++ b/about/licenses.html
@@ -28,6 +28,7 @@
   <script src="../js/i18n.js" defer></script>
   <script src="../js/topbar.js" defer></script>
   <script src="../js/xpClient.js" defer></script>
+  <script src="../js/debug.js" defer></script>
   <script src="../js/xp.js" defer></script>
   <script src="../js/sidebar.js" defer></script>
   <style>

--- a/css/portal.css
+++ b/css/portal.css
@@ -158,6 +158,10 @@ body{margin:0; background:linear-gradient(180deg, #0b1020 0%, #0a0d1a 100%); col
 /* Footer */
 .site-footer{ position:fixed; left:0; right:0; bottom:0; padding:10px 16px; border-top:1px solid var(--border); display:flex; gap:12px; align-items:center; justify-content:space-between; color:#9fb0d0; background:rgba(11,16,32,.9); backdrop-filter: blur(4px); z-index:50; }
 .footer-nav{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+.debug-dump-button{ margin-top:16px; padding:10px 16px; border-radius:12px; border:1px solid var(--border); background:rgba(110,231,231,.12); color:var(--accent); font:600 14px Poppins, sans-serif; cursor:pointer; transition:background .18s ease, border-color .18s ease, color .18s ease; display:inline-flex; align-items:center; gap:10px; }
+.debug-dump-button:hover{ background:rgba(110,231,231,.2); border-color:rgba(110,231,231,.5); color:#f0f6ff; }
+.debug-toast{ position:fixed; left:50%; bottom:calc(16px + env(safe-area-inset-bottom, 0px)); transform:translateX(-50%); background:rgba(10,14,32,.92); color:#e8eeff; border:1px solid rgba(110,231,231,.35); border-radius:12px; padding:10px 14px; font:600 13px Poppins, sans-serif; box-shadow:0 12px 32px rgba(5,8,22,.45); opacity:0; pointer-events:none; transition:opacity .2s ease, transform .2s ease; z-index:120; }
+.debug-toast.is-visible{ opacity:1; transform:translate(-50%, -6px); }
 .footer-nav .ft-link{ color:#9fb0d0; text-decoration:none; }
 .footer-nav .ft-link:hover{ text-decoration:underline; }
 .footer-nav .sep{ opacity:.5; }

--- a/game.html
+++ b/game.html
@@ -37,7 +37,7 @@
   <script src="js/analytics.js" defer></script>
   <script src="js/i18n.js" defer></script>
 </head>
-<body>
+<body data-game-host>
   <div class="topbar">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -157,9 +157,30 @@
   <script src="js/core/game-utils.js" defer></script>
   <script src="js/frame.js" defer></script>
   <script src="js/cookiebot-manager.js" defer></script>
+  <script src="/js/debug.js" defer></script>
   <script src="/js/xp.js" defer></script>
   <script src="/js/xp-game-hook.js" defer></script>
-  <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>
 

--- a/game_cats.html
+++ b/game_cats.html
@@ -28,7 +28,7 @@
   <script src="js/topbar.js" defer></script>
   <script src="js/xpClient.js" defer></script>
 </head>
-<body data-game-slug="cats" data-game-id="cats">
+<body data-game-host data-game-slug="cats" data-game-id="cats">
   <div class="topbar">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -177,9 +177,30 @@
       <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
     </div>
   </footer>
+  <script src="/js/debug.js" defer></script>
   <script src="/js/xp.js" defer></script>
   <script src="/js/xp-game-hook.js" defer></script>
-  <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>
 

--- a/game_trex.html
+++ b/game_trex.html
@@ -37,7 +37,7 @@
   </style>
 
 </head>
-<body data-game-slug="t-rex" data-game-id="t-rex">
+<body data-game-host data-game-slug="t-rex" data-game-id="t-rex">
   <div class="topbar">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -84,7 +84,7 @@
           <button id="restart" type="button">Restart</button>
         </div>
 
-        <canvas id="game"></canvas>
+        <canvas id="game" data-game-surface></canvas>
 
         <p class="game-credit">T-Rex Runner © <a href="https://github.com/wayou/t-rex-runner" target="_blank" rel="noopener">wayou</a> — MIT License</p>
       </div>
@@ -121,9 +121,30 @@
   <script src="js/sidebar.js" defer></script>
   <script src="games/t-rex/main.js" defer></script>
   <script src="js/cookiebot-manager.js" defer></script>
+  <script src="/js/debug.js" defer></script>
   <script src="/js/xp.js" defer></script>
   <script src="/js/xp-game-hook.js" defer></script>
-  <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>
 

--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -26,11 +26,11 @@
       gtag('js', new Date());
       gtag('config', 'G-JRP62LCXYK');
     </script>
-    <script src="../../js/i18n.js" defer></script>
-    <script src="../../js/topbar.js" defer></script>
-    <script src="../../js/xpClient.js" defer></script>
+    <script src="/js/i18n.js" defer></script>
+    <script src="/js/topbar.js" defer></script>
+    <script src="/js/xpClient.js" defer></script>
   </head>
-  <body data-game-slug="2048" data-game-id="2048">
+  <body data-game-host data-game-slug="2048" data-game-id="2048">
     <div class="topbar">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -137,10 +137,10 @@
       </div>
     </footer>
 
-    <script src="../../js/sidebar.js" defer></script>
+    <script src="/js/sidebar.js" defer></script>
     <script src="../game-shell.js" defer></script>
     <script src="script.js"></script>
-    <script src="../../js/cookiebot-manager.js" defer></script>
+    <script src="/js/cookiebot-manager.js" defer></script>
     <script>
       (function(){
         const allowedOrigin = location.origin;
@@ -179,8 +179,29 @@
         }
       })();
     </script>
-    <script src="../../js/xp.js" defer></script>
-    <script src="../../js/xp-game-hook.js" defer></script>
-    <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+    <script src="/js/debug.js" defer></script>
+    <script src="/js/xp.js" defer></script>
+  <script src="/js/xp-game-hook.js" defer></script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -26,11 +26,11 @@
       gtag('js', new Date());
       gtag('config', 'G-JRP62LCXYK');
     </script>
-    <script src="../../js/i18n.js" defer></script>
-    <script src="../../js/topbar.js" defer></script>
-    <script src="../../js/xpClient.js" defer></script>
+    <script src="/js/i18n.js" defer></script>
+    <script src="/js/topbar.js" defer></script>
+    <script src="/js/xpClient.js" defer></script>
   </head>
-  <body data-game-slug="pacman" data-game-id="pacman">
+  <body data-game-host data-game-slug="pacman" data-game-id="pacman">
     <div class="topbar">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -142,10 +142,10 @@
       </div>
     </footer>
 
-    <script src="../../js/sidebar.js" defer></script>
+    <script src="/js/sidebar.js" defer></script>
     <script src="../game-shell.js" defer></script>
     <script src="script.js"></script>
-    <script src="../../js/cookiebot-manager.js" defer></script>
+    <script src="/js/cookiebot-manager.js" defer></script>
     <script>
       (function(){
         const allowedOrigin = location.origin;
@@ -184,8 +184,29 @@
         }
       })();
     </script>
-    <script src="../../js/xp.js" defer></script>
-    <script src="../../js/xp-game-hook.js" defer></script>
-    <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+    <script src="/js/debug.js" defer></script>
+    <script src="/js/xp.js" defer></script>
+  <script src="/js/xp-game-hook.js" defer></script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -26,11 +26,11 @@
       gtag('js', new Date());
       gtag('config', 'G-JRP62LCXYK');
     </script>
-    <script src="../../js/i18n.js" defer></script>
-    <script src="../../js/topbar.js" defer></script>
-    <script src="../../js/xpClient.js" defer></script>
+    <script src="/js/i18n.js" defer></script>
+    <script src="/js/topbar.js" defer></script>
+    <script src="/js/xpClient.js" defer></script>
   </head>
-  <body data-game-slug="tetris" data-game-id="tetris">
+  <body data-game-host data-game-slug="tetris" data-game-id="tetris">
     <div class="topbar">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
@@ -149,10 +149,10 @@
       </div>
     </footer>
 
-    <script src="../../js/sidebar.js" defer></script>
+    <script src="/js/sidebar.js" defer></script>
     <script src="../game-shell.js" defer></script>
     <script src="script.js"></script>
-    <script src="../../js/cookiebot-manager.js" defer></script>
+    <script src="/js/cookiebot-manager.js" defer></script>
     <script>
       (function(){
         const allowedOrigin = location.origin;
@@ -191,8 +191,29 @@
         }
       })();
     </script>
-    <script src="../../js/xp.js" defer></script>
-    <script src="../../js/xp-game-hook.js" defer></script>
-    <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+    <script src="/js/debug.js" defer></script>
+    <script src="/js/xp.js" defer></script>
+  <script src="/js/xp-game-hook.js" defer></script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>

--- a/games/t-rex/index.html
+++ b/games/t-rex/index.html
@@ -22,7 +22,7 @@
     gtag('config', 'G-JRP62LCXYK');
   </script>
 </head>
-<body data-game-slug="t-rex" data-game-id="t-rex">
+<body data-game-host data-game-slug="t-rex" data-game-id="t-rex">
   <main class="game-shell">
     <header class="hud">
       <h1>T-Rex Runner</h1>
@@ -34,7 +34,7 @@
         <span class="xp-badge__label">Syncing XP…</span>
       </a>
     </header>
-    <canvas id="game" width="600" height="200" role="img" aria-label="Side scrolling runner game"></canvas>
+    <canvas id="game" data-game-surface width="600" height="200" role="img" aria-label="Side scrolling runner game"></canvas>
     <div class="controls">
       <p>Press <kbd>space</kbd>, <kbd>↑</kbd> or tap to jump.</p>
       <button id="restart" type="button">Restart</button>
@@ -43,11 +43,32 @@
   <footer class="footer">
     <a href="#" id="manageCookies">Manage cookies</a>
   </footer>
-  <script src="../../js/cookiebot-manager.js" defer></script>
+  <script src="/js/cookiebot-manager.js" defer></script>
   <script src="main.js"></script>
-  <script src="../../js/xp.js" defer></script>
-  <script src="../../js/xp-game-hook.js" defer></script>
-  <script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+  <script src="/js/debug.js" defer></script>
+  <script src="/js/xp.js" defer></script>
+  <script src="/js/xp-game-hook.js" defer></script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
   </footer>
   <script src="js/topbar.js" defer></script>
   <script src="js/xpClient.js" defer></script>
+  <script src="js/debug.js" defer></script>
   <script src="js/xp.js" defer></script>
   <script src="js/core/catalog.js" defer></script>
   <script src="js/core/game-utils.js" defer></script>

--- a/js/debug.js
+++ b/js/debug.js
@@ -1,0 +1,394 @@
+(function (window, document) {
+  const STORAGE_LOG_KEY = "kcswh:debug:log";
+  const STORAGE_META_KEY = "kcswh:debug:meta";
+  const STORAGE_ADMIN_KEY = "kcswh:admin";
+  const MAX_LINES = 1000;
+  const MIRROR_THRESHOLD = 5; // persist more eagerly
+  const ENTRY_MAX_CHARS = 2000;
+  const ADMIN_DURATION_MS = 24 * 60 * 60 * 1000;
+
+  let buffer = [];
+  let started = false;
+  let level = 0;
+  let startedAt = 0;
+  let totalLines = 0;
+  let dirtySinceMirror = 0;
+  let truncateLogged = false;
+  let adminActive = false;
+
+  function getStorage() {
+    try {
+      if (typeof window === "undefined") return null;
+      if (!window.localStorage) return null;
+      return window.localStorage;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function readJson(key) {
+    const store = getStorage();
+    if (!store) return null;
+    try {
+      const raw = store.getItem(key);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function buildEntry(kind, data) {
+    const ts = new Date().toISOString();
+    let payload = "{}";
+    if (data != null) {
+      try {
+        payload = JSON.stringify(data);
+      } catch (_) {
+        payload = JSON.stringify({ value: String(data) });
+      }
+    }
+    if (payload.length > ENTRY_MAX_CHARS) {
+      payload = payload.slice(0, ENTRY_MAX_CHARS) + "…";
+    }
+    return `[${ts}] ${kind} ${payload}`;
+  }
+
+  function enforceLimit(skipLog) {
+    if (!Array.isArray(buffer)) buffer = [];
+    if (buffer.length <= MAX_LINES) return;
+    const dropCount = buffer.length - MAX_LINES;
+    buffer.splice(0, dropCount);
+    if (!skipLog && !truncateLogged) {
+      truncateLogged = true;
+      const entry = buildEntry("recorder_truncate", { dropped: dropCount });
+      buffer.push(entry);
+      totalLines += 1;
+      dirtySinceMirror += 1;
+      enforceLimit(true);
+    }
+  }
+
+  function hydrateFromStorage() {
+    const storedBuffer = readJson(STORAGE_LOG_KEY);
+    if (Array.isArray(storedBuffer)) {
+      buffer = storedBuffer.slice(-MAX_LINES);
+    } else {
+      buffer = [];
+    }
+    const meta = readJson(STORAGE_META_KEY);
+    if (meta && typeof meta === "object") {
+      if (typeof meta.level === "number") level = meta.level;
+      if (typeof meta.startedAt === "number") startedAt = meta.startedAt;
+      if (typeof meta.lines === "number") totalLines = meta.lines;
+    }
+    enforceLimit(true);
+  }
+
+  function truncateForStorage() {
+    if (!Array.isArray(buffer) || buffer.length <= 1) {
+      return false;
+    }
+    const dropCount = Math.max(1, Math.ceil(buffer.length * 0.1));
+    buffer.splice(0, dropCount);
+    if (!truncateLogged) {
+      truncateLogged = true;
+      const entry = buildEntry("recorder_truncate", { dropped: dropCount });
+      buffer.push(entry);
+      totalLines += 1;
+      dirtySinceMirror += 1;
+    }
+    return true;
+  }
+
+  function persist(force) {
+    if (!started) return;
+    if (!force && dirtySinceMirror < MIRROR_THRESHOLD) return;
+    const store = getStorage();
+    if (!store) return;
+
+    let attempts = 0;
+    while (attempts < 2) {
+      attempts += 1;
+      try {
+        const payload = buffer.slice(-MAX_LINES);
+        store.setItem(STORAGE_LOG_KEY, JSON.stringify(payload));
+        store.setItem(STORAGE_META_KEY, JSON.stringify({
+          level,
+          startedAt,
+          lines: totalLines,
+        }));
+        dirtySinceMirror = 0;
+        return;
+      } catch (_) {
+        if (!truncateForStorage()) {
+          break;
+        }
+      }
+    }
+  }
+
+  function flush(force) {
+    try {
+      persist(!!force);
+    } catch (_) {}
+  }
+
+  function refreshAdmin() {
+    const record = readJson(STORAGE_ADMIN_KEY);
+    const now = Date.now();
+    let active = false;
+    if (record && record.v === true && typeof record.exp === "number") {
+      if (record.exp > now) {
+        active = true;
+      } else {
+        const store = getStorage();
+        if (store) {
+          try { store.removeItem(STORAGE_ADMIN_KEY); } catch (_) {}
+        }
+      }
+    }
+    adminActive = active;
+    return adminActive;
+  }
+
+  function hasAdminFlag() {
+    try {
+      const store = getStorage();
+      if (!store) return false;
+      return !!store.getItem(STORAGE_ADMIN_KEY);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function notifyAdminChange() {
+    try {
+      window.dispatchEvent(new CustomEvent("klog:admin", { detail: { active: adminActive } }));
+    } catch (_) {}
+  }
+
+  function enableAdmin(durationMs) {
+    const store = getStorage();
+    if (!store) return false;
+    const now = Date.now();
+    const exp = now + Math.max(Number(durationMs) || 0, ADMIN_DURATION_MS);
+    try {
+      store.setItem(STORAGE_ADMIN_KEY, JSON.stringify({ v: true, exp }));
+    } catch (_) {
+      return false;
+    }
+    refreshAdmin();
+    notifyAdminChange();
+    if (adminActive && !started) {
+      start(1);
+    }
+    return adminActive;
+  }
+
+  function maybeEnableFromUrl() {
+    try {
+      if (!window || !window.location || !window.location.search) return;
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("admin") === "1") {
+        enableAdmin(ADMIN_DURATION_MS);
+      }
+    } catch (_) {}
+  }
+
+  function isAdmin() {
+    if (!hasAdminFlag()) {
+      adminActive = false;
+      return false;
+    }
+    return refreshAdmin();
+  }
+
+  function recordDump(method, success, extra) {
+    const payload = { method, success: !!success };
+    if (extra && typeof extra === "object") {
+      Object.keys(extra).forEach((key) => {
+        if (extra[key] != null) {
+          payload[key] = extra[key];
+        }
+      });
+    }
+    try {
+      log("diagnostic_dump", payload);
+    } catch (_) {}
+  }
+
+  async function dumpToClipboard() {
+    flush(true);
+    const text = getText();
+    if (!window || typeof window.open !== "function") {
+      recordDump("window", false, { reason: "no_window" });
+      return false;
+    }
+
+    let child = null;
+    try {
+      child = window.open("about:blank", "_blank");
+    } catch (_) {
+      child = null;
+    }
+
+    if (!child || child.closed) {
+      recordDump("window", false, { reason: "blocked" });
+      return false;
+    }
+
+    try {
+      try {
+        child.opener = null;
+      } catch (_) {}
+
+      const doc = child.document;
+      if (!doc) {
+        throw new Error("no_document");
+      }
+
+      const escaped = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Arcade Hub Diagnostics</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{font-family:monospace;background:#050910;color:#e6ecff;margin:0;padding:16px;white-space:pre-wrap;word-break:break-word;}header{font-size:14px;margin-bottom:12px;opacity:0.8;}textarea{width:100%;height:240px;margin-top:12px;background:#0b1020;color:#e6ecff;border:1px solid rgba(230,236,255,0.2);padding:8px;font-family:inherit;}</style></head><body><header>Diagnostics dump generated ${new Date().toISOString()}</header><pre>${escaped || "(no diagnostics recorded)"}</pre><textarea readonly>${escaped}</textarea></body></html>`;
+
+      if (typeof doc.write === "function") {
+        doc.open();
+        doc.write(html);
+        doc.close();
+      } else {
+        doc.documentElement.innerHTML = html;
+      }
+
+      recordDump("window", true, { length: text.length });
+      return true;
+    } catch (error) {
+      const message = error && error.message ? String(error.message).slice(0, 120) : "error";
+      try {
+        child.close();
+      } catch (_) {}
+      recordDump("window", false, { reason: message });
+      return false;
+    }
+  }
+
+  function downloadFile() {
+    try {
+      const text = getText();
+      if (typeof Blob === "undefined" || typeof URL === "undefined") {
+        return false;
+      }
+      const blob = new Blob([text], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+      a.href = url;
+      a.download = `kcswh-diagnostic-${stamp}.txt`;
+      (document && document.body ? document.body : document.documentElement || document).appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function getText() {
+    if (!Array.isArray(buffer) || buffer.length === 0) return "";
+    return buffer.join("\n");
+  }
+
+  function start(requestedLevel) {
+    const nextLevel = Number(requestedLevel);
+    level = Number.isFinite(nextLevel) && nextLevel > 0 ? nextLevel : 1;
+    if (started) {
+      return true;
+    }
+    started = true;
+    if (!startedAt) {
+      startedAt = Date.now();
+    }
+    if (!Number.isFinite(totalLines) || totalLines < buffer.length) {
+      totalLines = buffer.length;
+    }
+    persist(true);
+    return true;
+  }
+
+  function stop() {
+    if (!started) return;
+    started = false;
+    persist(true);
+  }
+
+  function ensureStartedForLog() {
+    if (started) return true;
+    if (!isAdmin()) return false;
+    return start(level > 0 ? level : 1);
+  }
+
+  function log(kind, data) {
+    if (!started && !ensureStartedForLog()) return false;
+    if (!kind || typeof kind !== "string") return false;
+    try {
+      const entry = buildEntry(kind, data || {});
+      buffer.push(entry);
+      totalLines += 1;
+      dirtySinceMirror += 1;
+      truncateLogged = false;
+      enforceLimit(false);
+      persist(false);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function status() {
+    return {
+      level,
+      lines: totalLines,
+      startedAt,
+    };
+  }
+
+  hydrateFromStorage();
+  refreshAdmin();
+  maybeEnableFromUrl();
+  if (isAdmin()) {
+    start(1);
+  }
+
+  const api = {
+    start,
+    stop,
+    log,
+    getText,
+    dumpToClipboard,
+    downloadFile,
+    status,
+    enableAdmin,
+    isAdmin,
+    flush,
+  };
+
+  window.KLog = Object.assign({}, window.KLog || {}, api);
+
+  if (typeof window !== "undefined") {
+    window.addEventListener("storage", (event) => {
+      try {
+        if (!event) return;
+        if (event.key === STORAGE_ADMIN_KEY) {
+          const before = adminActive;
+          refreshAdmin();
+          if (before !== adminActive) {
+            notifyAdminChange();
+            if (adminActive && !started) {
+              start(1);
+            }
+          }
+        }
+      } catch (_) {}
+    });
+  }
+})(typeof window !== "undefined" ? window : this, typeof document !== "undefined" ? document : undefined);

--- a/js/xp.js
+++ b/js/xp.js
@@ -1,6 +1,19 @@
 (function (window, document) {
   const CHUNK_MS = 10_000;
-  const ACTIVE_WINDOW_MS = 5_000;
+  const HARD_IDLE_MS = parseNumber(window && window.XP_HARD_IDLE_MS, 6_000);
+  const isLikelyMobile = () => {
+    try {
+      if (typeof navigator !== "undefined" && navigator && typeof navigator.userAgentData === "object" && typeof navigator.userAgentData.mobile === "boolean") {
+        return navigator.userAgentData.mobile;
+      }
+      if (typeof navigator !== "undefined" && navigator && typeof navigator.userAgent === "string") {
+        return /Android|iPhone|iPad|iPod|Mobile|IEMobile|BlackBerry/i.test(navigator.userAgent);
+      }
+    } catch (_) {}
+    return false;
+  };
+  const DEFAULT_ACTIVE_WINDOW_MS = isLikelyMobile() ? 3_000 : 5_000;
+  const ACTIVE_WINDOW_MS = parseNumber(window && window.XP_ACTIVE_WINDOW_MS, DEFAULT_ACTIVE_WINDOW_MS);
   const CACHE_KEY = "kcswh:xp:last";
 
   const LEVEL_BASE_XP = 100;
@@ -15,7 +28,55 @@
     return Number.isFinite(parsed) ? parsed : fallback;
   }
 
+  function normalizeGameId(value) {
+    if (value == null) return "";
+    try {
+      const text = String(value);
+      return text ? text.trim() : "";
+    } catch (_) {
+      return "";
+    }
+  }
+
+  const HOST_SLUG_PATTERN = /^(2048|pacman|tetris|t-rex)$/i;
+
+  function __isGameHost() {
+    if (typeof window !== "undefined" && window && window.XP_IS_GAME_HOST) return true;
+    if (typeof document === "undefined" || !document || !document.body) return false;
+    if (typeof document.body.hasAttribute === "function" && document.body.hasAttribute("data-game-host")) return true;
+    try {
+      const slug = document.body.dataset?.gameSlug
+        || (location.pathname.split("/").filter(Boolean).slice(-1)[0] || "");
+      return HOST_SLUG_PATTERN.test(slug);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  const HOST_PAGE = __isGameHost();
+
   const MAX_SCORE_DELTA = parseNumber(window && window.XP_SCORE_DELTA_CEILING, DEFAULT_SCORE_DELTA_CEILING);
+  const BASELINE_XP_PER_SECOND = parseNumber(window && window.XP_BASELINE_XP_PER_SECOND, 10);
+  const TICK_MS = parseNumber(window && window.XP_TICK_MS, 1_000);
+  const AWARD_INTERVAL_MS = parseNumber(window && window.XP_AWARD_INTERVAL_MS, TICK_MS);
+  const ACTIVE_GRACE_MS = parseNumber(window && window.XP_ACTIVE_GRACE_MS, 300);
+  const MIN_EVENTS_PER_TICK = Math.max(1, Math.floor(parseNumber(window && window.XP_MIN_EVENTS_PER_TICK, 1)) || 1);
+  const HARD_IDLE_RESET = parseNumber(window && window.XP_HARD_IDLE_RESET, 1) !== 0;
+  const ACTIVITY_EXPONENT = parseNumber(window && window.XP_ACTIVITY_EXPONENT, 1.5);
+  const MAX_XP_PER_SECOND = parseNumber(window && window.XP_MAX_XP_PER_SECOND, 24);
+  const REQUIRE_SCORE_PULSE = parseNumber(window && window.XP_REQUIRE_SCORE, 1) === 1;
+  const SCORE_GRACE_MS = parseNumber(window && window.XP_SCORE_GRACE_MS, 8_000);
+  const GAME_SURFACE_SELECTOR = (window && window.XP_GAME_SURFACE_SELECTOR) || "#game, canvas, #gameFrame, #frameBox, #frameWrap, [data-game-surface]";
+  const BADGE_RECONCILE_INTERVAL_MS = parseNumber(window && window.XP_BADGE_RECONCILE_INTERVAL_MS, 15_000);
+  const SESSION_RENDER_MODE = (window && window.XP_SESSION_RENDER_MODE) || "monotonic";
+  const FLUSH_INTERVAL_MS = 15_000;
+  const FLUSH_THRESHOLD = 50;
+  const RUNTIME_CACHE_KEY = "kcswh:xp:regen";
+  const FLUSH_ENDPOINT = (typeof window !== "undefined" && window && typeof window.XP_FLUSH_ENDPOINT === "string") ? window.XP_FLUSH_ENDPOINT : null;
+
+  function isGameHost() {
+    return HOST_PAGE;
+  }
 
   const state = {
     badge: null,
@@ -31,13 +92,168 @@
     inputEvents: 0,
     activeUntil: 0,
     lastTick: 0,
-    timerId: null,
+    awardTimerId: null,
     pending: null,
     lastResultTs: 0,
     snapshot: null,
     scoreDelta: 0,
     scoreDeltaRemainder: 0,
+    lastTrustedInputTs: 0,
+    regen: {
+      carry: 0,
+      momentum: 0,
+      comboCount: 0,
+      pending: 0,
+      lastAward: 0,
+    },
+    flush: {
+      pending: 0,
+      lastSync: 0,
+      inflight: null,
+    },
+    boost: {
+      multiplier: 1,
+      expiresAt: 0,
+      source: null,
+    },
+    debug: {
+      lastNoHostLog: 0,
+      hardIdleActive: false,
+      initLogged: false,
+      adminInitLogged: false,
+      lastActivityLog: 0,
+      lastCapLog: 0,
+      lastVisibilityLog: 0,
+      lastAwardSkipLog: 0,
+      lastUnfreezeLog: 0,
+    },
+    lastScorePulseTs: 0,
+    phase: "idle",
+    lastInputAt: 0,
+    eventsSinceLastAward: 0,
+    scoreDeltaSinceLastAward: 0,
+    listenersAttached: false,
+    activityWindowFrozen: false,
+    isActive: false,
+    sessionXp: 0,
+    badgeShownXp: 0,
+    serverTotalXp: null,
+    badgeBaselineXp: 0,
+    pendingWindow: null,
+    lastSuccessfulWindowEnd: null,
+    badgeTimerId: null,
   };
+
+  function isFromGameSurface(ev) {
+    try {
+      const root = document;
+      if (!root) return false;
+      const path = (ev && typeof ev.composedPath === "function") ? ev.composedPath() : null;
+      const target = (path && path.length) ? path[0] : (ev && ev.target);
+      if (!target) return false;
+      const isElement = (typeof Element !== "undefined" && target instanceof Element) || (target && target.nodeType === 1);
+      if (!isElement) return false;
+      if (typeof target.closest === "function" && target.closest(GAME_SURFACE_SELECTOR)) return true;
+
+      if (ev && ev.type === "keydown") {
+        const active = root.activeElement;
+        if (active && typeof active.closest === "function" && active.closest(GAME_SURFACE_SELECTOR)) {
+          return true;
+        }
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  function isDebugAdminEnabled() {
+    try {
+      if (window && window.KLog && typeof window.KLog.isAdmin === "function") {
+        return !!window.KLog.isAdmin();
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  function getDebugLogger() {
+    try {
+      if (!window || !window.KLog || typeof window.KLog.log !== "function") return null;
+      return window.KLog;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function ensureDebugRecorderPrimed() {
+    const logger = getDebugLogger();
+    if (!logger) return false;
+    let admin = false;
+    if (typeof logger.isAdmin === "function") {
+      try {
+        admin = !!logger.isAdmin();
+      } catch (_) {
+        admin = false;
+      }
+    }
+    if (!admin) return false;
+    if (typeof logger.start === "function") {
+      try {
+        const status = typeof logger.status === "function" ? logger.status() : null;
+        const level = status && typeof status.level === "number" ? status.level : 0;
+        const startedAt = status && typeof status.startedAt === "number" ? status.startedAt : 0;
+        if (!Number.isFinite(level) || level <= 0 || !Number.isFinite(startedAt) || startedAt <= 0) {
+          logger.start(1);
+        }
+      } catch (_) {}
+    }
+    return true;
+  }
+
+  function writeDebugEntry(kind, data) {
+    const logger = getDebugLogger();
+    if (!logger) return false;
+    try {
+      return logger.log(kind, data || {});
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function logDebug(kind, data) {
+    try {
+      if (!ensureDebugRecorderPrimed()) return false;
+      return !!writeDebugEntry(kind, data || {});
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function resolvePagePath() {
+    try {
+      if (typeof location !== "undefined" && location && typeof location.pathname === "string") {
+        return location.pathname;
+      }
+    } catch (_) {}
+    return "";
+  }
+
+  function emitAdminInitLog() {
+    if (!isDebugAdminEnabled()) return;
+    if (state.debug.adminInitLogged) return;
+    const page = resolvePagePath();
+    const logged = logDebug("xp_init", { page, admin: true });
+    if (logged && isDebugAdminEnabled()) {
+      state.debug.adminInitLogged = true;
+    }
+  }
+
+  function logBlockNoHost(now) {
+    if (!state.running) return;
+    const ts = typeof now === "number" ? now : Date.now();
+    const last = Number(state.debug.lastNoHostLog) || 0;
+    if (ts - last < 2_000) return;
+    state.debug.lastNoHostLog = ts;
+    logDebug("block_no_host", { running: true });
+  }
 
   function resetActivityCounters(now) {
     const ts = typeof now === "number" ? now : Date.now();
@@ -48,6 +264,108 @@
     state.activeUntil = 0;
     state.scoreDelta = 0;
     state.scoreDeltaRemainder = 0;
+  }
+
+  function zeroTickCounters() {
+    state.eventsSinceLastAward = 0;
+    state.scoreDeltaSinceLastAward = 0;
+  }
+
+  function markActiveInput(now) {
+    if (!state.running) return;
+    const ts = typeof now === "number" ? now : Date.now();
+    state.lastInputAt = ts;
+    state.eventsSinceLastAward = Math.max(0, (state.eventsSinceLastAward || 0) + 1);
+    if (state.activityWindowFrozen) {
+      state.activityWindowFrozen = false;
+      if (state.debug.hardIdleActive) {
+        state.debug.hardIdleActive = false;
+      }
+      const lastLog = Number(state.debug.lastUnfreezeLog) || 0;
+      if ((ts - lastLog) > 2_000) {
+        state.debug.lastUnfreezeLog = ts;
+        logDebug("activity_unfrozen", {});
+      }
+    }
+  }
+
+  function getCurrentActivityRatio(now, delta) {
+    if (!Number.isFinite(delta) || delta <= 0) return 0;
+    if (!isDocumentVisible()) return 0;
+    const windowStart = now - delta;
+    const activeUntil = state.activeUntil || 0;
+    if (activeUntil <= windowStart) return 0;
+    const activeMs = Math.max(0, Math.min(delta, activeUntil - windowStart));
+    if (activeMs <= 0) return 0;
+    const ratio = Math.min(1, Math.max(0, activeMs / delta));
+    return Number.isFinite(ratio) ? ratio : 0;
+  }
+
+  function updateMomentum(activityRatio) {
+    const ratio = Math.min(1, Math.max(0, Number(activityRatio) || 0));
+    const prevMomentum = Number(state.regen.momentum) || 0;
+    let nextMomentum = prevMomentum;
+    if (ratio >= 0.75) {
+      nextMomentum = Math.min(1, prevMomentum + 0.12 + ((ratio - 0.75) * 0.4));
+      state.regen.comboCount = Math.min(20, (state.regen.comboCount || 0) + 1);
+    } else if (ratio >= 0.35) {
+      nextMomentum = Math.max(0, prevMomentum * 0.85 + ratio * 0.15);
+    } else {
+      nextMomentum = Math.max(0, prevMomentum * 0.5);
+      if (ratio <= 0.05) {
+        state.regen.comboCount = 0;
+      }
+    }
+    state.regen.momentum = nextMomentum;
+    return nextMomentum;
+  }
+
+  function computeBaseMultiplier(activityRatio) {
+    const clamped = Math.min(1, Math.max(0, Number(activityRatio) || 0));
+    const base = BASELINE_XP_PER_SECOND * Math.pow(clamped, ACTIVITY_EXPONENT);
+    if (!Number.isFinite(base)) return 0;
+    return Math.min(MAX_XP_PER_SECOND, Math.max(0, base));
+  }
+
+  function applyCombo(multiplier) {
+    const base = Number(multiplier) || 0;
+    if (base <= 0) return 0;
+    const comboCount = Math.max(0, Number(state.regen.comboCount) || 0);
+    if (comboCount <= 1) return base;
+    const comboBonus = Math.min(0.75, comboCount * 0.03);
+    return base * (1 + comboBonus);
+  }
+
+  function clearExpiredBoost(now) {
+    const ts = typeof now === "number" ? now : Date.now();
+    if (!state.boost) return;
+    if (state.boost.expiresAt && ts > state.boost.expiresAt) {
+      state.boost = { multiplier: 1, expiresAt: 0, source: null };
+      persistRuntimeState();
+    }
+  }
+
+  function applyBoost(multiplier) {
+    clearExpiredBoost();
+    const base = Number(multiplier) || 0;
+    if (base <= 0) return 0;
+    const boostMultiplier = Number(state.boost && state.boost.multiplier) || 1;
+    if (boostMultiplier <= 1) return base;
+    return base * boostMultiplier;
+  }
+
+  function accumulateLocalXp(xpDelta) {
+    const numeric = Number(xpDelta) || 0;
+    if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+    let carry = Number(state.regen.carry) || 0;
+    const total = numeric + carry;
+    const whole = Math.floor(total);
+    carry = total - whole;
+    state.regen.carry = Math.max(0, carry);
+    if (whole <= 0) return 0;
+    state.regen.pending = Math.max(0, (state.regen.pending || 0) + whole);
+    state.flush.pending = Math.max(0, (state.flush.pending || 0) + whole);
+    return whole;
   }
 
   function isDocumentVisible() {
@@ -87,7 +405,27 @@
       if (typeof parsed.totalToday === "number") state.totalToday = parsed.totalToday;
       if (typeof parsed.cap === "number") state.cap = parsed.cap;
       if (typeof parsed.totalLifetime === "number") state.totalLifetime = parsed.totalLifetime;
+      if (typeof parsed.badgeShownXp === "number") state.badgeShownXp = parsed.badgeShownXp;
+      if (typeof parsed.serverTotalXp === "number") state.serverTotalXp = parsed.serverTotalXp;
+      if (typeof parsed.badgeBaselineXp === "number") state.badgeBaselineXp = parsed.badgeBaselineXp;
       state.lastResultTs = parsed.ts || 0;
+      if (state.serverTotalXp == null && typeof state.totalLifetime === "number") {
+        state.serverTotalXp = state.totalLifetime;
+      }
+      if (typeof state.badgeShownXp !== "number" || Number.isNaN(state.badgeShownXp)) {
+        state.badgeShownXp = typeof state.totalLifetime === "number" ? state.totalLifetime : 0;
+      }
+      if (!Number.isFinite(state.badgeBaselineXp)) {
+        if (typeof state.serverTotalXp === "number") {
+          state.badgeBaselineXp = state.serverTotalXp;
+        } else if (typeof state.badgeShownXp === "number") {
+          state.badgeBaselineXp = state.badgeShownXp;
+        } else if (typeof state.totalLifetime === "number") {
+          state.badgeBaselineXp = state.totalLifetime;
+        } else {
+          state.badgeBaselineXp = 0;
+        }
+      }
     } catch (_) { /* ignore */ }
   }
 
@@ -97,10 +435,56 @@
         totalToday: state.totalToday,
         cap: state.cap,
         totalLifetime: state.totalLifetime,
+        badgeShownXp: state.badgeShownXp,
+        serverTotalXp: state.serverTotalXp,
+        badgeBaselineXp: state.badgeBaselineXp,
         ts: Date.now(),
       };
       window.localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
     } catch (_) { /* ignore */ }
+  }
+
+  function persistRuntimeState() {
+    if (typeof window === "undefined") return;
+    try {
+      const payload = {
+        carry: state.regen.carry || 0,
+        momentum: state.regen.momentum || 0,
+        comboCount: state.regen.comboCount || 0,
+        pending: state.regen.pending || 0,
+        flushPending: state.flush.pending || 0,
+        lastSync: state.flush.lastSync || 0,
+        boost: state.boost,
+      };
+      window.localStorage.setItem(RUNTIME_CACHE_KEY, JSON.stringify(payload));
+    } catch (_) { /* ignore */ }
+  }
+
+  function hydrateRuntimeState() {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(RUNTIME_CACHE_KEY);
+      if (!raw) {
+        if (!state.flush.lastSync) state.flush.lastSync = Date.now();
+        return;
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object") {
+        if (!state.flush.lastSync) state.flush.lastSync = Date.now();
+        return;
+      }
+      state.regen.carry = parseNumber(parsed.carry, state.regen.carry || 0) || 0;
+      state.regen.momentum = parseNumber(parsed.momentum, state.regen.momentum || 0) || 0;
+      state.regen.comboCount = Math.max(0, Math.floor(parseNumber(parsed.comboCount, state.regen.comboCount || 0) || 0));
+      state.regen.pending = Math.max(0, Math.floor(parseNumber(parsed.pending, state.regen.pending || 0) || 0));
+      state.flush.pending = Math.max(0, Math.floor(parseNumber(parsed.flushPending, state.flush.pending || 0) || 0));
+      state.flush.lastSync = parseNumber(parsed.lastSync, state.flush.lastSync || Date.now()) || Date.now();
+      if (parsed.boost && typeof parsed.boost === "object") {
+        state.boost = Object.assign({ multiplier: 1, expiresAt: 0, source: null }, parsed.boost);
+      }
+    } catch (_) {
+      if (!state.flush.lastSync) state.flush.lastSync = Date.now();
+    }
   }
 
   function ensureBadgeElements() {
@@ -122,15 +506,35 @@
     state.badge.classList.toggle("xp-badge--loading", !!isLoading);
   }
 
+  function resolveBadgeBaseline() {
+    if (typeof state.serverTotalXp === "number") {
+      return state.serverTotalXp;
+    }
+    if (Number.isFinite(state.badgeBaselineXp)) {
+      return state.badgeBaselineXp;
+    }
+    if (typeof state.badgeShownXp === "number" && Number.isFinite(state.badgeShownXp)) {
+      return state.badgeShownXp;
+    }
+    if (typeof state.totalLifetime === "number" && Number.isFinite(state.totalLifetime)) {
+      return state.totalLifetime;
+    }
+    return 0;
+  }
+
   function updateBadge() {
     if (!state.badge) return;
     ensureBadgeElements();
-    if (state.totalToday == null) {
-      state.totalToday = 0;
+    const baseline = resolveBadgeBaseline();
+    const session = Math.max(0, Number(state.sessionXp) || 0);
+    const priorShown = Math.max(0, Number(state.badgeShownXp) || 0);
+    let candidate = baseline + session;
+    if (SESSION_RENDER_MODE === "monotonic") {
+      candidate = Math.max(priorShown, candidate);
     }
-    if (state.totalLifetime == null) {
-      state.totalLifetime = 0;
-    }
+    state.badgeShownXp = candidate;
+    state.badgeBaselineXp = Math.max(Number(state.badgeBaselineXp) || 0, baseline);
+    state.totalLifetime = Math.max(Number(state.totalLifetime) || 0, candidate);
     state.snapshot = computeLevel(state.totalLifetime);
     const totalText = state.snapshot.totalXp.toLocaleString();
     state.labelEl.textContent = `Lvl ${state.snapshot.level}, ${totalText} XP`;
@@ -178,28 +582,94 @@
     maybeRefreshStatus();
   }
 
-  function handleResponse(data) {
-    if (!data || typeof data !== "object") return;
-    if (typeof data.totalToday === "number") {
-      const previous = state.totalToday;
-      state.totalToday = data.totalToday;
-      if (data.cap != null) state.cap = data.cap;
-      if (typeof data.totalLifetime === "number") state.totalLifetime = data.totalLifetime;
-      if (data.awarded && data.awarded > 0 && typeof previous === "number") {
-        bumpBadge();
-      }
-      state.lastResultTs = Date.now();
-      saveCache();
-      updateBadge();
+  function handleResponse(data, meta) {
+    const mergedMeta = Object.assign({}, meta);
+    if (data && typeof data.awarded === "number" && data.awarded > 0) {
+      mergedMeta.bump = true;
     }
+    applyServerDelta(data, mergedMeta);
     setBadgeLoading(false);
+    return data;
   }
 
   function handleError(err) {
+    try {
+      const message = err && err.message ? String(err.message).slice(0, 200) : "error";
+      logDebug("window_error", { message });
+    } catch (_) {}
     if (window.console && console.debug) {
       console.debug("XP window failed", err);
     }
     setBadgeLoading(false);
+  }
+
+  function applyServerDelta(data, meta) {
+    if (!data || typeof data !== "object") return;
+    const keys = Object.keys(data);
+    if (!keys.length) return;
+
+    if (typeof data.cap === "number") {
+      state.cap = data.cap;
+    }
+    if (typeof data.totalToday === "number") {
+      state.totalToday = Math.max(0, Number(data.totalToday) || 0);
+    }
+
+    const reasonRaw = data.reason || (data.debug && data.debug.reason) || null;
+    const reason = typeof reasonRaw === "string" ? reasonRaw.toLowerCase() : null;
+    const statusRaw = typeof data.status === "string" ? data.status.toLowerCase() : null;
+    const skipTotals = (statusRaw === "statusonly")
+      || reason === "too_soon"
+      || reason === "insufficient-activity";
+
+    const totalLifetime = (typeof data.totalLifetime === "number") ? data.totalLifetime
+      : (typeof data.total === "number" ? data.total : null);
+
+    if (skipTotals || totalLifetime == null) {
+      saveCache();
+      updateBadge();
+      return;
+    }
+
+    const ok = data.ok === true || statusRaw === "ok" || (!statusRaw && data.awarded != null);
+    if (!ok) {
+      saveCache();
+      updateBadge();
+      return;
+    }
+
+    const sanitizedTotal = Math.max(0, Number(totalLifetime) || 0);
+    const previousServer = typeof state.serverTotalXp === "number" ? state.serverTotalXp : null;
+    let acked = 0;
+    if (previousServer != null) {
+      if (sanitizedTotal >= previousServer) {
+        acked = sanitizedTotal - previousServer;
+        state.serverTotalXp = sanitizedTotal;
+      } else {
+        state.serverTotalXp = previousServer;
+      }
+    } else {
+      const baseline = Math.max(0, Number(state.badgeBaselineXp) || 0);
+      if (sanitizedTotal >= baseline) {
+        acked = sanitizedTotal - baseline;
+      }
+      state.serverTotalXp = sanitizedTotal;
+    }
+
+    if (acked > 0) {
+      const pendingSession = Math.max(0, Number(state.sessionXp) || 0);
+      const toSubtract = Math.min(acked, pendingSession);
+      state.sessionXp = Math.max(0, pendingSession - toSubtract);
+    }
+
+    state.badgeBaselineXp = Math.max(Number(state.badgeBaselineXp) || 0, state.serverTotalXp || 0);
+    state.totalLifetime = Math.max(Number(state.totalLifetime) || 0, state.serverTotalXp || 0);
+    state.lastResultTs = Date.now();
+    if (meta && meta.bump === true) {
+      bumpBadge();
+    }
+    saveCache();
+    updateBadge();
   }
 
   async function sendWindow(force) {
@@ -228,8 +698,14 @@
       return;
     }
 
+    const activeGameId = normalizeGameId(state.gameId);
+    if (!activeGameId) {
+      logDebug("drop_mismatched_gameid", { expected: state.gameId || null, payloadGameId: null });
+      return;
+    }
+
     const payload = {
-      gameId: state.gameId || "game",
+      gameId: activeGameId,
       windowStart: state.windowStart,
       windowEnd: now,
       visibilitySeconds: visibility,
@@ -244,24 +720,84 @@
     state.activeMs = 0;
     state.visibilitySeconds = 0;
     state.inputEvents = 0;
+    if (payload.gameId !== state.gameId) {
+      logDebug("drop_mismatched_gameid", { expected: state.gameId || null, payloadGameId: payload.gameId });
+      return;
+    }
+
+    try {
+      logDebug("send_window", {
+        gameId: payload.gameId,
+        windowStart: payload.windowStart,
+        windowEnd: payload.windowEnd,
+        visibilitySeconds: payload.visibilitySeconds,
+        inputEvents: payload.inputEvents,
+        scoreDelta: payload.scoreDelta || 0,
+        force: !!force,
+      });
+    } catch (_) {}
+    state.pendingWindow = {
+      start: payload.windowStart,
+      end: payload.windowEnd,
+      inputs: payload.inputEvents,
+      visSeconds: payload.visibilitySeconds,
+    };
+
     state.pending = window.XPClient.postWindow(payload)
-      .then((data) => handleResponse(data))
-      .catch(handleError)
+      .then((data) => {
+        try {
+          const snap = {
+            status: data && data.status,
+            reason: data && data.reason,
+            scoreDelta: data && data.scoreDelta,
+            debug: data && data.debug,
+          };
+          logDebug("window_result", snap);
+        } catch (_) {}
+        state.lastSuccessfulWindowEnd = payload.windowEnd;
+        state.pendingWindow = null;
+        return handleResponse(data, { source: "window" });
+      })
+      .catch((err) => {
+        state.pendingWindow = null;
+        handleError(err);
+      })
       .finally(() => { state.pending = null; });
     state.scoreDelta = 0;
   }
 
-  function tick() {
+  function onAwardTick() {
     const now = Date.now();
     const delta = state.lastTick ? Math.max(0, now - state.lastTick) : 0;
     state.lastTick = now;
-    if (!state.running) return;
-    const visible = isDocumentVisible();
-    if (!visible) {
-      resetActivityCounters(now);
+
+    if (!state.running || state.phase !== "running") {
+      if (state.flush && state.flush.pending) {
+        flushXp(false).catch(() => {});
+      }
       return;
     }
 
+    if (!isGameHost()) {
+      logBlockNoHost(now);
+      zeroTickCounters();
+      return;
+    }
+
+    if (!isDocumentVisible()) {
+      state.phase = "paused";
+      if (!state.debug.lastVisibilityLog || (now - state.debug.lastVisibilityLog) > 2_000) {
+        state.debug.lastVisibilityLog = now;
+        logDebug("block_visibility", { hidden: true });
+      }
+      resetActivityCounters(now);
+      state.activityWindowFrozen = true;
+      zeroTickCounters();
+      flushXp(true).catch(() => {});
+      return;
+    }
+
+    state.phase = "running";
     state.visibilitySeconds += delta / 1000;
     if (now <= state.activeUntil) {
       state.activeMs += delta;
@@ -269,45 +805,189 @@
     if (state.activeMs >= CHUNK_MS) {
       sendWindow(false);
     }
+
+    const lastTrusted = Number(state.lastTrustedInputTs) || 0;
+    if (lastTrusted && (now - lastTrusted) > HARD_IDLE_MS) {
+      state.activeUntil = now;
+      if (!state.debug.hardIdleActive) {
+        state.debug.hardIdleActive = true;
+        logDebug("block_hard_idle", { idleMs: now - lastTrusted });
+      }
+      state.activityWindowFrozen = true;
+      state.phase = "paused";
+      if (HARD_IDLE_RESET) {
+        state.activityWindowFrozen = true;
+        resetActivityCounters(now);
+        zeroTickCounters();
+      } else {
+        zeroTickCounters();
+      }
+    }
+
+    const sinceLastInput = now - (state.lastInputAt || 0);
+    const hasRecentInput = sinceLastInput <= ACTIVE_GRACE_MS;
+    const events = Number(state.eventsSinceLastAward) || 0;
+    const hasEvents = events >= MIN_EVENTS_PER_TICK;
+    const scoreDelta = Number(state.scoreDeltaSinceLastAward) || 0;
+    const hasScore = scoreDelta > 0;
+    const frameDelta = delta || AWARD_INTERVAL_MS;
+    let activityRatio = getCurrentActivityRatio(now, frameDelta);
+    if (!Number.isFinite(activityRatio) || activityRatio < 0) {
+      activityRatio = 0;
+    }
+
+    let isActive = false;
+    if (hasScore) {
+      isActive = true;
+    } else if (hasRecentInput && hasEvents) {
+      isActive = true;
+    }
+    if (state.activityWindowFrozen) {
+      isActive = false;
+    }
+    state.isActive = isActive;
+
+    if (!state.debug.lastActivityLog || (now - state.debug.lastActivityLog) > 2_000) {
+      state.debug.lastActivityLog = now;
+      logDebug("activity", { ratio: Number(activityRatio) || 0, events, sinceLastInput });
+    }
+
+    if (!isActive) {
+      const lastSkip = Number(state.debug.lastAwardSkipLog) || 0;
+      if ((now - lastSkip) > 500) {
+        state.debug.lastAwardSkipLog = now;
+        logDebug("award_skip", {
+          reason: state.activityWindowFrozen ? "frozen" : "inactive",
+          events,
+          sinceLastInput,
+        });
+      }
+      zeroTickCounters();
+      flushXp(false).catch(() => {});
+      return;
+    }
+
+    if (state.debug.hardIdleActive && !state.activityWindowFrozen) {
+      state.debug.hardIdleActive = false;
+    }
+
+    const awarded = awardLocalXp(activityRatio);
+    zeroTickCounters();
+    flushXp(false).catch(() => {});
+    return awarded;
   }
 
   function ensureTimer() {
-    if (state.timerId) return;
+    if (state.awardTimerId) return;
     state.lastTick = Date.now();
-    state.timerId = window.setInterval(tick, 1000);
+    state.awardTimerId = window.setInterval(onAwardTick, AWARD_INTERVAL_MS);
   }
 
   function clearTimer() {
-    if (state.timerId) {
-      window.clearInterval(state.timerId);
-      state.timerId = null;
+    if (state.awardTimerId) {
+      window.clearInterval(state.awardTimerId);
+      state.awardTimerId = null;
     }
   }
 
-  function startSession(gameId) {
-    attachBadge();
-    ensureTimer();
+  function ensureBadgeTimer() {
+    if (!window || typeof window.setInterval !== "function") return;
+    if (state.badgeTimerId) return;
+    if (!Number.isFinite(BADGE_RECONCILE_INTERVAL_MS) || BADGE_RECONCILE_INTERVAL_MS <= 0) return;
+    state.badgeTimerId = window.setInterval(() => {
+      try {
+        reconcileWithServer().catch(() => {});
+      } catch (_) {}
+    }, BADGE_RECONCILE_INTERVAL_MS);
+  }
 
+  function clearBadgeTimer() {
+    if (state.badgeTimerId && window && typeof window.clearInterval === "function") {
+      window.clearInterval(state.badgeTimerId);
+    }
+    state.badgeTimerId = null;
+  }
+
+  function startSession(gameId) {
+    if (!isGameHost()) {
+      logDebug("block_no_host", { when: "startSession" });
+      return;
+    }
+    const requestedId = normalizeGameId(gameId);
+    const fallbackId = requestedId || normalizeGameId(state.gameId);
+    if (!fallbackId) {
+      logDebug("xp_start_blocked", { reason: "missing_game_id" });
+      return;
+    }
+    if (state.running && state.gameId === fallbackId) {
+      logDebug("xp_start_ignored", { existingGameId: state.gameId || null });
+      return;
+    }
+    if (state.running && state.gameId && state.gameId !== fallbackId) {
+      logDebug("xp_restart", { previousGameId: state.gameId || null, nextGameId: fallbackId });
+      stopSession({ flush: true });
+      if (typeof window !== "undefined" && window && typeof window.setTimeout === "function") {
+        window.setTimeout(() => {
+          try { startSession(fallbackId); } catch (_) {}
+        }, 0);
+      }
+      return;
+    }
+    attachBadge();
+    hydrateRuntimeState();
+    ensureTimer();
+    ensureBadgeTimer();
+
+    state.phase = "running";
     state.running = true;
-    state.gameId = gameId || "game";
+    state.gameId = fallbackId;
     state.windowStart = Date.now();
     state.activeMs = 0;
     state.visibilitySeconds = 0;
     state.inputEvents = 0;
-    state.activeUntil = Date.now();
+    state.activeUntil = 0;
     state.scoreDelta = 0;
     state.scoreDeltaRemainder = 0;
+    state.lastScorePulseTs = 0;
+    state.lastInputAt = 0;
+    state.lastTrustedInputTs = 0;
+    state.eventsSinceLastAward = 0;
+    state.scoreDeltaSinceLastAward = 0;
+    state.activityWindowFrozen = false;
+    state.isActive = false;
+    state.sessionXp = 0;
+    const baseline = resolveBadgeBaseline();
+    const currentShown = Number(state.badgeShownXp) || 0;
+    state.badgeBaselineXp = Math.max(baseline, currentShown);
+    state.pendingWindow = null;
+    state.lastSuccessfulWindowEnd = null;
+    if (!state.flush.lastSync) state.flush.lastSync = Date.now();
+    state.debug.hardIdleActive = false;
+    state.debug.lastNoHostLog = 0;
+    state.debug.lastActivityLog = 0;
+    state.debug.lastCapLog = 0;
+    state.debug.lastVisibilityLog = 0;
+    state.debug.lastAwardSkipLog = 0;
+    logDebug("xp_start", { gameId: state.gameId, isHost: true });
   }
 
   function stopSession(options) {
     const opts = options || {};
+    const wasRunning = state.running === true;
+    if (wasRunning) {
+      logDebug("xp_stop", { flush: opts.flush !== false });
+    }
     /* xp stop flush guard */ if (state.running && opts.flush !== false) {
       const _minInputsGate = Math.max(2, Math.ceil(CHUNK_MS / 4000));
       if (!(state.visibilitySeconds > 1 && state.inputEvents >= _minInputsGate)) {
         // skip network flush if idle
       } else {
       sendWindow(true); }
+      flushXp(true).catch(() => {});
     }
+    clearTimer();
+    clearBadgeTimer();
+    state.phase = "idle";
     state.running = false;
     state.gameId = null;
     state.activeMs = 0;
@@ -316,11 +996,44 @@
     state.activeUntil = 0;
     state.scoreDelta = 0;
     state.scoreDeltaRemainder = 0;
+    state.eventsSinceLastAward = 0;
+    state.scoreDeltaSinceLastAward = 0;
+    state.lastInputAt = 0;
+    state.lastTrustedInputTs = 0;
+    state.activityWindowFrozen = false;
+    state.isActive = false;
+    state.lastScorePulseTs = 0;
+    state.pendingWindow = null;
+    state.lastSuccessfulWindowEnd = null;
+    state.badgeBaselineXp = Math.max(resolveBadgeBaseline(), Number(state.badgeShownXp) || 0);
+    state.sessionXp = 0;
+    state.debug.hardIdleActive = false;
+    state.debug.lastNoHostLog = 0;
+    state.debug.lastActivityLog = 0;
+    state.debug.lastCapLog = 0;
+    state.debug.lastVisibilityLog = 0;
+    updateBadge();
   }
 
-  function nudge() {
-    state.activeUntil = Date.now() + ACTIVE_WINDOW_MS;
+  function nudge(options) {
+    if (!state.running) return;
+    if (!isGameHost()) {
+      logDebug("block_no_host", { when: "nudge" });
+      return;
+    }
+    const now = Date.now();
+    state.activeUntil = now + ACTIVE_WINDOW_MS;
     state.inputEvents += 1;
+    if (!options || options.skipMark !== true) {
+      state.lastTrustedInputTs = now;
+      markActiveInput(now);
+    }
+  }
+
+  function recordTrustedInput() {
+    const now = Date.now();
+    state.lastTrustedInputTs = now;
+    markActiveInput(now);
   }
 
   function addScore(delta) {
@@ -353,16 +1066,187 @@
     const toAdd = Math.min(whole, capacity);
     state.scoreDelta = current + toAdd;
     state.scoreDeltaRemainder = Math.max(0, state.scoreDeltaRemainder - toAdd);
+    state.scoreDeltaSinceLastAward = Math.max(0, (state.scoreDeltaSinceLastAward || 0) + toAdd);
+    state.lastScorePulseTs = Date.now();
+  }
+
+  function pulseBadge() {
+    updateBadge();
+    bumpBadge();
+  }
+
+  function isAtCap() {
+    if (state.cap == null) return false;
+    if (typeof state.totalToday !== "number") return false;
+    return state.totalToday >= state.cap;
+  }
+
+  function awardLocalXp(activityRatio) {
+    if (!state.running) return 0;
+    if (isAtCap()) {
+      const now = Date.now();
+      if (!state.debug.lastCapLog || (now - state.debug.lastCapLog) > 2_000) {
+        state.debug.lastCapLog = now;
+        logDebug("block_cap", {
+          totalToday: Number(state.totalToday) || 0,
+          cap: state.cap,
+        });
+      }
+      return 0;
+    }
+    if (REQUIRE_SCORE_PULSE) {
+      const now = Date.now();
+      if (!state.lastScorePulseTs || (now - state.lastScorePulseTs) > SCORE_GRACE_MS) {
+        return 0;
+      }
+    }
+    const baseMultiplier = computeBaseMultiplier(activityRatio);
+    const momentum = updateMomentum(activityRatio);
+    let xpPerSecond = baseMultiplier * (1 + (momentum * 0.5));
+    xpPerSecond = applyCombo(xpPerSecond);
+    xpPerSecond = applyBoost(xpPerSecond);
+    xpPerSecond = Math.min(MAX_XP_PER_SECOND, Math.max(0, xpPerSecond));
+    const xpForTick = xpPerSecond * (AWARD_INTERVAL_MS / 1000);
+    const awarded = accumulateLocalXp(xpForTick);
+    if (awarded <= 0) return 0;
+    state.totalToday = (Number(state.totalToday) || 0) + awarded;
+    state.totalLifetime = (Number(state.totalLifetime) || 0) + awarded;
+    state.regen.lastAward = Date.now();
+    state.lastResultTs = state.regen.lastAward;
+    state.sessionXp = Math.max(0, (Number(state.sessionXp) || 0) + awarded);
+    saveCache();
+    persistRuntimeState();
+    pulseBadge();
+    const emitUpdate = (target) => {
+      if (!target || typeof target.dispatchEvent !== "function") return;
+      try {
+        target.dispatchEvent(new CustomEvent("xp:updated", { detail: { awarded } }));
+      } catch (_) {
+        try { target.dispatchEvent(new Event("xp:updated")); } catch (_) {}
+      }
+    };
+    if (typeof window !== "undefined") {
+      emitUpdate(window);
+    }
+    if (typeof document !== "undefined") {
+      emitUpdate(document);
+    }
+    logDebug("award", { awarded, activityRatio: Number(activityRatio) || 0 });
+    return awarded;
+  }
+
+  function shouldFlush(force) {
+    if (force) return true;
+    if (state.flush.inflight) return false;
+    if (!state.flush.pending) return false;
+    if (!isDocumentVisible()) return true;
+    if (isAtCap()) return true;
+    const now = Date.now();
+    if (state.flush.pending >= FLUSH_THRESHOLD) return true;
+    if (!state.flush.lastSync) return true;
+    if ((now - state.flush.lastSync) >= FLUSH_INTERVAL_MS) return true;
+    return false;
+  }
+
+  function markFlushSuccess(amount) {
+    const delta = Math.max(0, Number(amount) || 0);
+    if (delta > 0) {
+      state.flush.pending = Math.max(0, state.flush.pending - delta);
+      state.regen.pending = Math.max(0, state.regen.pending - delta);
+    }
+    state.flush.lastSync = Date.now();
+    persistRuntimeState();
+  }
+
+  function flushXp(force) {
+    if (state.flush.inflight) {
+      return state.flush.inflight;
+    }
+    if (!shouldFlush(force)) return Promise.resolve(false);
+    const pending = Math.max(0, state.flush.pending || 0);
+    if (!pending) return Promise.resolve(false);
+    const payload = {
+      pending,
+      totalToday: state.totalToday || 0,
+      totalLifetime: state.totalLifetime || 0,
+      ts: Date.now(),
+    };
+    const serialized = JSON.stringify(payload);
+    const done = () => { markFlushSuccess(pending); };
+
+    if (!FLUSH_ENDPOINT) {
+      done();
+      return Promise.resolve(true);
+    }
+
+    if (typeof navigator !== "undefined" && navigator && typeof navigator.sendBeacon === "function") {
+      const sent = navigator.sendBeacon(FLUSH_ENDPOINT, serialized);
+      if (sent) {
+        done();
+        return Promise.resolve(true);
+      }
+    }
+
+    if (typeof fetch !== "function") {
+      done();
+      return Promise.resolve(true);
+    }
+
+    const request = fetch(FLUSH_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: serialized,
+      keepalive: true,
+      credentials: "omit",
+    })
+      .then(() => { done(); return true; })
+      .catch((err) => {
+        if (window.console && console.debug) {
+          console.debug("XP flush failed", err);
+        }
+        persistRuntimeState();
+        return false;
+      })
+      .finally(() => { state.flush.inflight = null; });
+    state.flush.inflight = request;
+    return request;
+  }
+
+  function requestBoost(detail) {
+    if (!detail || typeof detail !== "object") return;
+    const multiplier = parseNumber(detail.multiplier, state.boost.multiplier || 1) || 1;
+    const durationMs = Math.max(0, parseNumber(detail.durationMs, 0) || 0);
+    const source = detail.source || null;
+    if (!Number.isFinite(multiplier) || multiplier <= 1) {
+      state.boost = { multiplier: 1, expiresAt: 0, source: null };
+      persistRuntimeState();
+      return;
+    }
+    const now = Date.now();
+    state.boost = {
+      multiplier: Math.max(1, multiplier),
+      expiresAt: durationMs > 0 ? now + durationMs : now + 15_000,
+      source,
+    };
+    persistRuntimeState();
+  }
+
+  function getFlushStatus() {
+    return {
+      pending: Math.max(0, state.flush.pending || 0),
+      lastSync: state.flush.lastSync || 0,
+      inflight: !!state.flush.inflight,
+    };
   }
 
   function setTotals(total, cap) {
-    state.totalToday = typeof total === "number" ? total : state.totalToday;
-    state.cap = typeof cap === "number" ? cap : state.cap;
+    const payload = { ok: true };
+    if (typeof total === "number") payload.totalToday = total;
+    if (typeof cap === "number") payload.cap = cap;
     if (arguments.length >= 3 && typeof arguments[2] === "number") {
-      state.totalLifetime = arguments[2];
+      payload.totalLifetime = arguments[2];
     }
-    saveCache();
-    updateBadge();
+    applyServerDelta(payload, { source: "setTotals" });
   }
 
   function getSnapshot() {
@@ -382,6 +1266,34 @@
     };
   }
 
+  function reconcileWithServer() {
+    if (!state.running && state.phase !== "running") {
+      return Promise.resolve(null);
+    }
+    if (!window.XPClient || typeof window.XPClient.fetchStatus !== "function") {
+      return Promise.resolve(null);
+    }
+    return window.XPClient.fetchStatus()
+      .then((data) => {
+        applyServerDelta(data, { source: "reconcile" });
+        try {
+          logDebug("badge_reconcile", {
+            badgeShownXp: Number(state.badgeShownXp) || 0,
+            serverTotalXp: typeof state.serverTotalXp === "number" ? state.serverTotalXp : null,
+            sessionXp: Number(state.sessionXp) || 0,
+          });
+        } catch (_) {}
+        return data;
+      })
+      .catch((err) => {
+        try {
+          const message = err && err.message ? String(err.message).slice(0, 200) : "error";
+          logDebug("badge_reconcile_error", { message });
+        } catch (_) {}
+        return null;
+      });
+  }
+
   function refreshStatus() {
     if (!window.XPClient || typeof window.XPClient.fetchStatus !== "function") return Promise.resolve(null);
     setBadgeLoading(true);
@@ -399,8 +1311,33 @@
   }
 
   function init() {
+    hydrateRuntimeState();
+    if (!state.debug.initLogged) {
+      state.debug.initLogged = true;
+      const page = resolvePagePath();
+      const admin = isDebugAdminEnabled();
+      const logged = logDebug("xp_init", { page, admin });
+      state.debug.adminInitLogged = admin && logged;
+    }
+
+    try {
+      refreshBadgeFromStorage();
+    } catch (_) {}
+
+    if (!isGameHost()) {
+      if (state.running === true) {
+        try { stopSession({ flush: true }); } catch (_) {}
+      }
+      return;
+    }
+
     if (typeof document !== "undefined") {
-      const handleDomReady = () => { try { refreshBadgeFromStorage(); } catch (_) {} };
+      const handleDomReady = () => {
+        try {
+          hydrateRuntimeState();
+          refreshBadgeFromStorage();
+        } catch (_) {}
+      };
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", handleDomReady, { once: true });
       } else {
@@ -411,7 +1348,9 @@
         state.lastTick = now;
         if (!isDocumentVisible()) {
           resetActivityCounters(now);
+          flushXp(true).catch(() => {});
         } else {
+          hydrateRuntimeState();
           refreshBadgeFromStorage();
         }
       }, { passive: true });
@@ -422,12 +1361,14 @@
 
       window.addEventListener("pageshow", () => {
         try {
+          hydrateRuntimeState();
           refreshBadgeFromStorage();
         } catch (_) {}
       }, { passive: true });
 
       window.addEventListener("focus", () => {
         try {
+          hydrateRuntimeState();
           refreshBadgeFromStorage();
         } catch (_) {}
       }, { passive: true });
@@ -436,7 +1377,8 @@
         try {
           if (!event) return;
           if (event.storageArea && event.storageArea !== window.localStorage) return;
-          if (event.key && event.key !== CACHE_KEY) return;
+          if (event.key && event.key !== CACHE_KEY && event.key !== RUNTIME_CACHE_KEY) return;
+          hydrateRuntimeState();
           refreshBadgeFromStorage();
         } catch (_) {}
       });
@@ -445,62 +1387,121 @@
         try { refreshBadgeFromStorage(); } catch (_) {}
       });
 
-      // Hardened activity bridge (same-origin, visible doc, requires userGesture:true, throttled)
-    (function(){
-      let __lastNudgeTs = 0;
       window.addEventListener("message", (event) => {
         try {
-          if (!event || !event.data) return;
-          if (typeof document !== "undefined" && document.hidden) return;
+          if (!event || !event.data || typeof event.data !== "object") return;
           if (event.origin && typeof location !== "undefined" && event.origin !== location.origin) return;
-          if (event.data.type !== "kcswh:activity") return;
-          if (event.data.userGesture !== true) return;
-
-          const now = Date.now();
-          if (now - __lastNudgeTs < 100) return; // ~10/sec
-          __lastNudgeTs = now;
-
-          if (typeof nudge === "function") nudge();
-        } catch {}
+          if (event.data.type !== "game-score") return;
+          if (!isGameHost()) return;
+          state.lastScorePulseTs = Date.now();
+          logDebug("score_pulse", {
+            gameId: event.data.gameId || state.gameId || "",
+            score: typeof event.data.score === "number" ? event.data.score : undefined,
+          });
+        } catch (_) {}
       }, { passive: true });
-    })();
 
-    // Top-frame input listeners -> nudge (only on real user gestures)
-    (function(){
-      // Decide if this event represents a true user gesture (not synthetic noise)
-      function isRealUserGesture(e){
-        // Prefer the platform signal if present
-        if (typeof navigator !== "undefined" && navigator.userActivation && navigator.userActivation.isActive) return true;
-        // Fallback heuristics
-        if (!e || e.isTrusted === false) return false;
-        switch (e.type) {
-          case "pointerdown":
-          case "touchstart":
-          case "keydown":
-          case "wheel":
-            return true;
-          // Explicitly ignore move/hover; too noisy and often synthetic in headless runs
-          case "pointermove":
-          case "mousemove":
-          default:
-            return false;
-        }
+      window.addEventListener("xp:boost", (event) => {
+        try { requestBoost(event && event.detail); } catch (_) {}
+      });
+
+      window.addEventListener("klog:admin", (event) => {
+        try {
+          const active = event && event.detail && event.detail.active === true;
+          if (!active) {
+            state.debug.adminInitLogged = false;
+            return;
+          }
+          emitAdminInitLog();
+        } catch (_) {}
+      }, { passive: true });
+
+      if (isDebugAdminEnabled()) {
+        emitAdminInitLog();
       }
 
-      ["pointerdown","keydown","wheel","touchstart" /* no 'pointermove' */].forEach(evt => {
-        try {
-          window.addEventListener(evt, (ev) => {
-            try { if (isRealUserGesture(ev) && typeof nudge === "function") nudge(); } catch(_) {}
-          }, { passive: true });
-        } catch(_) {}
-      });
-    })();
+      // Hardened activity bridge (same-origin, visible doc, requires userGesture:true, throttled)
+      (function(){
+        let __lastNudgeTs = 0;
+        window.addEventListener("message", (event) => {
+          try {
+            if (!event || !event.data) return;
+            if (typeof document !== "undefined" && document.hidden) return;
+            if (event.origin && typeof location !== "undefined" && event.origin !== location.origin) return;
+            if (event.data.type !== "kcswh:activity") return;
+            if (!state.running) return;
+            if (!isGameHost()) return;
+            if (event.data.userGesture !== true) return;
+
+            const now = Date.now();
+            let activationIsActive = true;
+            if (typeof navigator !== "undefined" && navigator.userActivation) {
+              activationIsActive = navigator.userActivation.isActive === true;
+            }
+            const recentlyTrusted = state.lastTrustedInputTs && (now - state.lastTrustedInputTs) <= ACTIVE_WINDOW_MS;
+            if (!activationIsActive && !recentlyTrusted) return;
+
+            if (now - __lastNudgeTs < 100) return; // ~10/sec
+            __lastNudgeTs = now;
+
+            try { recordTrustedInput(); } catch (_) {}
+            if (typeof nudge === "function") nudge({ skipMark: true });
+          } catch (_) {}
+        }, { passive: true });
+      })();
+
+      // Top-frame input listeners -> nudge (only on real user gestures)
+      (function(){
+        if (state.listenersAttached) return;
+        state.listenersAttached = true;
+        // Decide if this event represents a true user gesture (not synthetic noise)
+        function isRealUserGesture(e){
+          // Prefer the platform signal if present
+          if (typeof navigator !== "undefined" && navigator.userActivation && navigator.userActivation.isActive) return true;
+          // Fallback heuristics
+          if (!e || e.isTrusted === false) return false;
+          switch (e.type) {
+            case "pointerdown":
+            case "touchstart":
+            case "keydown":
+              return true;
+            case "wheel":
+              return !isLikelyMobile();
+            // Explicitly ignore move/hover; too noisy and often synthetic in headless runs
+            case "pointermove":
+            case "mousemove":
+            default:
+              return false;
+          }
+        }
+
+        const baseEvents = ["pointerdown","keydown","touchstart"]; // always track
+        const wheelEvents = isLikelyMobile() ? [] : ["wheel"];
+        baseEvents.concat(wheelEvents).forEach(evt => {
+          try {
+            window.addEventListener(evt, (ev) => {
+              try {
+                if (!isRealUserGesture(ev)) return;
+                if (!state.running) return;
+                if (!isGameHost()) return;
+                if (!isFromGameSurface(ev)) {
+                  logDebug("ignore_input_outside_surface", { type: ev && ev.type });
+                  return;
+                }
+                recordTrustedInput();
+                if (typeof nudge === "function") nudge({ skipMark: true });
+              } catch(_) {}
+            }, { passive: true });
+          } catch(_) {}
+        });
+      })();
+    }
   }
-}
 
   init();
 
   window.XP = Object.assign({}, window.XP || {}, {
+    __hostPage: HOST_PAGE,
     startSession,
     stopSession,
     nudge,
@@ -508,6 +1509,10 @@
     getSnapshot,
     refreshStatus,
     addScore,
+    awardLocalXp,
+    flushXp,
+    requestBoost,
+    getFlushStatus,
     scoreDeltaCeiling: MAX_SCORE_DELTA,
 
     isRunning: function(){ try { return !!(typeof state !== 'undefined' ? state.running : (this && this.__running)); } catch(_) { return !!(this && this.__running); } },});
@@ -515,6 +1520,7 @@
 // --- XP resume polyfill (idempotent) ---
 (function () {
   if (typeof window === 'undefined') return;
+  if (!window.XP || window.XP.__hostPage === false) return;
   if (!window.XP) return;
   if (window.XP.__xpResumeWired) return; // already wired
 
@@ -562,7 +1568,7 @@
       try {
         if (window.XP.isRunning && window.XP.isRunning()) {
           // already running; give a tiny prod so UI/timers align
-          try { window.XP.nudge && window.XP.nudge(); } catch (_) {}
+          try { window.XP.nudge && window.XP.nudge({ skipMark: true }); } catch (_) {}
           return;
         }
         var gid = window.XP.__lastGameId || undefined; // fall back to last seen gameId
@@ -578,6 +1584,7 @@
 
 (function () {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (!window.XP || window.XP.__hostPage === false) return;
   if (!window.XP) return;
   if (window.XP.__xpLifecycleWired) return;
   window.XP.__xpLifecycleWired = true;
@@ -591,6 +1598,14 @@
       XP[fnName](arg);
       return true;
     } catch (_) { return false; }
+  }
+
+  function flushRecorder() {
+    try {
+      if (window.KLog && typeof window.KLog.flush === 'function') {
+        window.KLog.flush(true);
+      }
+    } catch (_) {}
   }
 
   function clearRetry() {
@@ -616,7 +1631,7 @@
     if (runningNow) return;
     const ok = tryCall('resumeSession') || tryCall('nudge');
     if (ok) {
-      try { document.dispatchEvent(new Event('xp:visible')); } catch {}
+      try { document.dispatchEvent(new Event('xp:visible')); } catch (_) {}
       clearRetry();
     } else {
       retryResume(0);
@@ -632,7 +1647,7 @@
     if (!runningNow) return;
     tryCall('stopSession', { flush: true });
     clearRetry();
-    try { document.dispatchEvent(new Event('xp:hidden')); } catch {}
+    try { document.dispatchEvent(new Event('xp:hidden')); } catch (_) {}
   }
 
   function persisted(event){ return !!(event && event.persisted); }
@@ -643,15 +1658,22 @@
   }, { passive: true });
 
   window.addEventListener('pagehide', (event) => {
+    flushRecorder();
     if (persisted(event)) return;
     pause();
   }, { passive: true });
 
-  window.addEventListener('beforeunload', () => { pause(); });
+  window.addEventListener('beforeunload', () => {
+    flushRecorder();
+    pause();
+  });
 
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') resume();
-    else pause();
+    else {
+      flushRecorder();
+      pause();
+    }
   }, { passive: true });
 
   if (document.visibilityState === 'visible') {
@@ -664,5 +1686,5 @@
     if (nodes.length !== 1) {
       console.warn(`[xp] expected 1 xp-badge anchor with id="xpBadge", found ${nodes.length}`);
     }
-  } catch {}
+  } catch (_) {}
 })();

--- a/play.html
+++ b/play.html
@@ -30,7 +30,7 @@
   </style>
   <script src="/js/xpClient.js" defer></script>
 </head>
-<body>
+<body data-game-host>
   <header class="play-header">
     <a href="/">← Back</a>
     <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="xp.html">
@@ -198,9 +198,30 @@
   }, { passive: true });
 </script>
 
+<script src="/js/debug.js" defer></script>
 <script src="/js/xp.js" defer></script>
-<script src="/js/xp-game-hook.js" defer></script>
-<script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>
+  <script src="/js/xp-game-hook.js" defer></script>
+  <script>
+    if (!window.__xpAutoBooted) {
+      window.__xpAutoBooted = true;
+      let tries = 0;
+      function boot() {
+        const bridge = window.GameXpBridge;
+        if (bridge && typeof bridge.auto === "function") {
+          bridge.auto();
+          return;
+        }
+        if (tries++ >= 5) return;
+        window.setTimeout(boot, Math.min(50 * tries, 200));
+      }
+      if (document.readyState === "complete") {
+        boot();
+      } else {
+        window.addEventListener("DOMContentLoaded", boot, { once: true });
+        window.addEventListener("load", boot, { once: true });
+      }
+    }
+  </script>
 </body>
 </html>
 

--- a/scripts/check-games-xp-hook.mjs
+++ b/scripts/check-games-xp-hook.mjs
@@ -109,7 +109,7 @@ function countInlineBridgeScripts(source) {
       .replace(/^<script\b[^>]*>/i, "")
       .replace(/<\/script>\s*$/i, "");
     const js = stripJsComments(inner);
-    if (js.includes("GameXpBridge.auto(")) {
+    if (/(?:GameXpBridge\.auto|bridge\.auto)\s*\(/.test(js)) {
       count += 1;
     }
   }
@@ -127,6 +127,7 @@ async function analyzeFile(relPath) {
   const xpScripts = countScriptTags(xpScriptPattern, source);
   const hookScripts = countScriptTags(hookScriptPattern, source);
   const inlineScripts = countInlineBridgeScripts(source);
+  const bodyMatch = source.match(/<body\b[^>]*>/i);
 
   const issues = [];
   if (xpScripts === 0) {
@@ -145,6 +146,10 @@ async function analyzeFile(relPath) {
     issues.push("missing GameXpBridge auto bootstrap script");
   } else if (inlineScripts > 1) {
     issues.push(`found ${inlineScripts} GameXpBridge auto bootstrap scripts`);
+  }
+
+  if (!bodyMatch || !/data-game-host\b/i.test(bodyMatch[0])) {
+    issues.push("missing data-game-host attribute on <body>");
   }
 
   return { relPath, issues };

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -17,6 +17,9 @@ run("node", ["tests/xp-game-hook.test.mjs"], "xp-game-hook");
 run("node", ["tests/xp-multigame.test.mjs"], "xp-multigame");
 run("node", ["tests/xp-award-score.test.mjs"], "xp-award-score");
 run("node", ["tests/xp-award-score-rate.test.mjs"], "xp-award-score-rate");
+run("node", ["tests/xp-gate.test.mjs"], "xp-gate");
+run("node", ["tests/xp-game-hook-idempotent.test.mjs"], "xp-game-hook-idempotent");
+run("node", ["tests/recorder-admin-only.test.mjs"], "recorder-admin-only");
 
 try { run("npm", ["run", "-s", "lint:games"], "unit"); } catch { /* optional */ }
 

--- a/scripts/wire-xp.mjs
+++ b/scripts/wire-xp.mjs
@@ -84,7 +84,27 @@ function ensureSnippet(content, absPath, relPath) {
   const snippet =
     `${leadingNewline}${indent}<script src="${xpSrc}" defer></script>` +
     `\n${indent}<script src="${hookSrc}" defer></script>` +
-    `\n${indent}<script>(function start(){if(window.GameXpBridge?.auto)return void window.GameXpBridge.auto();if(document.readyState==='complete'||document.readyState==='interactive')return setTimeout(start,0);addEventListener('DOMContentLoaded',start,{once:true});})();</script>\n`;
+    `\n${indent}<script>\n` +
+    `${indent}  if (!window.__xpAutoBooted) {\n` +
+    `${indent}    window.__xpAutoBooted = true;\n` +
+    `${indent}    let tries = 0;\n` +
+    `${indent}    function boot() {\n` +
+    `${indent}      const bridge = window.GameXpBridge;\n` +
+    `${indent}      if (bridge && typeof bridge.auto === "function") {\n` +
+    `${indent}        bridge.auto();\n` +
+    `${indent}        return;\n` +
+    `${indent}      }\n` +
+    `${indent}      if (tries++ >= 5) return;\n` +
+    `${indent}      window.setTimeout(boot, Math.min(50 * tries, 200));\n` +
+    `${indent}    }\n` +
+    `${indent}    if (document.readyState === "complete") {\n` +
+    `${indent}      boot();\n` +
+    `${indent}    } else {\n` +
+    `${indent}      window.addEventListener("DOMContentLoaded", boot, { once: true });\n` +
+    `${indent}      window.addEventListener("load", boot, { once: true });\n` +
+    `${indent}    }\n` +
+    `${indent}  }\n` +
+    `${indent}</script>\n`;
   return before + snippet + after;
 }
 

--- a/tests/helpers/xp-env.mjs
+++ b/tests/helpers/xp-env.mjs
@@ -73,9 +73,20 @@ export function createEnvironment(options = {}) {
   let windowGameId = options.windowGameId || null;
 
   const attributes = new Map();
+  attributes.set('data-game-host', '');
 
   const bodyDataset = {};
   Object.defineProperty(bodyDataset, 'gameId', {
+    get() {
+      return bodyGameId;
+    },
+    set(value) {
+      bodyGameId = value == null ? value : String(value);
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(bodyDataset, 'gameSlug', {
     get() {
       return bodyGameId;
     },
@@ -116,6 +127,10 @@ export function createEnvironment(options = {}) {
         if (key === 'data-game-id') {
           bodyGameId = null;
         }
+      },
+      hasAttribute(name) {
+        const key = String(name).toLowerCase();
+        return attributes.has(key);
       },
       className: '',
       textContent: '',

--- a/tests/recorder-admin-only.test.mjs
+++ b/tests/recorder-admin-only.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import vm from "node:vm";
+
+async function loadRecorder({ admin }) {
+  const now = Date.now();
+  const localStorage = {
+    getItem(key) {
+      if (key === "kcswh:admin" && admin) {
+        return JSON.stringify({ v: true, exp: now + 86_400_000 });
+      }
+      return null;
+    },
+    setItem() {},
+    removeItem() {},
+  };
+
+  const document = {
+    body: { appendChild() {}, removeChild() {} },
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({ style: {}, setAttribute() {}, appendChild() {}, remove() {} }),
+    documentElement: { appendChild() {}, removeChild() {} },
+  };
+
+  const sandbox = {
+    console,
+    Date,
+    window: {
+      localStorage,
+      location: { search: "" },
+      dispatchEvent() {},
+      addEventListener() {},
+    },
+    document,
+    localStorage,
+    CustomEvent: class { constructor(type, init) { this.type = type; this.detail = init && init.detail; } },
+    URL: { createObjectURL() { return ""; }, revokeObjectURL() {} },
+    Blob: class {},
+    setTimeout: () => 1,
+    clearTimeout: () => {},
+  };
+  sandbox.window.window = sandbox.window;
+
+  vm.createContext(sandbox);
+  const src = await fs.readFile(new URL("../js/debug.js", import.meta.url), "utf8");
+  vm.runInContext(src, sandbox, { filename: "debug.js" });
+
+  const status = sandbox.window.KLog && typeof sandbox.window.KLog.status === "function"
+    ? sandbox.window.KLog.status()
+    : { startedAt: 0 };
+  return status;
+}
+
+(async () => {
+  const nonAdminStatus = await loadRecorder({ admin: false });
+  assert.equal(nonAdminStatus.startedAt || 0, 0, "recorder MUST NOT autostart without admin flag");
+
+  const adminStatus = await loadRecorder({ admin: true });
+  assert.ok((adminStatus.startedAt || 0) > 0, "recorder SHOULD autostart when admin flag present");
+
+  console.log("recorder-admin-only.test.mjs: PASS");
+})();

--- a/tests/xp-client.test.mjs
+++ b/tests/xp-client.test.mjs
@@ -25,6 +25,17 @@ const documentStub = {
   readyState: 'complete',
   hidden: false,
   visibilityState: 'visible',
+  body: {
+    dataset: { gameHost: '', gameSlug: 'unit-test', gameId: 'unit-test' },
+    hasAttribute(name) {
+      return name === 'data-game-host';
+    },
+    getAttribute(name) {
+      if (name === 'data-game-id') return 'unit-test';
+      if (name === 'data-game-host') return '';
+      return null;
+    },
+  },
   addEventListener(type, handler) {
     docListeners.set(type, handler);
   },

--- a/tests/xp-game-hook-idempotent.test.mjs
+++ b/tests/xp-game-hook-idempotent.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import vm from "node:vm";
+
+async function loadHookAndTrack() {
+  let addListenerCount = 0;
+  const document = {
+    title: "T-Rex",
+    readyState: "complete",
+    body: {
+      hasAttribute: (name) => (name === "data-game-host"),
+      dataset: { gameId: "t-rex" },
+      getAttribute: () => "t-rex",
+    },
+    addEventListener: () => { addListenerCount += 1; },
+    removeEventListener: () => {},
+  };
+
+  const sandbox = {
+    console,
+    document,
+    window: {
+      document,
+      addEventListener: () => { addListenerCount += 1; },
+      removeEventListener: () => {},
+      setTimeout: () => 1,
+      clearTimeout: () => {},
+      setInterval: () => 1,
+      clearInterval: () => {},
+      localStorage: { getItem() { return null; }, setItem() {}, removeItem() {} },
+      XP: {
+        startSession() {},
+        stopSession() {},
+        addScore() {},
+        isRunning() { return false; },
+      },
+    },
+    setTimeout: () => 1,
+    clearTimeout: () => {},
+    setInterval: () => 1,
+    clearInterval: () => {},
+    navigator: {},
+  };
+  sandbox.window.window = sandbox.window;
+
+  vm.createContext(sandbox);
+  const src = await fs.readFile(new URL("../js/xp-game-hook.js", import.meta.url), "utf8");
+  vm.runInContext(src, sandbox, { filename: "xp-game-hook.js" });
+
+  const bridge = sandbox.window.GameXpBridge;
+  assert.ok(bridge && typeof bridge.auto === "function", "GameXpBridge.auto must exist");
+
+  const before = addListenerCount;
+  bridge.auto("t-rex");
+  const afterFirst = addListenerCount;
+  assert.ok(afterFirst > before, "auto() should wire listeners on first call");
+
+  bridge.auto("t-rex");
+  const afterSecond = addListenerCount;
+  assert.equal(afterSecond, afterFirst, "auto() should be idempotent and not add listeners twice");
+}
+
+(async () => {
+  await loadHookAndTrack();
+  console.log("xp-game-hook-idempotent.test.mjs: PASS");
+})();

--- a/tests/xp-gate.test.mjs
+++ b/tests/xp-gate.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import vm from "node:vm";
+
+async function runXpWithDom({ hasHostAttr = false, slug = "", visibilityState = "visible" } = {}) {
+  const calls = { addEventListener: 0, setInterval: 0, setTimeout: 0 };
+  let timerId = 0;
+
+  const makeTimer = (type) => (...args) => {
+    calls[type] += 1;
+    return ++timerId;
+  };
+
+  const setIntervalStub = makeTimer("setInterval");
+  const setTimeoutStub = makeTimer("setTimeout");
+
+  const document = {
+    visibilityState,
+    hidden: visibilityState !== "visible",
+    readyState: "complete",
+    body: {
+      hasAttribute: (name) => (name === "data-game-host" ? !!hasHostAttr : false),
+      dataset: slug ? { gameSlug: slug } : {},
+      getAttribute: () => null,
+      appendChild() {},
+      removeChild() {},
+    },
+    addEventListener: () => { calls.addEventListener += 1; },
+    removeEventListener() {},
+    dispatchEvent() {},
+    getElementById: () => null,
+    createElement: () => ({ style: {}, setAttribute() {}, appendChild() {}, remove() {} }),
+    documentElement: { appendChild() {}, removeChild() {} },
+    activeElement: null,
+  };
+
+  const localStorage = {
+    getItem() { return null; },
+    setItem() {},
+    removeItem() {},
+  };
+
+  const windowObj = {
+    addEventListener: () => { calls.addEventListener += 1; },
+    removeEventListener() {},
+    setInterval: setIntervalStub,
+    setTimeout: setTimeoutStub,
+    clearInterval() {},
+    clearTimeout() {},
+    localStorage,
+    location: { pathname: slug ? `/${slug}/` : "/about/", search: "" },
+    navigator: { userAgent: "" },
+    document,
+    dispatchEvent() {},
+    KLog: { log() {} },
+  };
+
+  const sandbox = {
+    console,
+    Date,
+    performance: { now: () => Date.now() },
+    setInterval: setIntervalStub,
+    setTimeout: setTimeoutStub,
+    clearInterval: () => {},
+    clearTimeout: () => {},
+    location: windowObj.location,
+    document,
+    navigator: windowObj.navigator,
+    localStorage,
+    window: windowObj,
+    CustomEvent: class { constructor(type, init) { this.type = type; this.detail = init && init.detail; } },
+    Blob: class {},
+    URL: { createObjectURL() { return ""; }, revokeObjectURL() {} },
+    requestAnimationFrame: () => {},
+    cancelAnimationFrame: () => {},
+  };
+  sandbox.window.window = windowObj;
+
+  vm.createContext(sandbox);
+  const src = await fs.readFile(new URL("../js/xp.js", import.meta.url), "utf8");
+  vm.runInContext(src, sandbox, { filename: "xp.js" });
+
+  return calls;
+}
+
+(async () => {
+  {
+    const calls = await runXpWithDom({ hasHostAttr: false, slug: "" });
+    assert.equal(
+      calls.addEventListener + calls.setInterval + calls.setTimeout,
+      0,
+      "xp.js MUST NOT wire listeners or timers on non-host pages",
+    );
+  }
+
+  {
+    const calls = await runXpWithDom({ hasHostAttr: true, slug: "" });
+    assert.ok(
+      calls.addEventListener + calls.setInterval + calls.setTimeout > 0,
+      "xp.js SHOULD wire when the page is marked as a host",
+    );
+  }
+
+  {
+    const calls = await runXpWithDom({ hasHostAttr: false, slug: "tetris" });
+    assert.ok(
+      calls.addEventListener + calls.setInterval + calls.setTimeout > 0,
+      "xp.js SHOULD wire when slug fallback marks a direct game page",
+    );
+  }
+
+  console.log("xp-gate.test.mjs: PASS");
+})();

--- a/xp.html
+++ b/xp.html
@@ -28,6 +28,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="js/topbar.js" defer></script>
   <script src="js/xpClient.js" defer></script>
+  <script src="js/debug.js" defer></script>
   <script src="js/xp.js" defer></script>
   <script src="js/sidebar.js" defer></script>
   <script src="js/xp-page.js" defer></script>


### PR DESCRIPTION
## Summary
- update the XP bridge auto bootstrap to retain the last detected slug while idle and re-run the session start when navigating to a new game or resuming after a stop
- keep non-host pages from mutating the boot guard so diagnostics can still remember the most recent slug without blocking later start attempts

## Testing
- PLAYWRIGHT=1 npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa48c21008323a71d461a9df0a06e)