### PR TITLE
Add missing game licenses to licenses page

### DIFF
--- a/about/licenses.html
+++ b/about/licenses.html
@@ -429,6 +429,326 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre>
         </section>
+
+        <section class="license-section">
+          <h2>Asteroids</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/asteroids" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/asteroids" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Space Invaders</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/space-invaders" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/space-invaders" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Frogger</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/frogger" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/frogger" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Galaga</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/galaga" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/galaga" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Missile Command</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/missile-command" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/missile-command" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Simon</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/simon" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/simon" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Connect Four</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/connect-four" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/connect-four" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Whac-A-Mole</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/whac-a-mole" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/whac-a-mole" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Memory Match</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/memory-match" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/memory-match" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
+
+        <section class="license-section">
+          <h2>Sokoban</h2>
+          <p>
+            <span data-i18n="licensesOriginalBy">Original project by</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/sokoban" target="_blank" rel="noopener noreferrer">Arcade Hub contributors</a><br>
+            <span data-i18n="licensesLicenseMIT">Licensed under the MIT License.</span><br>
+            <span data-i18n="licensesSource">Source:</span>&nbsp;
+            <a href="https://github.com/kcswh/arcadePlatform/tree/main/games-open/sokoban" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </p>
+          <pre class="license-text">MIT License
+
+Copyright (c) 2024 Arcade Hub contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+        </section>
       </article>
     </main>
   </div>


### PR DESCRIPTION
Added MIT license entries for 10 games that were missing from the licenses page:
- Asteroids
- Space Invaders
- Frogger
- Galaga
- Missile Command
- Simon
- Connect Four
- Whac-A-Mole
- Memory Match
- Sokoban

All games use the standard Arcade Hub contributors MIT license, matching the existing format used for other games on the page.