### PR TITLE
Install chromium tool for GitHub Actions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
         run: npm run ci:guards
       - name: Install dependencies
         run: npm ci || npm i
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
       - name: Unit checks
         run: npm run test:unit
-      - name: Playwright smoke
+      - name: Playwright E2E tests
         run: npm run test:e2e
         env:
-          CI_NO_E2E: 1
+          PLAYWRIGHT: 1


### PR DESCRIPTION
- Remove PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD flag to allow browser installation
- Add explicit step to install Playwright Chromium with system dependencies
- Remove CI_NO_E2E flag and set PLAYWRIGHT=1 to enable E2E tests
- Rename step from 'Playwright smoke' to 'Playwright E2E tests'

This allows the previously skipped E2E tests to run in the CI workflow.