### PR TITLE
Fix poker_requests migration casts to avoid name[] = text[] error

### DIFF
--- a/supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql
+++ b/supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql
@@ -72,10 +72,10 @@ begin
       and t.relname = 'poker_requests'
       and c.contype = 'u'
       and (
-        select array_agg(a.attname order by k.ordinality)
+        select array_agg(a.attname::text order by k.ordinality)
         from unnest(c.conkey) with ordinality as k(attnum, ordinality)
         join pg_attribute a on a.attrelid = t.oid and a.attnum = k.attnum
-      ) = array['request_id']
+      ) = array['request_id']::text[]
   loop
     execute format('alter table public.poker_requests drop constraint %I', rec.conname);
   end loop;
@@ -95,10 +95,10 @@ begin
       and t.relname = 'poker_requests'
       and idx.indisunique
       and (
-        select array_agg(a.attname order by k.ordinality)
+        select array_agg(a.attname::text order by k.ordinality)
         from unnest(idx.indkey) with ordinality as k(attnum, ordinality)
         join pg_attribute a on a.attrelid = t.oid and a.attnum = k.attnum
-      ) = array['request_id']
+      ) = array['request_id']::text[]
   loop
     execute format('drop index if exists %I', rec.index_name);
   end loop;


### PR DESCRIPTION
### Motivation
- Prevent Postgres `SQLSTATE 42883` caused by comparing `name[]` (from `array_agg(a.attname)`) to a `text[]` literal in the legacy constraint/index detection logic of the poker requests migration file.

### Description
- In `supabase/migrations/20260117090000_poker_phase1_authoritative_seats.sql` cast `array_agg(a.attname order by k.ordinality)` to `array_agg(a.attname::text order by k.ordinality)` and cast the literal to `array['request_id']::text[]` in both DO blocks that drop legacy unique constraints/indexes.

### Testing
- No automated tests were executed during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bdc8342f48323bbc1917d7ddc13c6)