### PR TITLE
Poker: post blinds at start-hand and enforce real min-raise logic

### DIFF
--- a/tests/poker-reducer.test.mjs
+++ b/tests/poker-reducer.test.mjs
@@ -36,6 +36,7 @@ const run = async () => {
     const nextState = {
       ...state,
       toCallByUserId: { ...state.toCallByUserId, [state.turnUserId]: 5 },
+      currentBet: 5,
     };
     const actionsCall = getLegalActions(nextState, state.turnUserId).map((action) => action.type);
     assert.deepEqual(actionsCall, ["FOLD", "CALL", "RAISE"]);
@@ -522,6 +523,7 @@ const run = async () => {
       ...result.state,
       turnUserId: "user-1",
       toCallByUserId: { ...result.state.toCallByUserId, "user-1": 10 },
+      currentBet: 10,
     };
     result = applyAction(state, { type: "CALL", userId: "user-1" });
     state = result.state;

--- a/tests/poker-start-hand.legacy-init-upgrade.test.mjs
+++ b/tests/poker-start-hand.legacy-init-upgrade.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { dealHoleCards } from "../netlify/functions/_shared/poker-engine.mjs";
 import { deriveDeck } from "../netlify/functions/_shared/poker-deal-deterministic.mjs";
 import { buildActionConstraints, computeLegalActions } from "../netlify/functions/_shared/poker-legal-actions.mjs";
+import { TURN_MS } from "../netlify/functions/_shared/poker-reducer.mjs";
 import {
   getRng,
   isPlainObject,
@@ -43,12 +44,13 @@ const makeHandler = (storedState, updates) =>
     withoutPrivateState,
     computeLegalActions,
     buildActionConstraints,
+    TURN_MS,
     beginSql: async (fn) =>
       fn({
         unsafe: async (query, params) => {
           const text = String(query).toLowerCase();
           if (text.includes("from public.poker_tables")) {
-            return [{ id: tableId, status: "OPEN" }];
+            return [{ id: tableId, status: "OPEN", stakes: { sb: 1, bb: 2 } }];
           }
           if (text.includes("from public.poker_state")) {
             return [{ version: 1, state: JSON.parse(storedState.value) }];


### PR DESCRIPTION
### Motivation
- Make the server authoritative for initial betting by auto-posting small/big blinds at hand start and replacing the placeholder min-raise calculation with a real, tracked raise size.
- Ensure action constraints (toCall/minRaiseTo/maxRaiseTo/maxBetAmount) are driven by public state fields so UI only renders server-provided constraints.

### Description
- Post blinds on start-hand and persist blind effects in state and action log by reading `stakes` from `poker_tables`, deducting posted amounts from stacks (short-stack -> post all-in), updating `pot`, `contributionsByUserId`, `betThisRoundByUserId`, `toCallByUserId`, inserting `POST_SB`/`POST_BB` rows, and setting `currentBet`/`lastRaiseSize` and correct preflop turn order (UTG vs heads-up) in `netlify/functions/poker-start-hand.mjs`.
- Introduce `currentBet` and `lastRaiseSize` into hand state and add helpers (`deriveCurrentBet`/`deriveLastRaiseSize`) and `maxFromMap` in `netlify/functions/_shared/poker-reducer.mjs`, update `BET`/`RAISE`/`CALL` handling to update `currentBet`/`lastRaiseSize`, compute `toCall` from `currentBet - userBetThisRound`, and enforce min-raise rules with an all-in exception.
- Replace the placeholder min-raise logic in `netlify/functions/_shared/poker-legal-actions.mjs` so `computeLegalActions` computes `toCall`, `minRaiseTo`, and `maxRaiseTo` from `currentBet`/`lastRaiseSize`/user stacks.
- Validate action amounts in `netlify/functions/poker-act.mjs` against the new constraints (server authoritative), using the same derived `currentBet`/`lastRaiseSize` logic to accept/reject raises (allowing all-in short-raises while rejecting sub-minimum raises).
- Add and extend tests to assert blind posting, heads-up preflop order, `currentBet`/`lastRaiseSize` persistence, actionConstraints content, and illegal raise rejection in `tests/poker-start-hand.behavior.test.mjs`, `tests/poker-act.behavior.test.mjs`, and `tests/poker-reducer.test.mjs`.
- Security/validation: stakes are read from DB (no client-provided blind amounts), all amounts validated as non-negative integers, and private state (hole cards/deck/seed) remains excluded from public responses.

### Testing
- Ran `node scripts/check-lifecycle.js --files` and the lifecycle checks succeeded.
- Ran `npm test` and the full test suite completed successfully with unit and poker behavior tests passing, including `poker-start-hand-behavior`, `poker-start-hand-legacy-init-upgrade`, `poker-act-behavior`, and `poker-reducer`.
- Tests added/updated to assert `actionConstraints` include correct `toCall`/`minRaiseTo`/`maxRaiseTo` and that illegal raises are rejected (these new assertions pass under CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d235d59c8323ac647e01b1305e81)