### PR TITLE
Add poker-create-table Netlify function

### DIFF
--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -1,0 +1,123 @@
+import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
+
+const parseBody = (body) => {
+  if (!body) return { ok: true, value: {} };
+  try {
+    return { ok: true, value: JSON.parse(body) };
+  } catch {
+    return { ok: false, value: null };
+  }
+};
+
+const isPlainObject = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype;
+
+const parseMaxPlayers = (value) => {
+  if (value == null || value === "") return 6;
+  const num = Number(value);
+  if (!Number.isFinite(num) || !Number.isInteger(num) || num <= 0) return null;
+  return num;
+};
+
+export async function handler(event) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+  const cors = corsHeaders(origin);
+  if (!cors) {
+    return {
+      statusCode: 403,
+      headers: baseHeaders(),
+      body: JSON.stringify({ error: "forbidden_origin" }),
+    };
+  }
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 204, headers: cors, body: "" };
+  }
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, headers: cors, body: JSON.stringify({ error: "method_not_allowed" }) };
+  }
+
+  const parsed = parseBody(event.body);
+  if (!parsed.ok) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_json" }) };
+  }
+
+  const payload = parsed.value ?? {};
+  if (payload && !isPlainObject(payload)) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_payload" }) };
+  }
+
+  const stakesValue = payload?.stakes;
+  if (stakesValue != null && !isPlainObject(stakesValue)) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_stakes" }) };
+  }
+
+  const maxPlayers = parseMaxPlayers(payload?.maxPlayers);
+  if (maxPlayers == null) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_max_players" }) };
+  }
+
+  const token = extractBearerToken(event.headers);
+  const auth = await verifySupabaseJwt(token);
+  if (!auth.valid || !auth.userId) {
+    return { statusCode: 401, headers: cors, body: JSON.stringify({ error: "unauthorized", reason: auth.reason }) };
+  }
+
+  const stakes = stakesValue ?? {};
+  let stakesJson = "{}";
+  try {
+    stakesJson = JSON.stringify(stakes);
+  } catch {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_stakes" }) };
+  }
+
+  let tableId = null;
+  try {
+    await beginSql(async (tx) => {
+      const tableRows = await tx.unsafe(
+        "insert into public.poker_tables (stakes, max_players, status, created_by) values ($1::jsonb, $2, 'OPEN', $3) returning id;",
+        [stakesJson, maxPlayers, auth.userId]
+      );
+      tableId = tableRows?.[0]?.id || null;
+      if (!tableId) {
+        throw new Error("poker_table_insert_failed");
+      }
+
+      const state = { tableId, seats: [], stacks: {}, pot: 0, phase: "INIT" };
+      await tx.unsafe(
+        "insert into public.poker_state (table_id, version, state) values ($1, 0, $2::jsonb);",
+        [tableId, JSON.stringify(state)]
+      );
+
+      const escrowSystemKey = `POKER_TABLE:${tableId}`;
+      const escrowRows = await tx.unsafe(
+        `
+with inserted as (
+  insert into public.chips_accounts (account_type, system_key, status)
+  values ('ESCROW', $1, 'active')
+  on conflict (system_key) do nothing
+  returning id
+)
+select id from inserted
+union all
+select id from public.chips_accounts where system_key = $1
+limit 1;
+        `,
+        [escrowSystemKey]
+      );
+      const escrowId = escrowRows?.[0]?.id || null;
+      if (!escrowId) {
+        throw new Error("poker_escrow_missing");
+      }
+    });
+  } catch (error) {
+    klog("poker_create_table_error", { message: error?.message || "unknown_error" });
+    return { statusCode: 500, headers: cors, body: JSON.stringify({ error: "server_error" }) };
+  }
+
+  const escrowSystemKey = `POKER_TABLE:${tableId}`;
+  return {
+    statusCode: 200,
+    headers: cors,
+    body: JSON.stringify({ tableId, escrowSystemKey }),
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a server-only endpoint to create a poker table, seed an initial `poker_state`, and ensure a chips escrow account exists for the table. 
- Enforce authenticated creation using the project’s Supabase JWT flow and keep behavior idempotent for escrow account creation.

### Description
- Add new function `netlify/functions/poker-create-table.mjs` that accepts POST JSON with optional `stakes` and `maxPlayers` and returns `{ tableId, escrowSystemKey }`.
- Parse JSON safely and validate types, defaulting `maxPlayers` to `6` and `status` to `'OPEN'`, and require a Supabase JWT via `verifySupabaseJwt` for auth.
- Use `beginSql` to run an atomic transaction that inserts into `public.poker_tables`, inserts initial `public.poker_state` with the minimal object `{ tableId, seats: [], stacks: {}, pot: 0, phase: 'INIT' }`, and idempotently ensure the escrow `public.chips_accounts` row using an `INSERT ... ON CONFLICT` + select pattern to reuse existing system accounts.
- Handle CORS and OPTIONS preflight via `corsHeaders`, return appropriate status codes for bad input (`400`), unauthorized (`401`), method not allowed (`405`), forbidden origin (`403`), and server errors (`500`), and log server errors with `klog`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a36b7f71083239b247ba1d15a7038)