### PR TITLE
Add missing footers to arcade portal pages

### DIFF
--- a/about.en.html
+++ b/about.en.html
@@ -259,6 +259,27 @@
       }
     })();
   </script>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="about.en.html" data-href-pl="about.pl.html" href="about.en.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="about/licenses.html" data-href-pl="about/licenses.html" href="about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="legal/terms.en.html" data-href-pl="legal/terms.pl.html" href="legal/terms.en.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="legal/privacy.en.html" data-href-pl="legal/privacy.pl.html" href="legal/privacy.en.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/about.pl.html
+++ b/about.pl.html
@@ -259,6 +259,27 @@
       }
     })();
   </script>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="about.en.html" data-href-pl="about.pl.html" href="about.pl.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="about/licenses.html" data-href-pl="about/licenses.html" href="about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="legal/terms.en.html" data-href-pl="legal/terms.pl.html" href="legal/terms.pl.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="legal/privacy.en.html" data-href-pl="legal/privacy.pl.html" href="legal/privacy.pl.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/cookies-notice.en.html
+++ b/legal/cookies-notice.en.html
@@ -131,11 +131,29 @@
     <p>For details on data use, transfers, and your rights, read our <a class="ft-link" href="privacy.en.html">Privacy Policy</a> and <a class="ft-link" href="terms.en.html">Terms of Service</a>.</p>
 
     <p style="margin-top:16px;"><a class="ft-link" href="../index.html?lang=en">Back to portal</a></p>
-      <footer style="margin-top:24px;">
-        <a class="ft-link manage-cookies" id="manageCookies" href="#">Manage cookies</a>
-      </footer>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.en.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.en.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.en.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/cookies-notice.pl.html
+++ b/legal/cookies-notice.pl.html
@@ -131,11 +131,29 @@
     <p>Szczegóły dotyczące danych, transferów i Twoich praw znajdziesz w <a class="ft-link" href="privacy.pl.html">Polityce prywatności</a> oraz <a class="ft-link" href="terms.pl.html">Regulaminie</a>.</p>
 
     <p style="margin-top:16px;"><a class="ft-link" href="../index.html?lang=pl">Wróć do portalu</a></p>
-      <footer style="margin-top:24px;">
-        <a class="ft-link manage-cookies" id="manageCookies" href="#">Zarządzaj cookies</a>
-      </footer>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.pl.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.pl.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.pl.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/privacy.en.html
+++ b/legal/privacy.en.html
@@ -180,11 +180,29 @@
     <p>We may update this policy. Material changes will be posted here with an updated date.</p>
 
     <p style="margin-top:16px;"><a class="ft-link" href="../index.html?lang=en">Back to portal</a></p>
-      <footer style="margin-top:24px;">
-        <a class="ft-link manage-cookies" id="manageCookies" href="#">Manage cookies</a>
-      </footer>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.en.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.en.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.en.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/privacy.pl.html
+++ b/legal/privacy.pl.html
@@ -180,11 +180,29 @@
     <p>Polityka może być aktualizowana. Istotne zmiany opublikujemy tutaj wraz z nową datą.</p>
 
     <p style="margin-top:16px;"><a class="ft-link" href="../index.html?lang=pl">Wróć do portalu</a></p>
-      <footer style="margin-top:24px;">
-        <a class="ft-link manage-cookies" id="manageCookies" href="#">Zarządzaj cookies</a>
-      </footer>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.pl.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.pl.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.pl.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/terms.en.html
+++ b/legal/terms.en.html
@@ -161,6 +161,27 @@
     <p><a class="ft-link" href="../index.html?lang=en">Back to portal</a></p>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.en.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.en.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.en.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/legal/terms.pl.html
+++ b/legal/terms.pl.html
@@ -161,6 +161,27 @@
     <p><a class="ft-link" href="../index.html?lang=pl">Wróć do portalu</a></p>
     </main>
   </div>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="../about.en.html" data-href-pl="../about.pl.html" href="../about.pl.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="../about/licenses.html" data-href-pl="../about/licenses.html" href="../about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="terms.en.html" data-href-pl="terms.pl.html" href="terms.pl.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="privacy.en.html" data-href-pl="privacy.pl.html" href="privacy.pl.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
   <script src="../js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/play.html
+++ b/play.html
@@ -298,6 +298,27 @@
       }
     }
   </script>
+
+  <footer class="site-footer" role="contentinfo">
+    <nav class="footer-nav" aria-label="Footer">
+      <a class="ft-link" data-i18n="about" data-href-en="about.en.html" data-href-pl="about.pl.html" href="about.en.html">About</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="licenses" data-href-en="about/licenses.html" data-href-pl="about/licenses.html" href="about/licenses.html">Licenses</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="terms" data-href-en="legal/terms.en.html" data-href-pl="legal/terms.pl.html" href="legal/terms.en.html">Terms</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="privacy" data-href-en="legal/privacy.en.html" data-href-pl="legal/privacy.pl.html" href="legal/privacy.en.html">Privacy</a>
+      <span class="sep">•</span>
+      <a class="ft-link" data-i18n="contact" href="mailto:contact@kcswh.pl">Contact</a>
+      <span class="sep">•</span>
+      <a class="ft-link manage-cookies" data-i18n="manageCookies"
+         id="manageCookies" href="#" data-cookieconsent="ignore">Manage cookies</a>
+    </nav>
+    <div class="lang-switch" aria-label="Language">
+      <button type="button" class="lang-btn" data-lang="pl" aria-pressed="false">PL</button>
+      <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
+    </div>
+  </footer>
 </body>
 </html>
 


### PR DESCRIPTION
Added the full .site-footer component to 9 pages that were missing it:
- about.en.html, about.pl.html
- play.html
- legal/privacy.en.html, legal/privacy.pl.html
- legal/terms.en.html, legal/terms.pl.html
- legal/cookies-notice.en.html, legal/cookies-notice.pl.html

The footer includes:
- Navigation links (About, Licenses, Terms, Privacy, Contact, Manage cookies)
- Language switcher (PL/EN)
- Proper i18n attributes for internationalization support
- Correct relative paths for legal subdirectory pages

All footer links verified to avoid 404 errors.