### PR TITLE
Fix poker join pending handling, scope idempotency keys, and enhance auth/join logging

### DIFF
--- a/netlify/functions/poker-join.mjs
+++ b/netlify/functions/poker-join.mjs
@@ -144,6 +144,8 @@ export async function handler(event) {
     return { statusCode: 401, headers: cors, body: JSON.stringify({ error: "unauthorized", reason: auth.reason }) };
   }
 
+  klog("poker_join_begin", { tableId, userId: auth.userId, seatNo, hasRequestId: !!requestId });
+
   try {
     const result = await beginSql(async (tx) => {
       if (requestId) {
@@ -301,7 +303,7 @@ values ($1, $2, $3, 'ACTIVE', now(), now());
         }
 
         const idempotencyKey = requestId
-          ? `poker:join:${requestId}`
+          ? `poker:join:${tableId}:${auth.userId}:${requestId}`
           : `poker:join:${tableId}:${auth.userId}:${seatNo}:${buyIn}`;
 
         await postTransaction({

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -900,13 +900,13 @@
           buyIn: buyIn,
           requestId: joinRequestId
         });
+        if (isPendingResponse(joinResult)){
+          schedulePendingRetry('join', retryJoin);
+          return;
+        }
         if (joinResult && joinResult.ok === false){
           clearJoinPending();
           setActionError('join', JOIN_URL, joinResult.error || 'request_failed', t('pokerErrJoin', 'Failed to join'));
-          return;
-        }
-        if (isPendingResponse(joinResult)){
-          schedulePendingRetry('join', retryJoin);
           return;
         }
         clearJoinPending();


### PR DESCRIPTION
### Motivation
- Ensure a backend `{ pending: true }` join response is treated as pending (triggers retries) instead of being swallowed as a generic failure.
- Prevent idempotency collisions across users when `requestId` is present by scoping keys to `tableId` and `userId`.
- Make it easier to diagnose “second user” join failures by logging the active auth `userId` and session metadata on both client and server.
- Breaking impact: idempotency keys now include `tableId` and `userId` when `requestId` is used, so historical/in-flight keys using the old `requestId`-only format will not match (acceptable since `requestId` is ephemeral).

### Description
- Reordered join result handling in `poker/poker.js` so `isPendingResponse(joinResult)` is evaluated before the generic `joinResult.ok === false` check to preserve pending state and allow scheduled retries using the existing retry/backoff logic. (`joinTable` flow)
- In `netlify/functions/poker-join.mjs` scoped the idempotency key to include `tableId` and `auth.userId` when `requestId` is present (`poker:join:${tableId}:${auth.userId}:${requestId}`) and added a `klog` event `poker_join_begin` that records `{ tableId, userId, seatNo, hasRequestId }` at the start of the handler (after auth verification).
- Extended frontend Supabase diagnostics in `js/auth/supabaseClient.js` to include safe session fields (`userId`, `emailDomain`, `sessionExpiresAt`) when emitting `supabase:session_initial` and `supabase:auth_change`, and added a small `getEmailDomain` helper; logging still uses the project logger (`klog`/`KLog`) via existing `logDiag`.

### Testing
- Ran lifecycle guard `node scripts/check-lifecycle.js --files` as part of commit hooks and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eaadb38dc832391dd7e826deeaa3a)