### PR TITLE
Fix poker e2e GET/HEAD body handling

### DIFF
--- a/tools/_shared/poker-e2e-http.mjs
+++ b/tools/_shared/poker-e2e-http.mjs
@@ -93,17 +93,19 @@ const fetchJson = async (url, options = {}, { label, tries = DEFAULT_TRIES, time
 
 const api = async ({ base, origin, method, path, token, body, label, timeoutMs, tries } = {}) => {
   const url = new URL(path, base).toString();
+  const methodUpper = String(method ?? "GET").toUpperCase();
+  const allowBody = methodUpper !== "GET" && methodUpper !== "HEAD";
+  const hasBody = allowBody && body !== undefined;
   const headers = {
     origin,
   };
   if (typeof token === "string" && token.trim()) headers.authorization = `Bearer ${token}`;
-  if (body !== undefined) headers["content-type"] = "application/json";
+  if (hasBody) headers["content-type"] = "application/json";
 
-  const out = await fetchJson(
-    url,
-    { method, headers, body: body === undefined ? undefined : JSON.stringify(body) },
-    { label, timeoutMs, tries }
-  );
+  const options = { method, headers };
+  if (hasBody) options.body = JSON.stringify(body);
+
+  const out = await fetchJson(url, options, { label, timeoutMs, tries });
 
   return { status: out.res.status, json: out.json, text: out.text };
 };


### PR DESCRIPTION
### Motivation
- Node `fetch` rejects requests with a body for GET/HEAD methods; the poker E2E helper was serializing and sending a body (and `content-type`) even for GET/HEAD, causing CI failures (e.g. `seats-active` polling).

### Description
- Update `tools/_shared/poker-e2e-http.mjs` `api()` to normalize the method, compute `allowBody`/`hasBody`, and only set `options.body` and `content-type` when the method permits a body (GET/HEAD now omit the body entirely); other behavior (headers merging, auth, retries, logging) is preserved.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd551122083239b13f66dc8ab6427)