### PR TITLE
Audit and standardize kcswh.pl email addresses

### DIFF
--- a/SECURITY-ISSUES.md
+++ b/SECURITY-ISSUES.md
@@ -766,7 +766,7 @@ test.describe('Security Tests', () => {
 
 **DO NOT** open a public issue for security vulnerabilities.
 
-Email security@kcswh.pl with:
+Email contact@kcswh.pl with:
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact

--- a/landing/about.html
+++ b/landing/about.html
@@ -52,7 +52,7 @@
 
       <section>
         <h2>Contact</h2>
-        <p>Questions, feedback, or partnership ideas? Drop us a line at <a href="mailto:hello@kcswh.pl">hello@kcswh.pl</a>.</p>
+        <p>Questions, feedback, or partnership ideas? Drop us a line at <a href="mailto:contact@kcswh.pl">contact@kcswh.pl</a>.</p>
       </section>
 
       <section>

--- a/landing/index.html
+++ b/landing/index.html
@@ -70,7 +70,7 @@
         <div class="title">About</div>
         <div class="desc">Learn more about the project</div>
       </a>
-      <a class="tile" href="mailto:hello@kcswh.pl">
+      <a class="tile" href="mailto:contact@kcswh.pl">
         <div class="title">Contact</div>
         <div class="desc">Get in touch</div>
       </a>


### PR DESCRIPTION
Updated all non-standard email addresses to use the preferred contact@kcswh.pl:
- Changed security@kcswh.pl to contact@kcswh.pl in SECURITY-ISSUES.md
- Changed hello@kcswh.pl to contact@kcswh.pl in landing/index.html and landing/about.html

This ensures consistency across the project with approved email addresses: contact@kcswh.pl (preferred), info@kcswh.pl, support@kcswh.pl