### PR TITLE
Add poker chips transaction enum values

### DIFF
--- a/supabase/migrations/20260116000000_poker_chips_tx_types.sql
+++ b/supabase/migrations/20260116000000_poker_chips_tx_types.sql
@@ -1,0 +1,5 @@
+alter type public.chips_tx_type add value if not exists 'TABLE_BUY_IN';
+
+alter type public.chips_tx_type add value if not exists 'TABLE_CASH_OUT';
+
+alter type public.chips_tx_type add value if not exists 'HAND_SETTLEMENT';


### PR DESCRIPTION
### Motivation
- Extend `public.chips_tx_type` with poker/table-related transaction kinds while keeping changes idempotent and matching existing plain-SQL migration conventions.

### Description
- Create `supabase/migrations/20260116000000_poker_chips_tx_types.sql` that adds three separate statements: `ALTER TYPE public.chips_tx_type ADD VALUE IF NOT EXISTS 'TABLE_BUY_IN'`, `... 'TABLE_CASH_OUT'`, and `... 'HAND_SETTLEMENT'` and do not drop or recreate the enum.

### Testing
- No automated tests were run for this migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a18d17e888323affdda1c5b6577ec)