### PR TITLE
Allow poker transaction types in chips ledger helper

### DIFF
--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -6,6 +6,9 @@ const VALID_TX_TYPES = new Set([
   "BURN",
   "BUY_IN",
   "CASH_OUT",
+  "TABLE_BUY_IN",
+  "TABLE_CASH_OUT",
+  "HAND_SETTLEMENT",
   "RAKE_FEE",
   "PRIZE_PAYOUT",
 ]);


### PR DESCRIPTION
### Motivation
- The database enum for `chips_tx_type` was extended for poker flows and the server-side ledger helper must accept the new types without changing existing behavior.

### Description
- Add `"TABLE_BUY_IN"`, `"TABLE_CASH_OUT"`, and `"HAND_SETTLEMENT"` to the `VALID_TX_TYPES` set in `netlify/functions/_shared/chips-ledger.mjs` and make no other code changes; `netlify/functions/chips-tx.mjs` remains unchanged so poker types are server-only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a329500388323af4a003d8fee5d04)