### PR TITLE
Fix start-session endpoint CORS configuration

### DIFF
--- a/netlify/functions/award-xp.mjs
+++ b/netlify/functions/award-xp.mjs
@@ -104,10 +104,19 @@ const METADATA_MAX_BYTES = Math.max(0, asNumber(process.env.XP_METADATA_MAX_BYTE
 const DEBUG_ENABLED = process.env.XP_DEBUG === "1";
 const KEY_NS = process.env.XP_KEY_NS ?? "kcswh:xp:v2";
 const DRIFT_MS = Math.max(0, asNumber(process.env.XP_DRIFT_MS, 30_000));
-const CORS_ALLOW = (process.env.XP_CORS_ALLOW ?? "")
-  .split(",")
-  .map(s => s.trim())
-  .filter(Boolean);
+// Build CORS allowlist from env var + auto-include Netlify site URL
+const CORS_ALLOW = (() => {
+  const fromEnv = (process.env.XP_CORS_ALLOW ?? "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+  // Auto-include the Netlify site URL (handles custom domains)
+  const siteUrl = process.env.URL;
+  if (siteUrl && !fromEnv.includes(siteUrl)) {
+    fromEnv.push(siteUrl);
+  }
+  return fromEnv;
+})();
 
 const RAW_LOCK_TTL = Number(process.env.XP_LOCK_TTL_MS ?? 3_000);
 const LOCK_TTL_MS = Number.isFinite(RAW_LOCK_TTL) && RAW_LOCK_TTL >= 0 ? RAW_LOCK_TTL : 3_000;

--- a/netlify/functions/start-session.mjs
+++ b/netlify/functions/start-session.mjs
@@ -5,10 +5,19 @@ import { store } from "./_shared/store-upstash.mjs";
 const SESSION_TTL_SEC = Math.max(0, Number(process.env.XP_SESSION_TTL_SEC) || 604800); // 7 days default
 const KEY_NS = process.env.XP_KEY_NS ?? "kcswh:xp:v2";
 const DEBUG_ENABLED = process.env.XP_DEBUG === "1";
-const CORS_ALLOW = (process.env.XP_CORS_ALLOW ?? "")
-  .split(",")
-  .map(s => s.trim())
-  .filter(Boolean);
+// Build CORS allowlist from env var + auto-include Netlify site URL
+const CORS_ALLOW = (() => {
+  const fromEnv = (process.env.XP_CORS_ALLOW ?? "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean);
+  // Auto-include the Netlify site URL (handles custom domains)
+  const siteUrl = process.env.URL;
+  if (siteUrl && !fromEnv.includes(siteUrl)) {
+    fromEnv.push(siteUrl);
+  }
+  return fromEnv;
+})();
 
 // Rate limiting for session creation
 const SESSION_RATE_LIMIT_PER_IP_PER_MIN = Math.max(0, Number(process.env.XP_SESSION_RATE_LIMIT_IP) || 5);


### PR DESCRIPTION
The CORS logic was rejecting requests from the production site's custom domain when XP_CORS_ALLOW was configured. This change auto-includes process.env.URL (Netlify's site URL) in the allowlist, ensuring the production domain is always allowed regardless of XP_CORS_ALLOW config.