### PR TITLE
Make state.seats authoritative during action phases and avoid failing on DB presence drift

### DIFF
--- a/netlify/functions/poker-get-table.mjs
+++ b/netlify/functions/poker-get-table.mjs
@@ -119,14 +119,24 @@ export async function handler(event) {
           ? activeSeatRows.map((row) => row?.user_id).filter(Boolean)
           : [];
         const stateSeatUserIds = normalizeSeatUserIds(currentState.seats);
-        if (!hasSameUserIds(activeUserIds, stateSeatUserIds)) {
+        if (stateSeatUserIds.length <= 0) {
           throw new Error("state_invalid");
+        }
+        if (!stateSeatUserIds.includes(auth.userId)) {
+          throw new Error("state_invalid");
+        }
+        if (!hasSameUserIds(activeUserIds, stateSeatUserIds)) {
+          klog("poker_get_table_active_mismatch", {
+            tableId,
+            dbActiveCount: activeUserIds.length,
+            stateCount: stateSeatUserIds.length,
+          });
         }
         try {
           const holeCards = await loadHoleCardsByUserId(tx, {
             tableId,
             handId: currentState.handId,
-            activeUserIds,
+            activeUserIds: stateSeatUserIds,
           });
           myHoleCards = holeCards.holeCardsByUserId[auth.userId] || [];
         } catch (error) {

--- a/tests/poker-get-table.behavior.test.mjs
+++ b/tests/poker-get-table.behavior.test.mjs
@@ -138,14 +138,17 @@ const run = async () => {
   assert.equal(JSON.parse(invalidCardsResponse.body).error, "state_invalid");
 
   const mismatchResponse = await makeHandler([], storedState, "user-1", {
-    activeUserIds: ["user-1", "user-2"],
+    activeUserIds: ["user-1"],
   })({
     httpMethod: "GET",
     headers: { origin: "https://example.test", authorization: "Bearer token" },
     queryStringParameters: { tableId },
   });
-  assert.equal(mismatchResponse.statusCode, 409);
-  assert.equal(JSON.parse(mismatchResponse.body).error, "state_invalid");
+  assert.equal(mismatchResponse.statusCode, 200);
+  const mismatchPayload = JSON.parse(mismatchResponse.body);
+  assert.equal(mismatchPayload.state.state.phase, "PREFLOP");
+  assert.ok(Array.isArray(mismatchPayload.myHoleCards));
+  assert.equal(mismatchPayload.myHoleCards.length, 2);
 
   const initState = {
     ...baseState,


### PR DESCRIPTION
### Motivation
- Prevent 409 `state_invalid` when DB `public.poker_seats.status` flips to `INACTIVE` mid-hand by using the hand's stored `state.seats` as the authoritative participant list during action phases. 
- Keep DB seat rows available for UI/reporting, but avoid letting presence/heartbeat drift break in-flight hands or player actions.

### Description
- `netlify/functions/poker-get-table.mjs`: during action phases, require `state.seats` to be non-empty and include the caller, use `state.seats` as the `activeUserIds` passed to `loadHoleCardsByUserId`, and log mismatches between DB ACTIVE rows and `state.seats` via `klog` instead of throwing `state_invalid`.
- `netlify/functions/poker-act.mjs`: derive seat order from `normalizeSeatOrderFromState(currentState.seats)` and use that ordered list as the authoritative `activeUserIds` for hole-card loading and card derivation, and emit `klog` telemetry on DB vs state mismatches instead of rejecting the action.
- Tests: updated `tests/poker-get-table.behavior.test.mjs` and `tests/poker-act.behavior.test.mjs` to add cases where DB ACTIVE seats are missing/inactive while `state.seats` still contains the hand participants; assertions confirm the endpoints return 200 and do not produce `state_invalid` in these presence-drift scenarios.
- Minimal telemetry added: `poker_get_table_active_mismatch` and `poker_act_active_mismatch` klog events logged when DB active lists differ from state seats.

### Testing
- Ran `node tests/poker-get-table.behavior.test.mjs`, which passed (new mismatch case returns 200 and includes caller hole cards).
- Ran `node tests/poker-act.behavior.test.mjs`; it initially failed due to missing `POKER_DEAL_SECRET`, then passed when run with `POKER_DEAL_SECRET=test-secret` (i.e. `POKER_DEAL_SECRET=test-secret node tests/poker-act.behavior.test.mjs`).
- All modified behavior tests exercise the added scenarios and validate that presence drift no longer causes 409 `state_invalid` during action phases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697761c750608323b5be33a6b4e1a7b2)