### PR TITLE
Always show Dev Actions panel on table (remove ?dev gating)

### DIFF
--- a/poker/table.html
+++ b/poker/table.html
@@ -68,6 +68,28 @@
       </div>
     </div>
 
+    <div class="poker-panel" id="pokerDevActionsPanel">
+      <h3 data-i18n="pokerDevActionsTitle">Dev Actions</h3>
+      <div class="poker-form-row">
+        <button id="pokerStartHandBtn" class="poker-btn" data-i18n="pokerDevActionsStartHand">Start hand</button>
+        <span id="pokerStartHandStatus" class="poker-inline-status" aria-live="polite" hidden></span>
+      </div>
+      <div class="poker-form-row">
+        <label class="poker-label" for="pokerActType"><span data-i18n="pokerDevActionsActionLabel">Action</span></label>
+        <select id="pokerActType" class="poker-input">
+          <option value="CHECK">CHECK</option>
+          <option value="CALL">CALL</option>
+          <option value="FOLD">FOLD</option>
+          <option value="BET">BET</option>
+          <option value="RAISE">RAISE</option>
+        </select>
+        <label class="poker-label" for="pokerActAmount"><span data-i18n="pokerDevActionsAmountLabel">Amount</span></label>
+        <input type="number" id="pokerActAmount" class="poker-input" min="1" placeholder="0" disabled>
+        <button id="pokerActBtn" class="poker-btn" data-i18n="pokerDevActionsSendAction">Send action</button>
+        <span id="pokerActStatus" class="poker-inline-status" aria-live="polite" hidden></span>
+      </div>
+    </div>
+
     <div id="pokerTableContent" hidden>
       <div class="poker-header">
         <h2><span data-i18n="table">Table</span>: <span id="pokerTableId">-</span></h2>
@@ -99,28 +121,6 @@
           <div id="showdownTotal" class="poker-showdown-body">—</div>
         </div>
         <div id="showdownMeta" class="poker-showdown-meta" hidden></div>
-      </div>
-
-      <div class="poker-panel" id="pokerDevActionsPanel">
-        <h3 data-i18n="pokerDevActionsTitle">Dev Actions</h3>
-        <div class="poker-form-row">
-          <button id="pokerStartHandBtn" class="poker-btn" data-i18n="pokerDevActionsStartHand">Start hand</button>
-          <span id="pokerStartHandStatus" class="poker-inline-status" aria-live="polite" hidden></span>
-        </div>
-        <div class="poker-form-row">
-          <label class="poker-label" for="pokerActType"><span data-i18n="pokerDevActionsActionLabel">Action</span></label>
-          <select id="pokerActType" class="poker-input">
-            <option value="CHECK">CHECK</option>
-            <option value="CALL">CALL</option>
-            <option value="FOLD">FOLD</option>
-            <option value="BET">BET</option>
-            <option value="RAISE">RAISE</option>
-          </select>
-          <label class="poker-label" for="pokerActAmount"><span data-i18n="pokerDevActionsAmountLabel">Amount</span></label>
-          <input type="number" id="pokerActAmount" class="poker-input" min="1" placeholder="0" disabled>
-          <button id="pokerActBtn" class="poker-btn" data-i18n="pokerDevActionsSendAction">Send action</button>
-          <span id="pokerActStatus" class="poker-inline-status" aria-live="polite" hidden></span>
-        </div>
       </div>
 
       <div class="poker-panel">


### PR DESCRIPTION
### Motivation
- Make the Dev Actions panel and its controls always rendered on `/poker/table.html` so dev UI is visible without `?dev=1` while preserving existing auth and server-side safety checks.

### Description
- Move the Dev Actions DOM out of the main `#pokerTableContent` block in `poker/table.html` so the panel remains visible even when table content is hidden.
- Remove the `dev=1` URL flag gating in `poker/poker.js` by deleting `devFlagEnabled` checks and any writes to `devPanel.hidden` so visibility no longer depends on the flag.
- Keep controls disabled unless allowed by current client state by: replacing flag-driven enabling with auth-aware calls to `setDevActionsEnabled(true|false)` and adding `setDevActionsAuthStatus(authed)` to show a sign-in hint inline when unauthenticated.
- Resume `startHand`/`act` pending retry logic on visibility restore regardless of the dev flag (previous flag checks removed) so pending dev requests continue to retry after BFCache/visibility transitions.

### Testing
- Ran the full automated test suite with `npm test`, which completed and reported all unit and poker-related tests passing (including `poker-start-hand-behavior` and `poker-act-behavior`).
- Performed an automated browser smoke check with Playwright that loaded `/poker/table.html?tableId=demo` and verified the `#pokerDevActionsPanel` is visible without `dev=1`, producing a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7b3c80e883239288f3ba0186fc5e)