### PR TITLE
poker: heartbeat should not revive CLOSED tables; migration tolerant of missing created_at

### DIFF
--- a/supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql
+++ b/supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql
@@ -24,7 +24,7 @@ with ranked_seats as (
     ctid,
     row_number() over (
       partition by table_id, seat_no
-      order by joined_at desc nulls last, created_at desc nulls last, ctid desc
+      order by joined_at desc nulls last, ctid desc
     ) as rn
   from public.poker_seats
   where table_id is not null and seat_no is not null
@@ -37,7 +37,7 @@ with ranked_users as (
     ctid,
     row_number() over (
       partition by table_id, user_id
-      order by joined_at desc nulls last, created_at desc nulls last, ctid desc
+      order by joined_at desc nulls last, ctid desc
     ) as rn
   from public.poker_seats
   where table_id is not null and user_id is not null


### PR DESCRIPTION
### Motivation
- Prevent the heartbeat endpoint from reviving or touching seats/tables when a table is `CLOSED` and return a clear `table_not_found` when the table id is missing.
- Make the seat dedupe migration robust when `poker_seats.created_at` does not exist by removing the assumption that the column is present.

### Description
- In `netlify/functions/poker-heartbeat.mjs` query `public.poker_tables` for `status` and return a `404` (`table_not_found`) if no table row exists, and if `status = 'CLOSED'` return `{ ok: true, seated, seatNo, closed: true }` for seated users while skipping updates to `poker_seats` and `poker_tables.last_activity_at`; keep existing behavior for non-closed tables.
- Propagate transaction-level error payloads into proper HTTP responses from the handler when the transaction returns an error object.
- In `supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql` remove `created_at desc nulls last` from the `ORDER BY` in the two cleanup CTEs so ordering is `joined_at desc nulls last, ctid desc` and no longer assumes `created_at` exists.

### Testing
- Ran the full automated suite with `node scripts/test-all.mjs` and the test run completed successfully.
- `tests/poker-phase1.test.mjs` (migration/seat cleanup) and the poker-related heartbeat tests passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ba87e4194832397dd2b0b4389afc9)