### PR TITLE
Drive XP e2e tests past idle guard

### DIFF
--- a/tests/e2e/helpers/xp-driver.js
+++ b/tests/e2e/helpers/xp-driver.js
@@ -1,0 +1,32 @@
+const MIN_DURATION_MS = 12_000;
+const MIN_INPUTS = 10;
+const MIN_INTERVAL_MS = 200;
+
+function resolveStep(durationMs, inputCount) {
+  const duration = Math.max(MIN_DURATION_MS, Number(durationMs) || 0);
+  const inputs = Math.max(MIN_INPUTS, Number(inputCount) || 0);
+  return Math.max(MIN_INTERVAL_MS, Math.floor(duration / inputs));
+}
+
+async function driveActiveWindow(page, durationMs = MIN_DURATION_MS, inputCount = MIN_INPUTS) {
+  if (!page) return;
+
+  await page.bringToFront();
+
+  const inputs = Math.max(MIN_INPUTS, Number(inputCount) || 0);
+  const step = resolveStep(durationMs, inputs);
+
+  for (let i = 0; i < inputs; i += 1) {
+    const x = 120 + (i % 8) * 6;
+    const y = 160 + (i % 5) * 8;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.keyboard.press(i % 2 === 0 ? 'ArrowRight' : 'ArrowLeft');
+    await page.waitForTimeout(step);
+  }
+
+  await page.waitForTimeout(1_000);
+}
+
+module.exports = { driveActiveWindow };

--- a/tests/e2e/xp-idle.spec.js
+++ b/tests/e2e/xp-idle.spec.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@playwright/test');
+const { driveActiveWindow } = require('./helpers/xp-driver');
 
 const GAME_PAGE = process.env.XP_E2E_PAGE ?? '/game_cats.html';
 const SETTLE_DELAY_MS = 1_000;
 const IDLE_OBSERVE_MS = 12_000;
-const GESTURE_SPACING_MS = 800; // keep "active" continuous (each gesture extends ~2s)
 
 function initXpClientStub() {
   return `(() => {
@@ -57,26 +57,7 @@ test.describe('XP idle behaviour', () => {
 
     await page.waitForTimeout(SETTLE_DELAY_MS);
 
-    const performGesture = async (offset) => {
-      const base = 120 + offset * 30;
-      await page.mouse.move(base, base);
-      await page.waitForTimeout(50);
-      await page.mouse.down();
-      await page.waitForTimeout(50);
-      await page.mouse.up();
-      await page.waitForTimeout(50);
-      await page.keyboard.press('Space');
-    };
-
-    // ~14 gestures * 0.8s spacing ≈ 11–12s of continuous "active" time
-    for (let i = 0; i < 14; i += 1) {
-      await performGesture(i);
-      if (i < 13) {
-        await page.waitForTimeout(GESTURE_SPACING_MS);
-      }
-    }
-
-    await page.waitForTimeout(2_000); // brief buffer to allow sendWindow
+    await driveActiveWindow(page, IDLE_OBSERVE_MS, 12);
 
     const postCount = await page.evaluate(() =>
       (window.__xpCalls || []).filter(c => c.method === 'postWindow').length

--- a/tests/e2e/xp-progress-page.spec.js
+++ b/tests/e2e/xp-progress-page.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('@playwright/test');
+const { driveActiveWindow } = require('./helpers/xp-driver');
 
 const GAME_PAGE = '/games-open/2048/index.html';
 const XP_PAGE = '/xp.html';
@@ -219,6 +220,7 @@ test.describe('XP Progress page', () => {
 
     await page.goto(GAME_PAGE, { waitUntil: 'domcontentloaded' });
     await simulatePlayWindow(page);
+    await driveActiveWindow(page);
     await waitForAward(page, 1);
     const totals = await page.evaluate(() => window.__xpTestTotals);
     expect(totals.totalToday).toBeGreaterThan(0);
@@ -260,6 +262,7 @@ test.describe('XP Progress page', () => {
 
     await page.goto(GAME_PAGE, { waitUntil: 'domcontentloaded' });
     await simulatePlayWindow(page, 15);
+    await driveActiveWindow(page);
     await waitForAward(page, 1);
     const totals = await page.evaluate(() => window.__xpTestTotals);
     expect(totals.totalToday).toBeGreaterThanOrEqual(60);
@@ -289,6 +292,7 @@ test.describe('XP Progress page', () => {
 
     await page.goto(GAME_PAGE, { waitUntil: 'domcontentloaded' });
     await simulatePlayWindow(page, 12);
+    await driveActiveWindow(page);
     await waitForAward(page, 1);
     const totals = await page.evaluate(() => window.__xpTestTotals);
     expect(totals.totalToday).toBeGreaterThan(0);

--- a/tests/e2e/xp-score-protocol.spec.js
+++ b/tests/e2e/xp-score-protocol.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require('@playwright/test');
+const { driveActiveWindow } = require('./helpers/xp-driver');
 
 const GAME_PAGE = process.env.XP_E2E_PAGE ?? '/game_cats.html';
 const VISIBILITY_WARMUP_MS = 2_200;
@@ -66,6 +67,8 @@ async function runWindow(page, scoreDelta) {
       xp.addScore(delta);
     }, scoreDelta);
   }
+
+  await driveActiveWindow(page);
 
   await page.evaluate(() => {
     const xp = window.XP;


### PR DESCRIPTION
## Summary
- add a reusable `driveActiveWindow` helper that simulates enough visible user input to satisfy the XP idle guard
- switch the XP idle and XP progress specs to rely on the helper before checking for posted windows or awards
- extend the XP score protocol spec so each scored window includes the helper-driven activity before flushing

## Testing
- ⚠️ `npx playwright test tests/e2e/xp-idle.spec.js` *(blocked: Playwright Chromium binary download returns 403, so no browser is available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69183740433883238bc5bc6b6a4a056c)