### PR TITLE
Return caller hole cards in poker-get-table; strip private state and validate hole-cards table

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -41,6 +41,7 @@ run("node", ["tests/poker-leave.behavior.test.mjs"], "poker-leave-behavior");
 run("node", ["tests/poker-start-hand.behavior.test.mjs"], "poker-start-hand-behavior");
 run("node", ["tests/poker-act.behavior.test.mjs"], "poker-act-behavior");
 run("node", ["tests/poker-sweep.behavior.test.mjs"], "poker-sweep-behavior");
+run("node", ["tests/poker-get-table.behavior.test.mjs"], "poker-get-table-behavior");
 
 try { run("npm", ["run", "-s", "lint:games"], "unit"); } catch { /* optional */ }
 

--- a/tests/poker-get-table.behavior.test.mjs
+++ b/tests/poker-get-table.behavior.test.mjs
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { isHoleCardsTableMissing, loadHoleCardsByUserId } from "../netlify/functions/_shared/poker-hole-cards-store.mjs";
+import { normalizeJsonState, withoutPrivateState } from "../netlify/functions/_shared/poker-state-utils.mjs";
+import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
+
+const tableId = "11111111-1111-4111-8111-111111111111";
+
+const baseState = {
+  tableId,
+  phase: "PREFLOP",
+  seats: [
+    { userId: "user-1", seatNo: 1 },
+    { userId: "user-2", seatNo: 2 },
+    { userId: "user-3", seatNo: 3 },
+  ],
+  stacks: { "user-1": 100, "user-2": 100, "user-3": 100 },
+  pot: 0,
+  community: [],
+  dealerSeatNo: 1,
+  turnUserId: "user-1",
+  handId: "hand-1",
+  deck: [{ r: "2", s: "S" }],
+  holeCardsByUserId: {
+    "user-1": [{ r: "A", s: "S" }, { r: "K", s: "S" }],
+  },
+};
+
+const defaultHoleCards = {
+  "user-1": [{ r: "A", s: "S" }, { r: "K", s: "S" }],
+  "user-2": [{ r: "Q", s: "H" }, { r: "J", s: "H" }],
+  "user-3": [{ r: "9", s: "D" }, { r: "9", s: "C" }],
+};
+
+const makeHandler = (queries, storedState, userId, options = {}) =>
+  loadPokerHandler("netlify/functions/poker-get-table.mjs", {
+    baseHeaders: () => ({}),
+    corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
+    extractBearerToken: () => "token",
+    verifySupabaseJwt: async () => ({ valid: true, userId }),
+    isValidUuid: () => true,
+    normalizeJsonState,
+    withoutPrivateState,
+    isHoleCardsTableMissing,
+    loadHoleCardsByUserId,
+    beginSql: async (fn) =>
+      fn({
+        unsafe: async (query, params) => {
+          const text = String(query).toLowerCase();
+          queries.push({ query: String(query), params });
+          if (text.includes("from public.poker_tables")) {
+            return [{ id: tableId, stakes: "1/2", max_players: 6, status: "OPEN" }];
+          }
+          if (text.includes("from public.poker_seats") && text.includes("status = 'active'")) {
+            const activeUserIds = options.activeUserIds || ["user-1", "user-2", "user-3"];
+            return activeUserIds.map((id, index) => ({ user_id: id, seat_no: index + 1 }));
+          }
+          if (text.includes("from public.poker_seats")) {
+            return [
+              { user_id: "user-1", seat_no: 1, status: "ACTIVE" },
+              { user_id: "user-2", seat_no: 2, status: "ACTIVE" },
+              { user_id: "user-3", seat_no: 3, status: "ACTIVE" },
+            ];
+          }
+          if (text.includes("from public.poker_state")) {
+            return [{ version: storedState.version, state: JSON.parse(storedState.value) }];
+          }
+          if (text.includes("from public.poker_hole_cards")) {
+            if (options.holeCardsError) throw options.holeCardsError;
+            const rows = [];
+            const map = options.holeCardsByUserId || defaultHoleCards;
+            for (const [userIdValue, cards] of Object.entries(map)) {
+              rows.push({ user_id: userIdValue, cards });
+            }
+            return rows;
+          }
+          return [];
+        },
+      }),
+    klog: options.klog || (() => {}),
+  });
+
+const run = async () => {
+  const happyQueries = [];
+  const storedState = { value: JSON.stringify(baseState), version: 4 };
+  const happyHandler = makeHandler(happyQueries, storedState, "user-1");
+  const happyResponse = await happyHandler({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(happyResponse.statusCode, 200);
+  const happyPayload = JSON.parse(happyResponse.body);
+  assert.equal(happyPayload.ok, true);
+  assert.ok(Array.isArray(happyPayload.myHoleCards));
+  assert.equal(happyPayload.myHoleCards.length, 2);
+  assert.equal(happyPayload.state.state.deck, undefined);
+  assert.equal(happyPayload.state.state.holeCardsByUserId, undefined);
+  assert.equal(happyPayload.holeCardsByUserId, undefined);
+  assert.equal(JSON.stringify(happyPayload).includes("holeCardsByUserId"), false);
+  assert.equal(JSON.stringify(happyPayload).includes('"deck"'), false);
+
+  const missingTableError = new Error("missing table");
+  missingTableError.code = "42P01";
+  const missingTableResponse = await makeHandler([], storedState, "user-1", {
+    holeCardsError: missingTableError,
+  })({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(missingTableResponse.statusCode, 409);
+  assert.equal(JSON.parse(missingTableResponse.body).error, "state_invalid");
+
+  const missingRowResponse = await makeHandler([], storedState, "user-1", {
+    holeCardsByUserId: {
+      "user-1": defaultHoleCards["user-1"],
+      "user-2": defaultHoleCards["user-2"],
+    },
+  })({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(missingRowResponse.statusCode, 409);
+  assert.equal(JSON.parse(missingRowResponse.body).error, "state_invalid");
+
+  const invalidCardsResponse = await makeHandler([], storedState, "user-1", {
+    holeCardsByUserId: {
+      ...defaultHoleCards,
+      "user-2": [],
+    },
+  })({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(invalidCardsResponse.statusCode, 409);
+  assert.equal(JSON.parse(invalidCardsResponse.body).error, "state_invalid");
+
+  const mismatchResponse = await makeHandler([], storedState, "user-1", {
+    activeUserIds: ["user-1", "user-2"],
+  })({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(mismatchResponse.statusCode, 409);
+  assert.equal(JSON.parse(mismatchResponse.body).error, "state_invalid");
+
+  const initState = {
+    ...baseState,
+    phase: "INIT",
+    handId: "",
+  };
+  const nonActionQueries = [];
+  const nonActionResponse = await makeHandler(
+    nonActionQueries,
+    { value: JSON.stringify(initState), version: 2 },
+    "user-1"
+  )({
+    httpMethod: "GET",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    queryStringParameters: { tableId },
+  });
+  assert.equal(nonActionResponse.statusCode, 200);
+  const nonActionPayload = JSON.parse(nonActionResponse.body);
+  assert.deepEqual(nonActionPayload.myHoleCards, []);
+  const holeCardQueries = nonActionQueries.filter((entry) =>
+    entry.query.toLowerCase().includes("from public.poker_hole_cards")
+  );
+  assert.equal(holeCardQueries.length, 0);
+};
+
+await run();


### PR DESCRIPTION
### Motivation
- Ensure the client polling/reconnect endpoint for table state never leaks private poker data while allowing the caller to receive only their own hole cards during action phases.
- Map hole-cards DB problems (missing table, missing row, or invalid cards) to `409 state_invalid` so frontends can handle mid-hand reconnects safely.

### Description
- Updated `netlify/functions/poker-get-table.mjs` to load hole cards from `public.poker_hole_cards` during action phases (`PREFLOP|FLOP|TURN|RIVER`), validate `handId`, and verify active seats match state seats before returning data.
- The endpoint now returns `state: withoutPrivateState(currentState)` and `myHoleCards: [...]` (only the caller's cards) and guarantees `holeCardsByUserId` and `deck` are not present in the public JSON.
- Database/hole-card load errors are translated to `409 state_invalid` when appropriate (missing table, missing/invalid rows), and other errors are rethrown.
- Added `tests/poker-get-table.behavior.test.mjs` to cover happy path, missing table, missing row, invalid cards, active-seat mismatch, and non-action-phase behavior, and wired the test into `scripts/test-all.mjs`.

### Testing
- Ran the new behavior test with `node tests/poker-get-table.behavior.test.mjs`, which completed successfully.
- Added the test to the aggregate runner so `npm test` / `node scripts/test-all.mjs` will include `poker-get-table` behavior checks.
- Existing poker behavior tests were left unchanged and the new test re-uses existing test helpers to assert private fields are not present and that `myHoleCards` is returned only when expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974b8aba36c8323a42f4683784ce951)