### PR TITLE
Fix favorites auth bridge and add tests

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -27,6 +27,7 @@ run("node", ["tests/xp-gate.test.mjs"], "xp-gate");
 run("node", ["tests/xp-game-hook-idempotent.test.mjs"], "xp-game-hook-idempotent");
 run("node", ["tests/recorder-admin-only.test.mjs"], "recorder-admin-only");
 run("node", ["tests/secureStorage.test.mjs"], "secure-storage");
+run("node", ["tests/favorites-service.test.mjs"], "favorites-service");
 
 try { run("npm", ["run", "-s", "lint:games"], "unit"); } catch { /* optional */ }
 

--- a/tests/favorites-service.test.mjs
+++ b/tests/favorites-service.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const favoritesSource = await readFile(
+  path.join(__dirname, '..', 'js', 'core', 'FavoritesService.js'),
+  'utf8'
+);
+
+function createStorageMock() {
+  const store = new Map();
+  return {
+    __store: store,
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    }
+  };
+}
+
+function createTestContext(options = {}) {
+  const localStorageMock = createStorageMock();
+  const context = {
+    window: {},
+    console,
+    Promise,
+    JSON,
+    Date,
+    Math,
+    setTimeout,
+    clearTimeout,
+    localStorage: localStorageMock
+  };
+
+  context.window.window = context.window;
+  context.window.localStorage = localStorageMock;
+  context.bridgeCalls = 0;
+  context.supabaseAuthCalls = 0;
+
+  if (Object.prototype.hasOwnProperty.call(options, 'bridgeToken')) {
+    context.window.SupabaseAuthBridge = {
+      getAccessToken() {
+        context.bridgeCalls += 1;
+        return Promise.resolve(options.bridgeToken);
+      }
+    };
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'supabaseAuthToken')) {
+    context.window.SupabaseAuth = {
+      getAccessToken() {
+        context.supabaseAuthCalls += 1;
+        return Promise.resolve(options.supabaseAuthToken);
+      }
+    };
+  }
+
+  vm.createContext(context);
+  new vm.Script(favoritesSource, { filename: 'FavoritesService.js' }).runInContext(context);
+  return context;
+}
+
+console.log('Running FavoritesService auth bridge tests...\n');
+
+{
+  console.log('Test: uses SupabaseAuthBridge when available');
+  const ctx = createTestContext({ bridgeToken: 'bridge-token' });
+  const service = new ctx.window.FavoritesService();
+  const token = await service.getAccessToken();
+  assert.equal(token, 'bridge-token');
+  assert.equal(ctx.bridgeCalls, 1);
+  assert.equal(ctx.supabaseAuthCalls, 0);
+  console.log('  PASS');
+}
+
+{
+  console.log('Test: falls back to SupabaseAuth when bridge has no token');
+  const ctx = createTestContext({ bridgeToken: null, supabaseAuthToken: 'legacy-token' });
+  const service = new ctx.window.FavoritesService();
+  const token = await service.getAccessToken();
+  assert.equal(token, 'legacy-token');
+  assert.equal(ctx.bridgeCalls, 1);
+  assert.equal(ctx.supabaseAuthCalls, 1);
+  console.log('  PASS');
+}
+
+{
+  console.log('Test: returns null when no auth providers are available');
+  const ctx = createTestContext({});
+  const service = new ctx.window.FavoritesService();
+  const token = await service.getAccessToken();
+  assert.equal(token, null);
+  assert.equal(ctx.bridgeCalls, 0);
+  assert.equal(ctx.supabaseAuthCalls, 0);
+  console.log('  PASS');
+}
+
+console.log('\nAll FavoritesService auth bridge tests completed.');


### PR DESCRIPTION
## Summary
- fetch FavoritesService auth tokens through SupabaseAuthBridge with a SupabaseAuth fallback
- add coverage for FavoritesService auth token selection and wire it into the aggregated test runner

## Testing
- node tests/favorites-service.test.mjs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dcdb585883239ca8ff887469199c)