### PR TITLE
Poker UI: show CALL amount and bet/raise range hints

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -992,7 +992,7 @@
 
     function updateActAmountHint(allowedInfo, selectedType){
       if (!actAmountHintEl) return;
-      if (!allowedInfo || !allowedInfo.needsAmount || !shouldEnableDevActions()){
+      if (!allowedInfo || !allowedInfo.needsAmount || !shouldEnableDevActions() || !selectedType){
         actAmountHintEl.textContent = '';
         actAmountHintEl.hidden = true;
         return;


### PR DESCRIPTION
### Motivation
- Surface server-authoritative action constraints in the dev-actions UI so players see the CALL amount and BET/RAISE limits without changing server logic. 
- Keep the change UI-only, defensive, and minimal to avoid altering payloads or server behavior.

### Description
- Add a single new hint element (`#pokerActAmountHint`) inserted next to `pokerActAmount` and render it only when appropriate to show BET/RAISE constraints derived from `tableData._actionConstraints`.
- Update the CALL button label to show `CALL (<toCall>)` when `CALL` is allowed and `_actionConstraints.toCall` is a finite integer > 0, preserving and restoring the base label otherwise; localization keys used: `pokerCallWithAmount`, `pokerRaiseRange`, `pokerRaiseMin`, `pokerRaiseMax`, `pokerBetMax`.
- All logic is defensive (safe getters, null checks) and UI-only: amount validation and outgoing payloads are unchanged and continue to use existing `getActPayload()` and `_actionConstraints`.

### Testing
- Ran `node scripts/check-lifecycle.js --files` (passed with lifecycle waivers reported). 
- Ran full test suite via `npm test` and unit/poker tests passed (no regressions observed). 
- Quick headless UI snapshot was generated to verify the new hint/button label rendering during a local table page load.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c1135af48323a38d91e60ba18380)