### PR TITLE
Ensure poker E2E scripts always leave tables (shared cleanup helper)

### DIFF
--- a/tools/poker-e2e-3p-bet-fold-call-flop.mjs
+++ b/tools/poker-e2e-3p-bet-fold-call-flop.mjs
@@ -176,6 +176,7 @@ const run = async () => {
     assertOk(typeof tableId === "string" && tableId.length > 0, "poker-create-table missing tableId");
 
     // 2) join seats (0,1,2)
+    users[0].attempted = true;
     const join1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -184,8 +185,9 @@ const run = async () => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join-u1") },
     });
     assertStatus(join1.status, join1.text, 200, "poker-join u1");
-    users[0].joined = true;
+    if (join1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const join2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",
@@ -194,8 +196,9 @@ const run = async () => {
       body: { tableId, seatNo: 1, buyIn: 100, requestId: requestId("join-u2") },
     });
     assertStatus(join2.status, join2.text, 200, "poker-join u2");
-    users[1].joined = true;
+    if (join2.status === 200) users[1].joined = true;
 
+    users[2].attempted = true;
     const join3 = await callApi({
       label: "join-u3",
       path: "/.netlify/functions/poker-join",
@@ -204,7 +207,7 @@ const run = async () => {
       body: { tableId, seatNo: 2, buyIn: 100, requestId: requestId("join-u3") },
     });
     assertStatus(join3.status, join3.text, 200, "poker-join u3");
-    users[2].joined = true;
+    if (join3.status === 200) users[2].joined = true;
 
     // 3) heartbeats
     await heartbeatOnce("u1", u1Token, tableId);

--- a/tools/poker-e2e-flop-bet-call-turn.mjs
+++ b/tools/poker-e2e-flop-bet-call-turn.mjs
@@ -189,6 +189,7 @@ const run = async () => {
     assertOk(typeof tableId === "string" && tableId.length > 0, "poker-create-table missing tableId");
 
     // 2) join seats
+    users[0].attempted = true;
     const join1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -197,8 +198,9 @@ const run = async () => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join-u1") },
     });
     assertStatus(join1.status, join1.text, 200, "poker-join u1");
-    users[0].joined = true;
+    if (join1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const join2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",
@@ -207,7 +209,7 @@ const run = async () => {
       body: { tableId, seatNo: 1, buyIn: 100, requestId: requestId("join-u2") },
     });
     assertStatus(join2.status, join2.text, 200, "poker-join u2");
-    users[1].joined = true;
+    if (join2.status === 200) users[1].joined = true;
 
     // 3) heartbeats (once + background)
     await heartbeatOnce("u1", u1Token, tableId);

--- a/tools/poker-e2e-flop-check-bet-call-turn.mjs
+++ b/tools/poker-e2e-flop-check-bet-call-turn.mjs
@@ -137,6 +137,7 @@ const assertStatus = (status, text, want, label) => {
     tableId = create.json.tableId;
 
     // join
+    users[0].attempted = true;
     const join1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -145,6 +146,7 @@ const assertStatus = (status, text, want, label) => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join1") },
     });
     users[0].joined = join1.status === 200;
+    users[1].attempted = true;
     const join2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",

--- a/tools/poker-e2e-preflofp-flop-turn.mjs
+++ b/tools/poker-e2e-preflofp-flop-turn.mjs
@@ -160,6 +160,7 @@ const run = async () => {
     assertOk(typeof tableId === "string" && tableId.length > 0, "poker-create-table missing tableId");
 
     // 2) join seats
+    users[0].attempted = true;
     const join1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -168,8 +169,9 @@ const run = async () => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join-u1") },
     });
     assertStatus(join1.status, join1.text, 200, "poker-join u1");
-    users[0].joined = true;
+    if (join1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const join2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",
@@ -178,7 +180,7 @@ const run = async () => {
       body: { tableId, seatNo: 1, buyIn: 100, requestId: requestId("join-u2") },
     });
     assertStatus(join2.status, join2.text, 200, "poker-join u2");
-    users[1].joined = true;
+    if (join2.status === 200) users[1].joined = true;
 
     // 3) heartbeats
     await heartbeatOnce("u1", u1Token, tableId);

--- a/tools/poker-e2e-preflofp-flop.mjs
+++ b/tools/poker-e2e-preflofp-flop.mjs
@@ -140,6 +140,7 @@ const run = async () => {
     assertOk(typeof tableId === "string" && tableId.length > 0, "poker-create-table missing tableId");
 
     // 2) join seats
+    users[0].attempted = true;
     const join1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -148,8 +149,9 @@ const run = async () => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join-u1") },
     });
     assertStatus(join1.status, join1.text, 200, "poker-join u1");
-    users[0].joined = true;
+    if (join1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const join2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",
@@ -158,7 +160,7 @@ const run = async () => {
       body: { tableId, seatNo: 1, buyIn: 100, requestId: requestId("join-u2") },
     });
     assertStatus(join2.status, join2.text, 200, "poker-join u2");
-    users[1].joined = true;
+    if (join2.status === 200) users[1].joined = true;
 
     // 3) heartbeats
     await heartbeatOnce("u1", u1Token, tableId);

--- a/tools/poker-e2e-smoke.mjs
+++ b/tools/poker-e2e-smoke.mjs
@@ -144,6 +144,7 @@ const run = async () => {
     tableId = create.json?.tableId;
     assertOk(typeof tableId === "string" && tableId.length > 0, "poker-create-table missing tableId");
 
+    users[0].attempted = true;
     const joinU1 = await callApi({
       label: "join-u1",
       path: "/.netlify/functions/poker-join",
@@ -152,8 +153,9 @@ const run = async () => {
       body: { tableId, seatNo: 0, buyIn: 100, requestId: requestId("join-u1") },
     });
     assertResponse(joinU1.status, joinU1.text, 200, "poker-join u1");
-    users[0].joined = true;
+    if (joinU1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const joinU2 = await callApi({
       label: "join-u2",
       path: "/.netlify/functions/poker-join",
@@ -162,7 +164,7 @@ const run = async () => {
       body: { tableId, seatNo: 1, buyIn: 100, requestId: requestId("join-u2") },
     });
     assertResponse(joinU2.status, joinU2.text, 200, "poker-join u2");
-    users[1].joined = true;
+    if (joinU2.status === 200) users[1].joined = true;
 
     // Start heartbeat loops (keeps seats alive)
     heartbeatTimers.push(setInterval(() => void heartbeatOnce("u1", u1Token, tableId), HEARTBEAT_MS));

--- a/tools/poker-e2e-termux.mjs
+++ b/tools/poker-e2e-termux.mjs
@@ -123,6 +123,7 @@ async function main() {
     console.log("tableId=", tableId);
 
     // 2) join seat 0 (user1) + seat 1 (user2)
+    users[0].attempted = true;
     const join1 = await apiCall(
       "POST",
       "/.netlify/functions/poker-join",
@@ -132,8 +133,9 @@ async function main() {
     );
     console.log("join1:", join1.status, join1.json || join1.text);
     assertStatus(join1.status, join1.text, 200, "join-u1");
-    users[0].joined = true;
+    if (join1.status === 200) users[0].joined = true;
 
+    users[1].attempted = true;
     const join2 = await apiCall(
       "POST",
       "/.netlify/functions/poker-join",
@@ -143,7 +145,7 @@ async function main() {
     );
     console.log("join2:", join2.status, join2.json || join2.text);
     assertStatus(join2.status, join2.text, 200, "join-u2");
-    users[1].joined = true;
+    if (join2.status === 200) users[1].joined = true;
 
     // 3) heartbeats (once + background)
     await heartbeatOnce("u1", t1);


### PR DESCRIPTION
### Motivation
- Prevent E2E runs from draining test users' chips by ensuring every script attempts to call `poker-leave` for any user who successfully joined, even on failures or crashes.
- Centralise cleanup to avoid duplication and make cleanup best-effort, idempotent, and safe for CI/nightly runs.

### Description
- Add a shared helper `tools/_shared/poker-e2e-cleanup.mjs` that exposes `apiLeave` and `cleanupPokerTable({ baseUrl, origin, tableId, users, timers, klog })`, where `users` is an array of `{ label, token, joined }` and `cleanupPokerTable` clears timers and calls `poker-leave` for joined users while logging failures.
- Update all poker E2E scripts to track joins and use the shared cleanup in a `finally` block so cleanup always runs; changed scripts include `tools/poker-e2e-smoke.mjs`, `tools/poker-e2e-termux.mjs`, `tools/poker-e2e-preflofp-flop.mjs`, `tools/poker-e2e-preflofp-flop-turn.mjs`, `tools/poker-e2e-flop-bet-call-turn.mjs`, `tools/poker-e2e-flop-check-bet-call-turn.mjs`, and `tools/poker-e2e-3p-bet-fold-call-flop.mjs`.
- Implemented best-effort and idempotent semantics: cleanup swallows and logs errors via `klog`/fallback logger, clears `setInterval`/`setTimeout` handles, uses per-user leave calls (`apiLeave`) with unique `requestId`, and does not mask the original test failure (`runError` is rethrown after cleanup).
- Kept existing auth flow (no new secrets), reused the existing `api` wrapper in `tools/_shared/poker-e2e-http.mjs`, and used identical logging conventions (`klog`) to avoid widening auth or logging surfaces.

### Testing
- Automated tests: none were executed as part of this change (no CI/test runs were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c7089fcdc83238621c4c37a1c64a5)