### PR TITLE
Add per-turn timer and server auto-timeout (CHECK/FOLD) with UI countdown

### DIFF
--- a/netlify/functions/_shared/poker-turn-timeout.mjs
+++ b/netlify/functions/_shared/poker-turn-timeout.mjs
@@ -1,0 +1,180 @@
+import { deriveCommunityCards } from "./poker-deal-deterministic.mjs";
+import { advanceIfNeeded, applyAction } from "./poker-reducer.mjs";
+import { computeShowdown } from "./poker-showdown.mjs";
+import { isPlainObject } from "./poker-state-utils.mjs";
+
+const ADVANCE_LIMIT = 4;
+
+const isActionPhase = (phase) => phase === "PREFLOP" || phase === "FLOP" || phase === "TURN" || phase === "RIVER";
+
+const normalizeSeatOrderFromState = (seats) => {
+  if (!Array.isArray(seats)) return [];
+  const ordered = seats.slice().sort((a, b) => Number(a?.seatNo ?? 0) - Number(b?.seatNo ?? 0));
+  const out = [];
+  const seen = new Set();
+  for (const seat of ordered) {
+    if (typeof seat?.userId !== "string") continue;
+    const userId = seat.userId.trim();
+    if (!userId) continue;
+    if (seen.has(userId)) return [];
+    seen.add(userId);
+    out.push(userId);
+  }
+  return out;
+};
+
+const allEqualNumbers = (values) => {
+  if (!Array.isArray(values) || values.length === 0) return true;
+  const first = values[0];
+  if (!Number.isFinite(first)) return false;
+  for (let i = 1; i < values.length; i += 1) {
+    if (!Number.isFinite(values[i]) || values[i] !== first) return false;
+  }
+  return true;
+};
+
+const getTimeoutAction = (state) => {
+  if (!state || typeof state !== "object" || Array.isArray(state)) return null;
+  if (!state.turnUserId) return null;
+  const toCall = Number(state.toCallByUserId?.[state.turnUserId] || 0);
+  return { type: toCall > 0 ? "FOLD" : "CHECK", userId: state.turnUserId };
+};
+
+const ensureShowdown = ({ state, seatUserIdsInOrder }) => {
+  if (state.phase !== "SHOWDOWN" || state.showdown) return state;
+  const showdownUserIds = seatUserIdsInOrder.filter(
+    (userId) => typeof userId === "string" && !state.foldedByUserId?.[userId]
+  );
+  if (showdownUserIds.length === 0) {
+    throw new Error("showdown_no_players");
+  }
+
+  let showdownCommunity = Array.isArray(state.community) ? state.community.slice() : [];
+  if (showdownCommunity.length > 5) {
+    throw new Error("showdown_invalid_community");
+  }
+  if (showdownCommunity.length < 5) {
+    showdownCommunity = deriveCommunityCards({
+      handSeed: state.handSeed,
+      seatUserIdsInOrder,
+      communityDealt: 5,
+    });
+  }
+
+  const players = showdownUserIds.map((userId) => {
+    const holeCards = state.holeCardsByUserId?.[userId];
+    if (!Array.isArray(holeCards) || holeCards.length !== 2) {
+      throw new Error("showdown_missing_hole_cards");
+    }
+    return { userId, holeCards };
+  });
+
+  const showdownResult = computeShowdown({ community: showdownCommunity, players });
+  const winners = Array.isArray(showdownResult?.winners) ? showdownResult.winners : [];
+  if (winners.length === 0) {
+    throw new Error("showdown_no_winners");
+  }
+  const winnersInSeatOrder = seatUserIdsInOrder.filter((userId) => winners.includes(userId));
+  if (winnersInSeatOrder.length === 0) {
+    throw new Error("showdown_winners_invalid");
+  }
+
+  const hasSidePots = Array.isArray(state.sidePots) && state.sidePots.length > 0;
+  const contributions = state.contributionsByUserId;
+  const hasUnequalContrib =
+    isPlainObject(contributions) &&
+    showdownUserIds.length > 1 &&
+    !allEqualNumbers(showdownUserIds.map((userId) => Number(contributions[userId])));
+  if (hasSidePots || hasUnequalContrib) {
+    throw new Error("showdown_side_pots_unsupported");
+  }
+
+  const potValue = Number(state.pot ?? 0);
+  if (!Number.isFinite(potValue) || potValue < 0) {
+    throw new Error("showdown_invalid_pot");
+  }
+  const nextStacks = { ...state.stacks };
+  if (potValue > 0) {
+    const share = Math.floor(potValue / winnersInSeatOrder.length);
+    let remainder = potValue - share * winnersInSeatOrder.length;
+    for (const userId of winnersInSeatOrder) {
+      const baseStack = Number(nextStacks[userId] ?? 0);
+      if (!Number.isFinite(baseStack)) {
+        throw new Error("showdown_invalid_stack");
+      }
+      const bonus = remainder > 0 ? 1 : 0;
+      if (remainder > 0) remainder -= 1;
+      nextStacks[userId] = baseStack + share + bonus;
+    }
+  }
+
+  return {
+    ...state,
+    community: showdownCommunity,
+    communityDealt: showdownCommunity.length,
+    stacks: potValue > 0 ? nextStacks : state.stacks,
+    pot: 0,
+    showdown: {
+      winners: winnersInSeatOrder,
+      reason: "computed",
+      potAwarded: potValue,
+      awardedAt: new Date().toISOString(),
+    },
+  };
+};
+
+const maybeApplyTurnTimeout = ({ tableId, state, privateState, nowMs }) => {
+  if (!state || typeof state !== "object" || Array.isArray(state)) return { applied: false, state };
+  if (!isActionPhase(state.phase) || !state.turnUserId) return { applied: false, state };
+  const deadline = Number(state.turnDeadlineAt);
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  if (!Number.isFinite(deadline) || now <= deadline) return { applied: false, state };
+
+  const action = getTimeoutAction(state);
+  if (!action) return { applied: false, state };
+
+  const turnNo = Number.isInteger(state.turnNo) ? state.turnNo : 0;
+  const handId = typeof state.handId === "string" && state.handId.trim() ? state.handId.trim() : "unknown";
+  const requestId = `auto:${tableId}:${handId}:${turnNo}`;
+  const lastByUserId = isPlainObject(state.lastActionRequestIdByUserId) ? state.lastActionRequestIdByUserId : {};
+  if (lastByUserId[action.userId] === requestId) {
+    return { applied: false, state, requestId, replayed: true };
+  }
+
+  const applied = applyAction(privateState, action);
+  let nextState = applied.state;
+  const events = Array.isArray(applied.events) ? applied.events.slice() : [];
+  let loops = 0;
+  while (loops < ADVANCE_LIMIT) {
+    const prevPhase = nextState.phase;
+    const advanced = advanceIfNeeded(nextState);
+    nextState = advanced.state;
+    if (Array.isArray(advanced.events) && advanced.events.length > 0) {
+      events.push(...advanced.events);
+    }
+    if (!Array.isArray(advanced.events) || advanced.events.length === 0) break;
+    if (nextState.phase === prevPhase) break;
+    loops += 1;
+  }
+
+  if (nextState.phase === "SHOWDOWN" && !nextState.showdown) {
+    const seatUserIdsInOrder = normalizeSeatOrderFromState(nextState.seats);
+    if (seatUserIdsInOrder.length === 0) {
+      throw new Error("showdown_no_players");
+    }
+    nextState = ensureShowdown({ state: nextState, seatUserIdsInOrder });
+  }
+
+  const { holeCardsByUserId: _ignoredHoleCards, deck: _ignoredDeck, ...stateBase } = nextState;
+  const updatedState = {
+    ...stateBase,
+    communityDealt: Array.isArray(nextState.community) ? nextState.community.length : 0,
+    lastActionRequestIdByUserId: {
+      ...lastByUserId,
+      [action.userId]: requestId,
+    },
+  };
+  return { applied: true, state: updatedState, events, action, requestId };
+};
+
+export { getTimeoutAction, maybeApplyTurnTimeout, normalizeSeatOrderFromState };

--- a/netlify/functions/poker-start-hand.mjs
+++ b/netlify/functions/poker-start-hand.mjs
@@ -3,6 +3,7 @@ import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySup
 import { isValidTwoCards } from "./_shared/poker-cards-utils.mjs";
 import { dealHoleCards } from "./_shared/poker-engine.mjs";
 import { deriveDeck } from "./_shared/poker-deal-deterministic.mjs";
+import { TURN_MS } from "./_shared/poker-reducer.mjs";
 import {
   getRng,
   isPlainObject,
@@ -325,6 +326,10 @@ export async function handler(event) {
         lastStartHandUserId: auth.userId,
         startedAt: new Date().toISOString(),
       };
+      const nowMs = Date.now();
+      updatedState.turnNo = 1;
+      updatedState.turnStartedAt = nowMs;
+      updatedState.turnDeadlineAt = nowMs + TURN_MS;
 
       if (!isStateStorageValid(updatedState, { requireHandSeed: true, requireCommunityDealt: true, requireNoDeck: true })) {
         klog("poker_state_corrupt", { tableId, phase: updatedState.phase });

--- a/poker/poker.css
+++ b/poker/poker.css
@@ -62,6 +62,8 @@
 
 .poker-info-item strong{color:#e8eeff;}
 
+.poker-turn-timer{font:600 12px Poppins, sans-serif; color:var(--muted); margin-bottom:10px;}
+
 .poker-seats-grid{display:grid; grid-template-columns:repeat(auto-fill, minmax(120px, 1fr)); gap:10px; margin-bottom:16px;}
 
 .poker-seat{background:var(--card-2); border:1px solid var(--border); border-radius:10px; padding:12px; text-align:center;}

--- a/poker/table.html
+++ b/poker/table.html
@@ -80,6 +80,7 @@
 
       <div class="poker-board-panel">
         <div class="poker-phase-label" id="pokerPhaseLabel">Phase: UNKNOWN</div>
+        <div class="poker-turn-timer" id="pokerTurnTimer" aria-live="polite" hidden></div>
         <div id="pokerBoard" class="poker-board" aria-live="polite"></div>
       </div>
 

--- a/tests/helpers/poker-test-helpers.mjs
+++ b/tests/helpers/poker-test-helpers.mjs
@@ -53,8 +53,10 @@ export const loadPokerHandler = (filePath, mocks) => {
     "isPlainObject",
     "isStateStorageValid",
     "klog",
+    "maybeApplyTurnTimeout",
     "normalizeJsonState",
     "normalizeRequestId",
+    "normalizeSeatOrderFromState",
     "postTransaction",
     "shuffle",
     "verifySupabaseJwt",
@@ -66,6 +68,7 @@ export const loadPokerHandler = (filePath, mocks) => {
     "upgradeLegacyInitStateWithSeats",
     "PRESENCE_TTL_SEC",
     "TABLE_EMPTY_CLOSE_SEC",
+    "TURN_MS",
   ];
   const injectedNames = injectable.filter((name) => !declared.has(name));
   const destructureLine = injectedNames.length ? `const { ${injectedNames.join(", ")} } = mocks;` : "";


### PR DESCRIPTION
### Motivation

- Prevent a hand from stalling when the current turn player does not act by adding a per-turn deadline and automatic server fallback action.  
- Ensure server-side enforcement is idempotent and deterministic so retries or concurrent refreshes cannot double-apply timeouts.  
- Give clients a minimal UI indication of remaining turn time to nudge players and surface automatic progress.

### Description

- Add a turn timer and utilities to the reducer in `netlify/functions/_shared/poker-reducer.mjs` (`TURN_MS`, `turnStartedAt`, `turnDeadlineAt`, `turnNo`, `stampTurnTimer`), and stamp/reset timers on hand start, on applyAction, and when advancing streets.  
- Implement a shared timeout helper `netlify/functions/_shared/poker-turn-timeout.mjs` which computes the deterministic auto-action (`CHECK` if `toCall == 0`, otherwise `FOLD`), runs it via reducer logic, advances the hand as needed, and returns an idempotent `requestId` of the form `auto:<tableId>:<handId>:<turnNo>`.  
- Wire opportunistic timeout enforcement into server endpoints: `netlify/functions/poker-act.mjs` now calls `maybeApplyTurnTimeout` before applying a user action, and `netlify/functions/poker-get-table.mjs` similarly attempts to advance timed-out turns when clients poll the table; `netlify/functions/poker-start-hand.mjs` initializes the per-turn timers on hand start.  
- Update UI to show a turn countdown: add element and styles in `poker/table.html` and `poker/poker.css`, and render + tick the countdown in `poker/poker.js` when `turnDeadlineAt` is present.  
- Tests and test helpers updated: add unit checks for timeout-action selection in `tests/poker-reducer.test.mjs`, add a behavior case exercising `poker-get-table` auto-advance in `tests/poker-act.behavior.test.mjs`, and expose/inject new helpers in `tests/helpers/poker-test-helpers.mjs` for deterministic behavior.

### Testing

- Ran reducer unit tests with `node tests/poker-reducer.test.mjs` and they passed (timeout-action helper unit checks included).  
- Ran behavior tests with deterministic deck secret set using `POKER_DEAL_SECRET=test node tests/poker-act.behavior.test.mjs` and they passed; the test suite initially surfaced the missing `POKER_DEAL_SECRET` requirement and succeeded once provided.  
- Captured a UI screenshot of the table page with the new timer displaying, produced as `artifacts/poker-turn-timer.png`.  

Notes: the auto-action is recorded like a normal action (inserted into `public.poker_actions`) and uses a deterministic `requestId` to remain idempotent; no private state is exposed by the changes (private fields continue to be stripped before responses).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d86eff68832396937bf485fa6d85)