### PR TITLE
Add deterministic 7-card poker hand evaluator

### DIFF
--- a/netlify/functions/_shared/poker-eval.mjs
+++ b/netlify/functions/_shared/poker-eval.mjs
@@ -1,0 +1,315 @@
+const HAND_CATEGORY = {
+  HIGH_CARD: 1,
+  PAIR: 2,
+  TWO_PAIR: 3,
+  TRIPS: 4,
+  STRAIGHT: 5,
+  FLUSH: 6,
+  FULL_HOUSE: 7,
+  QUADS: 8,
+  STRAIGHT_FLUSH: 9,
+};
+
+const CATEGORY_NAME = {
+  1: "HIGH_CARD",
+  2: "PAIR",
+  3: "TWO_PAIR",
+  4: "TRIPS",
+  5: "STRAIGHT",
+  6: "FLUSH",
+  7: "FULL_HOUSE",
+  8: "QUADS",
+  9: "STRAIGHT_FLUSH",
+};
+
+const normalizeRank = (r) => {
+  if (typeof r === "number" && Number.isInteger(r)) {
+    if (r >= 2 && r <= 14) return r;
+    return null;
+  }
+  if (typeof r !== "string") return null;
+  const v = r.trim().toUpperCase();
+  if (v === "A") return 14;
+  if (v === "K") return 13;
+  if (v === "Q") return 12;
+  if (v === "J") return 11;
+  if (v === "T") return 10;
+  if (/^\d+$/.test(v)) {
+    const n = Number(v);
+    if (n >= 2 && n <= 10) return n;
+  }
+  return null;
+};
+
+const normalizeSuit = (s) => {
+  if (typeof s !== "string") return null;
+  const v = s.trim();
+  if (!v) return null;
+  return v.toUpperCase();
+};
+
+const cardKey = (card) => `${card.rank}-${card.suit}`;
+
+const assertValidCards = (cards) => {
+  if (!Array.isArray(cards)) throw new Error("invalid_card");
+  if (cards.length < 5) throw new Error("insufficient_cards");
+  const seen = new Set();
+  return cards.map((card) => {
+    if (!card || typeof card !== "object") throw new Error("invalid_card");
+    if (!("r" in card) || !("s" in card)) throw new Error("invalid_card");
+    const rank = normalizeRank(card.r);
+    const suit = normalizeSuit(card.s);
+    if (!rank || !suit) throw new Error("invalid_card");
+    const normalized = { rank, suit, raw: card };
+    const key = cardKey(normalized);
+    if (seen.has(key)) throw new Error("duplicate_card");
+    seen.add(key);
+    return normalized;
+  });
+};
+
+const compareRankVectors = (a, b) => {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (a[i] || 0) - (b[i] || 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+  return 0;
+};
+
+const byRankDesc = (a, b) => {
+  if (a.rank !== b.rank) return b.rank - a.rank;
+  return a.suit.localeCompare(b.suit);
+};
+
+const findStraight = (ranksDesc) => {
+  const set = new Set(ranksDesc);
+  if (set.has(14)) set.add(1);
+  for (let high = 14; high >= 5; high -= 1) {
+    let ok = true;
+    for (let i = 0; i < 5; i += 1) {
+      if (!set.has(high - i)) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) {
+      const ranks = [];
+      for (let i = 0; i < 5; i += 1) ranks.push(high - i);
+      return { high, ranks };
+    }
+  }
+  return null;
+};
+
+const pickStraightCards = (ranks, cardsByRank) => {
+  return ranks.map((r) => {
+    const actual = r === 1 ? 14 : r;
+    const list = cardsByRank.get(actual) || [];
+    return list[0];
+  });
+};
+
+const evaluateBestHand = (cards) => {
+  const normalized = assertValidCards(cards);
+  const allCardsSorted = normalized.slice().sort(byRankDesc);
+  const cardsByRank = new Map();
+  const cardsBySuit = new Map();
+
+  normalized.forEach((card) => {
+    if (!cardsByRank.has(card.rank)) cardsByRank.set(card.rank, []);
+    cardsByRank.get(card.rank).push(card);
+    if (!cardsBySuit.has(card.suit)) cardsBySuit.set(card.suit, []);
+    cardsBySuit.get(card.suit).push(card);
+  });
+
+  cardsByRank.forEach((list) => list.sort((a, b) => a.suit.localeCompare(b.suit)));
+  cardsBySuit.forEach((list) => list.sort(byRankDesc));
+
+  const uniqueRanksDesc = Array.from(cardsByRank.keys()).sort((a, b) => b - a);
+  const ranksByCount = { 4: [], 3: [], 2: [], 1: [] };
+  uniqueRanksDesc.forEach((rank) => {
+    const count = cardsByRank.get(rank).length;
+    if (!ranksByCount[count]) ranksByCount[count] = [];
+    ranksByCount[count].push(rank);
+  });
+
+  let bestStraightFlush = null;
+  const suitNames = Array.from(cardsBySuit.keys()).sort();
+  suitNames.forEach((suit) => {
+    const suited = cardsBySuit.get(suit);
+    if (suited.length < 5) return;
+    const suitRanks = Array.from(new Set(suited.map((c) => c.rank))).sort((a, b) => b - a);
+    const straight = findStraight(suitRanks);
+    if (!straight) return;
+    const cardsByRankSuit = new Map();
+    suited.forEach((card) => {
+      if (!cardsByRankSuit.has(card.rank)) cardsByRankSuit.set(card.rank, []);
+      cardsByRankSuit.get(card.rank).push(card);
+    });
+    cardsByRankSuit.forEach((list) => list.sort((a, b) => a.suit.localeCompare(b.suit)));
+    const candidate = {
+      high: straight.high === 1 ? 5 : straight.high,
+      ranks: straight.ranks,
+      suit,
+      cards: pickStraightCards(straight.ranks, cardsByRankSuit),
+    };
+    if (!bestStraightFlush) {
+      bestStraightFlush = candidate;
+      return;
+    }
+    if (candidate.high > bestStraightFlush.high) {
+      bestStraightFlush = candidate;
+      return;
+    }
+    if (candidate.high === bestStraightFlush.high && suit.localeCompare(bestStraightFlush.suit) < 0) {
+      bestStraightFlush = candidate;
+    }
+  });
+
+  if (bestStraightFlush) {
+    const ranks = [bestStraightFlush.high === 1 ? 5 : bestStraightFlush.high];
+    return {
+      category: HAND_CATEGORY.STRAIGHT_FLUSH,
+      name: CATEGORY_NAME[HAND_CATEGORY.STRAIGHT_FLUSH],
+      ranks,
+      best5: bestStraightFlush.cards.map((c) => c.raw),
+      key: `${HAND_CATEGORY.STRAIGHT_FLUSH}:${ranks.join(",")}`,
+    };
+  }
+
+  if (ranksByCount[4].length) {
+    const quadRank = ranksByCount[4][0];
+    const quadCards = cardsByRank.get(quadRank).slice(0, 4);
+    const kicker = allCardsSorted.find((card) => card.rank !== quadRank);
+    const ranks = [quadRank, kicker.rank];
+    return {
+      category: HAND_CATEGORY.QUADS,
+      name: CATEGORY_NAME[HAND_CATEGORY.QUADS],
+      ranks,
+      best5: [...quadCards, kicker].map((c) => c.raw),
+      key: `${HAND_CATEGORY.QUADS}:${ranks.join(",")}`,
+    };
+  }
+
+  if (ranksByCount[3].length) {
+    const tripRank = ranksByCount[3][0];
+    const pairRank = ranksByCount[2].find((rank) => rank !== tripRank) || ranksByCount[3][1];
+    if (pairRank) {
+      const tripCards = cardsByRank.get(tripRank).slice(0, 3);
+      const pairCards = cardsByRank.get(pairRank).slice(0, 2);
+      const ranks = [tripRank, pairRank];
+      return {
+        category: HAND_CATEGORY.FULL_HOUSE,
+        name: CATEGORY_NAME[HAND_CATEGORY.FULL_HOUSE],
+        ranks,
+        best5: [...tripCards, ...pairCards].map((c) => c.raw),
+        key: `${HAND_CATEGORY.FULL_HOUSE}:${ranks.join(",")}`,
+      };
+    }
+  }
+
+  let bestFlush = null;
+  suitNames.forEach((suit) => {
+    const suited = cardsBySuit.get(suit);
+    if (suited.length < 5) return;
+    const top = suited.slice(0, 5);
+    const ranks = top.map((c) => c.rank);
+    if (!bestFlush) {
+      bestFlush = { suit, ranks, cards: top };
+      return;
+    }
+    const cmp = compareRankVectors(ranks, bestFlush.ranks);
+    if (cmp > 0) {
+      bestFlush = { suit, ranks, cards: top };
+      return;
+    }
+    if (cmp === 0 && suit.localeCompare(bestFlush.suit) < 0) {
+      bestFlush = { suit, ranks, cards: top };
+    }
+  });
+
+  if (bestFlush) {
+    return {
+      category: HAND_CATEGORY.FLUSH,
+      name: CATEGORY_NAME[HAND_CATEGORY.FLUSH],
+      ranks: bestFlush.ranks,
+      best5: bestFlush.cards.map((c) => c.raw),
+      key: `${HAND_CATEGORY.FLUSH}:${bestFlush.ranks.join(",")}`,
+    };
+  }
+
+  const straight = findStraight(uniqueRanksDesc);
+  if (straight) {
+    const ranks = [straight.high === 1 ? 5 : straight.high];
+    const best5 = pickStraightCards(straight.ranks, cardsByRank);
+    return {
+      category: HAND_CATEGORY.STRAIGHT,
+      name: CATEGORY_NAME[HAND_CATEGORY.STRAIGHT],
+      ranks,
+      best5: best5.map((c) => c.raw),
+      key: `${HAND_CATEGORY.STRAIGHT}:${ranks.join(",")}`,
+    };
+  }
+
+  if (ranksByCount[3].length) {
+    const tripRank = ranksByCount[3][0];
+    const tripCards = cardsByRank.get(tripRank).slice(0, 3);
+    const kickers = allCardsSorted.filter((card) => card.rank !== tripRank).slice(0, 2);
+    const ranks = [tripRank, ...kickers.map((c) => c.rank)];
+    return {
+      category: HAND_CATEGORY.TRIPS,
+      name: CATEGORY_NAME[HAND_CATEGORY.TRIPS],
+      ranks,
+      best5: [...tripCards, ...kickers].map((c) => c.raw),
+      key: `${HAND_CATEGORY.TRIPS}:${ranks.join(",")}`,
+    };
+  }
+
+  if (ranksByCount[2].length >= 2) {
+    const highPair = ranksByCount[2][0];
+    const lowPair = ranksByCount[2][1];
+    const highPairCards = cardsByRank.get(highPair).slice(0, 2);
+    const lowPairCards = cardsByRank.get(lowPair).slice(0, 2);
+    const kicker = allCardsSorted.find((card) => card.rank !== highPair && card.rank !== lowPair);
+    const ranks = [highPair, lowPair, kicker.rank];
+    return {
+      category: HAND_CATEGORY.TWO_PAIR,
+      name: CATEGORY_NAME[HAND_CATEGORY.TWO_PAIR],
+      ranks,
+      best5: [...highPairCards, ...lowPairCards, kicker].map((c) => c.raw),
+      key: `${HAND_CATEGORY.TWO_PAIR}:${ranks.join(",")}`,
+    };
+  }
+
+  if (ranksByCount[2].length) {
+    const pairRank = ranksByCount[2][0];
+    const pairCards = cardsByRank.get(pairRank).slice(0, 2);
+    const kickers = allCardsSorted.filter((card) => card.rank !== pairRank).slice(0, 3);
+    const ranks = [pairRank, ...kickers.map((c) => c.rank)];
+    return {
+      category: HAND_CATEGORY.PAIR,
+      name: CATEGORY_NAME[HAND_CATEGORY.PAIR],
+      ranks,
+      best5: [...pairCards, ...kickers].map((c) => c.raw),
+      key: `${HAND_CATEGORY.PAIR}:${ranks.join(",")}`,
+    };
+  }
+
+  const bestHigh = allCardsSorted.slice(0, 5);
+  const ranks = bestHigh.map((c) => c.rank);
+  return {
+    category: HAND_CATEGORY.HIGH_CARD,
+    name: CATEGORY_NAME[HAND_CATEGORY.HIGH_CARD],
+    ranks,
+    best5: bestHigh.map((c) => c.raw),
+    key: `${HAND_CATEGORY.HIGH_CARD}:${ranks.join(",")}`,
+  };
+};
+
+const compareHands = (a, b) => {
+  if (a.category !== b.category) return a.category > b.category ? 1 : -1;
+  return compareRankVectors(a.ranks, b.ranks);
+};
+
+export { HAND_CATEGORY, evaluateBestHand, compareHands };

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -31,6 +31,7 @@ run("node", ["tests/secureStorage.test.mjs"], "secure-storage");
 run("node", ["tests/favorites-service.test.mjs"], "favorites-service");
 run("node", ["tests/poker-phase1.test.mjs"], "poker-phase1");
 run("node", ["tests/poker-engine.test.mjs"], "poker-engine");
+run("node", ["tests/poker-eval.test.mjs"], "poker-eval");
 run("node", ["tests/poker-contract.phase1.test.mjs"], "poker-contract-phase1");
 run("node", ["tests/poker-db-lockdown.contract.test.mjs"], "poker-db-lockdown");
 run("node", ["tests/poker-hole-cards.rls.test.mjs"], "poker-hole-cards-rls");

--- a/tests/poker-eval.test.mjs
+++ b/tests/poker-eval.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import {
+  HAND_CATEGORY,
+  evaluateBestHand,
+  compareHands,
+} from "../netlify/functions/_shared/poker-eval.mjs";
+
+const c = (r, s) => ({ r, s });
+const E = (cards) => evaluateBestHand(cards);
+const cmp = (a, b) => compareHands(E(a), E(b));
+
+const runInvalidInputTests = () => {
+  assert.throws(
+    () => evaluateBestHand([c("A", "S"), c("K", "H"), c("Q", "D"), c("J", "C")]),
+    (err) => err && err.message === "insufficient_cards",
+  );
+  assert.throws(
+    () => evaluateBestHand([c("A", "S"), c("A", "S"), c("Q", "D"), c("J", "C"), c("9", "H")]),
+    (err) => err && err.message === "duplicate_card",
+  );
+  assert.throws(
+    () => evaluateBestHand([c("Z", "S"), c("A", "H"), c("Q", "D"), c("J", "C"), c("9", "H")]),
+    (err) => err && err.message === "invalid_card",
+  );
+  assert.throws(
+    () => evaluateBestHand([c("A", "S"), c("K", null), c("Q", "D"), c("J", "C"), c("9", "H")]),
+    (err) => err && err.message === "invalid_card",
+  );
+};
+
+const runCategoryOrderingTests = () => {
+  const highCard = [c("A", "S"), c("K", "D"), c("Q", "H"), c("9", "C"), c("7", "S"), c("4", "D"), c("2", "H")];
+  const pair = [c("J", "S"), c("J", "D"), c("A", "H"), c("K", "C"), c("9", "S"), c("5", "D"), c("2", "H")];
+  const twoPair = [c("Q", "H"), c("Q", "S"), c("8", "D"), c("8", "S"), c("A", "C"), c("4", "H"), c("2", "D")];
+  const trips = [c("K", "S"), c("K", "H"), c("K", "D"), c("A", "C"), c("9", "S"), c("4", "H"), c("2", "D")];
+  const straight = [c("9", "S"), c("8", "D"), c("7", "H"), c("6", "C"), c("5", "S"), c("A", "D"), c("2", "H")];
+  const flush = [c("A", "S"), c("Q", "S"), c("9", "S"), c("6", "S"), c("3", "S"), c("2", "D"), c("4", "H")];
+  const fullHouse = [c("T", "S"), c("T", "H"), c("T", "D"), c("2", "S"), c("2", "D"), c("9", "C"), c("4", "H")];
+  const quads = [c("9", "S"), c("9", "H"), c("9", "D"), c("9", "C"), c("A", "H"), c("4", "D"), c("2", "S")];
+  const straightFlush = [c("A", "S"), c("K", "S"), c("Q", "S"), c("J", "S"), c("T", "S"), c("2", "D"), c("3", "C")];
+
+  assert.ok(cmp(pair, highCard) > 0);
+  assert.ok(cmp(twoPair, pair) > 0);
+  assert.ok(cmp(trips, twoPair) > 0);
+  assert.ok(cmp(straight, trips) > 0);
+  assert.ok(cmp(flush, straight) > 0);
+  assert.ok(cmp(fullHouse, flush) > 0);
+  assert.ok(cmp(quads, fullHouse) > 0);
+  assert.ok(cmp(straightFlush, quads) > 0);
+};
+
+const runWheelStraightTest = () => {
+  const wheel = [c("A", "S"), c("2", "D"), c("3", "H"), c("4", "C"), c("5", "S"), c("9", "H"), c("K", "D")];
+  const result = E(wheel);
+  assert.equal(result.category, HAND_CATEGORY.STRAIGHT);
+  assert.equal(result.ranks[0], 5);
+};
+
+const runTieTest = () => {
+  const handA = [c("A", "S"), c("K", "S"), c("Q", "S"), c("J", "S"), c("T", "S"), c("2", "D"), c("3", "C")];
+  const handB = [c("A", "H"), c("K", "H"), c("Q", "H"), c("J", "H"), c("T", "H"), c("2", "C"), c("3", "D")];
+  assert.equal(compareHands(E(handA), E(handB)), 0);
+};
+
+const runFlushTieBreakTest = () => {
+  const flushA = [c("A", "S"), c("Q", "S"), c("9", "S"), c("6", "S"), c("3", "S"), c("2", "D"), c("4", "H")];
+  const flushK = [c("K", "H"), c("Q", "H"), c("9", "H"), c("6", "H"), c("3", "H"), c("2", "S"), c("4", "D")];
+  assert.ok(cmp(flushA, flushK) > 0);
+};
+
+runInvalidInputTests();
+runCategoryOrderingTests();
+runWheelStraightTest();
+runTieTest();
+runFlushTieBreakTest();


### PR DESCRIPTION
### Motivation
- Provide a deterministic, dependency-free 7-card Texas Hold’em evaluator so showdown logic can deterministically pick best 5-card hands and be used by reducer/pot settlement.

### Description
- Add `netlify/functions/_shared/poker-eval.mjs` implementing `HAND_CATEGORY`, `evaluateBestHand(cards)` and `compareHands(a,b)` with rank/suit normalization, duplicate/validation checks, and deterministic best-5 selection (including wheel straight and straight-flush detection). 
- Implement exact tie-break rank vectors for all categories (`STRAIGHT_FLUSH`, `QUADS`, `FULL_HOUSE`, `FLUSH`, `STRAIGHT`, `TRIPS`, `TWO_PAIR`, `PAIR`, `HIGH_CARD`) and stable `key` string formatting. 
- Add unit tests in `tests/poker-eval.test.mjs` covering invalid inputs, category ordering, wheel straight, tie handling, and flush tiebreak behavior using `node:assert/strict`. 
- Wire the new test into the aggregate runner by adding a single line to `scripts/test-all.mjs` to run `tests/poker-eval.test.mjs`.

### Testing
- Ran `node tests/poker-eval.test.mjs` and the test file passed successfully. 
- Ran the full suite via `node scripts/test-all.mjs` which completed and reported the `poker-eval` test as passed along with the existing unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697518a33df08323984567009b29b62b)