### PR TITLE
ci(poker): fix nightly e2e deps

### DIFF
--- a/.github/workflows/nightly-poker.yml
+++ b/.github/workflows/nightly-poker.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Install supabase-js for E2E scripts
+        run: npm i --no-save @supabase/supabase-js
+
       - name: Unit tests (fast)
         run: npm test --silent
         env:


### PR DESCRIPTION
Install @supabase/supabase-js in CI so tools/poker-e2e-termux.mjs runs on GitHub runner.