### PR TITLE
Add poker-start-hand Netlify function

### DIFF
--- a/netlify/functions/poker-start-hand.mjs
+++ b/netlify/functions/poker-start-hand.mjs
@@ -61,9 +61,8 @@ export async function handler(event) {
     const headers = {
       ...baseHeaders(),
       "access-control-allow-origin": "null",
-      "access-control-allow-credentials": "true",
       "access-control-allow-headers": "authorization, content-type",
-      "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
+      "access-control-allow-methods": "POST, OPTIONS",
     };
     return {
       statusCode: 403,


### PR DESCRIPTION
### Motivation
- Provide a server-side endpoint to begin a new poker hand that atomically locks table state, bumps version, and records an action log without performing gameplay (dealing/betting) yet.
- Implement a simple server-side idempotency strategy so repeated requests with the same `requestId` do not duplicate actions or bump state.

### Description
- Added `netlify/functions/poker-start-hand.mjs` which validates CORS, accepts only `POST`, parses the JSON payload, and validates `tableId` and optional `requestId`.
- Enforces auth using `extractBearerToken` + `verifySupabaseJwt`, and returns 401 when unauthorized.
- Runs the core logic in a transaction via `beginSql(...)` and locks the `public.poker_state` row using `FOR UPDATE`, checks `public.poker_tables` status, and loads `public.poker_seats` for seated players.
- Implements idempotency by checking `currentState.lastStartHandRequestId` under lock and returning the existing hand when it matches `requestId`; otherwise computes `handId`, `buttonSeatNo`, `nextToActSeatNo`, updates `poker_state` with `version+1` and minimal `state` fields, and inserts a `poker_actions` row with `action_type='START_HAND'`.
- Error handling returns the specified error codes (e.g. `table_not_found`, `table_not_open`, `not_enough_players`, `already_in_hand`) and logs unexpected errors with `klog("poker_start_hand_error", { message })`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a804ae6a88323acf2de69fe4a6309)