### PR TITLE
Reject all-in poker actions with stable 409 and UI message

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -105,6 +105,7 @@
     pokerErrLoadTable: { en: 'Failed to load table', pl: 'Nie udało się załadować stołu' },
     pokerErrJoin: { en: 'Failed to join', pl: 'Nie udało się dołączyć' },
     pokerErrLeave: { en: 'Failed to leave', pl: 'Nie udało się opuścić stołu' },
+    pokerAllInUnsupported: { en: 'All-in is not supported yet. Keep at least 1 chip.', pl: 'All-in nie jest jeszcze obsługiwany. Zostaw co najmniej 1 żeton.' },
     pokerErrJoinPending: { en: 'Join still pending. Please try again.', pl: 'Dołączanie wciąż trwa. Spróbuj ponownie.' },
     pokerErrLeavePending: { en: 'Leave still pending. Please try again.', pl: 'Opuszczanie wciąż trwa. Spróbuj ponownie.' },
     pokerJoinPending: { en: 'Joining...', pl: 'Dołączanie...' },

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -679,15 +679,23 @@
       setPendingState('leave', false);
     }
 
+    function resolveActionErrorMessage(code, message){
+      if (code === 'all_in_unsupported'){
+        return t('pokerAllInUnsupported', 'All-in is not supported yet. Keep at least 1 chip.');
+      }
+      return message;
+    }
+
     function setActionError(action, endpoint, code, message){
-      if (!message) return;
-      setError(errorEl, message);
+      var resolvedMessage = resolveActionErrorMessage(code, message);
+      if (!resolvedMessage) return;
+      setError(errorEl, resolvedMessage);
       persistLastError({
         ts: Date.now(),
         action: action,
         endpoint: endpoint,
         code: code || 'unknown_error',
-        message: message
+        message: resolvedMessage
       });
     }
 

--- a/tests/poker-act.behavior.test.mjs
+++ b/tests/poker-act.behavior.test.mjs
@@ -280,6 +280,19 @@ const run = async () => {
   assert.equal(invalidCall.response.statusCode, 400);
   assert.equal(JSON.parse(invalidCall.response.body).error, "invalid_action");
 
+  const allInState = {
+    ...baseState,
+    stacks: { ...baseState.stacks, "user-1": 10 },
+  };
+  const allInBet = await runCase({
+    state: allInState,
+    action: { type: "BET", amount: 10 },
+    requestId: "req-all-in",
+    userId: "user-1",
+  });
+  assert.equal(allInBet.response.statusCode, 409);
+  assert.equal(JSON.parse(allInBet.response.body).error, "all_in_unsupported");
+
   const corruptCalls = [];
   const corruptState = {
     ...baseState,


### PR DESCRIPTION
### Motivation
- Prevent accidental or unsupported all-in transitions that would trigger reducer side-pot errors and inadvertently advance streets. 
- Provide a predictable, server-authoritative rejection for any action that would reduce a player stack to zero or would trigger side-pot handling. 
- Surface a clear, localized UI message so users know to keep at least 1 chip rather than seeing a generic error.

### Description
- Netlify function `netlify/functions/poker-act.mjs`: added `hasAnyAllIn` helper, a `logAllInUnsupported` klog path, a pre-advance check that rejects actions which would make the actor's stack become `0`, and a try/catch around `advanceIfNeeded` to map reducer errors (`all_in_side_pots_unsupported` or `invalid_state` when any all-in exists) into a stable `409` with `{ "error": "all_in_unsupported" }` while logging `poker_act_rejected` with `code: all_in_unsupported`.
- UI `poker/poker.js`: added an error-to-message resolver and mapped the `all_in_unsupported` code to a friendly message so `setActionError` shows `All-in is not supported yet. Keep at least 1 chip.` instead of a generic toast.
- i18n `js/i18n.js`: added `pokerAllInUnsupported` localized string (English + Polish).
- Tests `tests/poker-act.behavior.test.mjs`: added a behavior test case that attempts a `BET` equal to the user’s stack and asserts the API returns `409` with `{ error: "all_in_unsupported" }`.

### Testing
- Ran the modified behavior test: `node tests/poker-act.behavior.test.mjs` initially failed due to missing secret env (`POKER_DEAL_SECRET`).
- Re-ran with secret: `POKER_DEAL_SECRET=test-secret node tests/poker-act.behavior.test.mjs` and the test suite that includes the new all-in case passed.
- No other automated tests were modified; changes are limited and keep logging via existing `klog` paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c53741848323bb86ddd97f38d628)