### PR TITLE
Enable All-In + Side Pots (MVP, deterministic, server-authoritative)

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -105,7 +105,6 @@
     pokerErrLoadTable: { en: 'Failed to load table', pl: 'Nie udało się załadować stołu' },
     pokerErrJoin: { en: 'Failed to join', pl: 'Nie udało się dołączyć' },
     pokerErrLeave: { en: 'Failed to leave', pl: 'Nie udało się opuścić stołu' },
-    pokerAllInUnsupported: { en: 'All-in is not supported yet. Keep at least 1 chip.', pl: 'All-in nie jest jeszcze obsługiwany. Zostaw co najmniej 1 żeton.' },
     pokerErrJoinPending: { en: 'Join still pending. Please try again.', pl: 'Dołączanie wciąż trwa. Spróbuj ponownie.' },
     pokerErrLeavePending: { en: 'Leave still pending. Please try again.', pl: 'Opuszczanie wciąż trwa. Spróbuj ponownie.' },
     pokerJoinPending: { en: 'Joining...', pl: 'Dołączanie...' },

--- a/netlify/functions/_shared/poker-payout.mjs
+++ b/netlify/functions/_shared/poker-payout.mjs
@@ -65,6 +65,9 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
   if (!pots && isPlainObject(state.contributionsByUserId)) {
     pots = buildSidePots({ contributionsByUserId: state.contributionsByUserId, eligibleUserIds: showdownUserIds })
       .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
+    if (pots.length === 0) {
+      pots = null;
+    }
   }
   if (!pots) {
     pots = [{ amount: normalizePotAmount(state.pot ?? 0), eligibleUserIds: showdownUserIds.slice() }];

--- a/netlify/functions/_shared/poker-state-utils.mjs
+++ b/netlify/functions/_shared/poker-state-utils.mjs
@@ -50,6 +50,29 @@ const validateCardsArray = (cards, options = {}) => {
 
 const validateNoDuplicates = (keys) => new Set(keys).size === keys.length;
 
+const isValidContributionMap = (value) => {
+  if (value == null) return true;
+  if (!isPlainObject(value)) return false;
+  for (const amount of Object.values(value)) {
+    const num = Number(amount);
+    if (!Number.isFinite(num) || num < 0) return false;
+  }
+  return true;
+};
+
+const isValidSidePots = (value) => {
+  if (value == null) return true;
+  if (!Array.isArray(value)) return false;
+  for (const pot of value) {
+    if (!isPlainObject(pot)) return false;
+    const amount = Number(pot.amount);
+    if (!Number.isFinite(amount) || amount < 0) return false;
+    if (!Array.isArray(pot.eligibleUserIds)) return false;
+    if (pot.eligibleUserIds.some((userId) => typeof userId !== "string" || !userId.trim())) return false;
+  }
+  return true;
+};
+
 const normalizeJsonState = (value) => {
   if (!value) return {};
   if (typeof value === "string") {
@@ -252,6 +275,8 @@ const isStateStorageValid = (state, options = {}) => {
   if (holeCardKeys.length > 0 && deckKeys.length > 0) {
     if (holeCardKeys.some((key) => deckKeys.includes(key))) return false;
   }
+  if (!isValidContributionMap(state.contributionsByUserId)) return false;
+  if (!isValidSidePots(state.sidePots)) return false;
   return true;
 };
 

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -681,23 +681,15 @@
       setPendingState('leave', false);
     }
 
-    function resolveActionErrorMessage(code, message){
-      if (code === 'all_in_unsupported'){
-        return t('pokerAllInUnsupported', 'All-in is not supported yet. Keep at least 1 chip.');
-      }
-      return message;
-    }
-
     function setActionError(action, endpoint, code, message){
-      var resolvedMessage = resolveActionErrorMessage(code, message);
-      if (!resolvedMessage) return;
-      setError(errorEl, resolvedMessage);
+      if (!message) return;
+      setError(errorEl, message);
       persistLastError({
         ts: Date.now(),
         action: action,
         endpoint: endpoint,
         code: code || 'unknown_error',
-        message: resolvedMessage
+        message: message
       });
     }
 


### PR DESCRIPTION
### Motivation
- Allow players to go all-in and support deterministic showdown payouts (side-pots derived from contributions) instead of rejecting stack-zero actions with `all_in_unsupported`.
- Keep server-authoritative dealing/hole-cards and deterministic community progression while making round-completion ignore all-in players.
- Preserve existing betting/raise rules (min-raise, integer amounts) and avoid introducing new dependencies.

### Description
- Update `netlify/functions/_shared/poker-reducer.mjs` to track `contributionsByUserId`, derive `allInByUserId` from stacks, return no legal actions for `stack === 0`, increment contributions on `CALL`/`BET`/`RAISE`, and auto-advance remaining streets to `SHOWDOWN` when eligible players are all-in (no more betting players) instead of throwing `all_in_side_pots_unsupported`.
- Remove server-side blocking mapping in `netlify/functions/poker-act.mjs` that turned all-in reducer errors into 409 `all_in_unsupported`, letting reducer/payout logic handle progression and payout.
- Add validation for `contributionsByUserId` and optional `sidePots` in `netlify/functions/_shared/poker-state-utils.mjs` and make `netlify/functions/_shared/poker-payout.mjs` fall back to the main `pot` when computed side-pot list is empty.
- Remove the dead i18n string and client mapping for `all_in_unsupported` by updating `js/i18n.js` and `poker/poker.js` so the UI no longer shows the old “All-in not supported” message.
- Extend and update tests: `tests/poker-reducer.test.mjs` now checks that all-in calls are allowed, contributions increment, round completion ignores all-in players, and advance to showdown proceeds; `tests/poker-act.behavior.test.mjs` updated to expect 200 for all-in bets and added timeout→showdown coverage.

### Testing
- Ran `node tests/poker-reducer.test.mjs` and the suite completed successfully.
- Ran `node tests/poker-act.behavior.test.mjs` with environment variable set using `POKER_DEAL_SECRET=test-secret` and it passed; running it without `POKER_DEAL_SECRET` fails due to deterministic-deal secret being required (test environment requirement).
- Verified the updated behavior by exercising key scenarios in the behavior tests: all-in bet/call accepted, `contributionsByUserId` updated, auto-advance to `SHOWDOWN`, and `awardPotsAtShowdown` payouts succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f12a24a88323a340ba7e9d07ebc7)