### PR TITLE
Add poker-list-tables Netlify function

### DIFF
--- a/netlify/functions/poker-list-tables.mjs
+++ b/netlify/functions/poker-list-tables.mjs
@@ -1,0 +1,87 @@
+import { baseHeaders, corsHeaders, executeSql, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
+
+const parseLimit = (value) => {
+  if (value == null || value === "") return { ok: true, value: 20 };
+  const num = Number(value);
+  if (!Number.isFinite(num) || !Number.isInteger(num)) return { ok: false, value: null };
+  const clamped = Math.min(50, Math.max(1, num));
+  return { ok: true, value: clamped };
+};
+
+const parseStatus = (value) => {
+  if (value == null || value === "") return { ok: true, value: "OPEN" };
+  const normalized = String(value).trim().toUpperCase();
+  if (normalized !== "OPEN" && normalized !== "ALL") return { ok: false, value: null };
+  return { ok: true, value: normalized };
+};
+
+export async function handler(event) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+  const cors = corsHeaders(origin);
+  if (!cors) {
+    return {
+      statusCode: 403,
+      headers: baseHeaders(),
+      body: JSON.stringify({ error: "forbidden_origin" }),
+    };
+  }
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 204, headers: cors, body: "" };
+  }
+  if (event.httpMethod !== "GET") {
+    return { statusCode: 405, headers: cors, body: JSON.stringify({ error: "method_not_allowed" }) };
+  }
+
+  const token = extractBearerToken(event.headers);
+  const auth = await verifySupabaseJwt(token);
+  if (!auth.valid || !auth.userId) {
+    return { statusCode: 401, headers: cors, body: JSON.stringify({ error: "unauthorized", reason: auth.reason }) };
+  }
+
+  const queryParams = event.queryStringParameters || {};
+  const limitParsed = parseLimit(queryParams.limit);
+  if (!limitParsed.ok) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_limit" }) };
+  }
+  const statusParsed = parseStatus(queryParams.status);
+  if (!statusParsed.ok) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "invalid_status" }) };
+  }
+  const limit = limitParsed.value;
+  const status = statusParsed.value;
+
+  const statusFilter = status === "OPEN" ? " where t.status = 'OPEN'" : "";
+  const query = `
+select t.id, t.stakes, t.max_players, t.status, t.created_by, t.created_at, t.updated_at,
+       coalesce(s.seat_count, 0) as seat_count
+from public.poker_tables t
+left join (
+  select table_id, count(*)::int as seat_count
+  from public.poker_seats
+  group by table_id
+) s on s.table_id = t.id${statusFilter}
+order by t.created_at desc
+limit $1;
+  `;
+
+  try {
+    const rows = await executeSql(query, [limit]);
+    const tables = Array.isArray(rows)
+      ? rows.map((row) => ({
+          id: row.id,
+          stakes: row.stakes,
+          maxPlayers: row.max_players,
+          status: row.status,
+          createdBy: row.created_by,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+          seatCount: row.seat_count ?? 0,
+        }))
+      : [];
+
+    return { statusCode: 200, headers: cors, body: JSON.stringify({ ok: true, tables }) };
+  } catch (error) {
+    klog("poker_list_tables_error", { message: error?.message || "unknown_error" });
+    return { statusCode: 500, headers: cors, body: JSON.stringify({ error: "server_error" }) };
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal server-side lobby endpoint so clients can discover recent poker `tableId`s without copy/paste. 
- Keep behavior consistent with existing poker Netlify functions for CORS, HTTP method handling, and Supabase JWT auth.

### Description
- Add a new function at `netlify/functions/poker-list-tables.mjs` that handles CORS via `corsHeaders`, returns `204` for `OPTIONS`, and rejects non-GET requests with `405`.
- Authenticate requests using `extractBearerToken` + `verifySupabaseJwt` and return `401` when unauthorized, without logging tokens.
- Parse query params `limit` (default `20`, integer, clamped `1..50`) and `status` (default `OPEN`, allowed `OPEN` or `ALL`) and return `400` for invalid values.
- Run a single SQL query (via `executeSql`) that left-joins `poker_seats` to compute `seat_count`, orders by `created_at desc`, applies the `OPEN` filter when requested, and maps DB fields to the response shape (`maxPlayers`, `createdBy`, `createdAt`, `updatedAt`, `seatCount`).
- Unexpected DB errors are caught and logged with `klog("poker_list_tables_error", ...)` and return `500` with `{ error: "server_error" }`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6e512f3483238ed01827985119d5)