### PR TITLE
Fix footer positioning on large screens

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -186,7 +186,7 @@ button:focus-visible, a:focus-visible{ outline:2px solid var(--accent); outline-
 }
 
 /* Footer */
-.site-footer{ position:fixed; left:0; right:0; bottom:0; padding:10px 16px; border-top:1px solid var(--border); display:flex; gap:12px; align-items:center; justify-content:space-between; color:#9fb0d0; background:rgba(11,16,32,.9); backdrop-filter: blur(4px); z-index:50; }
+.site-footer{ position:fixed; left:0; right:0; bottom:0; width:100%; padding:10px 16px; border-top:1px solid var(--border); display:flex; gap:12px; align-items:center; justify-content:space-between; color:#9fb0d0; background:rgba(11,16,32,.98); backdrop-filter: blur(4px); z-index:100; box-sizing:border-box; }
 .footer-nav{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .footer-nav .ft-link{ color:#9fb0d0; text-decoration:none; }
 .footer-nav .ft-link:hover{ text-decoration:underline; }

--- a/css/portal.css
+++ b/css/portal.css
@@ -220,7 +220,7 @@ body{margin:0; background:linear-gradient(180deg, #0b1020 0%, #0a0d1a 100%); col
 .slot-card .slot-badge{ position:absolute; top:8px; right:8px; font:700 10px/1 Poppins, sans-serif; color:#9fb0d0; background:rgba(15,20,48,.7); border:1px solid var(--border); padding:4px 6px; border-radius:999px; letter-spacing:.2px; }
 
 /* Footer */
-.site-footer{ position:fixed; left:0; right:0; bottom:0; padding:10px 16px; border-top:1px solid var(--border); display:flex; gap:12px; align-items:center; justify-content:space-between; color:#9fb0d0; background:rgba(11,16,32,.9); backdrop-filter: blur(4px); z-index:50; }
+.site-footer{ position:fixed; left:0; right:0; bottom:0; width:100%; padding:10px 16px; border-top:1px solid var(--border); display:flex; gap:12px; align-items:center; justify-content:space-between; color:#9fb0d0; background:rgba(11,16,32,.98); backdrop-filter: blur(4px); z-index:100; box-sizing:border-box; }
 .footer-nav{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
 .debug-dump-button{ margin-top:16px; padding:10px 16px; border-radius:12px; border:1px solid var(--border); background:rgba(110,231,231,.12); color:var(--accent); font:600 14px Poppins, sans-serif; cursor:pointer; transition:background .18s ease, border-color .18s ease, color .18s ease; display:inline-flex; align-items:center; gap:10px; }
 .debug-dump-button:hover{ background:rgba(110,231,231,.2); border-color:rgba(110,231,231,.5); color:#f0f6ff; }


### PR DESCRIPTION
Ensure footer stays fixed at viewport bottom by:
- Adding explicit width: 100% for full-width coverage
- Increasing z-index from 50 to 100 for proper stacking
- Making background slightly more opaque (.98 vs .9)
- Adding box-sizing: border-box for consistent sizing