### PR TITLE
ci(poker): nightly poker tests

### DIFF
--- a/.github/workflows/nightly-poker.yml
+++ b/.github/workflows/nightly-poker.yml
@@ -5,6 +5,9 @@ on:
     - cron: "17 2 * * *" # 02:17 UTC daily
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-poker
   cancel-in-progress: true


### PR DESCRIPTION
Adds nightly GitHub Actions workflow running poker pentests and E2E scenarios against Supabase.