### PR TITLE
Fix idempotency scoping for poker JOIN/LEAVE/HEARTBEAT

### DIFF
--- a/netlify/functions/poker-join.mjs
+++ b/netlify/functions/poker-join.mjs
@@ -58,9 +58,6 @@ const parseSeats = (value) => (Array.isArray(value) ? value : []);
 
 const parseStacks = (value) => (value && typeof value === "object" && !Array.isArray(value) ? value : {});
 
-const JOIN_REQUEST_READ_SQL =
-  "select result_json, created_at from public.poker_requests where table_id = $1 and user_id = $2 and request_id = $3 and kind = $4 limit 1; /* table_id = $1 and request_id = $2 */";
-
 export async function handler(event) {
   const origin = event.headers?.origin || event.headers?.Origin;
   const cors = corsHeaders(origin);
@@ -140,7 +137,6 @@ export async function handler(event) {
         requestId,
         kind: "JOIN",
         pendingStaleSec: REQUEST_PENDING_STALE_SEC,
-        readSql: JOIN_REQUEST_READ_SQL,
       });
       if (requestInfo.status === "stored") return requestInfo.result;
       if (requestInfo.status === "pending") return { ok: false, pending: true, requestId };
@@ -356,6 +352,14 @@ values ($1, $2, $3, 'ACTIVE', now(), now(), $4);
         throw error;
       }
     });
+
+    if (result?.pending) {
+      return {
+        statusCode: 202,
+        headers: cors,
+        body: JSON.stringify({ error: "request_pending", requestId: result.requestId || requestId }),
+      };
+    }
 
     return {
       statusCode: 200,

--- a/netlify/functions/poker-leave.mjs
+++ b/netlify/functions/poker-leave.mjs
@@ -43,9 +43,6 @@ const parseSeats = (value) => (Array.isArray(value) ? value : []);
 
 const parseStacks = (value) => (value && typeof value === "object" && !Array.isArray(value) ? value : {});
 
-const LEAVE_REQUEST_READ_SQL =
-  "select result_json, created_at from public.poker_requests where table_id = $1 and user_id = $2 and request_id = $3 and kind = $4 limit 1; /* table_id = $1 and request_id = $2 */";
-
 const normalizeSeatStack = (value) => {
   if (value == null) return null;
   const num = Number(value);
@@ -133,7 +130,6 @@ export async function handler(event) {
         requestId,
         kind: "LEAVE",
         pendingStaleSec: REQUEST_PENDING_STALE_SEC,
-        readSql: LEAVE_REQUEST_READ_SQL,
       });
       if (requestInfo.status === "stored") return requestInfo.result;
       if (requestInfo.status === "pending") return { ok: false, pending: true, requestId };
@@ -297,6 +293,14 @@ export async function handler(event) {
         throw error;
       }
     });
+
+    if (result?.pending) {
+      return {
+        statusCode: 202,
+        headers: cors,
+        body: JSON.stringify({ error: "request_pending", requestId: result.requestId || requestId }),
+      };
+    }
 
     return {
       statusCode: 200,

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -45,6 +45,8 @@ run("node", ["tests/poker-join.test.mjs"], "poker-join");
 run("node", ["tests/poker-sweep.test.mjs"], "poker-sweep");
 run("node", ["tests/poker-invariants.test.mjs"], "poker-invariants");
 run("node", ["tests/poker-leave.behavior.test.mjs"], "poker-leave-behavior");
+run("node", ["tests/poker-join.behavior.test.mjs"], "poker-join-behavior");
+run("node", ["tests/poker-heartbeat.behavior.test.mjs"], "poker-heartbeat-behavior");
 run("node", ["tests/poker-start-hand.behavior.test.mjs"], "poker-start-hand-behavior");
 run("node", ["tests/poker-start-hand.legacy-init-upgrade.test.mjs"], "poker-start-hand-legacy-init-upgrade");
 run("node", ["tests/poker-act.behavior.test.mjs"], "poker-act-behavior");

--- a/tests/helpers/poker-test-helpers.mjs
+++ b/tests/helpers/poker-test-helpers.mjs
@@ -81,6 +81,7 @@ export const loadPokerHandler = (filePath, mocks) => {
     "upgradeLegacyInitState",
     "upgradeLegacyInitStateWithSeats",
     "PRESENCE_TTL_SEC",
+    "HEARTBEAT_INTERVAL_SEC",
     "storePokerRequestResult",
     "TABLE_EMPTY_CLOSE_SEC",
     "TURN_MS",

--- a/tests/poker-heartbeat.behavior.test.mjs
+++ b/tests/poker-heartbeat.behavior.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
+
+const tableId = "11111111-1111-4111-8111-111111111111";
+const userId = "user-heartbeat";
+
+const makeHeartbeatHandler = ({ requestStore, queries, sideEffects, failStoreResult = false }) =>
+  loadPokerHandler("netlify/functions/poker-heartbeat.mjs", {
+    baseHeaders: () => ({}),
+    corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
+    extractBearerToken: () => "token",
+    verifySupabaseJwt: async () => ({ valid: true, userId }),
+    isValidUuid: () => true,
+    normalizeRequestId: (value) => ({ ok: true, value: value ?? null }),
+    beginSql: async (fn) =>
+      fn({
+        unsafe: async (query, params) => {
+          queries.push({ query: String(query), params });
+          const text = String(query).toLowerCase();
+          if (text.includes("from public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            const entry = requestStore.get(key);
+            if (!entry) return [];
+            return [{ result_json: entry.resultJson, created_at: entry.createdAt }];
+          }
+          if (text.includes("insert into public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            if (requestStore.has(key)) return [];
+            requestStore.set(key, { resultJson: null, createdAt: new Date().toISOString() });
+            return [{ request_id: params?.[2] }];
+          }
+          if (text.includes("update public.poker_requests")) {
+            if (failStoreResult) throw new Error("store_failed");
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            const entry = requestStore.get(key) || { createdAt: new Date().toISOString() };
+            entry.resultJson = params?.[4] ?? null;
+            requestStore.set(key, entry);
+            return [{ request_id: params?.[2] }];
+          }
+          if (text.includes("delete from public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            requestStore.delete(key);
+            return [];
+          }
+          if (text.includes("from public.poker_tables where id = $1")) {
+            return [{ status: "OPEN" }];
+          }
+          if (text.includes("from public.poker_seats where table_id = $1 and user_id = $2")) {
+            return [{ seat_no: 3 }];
+          }
+          if (text.includes("update public.poker_seats set status = 'active'")) {
+            sideEffects.seatTouch += 1;
+            return [];
+          }
+          if (text.includes("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1")) {
+            sideEffects.tableTouch += 1;
+            return [];
+          }
+          return [];
+        },
+      }),
+    klog: () => {},
+  });
+
+const callHeartbeat = (handler, requestId) =>
+  handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ tableId, requestId }),
+  });
+
+const run = async () => {
+  const requestStore = new Map();
+  const queries = [];
+  const sideEffects = { seatTouch: 0, tableTouch: 0 };
+  const handler = makeHeartbeatHandler({ requestStore, queries, sideEffects });
+
+  const first = await callHeartbeat(handler, "hb-1");
+  assert.equal(first.statusCode, 200);
+  const firstBody = JSON.parse(first.body);
+  assert.equal(firstBody.ok, true);
+  assert.equal(sideEffects.seatTouch, 1);
+  assert.equal(sideEffects.tableTouch, 1);
+
+  const second = await callHeartbeat(handler, "hb-1");
+  assert.equal(second.statusCode, 200);
+  assert.deepEqual(JSON.parse(second.body), firstBody);
+  assert.equal(sideEffects.seatTouch, 1, "replayed heartbeat should not rerun seat touch");
+  assert.equal(sideEffects.tableTouch, 1, "replayed heartbeat should not rerun table touch");
+  assert.ok(
+    queries.some((q) =>
+      q.query.toLowerCase().includes("from public.poker_requests where table_id = $1 and user_id = $2 and request_id = $3 and kind = $4")
+    ),
+    "heartbeat should scope poker_requests reads by table/user/request/kind"
+  );
+
+  const pendingStore = new Map();
+  const pendingEffects = { seatTouch: 0, tableTouch: 0 };
+  const failingStoreHandler = makeHeartbeatHandler({
+    requestStore: pendingStore,
+    queries: [],
+    sideEffects: pendingEffects,
+    failStoreResult: true,
+  });
+  const failed = await callHeartbeat(failingStoreHandler, "hb-pending");
+  assert.equal(failed.statusCode, 500);
+  assert.equal(pendingEffects.seatTouch, 1);
+  assert.equal(pendingEffects.tableTouch, 1);
+
+  const retry = await callHeartbeat(
+    makeHeartbeatHandler({ requestStore: pendingStore, queries: [], sideEffects: pendingEffects }),
+    "hb-pending"
+  );
+  assert.equal(retry.statusCode, 202);
+  assert.deepEqual(JSON.parse(retry.body), { error: "request_pending", requestId: "hb-pending" });
+  assert.equal(pendingEffects.seatTouch, 1, "pending heartbeat should not rerun seat touch");
+  assert.equal(pendingEffects.tableTouch, 1, "pending heartbeat should not rerun table touch");
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/poker-join.behavior.test.mjs
+++ b/tests/poker-join.behavior.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
+import { updatePokerStateOptimistic } from "../netlify/functions/_shared/poker-state-write.mjs";
+
+const tableId = "11111111-1111-4111-8111-111111111111";
+const userId = "user-join";
+
+const makeJoinHandler = ({ requestStore, queries, sideEffects, failStoreResult = false }) =>
+  loadPokerHandler("netlify/functions/poker-join.mjs", {
+    baseHeaders: () => ({}),
+    corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
+    extractBearerToken: () => "token",
+    verifySupabaseJwt: async () => ({ valid: true, userId }),
+    isValidUuid: () => true,
+    normalizeRequestId: (value) => ({ ok: true, value: value ?? null }),
+    updatePokerStateOptimistic,
+    beginSql: async (fn) =>
+      fn({
+        unsafe: async (query, params) => {
+          queries.push({ query: String(query), params });
+          const text = String(query).toLowerCase();
+          if (text.includes("from public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            const entry = requestStore.get(key);
+            if (!entry) return [];
+            return [{ result_json: entry.resultJson, created_at: entry.createdAt }];
+          }
+          if (text.includes("insert into public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            if (requestStore.has(key)) return [];
+            requestStore.set(key, { resultJson: null, createdAt: new Date().toISOString() });
+            return [{ request_id: params?.[2] }];
+          }
+          if (text.includes("update public.poker_requests")) {
+            if (failStoreResult) throw new Error("store_failed");
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            const entry = requestStore.get(key) || { createdAt: new Date().toISOString() };
+            entry.resultJson = params?.[4] ?? null;
+            requestStore.set(key, entry);
+            return [{ request_id: params?.[2] }];
+          }
+          if (text.includes("delete from public.poker_requests")) {
+            const key = `${params?.[0]}|${params?.[1]}|${params?.[2]}|${params?.[3]}`;
+            requestStore.delete(key);
+            return [];
+          }
+          if (text.includes("from public.poker_tables")) {
+            return [{ id: tableId, status: "OPEN", max_players: 6 }];
+          }
+          if (text.includes("from public.poker_seats") && text.includes("user_id = $2") && text.includes("limit 1")) {
+            return [];
+          }
+          if (text.includes("insert into public.poker_seats")) {
+            sideEffects.seatInsert += 1;
+            return [];
+          }
+          if (text.includes("from public.chips_accounts")) {
+            return [{ id: "escrow-1" }];
+          }
+          if (text.includes("from public.poker_state") && text.includes("for update")) {
+            return [{ version: 1, state: JSON.stringify({ tableId, seats: [], stacks: {}, pot: 0, phase: "INIT" }) }];
+          }
+          if (text.includes("update public.poker_state") && text.includes("version = version + 1")) {
+            return [{ version: 2 }];
+          }
+          if (text.includes("update public.poker_tables")) {
+            return [];
+          }
+          return [];
+        },
+      }),
+    postTransaction: async () => {
+      sideEffects.ledger += 1;
+      return { transaction: { id: "tx-join" } };
+    },
+    klog: () => {},
+    HEARTBEAT_INTERVAL_SEC: 15,
+  });
+
+const callJoin = (handler, requestId) =>
+  handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ tableId, seatNo: 2, buyIn: 100, requestId }),
+  });
+
+const run = async () => {
+  const requestStore = new Map();
+  const queries = [];
+  const sideEffects = { seatInsert: 0, ledger: 0 };
+  const handler = makeJoinHandler({ requestStore, queries, sideEffects });
+
+  const first = await callJoin(handler, "join-1");
+  assert.equal(first.statusCode, 200);
+  const firstBody = JSON.parse(first.body);
+  assert.equal(firstBody.ok, true);
+  assert.equal(sideEffects.seatInsert, 1);
+  assert.equal(sideEffects.ledger, 1);
+
+  const second = await callJoin(handler, "join-1");
+  assert.equal(second.statusCode, 200);
+  assert.deepEqual(JSON.parse(second.body), firstBody);
+  assert.equal(sideEffects.seatInsert, 1, "replayed join should not re-run seat insert");
+  assert.equal(sideEffects.ledger, 1, "replayed join should not re-run ledger tx");
+  assert.ok(
+    queries.some((q) =>
+      q.query.toLowerCase().includes("from public.poker_requests where table_id = $1 and user_id = $2 and request_id = $3 and kind = $4")
+    ),
+    "join should scope poker_requests reads by table/user/request/kind"
+  );
+
+  const pendingStore = new Map();
+  const pendingQueries = [];
+  const pendingSideEffects = { seatInsert: 0, ledger: 0 };
+  const failingStoreHandler = makeJoinHandler({
+    requestStore: pendingStore,
+    queries: pendingQueries,
+    sideEffects: pendingSideEffects,
+    failStoreResult: true,
+  });
+
+  const failed = await callJoin(failingStoreHandler, "join-pending");
+  assert.equal(failed.statusCode, 500);
+  assert.equal(pendingSideEffects.seatInsert, 1);
+  assert.equal(pendingSideEffects.ledger, 1);
+
+  const retry = await callJoin(makeJoinHandler({ requestStore: pendingStore, queries: [], sideEffects: pendingSideEffects }), "join-pending");
+  assert.equal(retry.statusCode, 202);
+  assert.deepEqual(JSON.parse(retry.body), { error: "request_pending", requestId: "join-pending" });
+  assert.equal(pendingSideEffects.seatInsert, 1, "pending join should not re-run seat insert");
+  assert.equal(pendingSideEffects.ledger, 1, "pending join should not re-run ledger tx");
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- The DB migration changed the uniqueness on `public.poker_requests` to scope by `table_id, kind, request_id, user_id`, but JOIN/LEAVE/HEARTBEAT still used the old `(table_id, request_id)` patterns and could fail after the migration.
- Handlers must adopt the shared idempotency flow (pending/stale/replay/result) used by newer endpoints so replays, pending states and partial failures behave consistently.

### Description
- Updated `netlify/functions/poker-join.mjs`, `netlify/functions/poker-leave.mjs`, and `netlify/functions/poker-heartbeat.mjs` to use the shared helper flow (`ensurePokerRequest`, `storePokerRequestResult`, `deletePokerRequest`) and the `kind` + `user_id` scoping instead of endpoint-local SQL constants.
- Removed per-endpoint raw idempotency read-SQL constants and aligned logic to the helper which reads/inserts/updates/deletes with `table_id, user_id, request_id, kind` and uses `on conflict (table_id, kind, request_id, user_id)`.
- Added mutation-aware cleanup/retention semantics and pending handling: delete idempotency row on non-mutating failures, retain row and log when mutation occurred then store result on success, and return `202 { error: "request_pending", requestId }` when a request is still pending.
- Tests updated and expanded: `tests/poker-phase1.test.mjs` updated to assert helper-based scoping and no legacy `(table_id, request_id)` conflict, behavior tests added for join/heartbeat and expanded for leave, `tests/helpers/poker-test-helpers.mjs` injected `HEARTBEAT_INTERVAL_SEC`, and `scripts/test-all.mjs` wired the new behavior tests.

### Testing
- Ran the focused suites and behavior tests: `node tests/poker-phase1.test.mjs`, `node tests/poker-leave.behavior.test.mjs`, `node tests/poker-join.behavior.test.mjs`, `node tests/poker-heartbeat.behavior.test.mjs` and they passed locally.
- Ran full test runner with `npm test` and all automated tests passed locally.
- New/updated tests: `tests/poker-join.behavior.test.mjs`, `tests/poker-heartbeat.behavior.test.mjs`, updated `tests/poker-leave.behavior.test.mjs` and `tests/poker-phase1.test.mjs` to cover idempotent replay, pending semantics and SQL scoping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846e69a9c48323b56a6bb63e48a41b)