### PR TITLE
Fix daily XP limit display bug

### DIFF
--- a/js/xp-page.js
+++ b/js/xp-page.js
@@ -2,6 +2,7 @@
   const levelEl = document.getElementById("xpLevel");
   const totalEl = document.getElementById("xpTotal");
   const capEl = document.getElementById("xpDailyCap");
+  const dailyRemainingEl = document.getElementById("xpDailyRemaining");
   const todayEl = document.getElementById("xpToday");
   const todayCapEl = document.getElementById("xpTodayCap");
   const progressBar = document.querySelector(".xp-progress__bar");
@@ -20,6 +21,8 @@
     if (totalEl) totalEl.textContent = formatNumber(snapshot.totalXp);
     const capText = snapshot.cap == null ? "—" : `${formatNumber(snapshot.cap)} XP`;
     if (capEl) capEl.textContent = capText;
+    const remainingText = snapshot.dailyRemaining === Infinity ? "—" : `${formatNumber(snapshot.dailyRemaining)} XP`;
+    if (dailyRemainingEl) dailyRemainingEl.textContent = remainingText;
     if (todayEl) todayEl.textContent = formatNumber(snapshot.totalToday);
     if (todayCapEl) todayCapEl.textContent = snapshot.cap == null ? "—" : `${formatNumber(snapshot.cap)} XP`;
 

--- a/js/xp/core.js
+++ b/js/xp/core.js
@@ -1949,6 +1949,7 @@ function bootXpCore(window, document) {
     return {
       totalToday: typeof state.totalToday === "number" ? state.totalToday : 0,
       cap: state.cap != null ? state.cap : null,
+      dailyRemaining: getRemainingDaily(),
       totalXp: state.snapshot.totalXp,
       level: state.snapshot.level,
       xpIntoLevel: state.snapshot.xpIntoLevel,

--- a/xp.html
+++ b/xp.html
@@ -100,6 +100,10 @@
             <span class="xp-summary__label">Daily limit</span>
             <span class="xp-summary__value" id="xpDailyCap">0 XP</span>
           </div>
+          <div class="xp-summary__metric">
+            <span class="xp-summary__label">Daily limit remaining</span>
+            <span class="xp-summary__value" id="xpDailyRemaining">0 XP</span>
+          </div>
         </section>
 
         <section class="xp-card" aria-labelledby="xpProgressTitle">


### PR DESCRIPTION
The XP dashboard now displays both the daily limit (3000 XP) and the remaining daily limit. Previously, only the cap was shown, which was confusing as it always displayed 3000 XP regardless of how much the user had earned that day.

Changes:
- Add dailyRemaining field to getSnapshot() in core.js
- Add "Daily limit remaining" metric to xp.html
- Update xp-page.js to populate the new remaining field