### PR TITLE
Disable prepared statements in Supabase Postgres client and add poker join smoke script

### DIFF
--- a/netlify/functions/_shared/supabase-admin.mjs
+++ b/netlify/functions/_shared/supabase-admin.mjs
@@ -69,9 +69,19 @@ if (!SUPABASE_DB_URL) {
   klog("chips_db_url_missing", { hasDbUrl: false });
 }
 
-const sql = SUPABASE_DB_URL
-  ? postgres(SUPABASE_DB_URL, { max: 1, idle_timeout: 30, connect_timeout: 10 })
-  : null;
+const POSTGRES_OPTIONS = { max: 1, idle_timeout: 30, connect_timeout: 10, prepare: false };
+
+const sql = SUPABASE_DB_URL ? postgres(SUPABASE_DB_URL, POSTGRES_OPTIONS) : null;
+
+if (SUPABASE_DB_URL) {
+  let dbHost = "unknown";
+  try {
+    dbHost = new URL(SUPABASE_DB_URL).host || "unknown";
+  } catch {
+    dbHost = "invalid";
+  }
+  klog("chips_db_client_init", { dbHost, preparedStatementsDisabled: POSTGRES_OPTIONS.prepare === false });
+}
 
 const CORS_ALLOW = (() => {
   const fromEnv = (process.env.XP_CORS_ALLOW ?? "")

--- a/scripts/poker-join-smoke.mjs
+++ b/scripts/poker-join-smoke.mjs
@@ -1,0 +1,54 @@
+const joinUrl = process.env.POKER_JOIN_URL;
+const authToken = process.env.POKER_AUTH_TOKEN;
+const tableId = process.env.POKER_TABLE_ID;
+const seatNo = Number.parseInt(process.env.POKER_SEAT_NO ?? "0", 10);
+const buyIn = Number.parseInt(process.env.POKER_BUY_IN ?? "100", 10);
+const count = Number.parseInt(process.env.POKER_JOIN_COUNT ?? "20", 10);
+
+if (!joinUrl || !authToken || !tableId) {
+  console.error("Missing required env vars: POKER_JOIN_URL, POKER_AUTH_TOKEN, POKER_TABLE_ID");
+  process.exit(1);
+}
+
+if (!Number.isFinite(seatNo) || seatNo < 0) {
+  console.error("POKER_SEAT_NO must be a non-negative integer");
+  process.exit(1);
+}
+
+if (!Number.isFinite(buyIn) || buyIn <= 0) {
+  console.error("POKER_BUY_IN must be a positive integer");
+  process.exit(1);
+}
+
+const run = async () => {
+  const results = [];
+  for (let i = 0; i < count; i += 1) {
+    const requestId = `smoke-${Date.now()}-${i}`;
+    const response = await fetch(joinUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${authToken}`,
+      },
+      body: JSON.stringify({ tableId, seatNo, buyIn, requestId }),
+    });
+
+    const text = await response.text();
+    results.push({ status: response.status, body: text });
+    const summary = text.length > 120 ? `${text.slice(0, 120)}…` : text;
+    console.log(`#${i + 1}/${count} status=${response.status} body=${summary}`);
+  }
+
+  const failures = results.filter((item) => item.status !== 200);
+  if (failures.length > 0) {
+    console.error(`Completed with ${failures.length} non-200 responses.`);
+    process.exit(1);
+  }
+
+  console.log(`Completed ${count} join requests successfully.`);
+};
+
+run().catch((error) => {
+  console.error("Smoke test failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Prevent "prepared statement \"...\" does not exist" errors by disabling prepared statements in the shared Postgres client used by poker Netlify functions.
- Provide a simple smoke runner to repeatedly call the `poker-join` endpoint to validate behavior under load.

### Description

- Set `prepare: false` in the Postgres client options via a new `POSTGRES_OPTIONS` object and initialize the client with `postgres(SUPABASE_DB_URL, POSTGRES_OPTIONS)` in `netlify/functions/_shared/supabase-admin.mjs`.
- Emit a cold-start log entry via `klog("chips_db_client_init", ...)` that records the (redacted) DB host and whether prepared statements are disabled.
- Add a smoke script `scripts/poker-join-smoke.mjs` that performs repeated `POST` calls to the `poker-join` endpoint with configurable count, table id, seat, buy-in and auth token.

### Testing

- No automated tests were executed as part of this change.
- A local smoke test script was added at `scripts/poker-join-smoke.mjs` for manual or CI execution to perform repeated join attempts (not run in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa9a78c488323a891ba5310b99db9)