### PR TITLE
Fix critical issue from code review report

### DIFF
--- a/js/xp-game-hook.js
+++ b/js/xp-game-hook.js
@@ -687,7 +687,10 @@
       try { xp.nudge(); return; } catch (_) {}
     }
     if (window && window.parent && window.parent !== window && typeof window.parent.postMessage === "function") {
-      try { window.parent.postMessage({ type: "kcswh:activity", userGesture: true }, window.location ? window.location.origin || "*" : "*"); } catch (_) {}
+      const targetOrigin = window.location?.origin;
+      if (targetOrigin && targetOrigin !== "null") {
+        try { window.parent.postMessage({ type: "kcswh:activity", userGesture: true }, targetOrigin); } catch (_) {}
+      }
     }
   }
 


### PR DESCRIPTION
Replace fallback to "*" origin with explicit origin validation. The postMessage now only fires when a valid, non-null origin is available, preventing malicious parent frames from intercepting activity messages.