### PR TITLE
Poker: groundwork for hole cards (validator, handId fallback, migration, tests)

### DIFF
--- a/netlify/functions/_shared/poker-cards-utils.mjs
+++ b/netlify/functions/_shared/poker-cards-utils.mjs
@@ -1,0 +1,10 @@
+export const isValidTwoCards = (cards) => {
+  if (!Array.isArray(cards) || cards.length !== 2) return false;
+  for (const card of cards) {
+    if (!card || typeof card !== "object") return false;
+    if (typeof card.s !== "string") return false;
+    const rankType = typeof card.r;
+    if (rankType !== "string" && rankType !== "number") return false;
+  }
+  return true;
+};

--- a/netlify/functions/poker-start-hand.mjs
+++ b/netlify/functions/poker-start-hand.mjs
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
 import { createDeck, dealHoleCards, shuffle } from "./_shared/poker-engine.mjs";
 import { getRng, isPlainObject, isStateStorageValid, normalizeJsonState, withoutPrivateState } from "./_shared/poker-state-utils.mjs";
@@ -146,7 +147,10 @@ export async function handler(event) {
       const turnUserId = validSeats[1]?.user_id || validSeats[0].user_id;
 
       const rng = getRng();
-      const handId = `hand_${Date.now()}_${Math.floor(rng() * 1e6)}`;
+      const handId =
+        typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `hand_${Date.now()}_${Math.floor(rng() * 1e6)}`;
       const derivedSeats = validSeats.map((seat) => ({ userId: seat.user_id, seatNo: seat.seat_no }));
       const activeUserIds = new Set(validSeats.map((seat) => seat.user_id));
       const activeUserIdList = validSeats.map((seat) => seat.user_id);

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -31,6 +31,7 @@ run("node", ["tests/favorites-service.test.mjs"], "favorites-service");
 run("node", ["tests/poker-phase1.test.mjs"], "poker-phase1");
 run("node", ["tests/poker-engine.test.mjs"], "poker-engine");
 run("node", ["tests/poker-contract.phase1.test.mjs"], "poker-contract-phase1");
+run("node", ["tests/poker-hole-cards.rls.test.mjs"], "poker-hole-cards-rls");
 run("node", ["tests/poker-reducer.test.mjs"], "poker-reducer");
 run("node", ["tests/poker-leave.test.mjs"], "poker-leave");
 run("node", ["tests/poker-join.test.mjs"], "poker-join");

--- a/supabase/migrations/20260117100000_poker_hole_cards.sql
+++ b/supabase/migrations/20260117100000_poker_hole_cards.sql
@@ -1,0 +1,16 @@
+create table public.poker_hole_cards (
+  table_id uuid not null references public.poker_tables (id) on delete cascade,
+  hand_id text not null,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  cards jsonb not null,
+  created_at timestamptz not null default now(),
+  unique (table_id, hand_id, user_id)
+);
+
+create index poker_hole_cards_table_hand_idx on public.poker_hole_cards (table_id, hand_id);
+
+alter table public.poker_hole_cards enable row level security;
+
+revoke all on table public.poker_hole_cards from anon;
+revoke all on table public.poker_hole_cards from authenticated;
+grant select, insert, update, delete on table public.poker_hole_cards to service_role;

--- a/tests/helpers/poker-test-helpers.mjs
+++ b/tests/helpers/poker-test-helpers.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isValidTwoCards } from "../../netlify/functions/_shared/poker-cards-utils.mjs";
 
 const root = process.cwd();
 
@@ -60,15 +61,20 @@ export const loadPokerHandler = (filePath, mocks) => {
   ];
   const injectedNames = injectable.filter((name) => !declared.has(name));
   const destructureLine = injectedNames.length ? `const { ${injectedNames.join(", ")} } = mocks;` : "";
+  const needsTwoCards =
+    !declared.has("isValidTwoCards") && /\bisValidTwoCards\b/.test(rewritten);
+  const twoCardsLine = needsTwoCards ? "const isValidTwoCards = isValidTwoCardsImpl;" : "";
   const factory = new Function(
     "mocks",
+    "isValidTwoCardsImpl",
     `"use strict";
 ${destructureLine}
+${twoCardsLine}
 ${rewritten}
 return handler;`
   );
   try {
-    return factory(mocks);
+    return factory(mocks, isValidTwoCards);
   } catch (error) {
     throw new Error(`[poker-test-helpers] Failed to compile ${filePath}: ${error?.message || error}`);
   }

--- a/tests/poker-hole-cards.rls.test.mjs
+++ b/tests/poker-hole-cards.rls.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationsDir = path.join(process.cwd(), "supabase", "migrations");
+const migrationFiles = fs.readdirSync(migrationsDir);
+const migrationFile = migrationFiles.find((file) => file.includes("poker_hole_cards"));
+
+assert.ok(migrationFile, "poker_hole_cards migration file should exist");
+
+const migrationSrc = fs.readFileSync(path.join(migrationsDir, migrationFile), "utf8");
+
+assert.ok(/create\s+table\s+public\.poker_hole_cards/i.test(migrationSrc), "migration should create poker_hole_cards");
+assert.ok(/enable\s+row\s+level\s+security/i.test(migrationSrc), "migration should enable RLS");
+assert.ok(/revoke\s+all\s+on\s+table\s+public\.poker_hole_cards\s+from\s+anon/i.test(migrationSrc), "revoke anon");
+assert.ok(
+  /revoke\s+all\s+on\s+table\s+public\.poker_hole_cards\s+from\s+authenticated/i.test(migrationSrc),
+  "revoke authenticated"
+);
+assert.ok(
+  /grant\s+select,\s*insert,\s*update,\s*delete\s+on\s+table\s+public\.poker_hole_cards\s+to\s+service_role/i.test(
+    migrationSrc
+  ),
+  "grant service_role"
+);
+
+const hasUniqueConstraint = /unique\s*\(\s*table_id\s*,\s*hand_id\s*,\s*user_id\s*\)/i.test(migrationSrc);
+const hasUniqueIndex = /create\s+unique\s+index[\s\S]*table_id[\s\S]*hand_id[\s\S]*user_id/i.test(migrationSrc);
+assert.ok(hasUniqueConstraint || hasUniqueIndex, "migration should enforce uniqueness on (table_id, hand_id, user_id)");


### PR DESCRIPTION
### Motivation
- Prepare the codebase to move hole cards out of `poker_state` by adding a shared validator and server-side storage migration.
- Make hand identifiers deterministic and compatible across Node versions while preserving prior test-friendly fallback behavior.
- Simplify the poker test harness so callers no longer need to mock `isValidTwoCards`.

### Description
- Add a dependency-free shared validator `isValidTwoCards` at `netlify/functions/_shared/poker-cards-utils.mjs` that validates an array of two card objects.
- Update `tests/helpers/poker-test-helpers.mjs` to import the real validator and inject it automatically into loaded handlers when they reference `isValidTwoCards`, removing the need for tests to include it in `mocks`.
- Update `netlify/functions/poker-start-hand.mjs` to import `node:crypto` and prefer `crypto.randomUUID()` for `handId`, falling back to the previous `hand_${Date.now()}_${Math.floor(rng() * 1e6)}` scheme when `randomUUID` is unavailable. 
- Add a Supabase migration `supabase/migrations/20260117100000_poker_hole_cards.sql` that creates `public.poker_hole_cards` with the required columns, uniqueness constraint `(table_id, hand_id, user_id)`, index on `(table_id, hand_id)`, RLS enabled, and the required `revoke`/`grant` statements. 
- Add a migration contract test `tests/poker-hole-cards.rls.test.mjs` and wire it into the default test runner in `scripts/test-all.mjs`.

### Testing
- Ran the project test suite with `npm test`, which runs the full `scripts/test-all.mjs` flow, and it completed successfully. 
- The added `poker-hole-cards.rls.test.mjs` was executed and passed as part of the test run. 
- Syntax and unit guards (`scripts/syntax-check.mjs`) ran successfully as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749857e19c832397c67fef69ab4007)