### PR TITLE
Make LEAVE cashout use authoritative poker_state stacks

### DIFF
--- a/tests/poker-leave.behavior.test.mjs
+++ b/tests/poker-leave.behavior.test.mjs
@@ -5,7 +5,7 @@ import { updatePokerStateOptimistic } from "../netlify/functions/_shared/poker-s
 const tableId = "11111111-1111-4111-8111-111111111111";
 const userId = "user-1";
 
-const mockTx = (seatStack) => ({
+const mockTx = (seatStack, stateStack = undefined) => ({
   unsafe: async (query, params) => {
     const text = String(query).toLowerCase();
     if (text.includes("from public.poker_tables")) {
@@ -21,7 +21,10 @@ const mockTx = (seatStack) => ({
           state: JSON.stringify({
             tableId,
             seats: [{ userId, seatNo: 1 }],
-            stacks: { "someone-else": 123 },
+            stacks:
+              stateStack === undefined
+                ? { "someone-else": 123 }
+                : { "someone-else": 123, [userId]: stateStack },
             pot: 0,
           }),
         },
@@ -64,7 +67,7 @@ const mockConflictTx = (seatStack) => ({
   },
 });
 
-const makeHandler = (seatStack, postCalls, queries) =>
+const makeHandler = (seatStack, postCalls, queries, stateStack = undefined) =>
   loadPokerHandler("netlify/functions/poker-leave.mjs", {
     baseHeaders: () => ({}),
     corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
@@ -74,7 +77,7 @@ const makeHandler = (seatStack, postCalls, queries) =>
     normalizeRequestId: () => ({ ok: true, value: null }),
     updatePokerStateOptimistic,
     beginSql: async (fn) => {
-      const tx = mockTx(seatStack);
+      const tx = mockTx(seatStack, stateStack);
       return fn({
         unsafe: async (query, params) => {
           queries.push({ query: String(query), params });
@@ -89,7 +92,7 @@ const makeHandler = (seatStack, postCalls, queries) =>
     klog: () => {},
   });
 
-const makeHandlerWithRequests = (seatStack, postCalls, queries, requestStore) =>
+const makeHandlerWithRequests = (seatStack, postCalls, queries, requestStore, stateStack = undefined) =>
   loadPokerHandler("netlify/functions/poker-leave.mjs", {
     baseHeaders: () => ({}),
     corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
@@ -99,7 +102,7 @@ const makeHandlerWithRequests = (seatStack, postCalls, queries, requestStore) =>
     normalizeRequestId: (value) => ({ ok: true, value: value ?? null }),
     updatePokerStateOptimistic,
     beginSql: async (fn) => {
-      const tx = mockTx(seatStack);
+      const tx = mockTx(seatStack, stateStack);
       return fn({
         unsafe: async (query, params) => {
           queries.push({ query: String(query), params });
@@ -139,6 +142,60 @@ const makeHandlerWithRequests = (seatStack, postCalls, queries, requestStore) =>
     klog: () => {},
   });
 
+
+
+const makeStatefulHandler = (seatStack, stateStack, postCalls, queries) => {
+  const db = {
+    seatPresent: true,
+    version: 1,
+    state: {
+      tableId,
+      seats: [{ userId, seatNo: 1 }],
+      stacks: { "someone-else": 123, [userId]: stateStack },
+      pot: 0,
+    },
+  };
+
+  return loadPokerHandler("netlify/functions/poker-leave.mjs", {
+    baseHeaders: () => ({}),
+    corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
+    extractBearerToken: () => "token",
+    verifySupabaseJwt: async () => ({ valid: true, userId }),
+    isValidUuid: () => true,
+    normalizeRequestId: () => ({ ok: true, value: null }),
+    updatePokerStateOptimistic,
+    beginSql: async (fn) => {
+      return fn({
+        unsafe: async (query, params) => {
+          queries.push({ query: String(query), params });
+          const text = String(query).toLowerCase();
+          if (text.includes("from public.poker_tables")) return [{ id: tableId, status: "OPEN" }];
+          if (text.includes("from public.poker_state")) {
+            return [{ version: db.version, state: JSON.stringify(db.state) }];
+          }
+          if (text.includes("from public.poker_seats") && text.includes("for update")) {
+            return db.seatPresent ? [{ seat_no: 1, status: "ACTIVE", stack: seatStack }] : [];
+          }
+          if (text.includes("update public.poker_state") && text.includes("version = version + 1")) {
+            db.version += 1;
+            db.state = JSON.parse(params?.[2] || "{}");
+            return [{ version: db.version }];
+          }
+          if (text.includes("delete from public.poker_seats")) {
+            db.seatPresent = false;
+            return [];
+          }
+          return [];
+        },
+      });
+    },
+    postTransaction: async (payload) => {
+      postCalls.push(payload);
+      return { transaction: { id: "tx-1" } };
+    },
+    klog: () => {},
+  });
+};
 const run = async () => {
   const postCalls = [];
   const queries = [];
@@ -188,6 +245,35 @@ const run = async () => {
     "leave should delete poker_seats row when stack is negative"
   );
 
+  const authoritativeCalls = [];
+  const authoritativeQueries = [];
+  const authoritativeHandler = makeHandler(100, authoritativeCalls, authoritativeQueries, 124);
+  const authoritativeResponse = await authoritativeHandler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ tableId }),
+  });
+  assert.equal(authoritativeResponse.statusCode, 200);
+  const authoritativeBody = JSON.parse(authoritativeResponse.body);
+  assert.equal(authoritativeBody.ok, true);
+  assert.equal(authoritativeBody.cashedOut, 124, "leave should cash out authoritative poker_state stack");
+  assert.equal(authoritativeCalls.length, 1, "leave should execute one ledger transaction");
+  assert.equal(authoritativeCalls[0]?.entries?.[1]?.amount, 124, "ledger credit should match state stack");
+  const authoritativeStateUpdate = authoritativeQueries.find((q) =>
+    q.query.toLowerCase().includes("update public.poker_state set version = version + 1")
+  );
+  assert.ok(authoritativeStateUpdate, "leave should update poker_state for authoritative stack cashout");
+  const authoritativeUpdatedState = JSON.parse(authoritativeStateUpdate.params?.[2] || "{}");
+  assert.ok(
+    !authoritativeUpdatedState.seats?.some((seat) => seat?.userId === userId),
+    "authoritative cashout should remove user from seats"
+  );
+  assert.equal(
+    authoritativeUpdatedState.stacks?.[userId],
+    undefined,
+    "authoritative cashout should remove user stack from state"
+  );
+
   const repeatCalls = [];
   const repeatQueries = [];
   const repeatHandler = makeHandler(null, repeatCalls, repeatQueries);
@@ -219,6 +305,27 @@ const run = async () => {
   assert.equal(second.statusCode, 200);
   assert.deepEqual(JSON.parse(second.body), firstBody);
   assert.equal(idempotentCalls.length, 1, "replayed leave should not execute cashout side effect twice");
+
+  const nonIdempotentCalls = [];
+  const nonIdempotentQueries = [];
+  const nonIdempotentHandler = makeStatefulHandler(100, 124, nonIdempotentCalls, nonIdempotentQueries);
+  const nonIdempotentFirst = await nonIdempotentHandler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ tableId }),
+  });
+  assert.equal(nonIdempotentFirst.statusCode, 200);
+  assert.equal(nonIdempotentCalls.length, 1, "first non-idempotent leave should cash out once");
+  const nonIdempotentSecond = await nonIdempotentHandler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ tableId }),
+  });
+  assert.equal(nonIdempotentSecond.statusCode, 200);
+  assert.equal(nonIdempotentCalls.length, 1, "second non-idempotent leave should not double-credit after state cleanup");
+  const nonIdempotentSecondBody = JSON.parse(nonIdempotentSecond.body);
+  assert.equal(nonIdempotentSecondBody.cashedOut, 0, "second non-idempotent leave should cash out zero when already left");
+
   const requestScopedRead = idempotentQueries.find((q) =>
     q.query.toLowerCase().includes("from public.poker_requests where table_id = $1 and user_id = $2 and request_id = $3 and kind = $4")
   );

--- a/tests/poker-leave.test.mjs
+++ b/tests/poker-leave.test.mjs
@@ -20,8 +20,20 @@ assert.ok(
   "leave should normalize stack from seat row"
 );
 assert.ok(
-  /const cashOutAmount = stackValue != null && stackValue > 0 \? stackValue : 0;/.test(leaveSrc),
-  "leave should clamp cashOutAmount to positive values"
+  /const stateStackRaw = currentState\?\.stacks\?\.\[auth\.userId\];/.test(leaveSrc),
+  "leave should read authoritative stack from poker_state"
+);
+assert.ok(
+  /const stateStack = normalizeNonNegativeInt\(Number\(stateStackRaw\)\);/.test(leaveSrc),
+  "leave should normalize authoritative stack to a non-negative integer"
+);
+assert.ok(
+  /const seatStack = normalizeNonNegativeInt\(Number\(rawSeatStack\)\);/.test(leaveSrc),
+  "leave should normalize seat stack as fallback"
+);
+assert.ok(
+  /const cashOutAmount = stateStack \?\? seatStack \?\? 0;/.test(leaveSrc),
+  "leave should prefer state stack over seat stack and default to 0"
 );
 assert.ok(
   /const isStackMissing = rawSeatStack == null;/.test(leaveSrc),


### PR DESCRIPTION
### Motivation
- Fix a bug where LEAVE credited the user from a potentially stale `poker_seats.stack` instead of the server-authoritative `poker_state.state.stacks[userId]`, causing the ledger `cashout` to disagree with the game result.
- Preserve existing escrow-only ledger semantics (JOIN/LEAVE) and idempotency while ensuring no negative or double credits occur.

### Description
- Added a local helper `normalizeNonNegativeInt` and changed cashout computation to prefer `currentState.stacks[userId]` normalized to a non-negative integer, fall back to the seat stack, then default to `0` (`const cashOutAmount = stateStack ?? seatStack ?? 0`).
- Kept the existing seat-row locking, removed the user from `seats` and deleted `stacks[userId]` in the updated state so repeated LEAVE calls cannot double-credit.
- Added a `stackSource` field to the leave klog to aid debugging and keep `TABLE_CASH_OUT` ledger behavior unchanged (idempotency key preserved).
- Extended tests: updated `tests/poker-leave.behavior.test.mjs` to cover authoritative state vs seat mismatch (e.g. seat=100, state=124) and a stateful non-idempotent fixture proving second LEAVE cashes out `0`; updated static assertions in `tests/poker-leave.test.mjs` to match the new code patterns.

### Testing
- Ran `npm test poker-leave-behavior` and the behavior test suite passed.
- Ran `npm test poker-phase1` and the broader poker phase1 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847d9936708323aee522b62a4222df)