### PR TITLE
Add poker side-pot builder utility

### DIFF
--- a/netlify/functions/_shared/poker-side-pots.mjs
+++ b/netlify/functions/_shared/poker-side-pots.mjs
@@ -1,0 +1,49 @@
+const normalizeContribution = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  if (num <= 0) return 0;
+  return Math.floor(num);
+};
+
+const normalizeContributions = ({ contributionsByUserId, eligibleUserIds }) => {
+  if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
+  const source = contributionsByUserId && typeof contributionsByUserId === "object"
+    ? contributionsByUserId
+    : {};
+  return eligibleUserIds.map((userId) => ({
+    userId,
+    contribution: normalizeContribution(source[userId]),
+  }));
+};
+
+const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
+  if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
+  const normalized = normalizeContributions({ contributionsByUserId, eligibleUserIds });
+  const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
+    .sort((a, b) => a - b);
+  if (levels.length === 0) return [];
+  const pots = [];
+  let prev = 0;
+  levels.forEach((level) => {
+    const participants = normalized
+      .filter(({ contribution }) => contribution >= level)
+      .map(({ userId }) => userId);
+    const delta = level - prev;
+    const amount = delta * participants.length;
+    if (amount > 0) {
+      pots.push({
+        amount,
+        eligibleUserIds: participants,
+        minContribution: prev,
+        maxContribution: level,
+      });
+    }
+    prev = level;
+  });
+  return pots;
+};
+
+export {
+  buildSidePots,
+  normalizeContributions,
+};

--- a/tests/poker-side-pots.test.mjs
+++ b/tests/poker-side-pots.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { buildSidePots } from "../netlify/functions/_shared/poker-side-pots.mjs";
+
+const runEmptyInputTest = () => {
+  assert.deepEqual(buildSidePots({ contributionsByUserId: {}, eligibleUserIds: [] }), []);
+  assert.deepEqual(buildSidePots({ contributionsByUserId: {}, eligibleUserIds: ["a"] }), []);
+};
+
+const runSinglePlayerTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { a: 50 },
+    eligibleUserIds: ["a"],
+  });
+  assert.deepEqual(pots, [{
+    amount: 50,
+    eligibleUserIds: ["a"],
+    minContribution: 0,
+    maxContribution: 50,
+  }]);
+};
+
+const runEveryoneEqualTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { a: 10, b: 10, c: 10 },
+    eligibleUserIds: ["a", "b", "c"],
+  });
+  assert.deepEqual(pots, [{
+    amount: 30,
+    eligibleUserIds: ["a", "b", "c"],
+    minContribution: 0,
+    maxContribution: 10,
+  }]);
+};
+
+const runTypicalSidePotsTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { A: 100, B: 50, C: 20 },
+    eligibleUserIds: ["A", "B", "C"],
+  });
+  assert.deepEqual(pots, [
+    {
+      amount: 60,
+      eligibleUserIds: ["A", "B", "C"],
+      minContribution: 0,
+      maxContribution: 20,
+    },
+    {
+      amount: 60,
+      eligibleUserIds: ["A", "B"],
+      minContribution: 20,
+      maxContribution: 50,
+    },
+    {
+      amount: 50,
+      eligibleUserIds: ["A"],
+      minContribution: 50,
+      maxContribution: 100,
+    },
+  ]);
+};
+
+const runIgnoreNonEligibleTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { A: 40, B: 10, C: 999 },
+    eligibleUserIds: ["A", "B"],
+  });
+  assert.deepEqual(pots, [
+    {
+      amount: 20,
+      eligibleUserIds: ["A", "B"],
+      minContribution: 0,
+      maxContribution: 10,
+    },
+    {
+      amount: 30,
+      eligibleUserIds: ["A"],
+      minContribution: 10,
+      maxContribution: 40,
+    },
+  ]);
+};
+
+const runStableOrderingTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { A: 100, B: 50, C: 20 },
+    eligibleUserIds: ["B", "A", "C"],
+  });
+  assert.deepEqual(pots, [
+    {
+      amount: 60,
+      eligibleUserIds: ["B", "A", "C"],
+      minContribution: 0,
+      maxContribution: 20,
+    },
+    {
+      amount: 60,
+      eligibleUserIds: ["B", "A"],
+      minContribution: 20,
+      maxContribution: 50,
+    },
+    {
+      amount: 50,
+      eligibleUserIds: ["A"],
+      minContribution: 50,
+      maxContribution: 100,
+    },
+  ]);
+};
+
+const runInvalidContributionsTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { A: "10", B: Number.NaN, C: -5, D: 4.9 },
+    eligibleUserIds: ["A", "B", "C", "D"],
+  });
+  assert.deepEqual(pots, [
+    {
+      amount: 8,
+      eligibleUserIds: ["A", "D"],
+      minContribution: 0,
+      maxContribution: 4,
+    },
+    {
+      amount: 6,
+      eligibleUserIds: ["A"],
+      minContribution: 4,
+      maxContribution: 10,
+    },
+  ]);
+};
+
+runEmptyInputTest();
+runSinglePlayerTest();
+runEveryoneEqualTest();
+runTypicalSidePotsTest();
+runIgnoreNonEligibleTest();
+runStableOrderingTest();
+runInvalidContributionsTest();


### PR DESCRIPTION
### Motivation
- Provide a small, engine-only utility to convert per-player contributions into an ordered list of main pot + side pots so later payout logic can consume deterministic pot layers. 
- Normalize messy contribution inputs (strings, NaN, negatives, floats) to a safe integer policy so callers don't need to pre-validate. 
- Keep the change isolated to a single shared helper and its unit tests with no schema, reducer, or UI changes. 
- Breaking impact: none.

### Description
- Add `netlify/functions/_shared/poker-side-pots.mjs` which exports `buildSidePots` and `normalizeContributions` and implements the specified layering algorithm. 
- Normalization policy is `Number(value)` → clamp negatives to `0` → `Math.floor` positive values, treating non-finite numbers as `0`. 
- `buildSidePots({ contributionsByUserId, eligibleUserIds })` only considers `eligibleUserIds`, validates `eligibleUserIds` as a non-empty array (otherwise returns `[]`), builds sorted distinct positive contribution levels, and emits pots with `amount`, `eligibleUserIds` (stable order), `minContribution`, and `maxContribution`. 
- Add unit tests `tests/poker-side-pots.test.mjs` covering empty/invalid input, single-player, equal stacks, typical side pots, ignoring non-eligible users, stable ordering, and invalid contribution normalization.

### Testing
- Ran the new test file with `node tests/poker-side-pots.test.mjs` and all tests passed. 
- No new runtime dependencies were added and the helper is deterministic and order-stable as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979e1213f488323b9b39e3474ab5851)