### PR TITLE
Enable poker RLS + minimal read policies and DB read tests

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -38,6 +38,7 @@ run("node", ["tests/poker-eval.test.mjs"], "poker-eval");
 run("node", ["tests/poker-contract.phase1.test.mjs"], "poker-contract-phase1");
 run("node", ["tests/poker-db-lockdown.contract.test.mjs"], "poker-db-lockdown");
 run("node", ["tests/poker-hole-cards.rls.test.mjs"], "poker-hole-cards-rls");
+run("node", ["tests/poker-rls.read.test.mjs"], "poker-rls-read");
 run("node", ["tests/poker-reducer.test.mjs"], "poker-reducer");
 run("node", ["tests/poker-leave.test.mjs"], "poker-leave");
 run("node", ["tests/poker-join.test.mjs"], "poker-join");

--- a/supabase/migrations/20260117130000_enable_poker_rls.sql
+++ b/supabase/migrations/20260117130000_enable_poker_rls.sql
@@ -1,0 +1,50 @@
+ALTER TABLE public.poker_tables ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poker_seats ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poker_actions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.poker_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "poker_seats_read_own"
+  ON public.poker_seats
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "poker_tables_read_if_seated"
+  ON public.poker_tables
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.poker_seats s
+      WHERE s.table_id = poker_tables.id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "poker_actions_read_if_seated"
+  ON public.poker_actions
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.poker_seats s
+      WHERE s.table_id = poker_actions.table_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "poker_requests_read_if_seated"
+  ON public.poker_requests
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.poker_seats s
+      WHERE s.table_id = poker_requests.table_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.poker_tables FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.poker_seats FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.poker_actions FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE ON TABLE public.poker_requests FROM anon, authenticated;

--- a/tests/poker-rls.read.test.mjs
+++ b/tests/poker-rls.read.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import postgres from "postgres";
+
+const dbUrl = process.env.POKER_RLS_TEST_DB_URL;
+
+if (!dbUrl) {
+  process.stdout.write("Skipping poker RLS read tests: POKER_RLS_TEST_DB_URL not set.\n");
+  process.exit(0);
+}
+
+const migrationsDir = path.join(process.cwd(), "supabase", "migrations");
+const migrationFiles = fs.readdirSync(migrationsDir);
+
+function findMigration(label, match) {
+  const matches = migrationFiles.filter((file) => file.includes(match));
+  assert.equal(
+    matches.length,
+    1,
+    `${label} expected exactly 1 migration matching "${match}", got ${matches.length}: ${matches.join(", ")}`
+  );
+  return path.join(migrationsDir, matches[0]);
+}
+
+const pokerTablesMigration = findMigration("poker_tables", "poker_tables");
+const pokerPhase1Migration = findMigration("poker_phase1", "poker_phase1_authoritative_seats");
+const pokerRlsMigration = findMigration("poker_rls", "enable_poker_rls");
+
+const sql = postgres(dbUrl, { max: 1 });
+
+const runMigration = async (file) => {
+  const content = fs.readFileSync(file, "utf8");
+  await sql.unsafe(content);
+};
+
+const ensureRole = async (role) => {
+  await sql.unsafe(`DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
+    CREATE ROLE ${role};
+  END IF;
+END $$;`);
+};
+
+try {
+  await sql.unsafe("DROP SCHEMA IF EXISTS public CASCADE;");
+  await sql.unsafe("CREATE SCHEMA public;");
+  await sql.unsafe("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";");
+  await sql.unsafe("CREATE SCHEMA IF NOT EXISTS auth;");
+  await sql.unsafe(`
+    CREATE OR REPLACE FUNCTION auth.uid()
+    RETURNS uuid
+    LANGUAGE sql
+    STABLE
+    AS $$
+      SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid;
+    $$;
+  `);
+  await ensureRole("anon");
+  await ensureRole("authenticated");
+  await sql.unsafe("GRANT USAGE ON SCHEMA public TO anon, authenticated;");
+  await sql.unsafe("GRANT USAGE ON SCHEMA auth TO anon, authenticated;");
+  await sql.unsafe("GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated;");
+
+  await runMigration(pokerTablesMigration);
+  await runMigration(pokerPhase1Migration);
+  await runMigration(pokerRlsMigration);
+
+  await sql.unsafe(
+    "GRANT SELECT ON TABLE public.poker_tables, public.poker_seats, public.poker_actions, public.poker_requests TO anon, authenticated;"
+  );
+
+  const tableA = "11111111-1111-1111-1111-111111111111";
+  const tableB = "22222222-2222-2222-2222-222222222222";
+  const userWithSeat = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const otherUser = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  const userWithoutSeat = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+  await sql`
+    insert into public.poker_tables (id, stakes, max_players, status, created_by)
+    values (${tableA}, '{}'::jsonb, 6, 'OPEN', ${userWithSeat}),
+           (${tableB}, '{}'::jsonb, 6, 'OPEN', ${otherUser});
+  `;
+
+  await sql`
+    insert into public.poker_seats (table_id, user_id, seat_no, status)
+    values (${tableA}, ${userWithSeat}, 1, 'ACTIVE'),
+           (${tableB}, ${otherUser}, 1, 'ACTIVE');
+  `;
+
+  await sql.unsafe("SET ROLE authenticated;");
+  await sql.unsafe(`SELECT set_config('request.jwt.claim.sub', '${userWithSeat}', true);`);
+  const seatedRows = await sql`select id from public.poker_tables order by id;`;
+  assert.deepEqual(
+    seatedRows.map((row) => row.id),
+    [tableA],
+    "authenticated user with seat should only read their table"
+  );
+
+  await sql.unsafe(`SELECT set_config('request.jwt.claim.sub', '${userWithoutSeat}', true);`);
+  const noSeatRows = await sql`select id from public.poker_tables;`;
+  assert.equal(noSeatRows.length, 0, "authenticated user without seat should not read tables");
+
+  await sql.unsafe("RESET ROLE;");
+  await sql.unsafe("SET ROLE anon;");
+  await sql.unsafe("SELECT set_config('request.jwt.claim.sub', '', true);");
+  const anonRows = await sql`select id from public.poker_tables;`;
+  assert.equal(anonRows.length, 0, "anon users should not read tables");
+} finally {
+  await sql.unsafe("RESET ROLE;");
+  await sql.end({ timeout: 5 });
+}


### PR DESCRIPTION
### Motivation
- Harden poker realtime surface by enabling Row Level Security (RLS) on poker tables so client-side Supabase realtime reads only expose rows to seated users.
- Ensure unauthenticated and unseated users cannot read poker tables, seats, actions, or requests while keeping all writes server-authoritative via Netlify functions/service role.
- Provide a minimal, DB-backed test that verifies seated vs unseated read visibility to prevent regressions and satisfy linter/contract checks.

### Description
- Added `supabase/migrations/20260117130000_enable_poker_rls.sql` which enables RLS on `public.poker_tables`, `public.poker_seats`, `public.poker_actions`, and `public.poker_requests`, creates select policies (`poker_seats_read_own`, `poker_tables_read_if_seated`, `poker_actions_read_if_seated`, `poker_requests_read_if_seated`), and explicitly revokes `INSERT/UPDATE/DELETE` from `anon` and `authenticated` to make client writes explicit deny. 
- Added a new test `tests/poker-rls.read.test.mjs` that installs the relevant migrations into a test DB and asserts that an authenticated user with a seat can read their table, an authenticated user without a seat cannot, and anon cannot read tables by simulating `auth.uid()` via `request.jwt.claim.sub` session config. 
- Wired the new test into the runner by updating `scripts/test-all.mjs` to run `tests/poker-rls.read.test.mjs` as `poker-rls-read`.

### Testing
- Ran `node tests/poker-rls.read.test.mjs` locally which printed: `Skipping poker RLS read tests: POKER_RLS_TEST_DB_URL not set.` and exited (test is guarded and skipped when no test DB URL is present). 
- Confirmed the new migration file and test were added and included in the main test runner via `scripts/test-all.mjs`; no functional/gameplay code was changed. 
- Note: when run against a configured test DB (set `POKER_RLS_TEST_DB_URL`), the test exercises migrations and RLS behavior and is expected to pass (was not executed here due to missing DB URL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833cb219e883239ba9b04cb6bea59c)