### PR TITLE
Add Supabase migration for poker tables schema

### DIFF
--- a/supabase/migrations/20260116120000_poker_tables.sql
+++ b/supabase/migrations/20260116120000_poker_tables.sql
@@ -1,0 +1,40 @@
+create table public.poker_tables (
+  id uuid primary key default gen_random_uuid(),
+  stakes jsonb not null default '{}'::jsonb,
+  max_players int not null default 6,
+  status text not null default 'OPEN',
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table public.poker_seats (
+  table_id uuid not null references public.poker_tables (id) on delete cascade,
+  user_id uuid not null,
+  seat_no int not null,
+  status text not null default 'SEATED',
+  created_at timestamptz not null default now(),
+  unique (table_id, seat_no),
+  unique (table_id, user_id)
+);
+
+create table public.poker_state (
+  table_id uuid primary key references public.poker_tables (id) on delete cascade,
+  version bigint not null default 0,
+  state jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+create table public.poker_actions (
+  id bigserial primary key,
+  table_id uuid not null references public.poker_tables (id) on delete cascade,
+  version bigint,
+  user_id uuid,
+  action_type text not null,
+  amount int,
+  created_at timestamptz not null default now()
+);
+
+create index poker_seats_table_id_idx on public.poker_seats (table_id);
+
+create index poker_actions_table_id_created_at_idx on public.poker_actions (table_id, created_at);


### PR DESCRIPTION
### Motivation
- Add the minimal Supabase schema to support poker table/state functionality required by upcoming server functions.
- Keep the change limited to a single migration file and avoid changing any JS, Netlify functions, or helpers.

### Description
- Add migration file `supabase/migrations/20260116120000_poker_tables.sql` that creates `public.poker_tables`, `public.poker_seats`, `public.poker_state`, and `public.poker_actions`.
- Columns, defaults, and types match the spec (UUID PK with `gen_random_uuid()`, JSONB defaults, `created_at`/`updated_at` timestamps, and `version` default for state).
- Foreign keys use `ON DELETE CASCADE`, and unique constraints `UNIQUE(table_id, seat_no)` and `UNIQUE(table_id, user_id)` are included for `poker_seats`.
- Add lightweight indexes `poker_seats(table_id)` and `poker_actions(table_id, created_at)`; no RLS or other repo files were modified and no breaking impacts are expected.

### Testing
- No automated tests were run because this is a schema-only migration and does not change application code.
- The migration file was added only and should apply cleanly on Supabase when run in the target environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a34638f888323bfcff3cb7af81d89)