### PR TITLE
Fix bot seeding escrow-only TABLE_BUY_IN userId handling

### DIFF
--- a/netlify/functions/poker-join.mjs
+++ b/netlify/functions/poker-join.mjs
@@ -170,7 +170,7 @@ returning seat_no;
 
     try {
       await postTransaction({
-        userId: botUserId,
+        userId: null,
         txType: "TABLE_BUY_IN",
         idempotencyKey: `bot-seed-buyin:${tableId}:${seatNo}`,
         metadata: {

--- a/tests/poker-join.bot-seed.behavior.test.mjs
+++ b/tests/poker-join.bot-seed.behavior.test.mjs
@@ -180,6 +180,7 @@ const run = async () => {
     const botSeedLedger = ctx.ledgerCalls.filter((entry) => entry.metadata?.reason === "BOT_SEED_BUY_IN");
     assert.equal(botSeedLedger.length, 2);
     for (const ledgerCall of botSeedLedger) {
+      assert.equal(ledgerCall.userId, null);
       assert.equal(Array.isArray(ledgerCall.entries), true);
       assert.equal(ledgerCall.entries.length, 2);
       assert.equal(ledgerCall.entries.filter((entry) => entry.accountType === "USER").length, 0);


### PR DESCRIPTION
### Motivation
- Production bot seeding ledger posts were being rejected as `invalid_escrow_only_entries` because escrow-only `TABLE_BUY_IN` transactions were submitted with the bot's UUID in `userId` instead of `null` which violates the chips-ledger escrow-only rules.

### Description
- Change the bot-seeding `postTransaction` call in `netlify/functions/poker-join.mjs` to send `userId: null` while keeping bot attribution in `metadata` and preserving `createdBy` and idempotency keys, and add a regression assertion in `tests/poker-join.bot-seed.behavior.test.mjs` that verifies `ledgerCall.userId === null` for `BOT_SEED_BUY_IN` calls.

### Testing
- Ran `node tests/poker-join.behavior.test.mjs` and `node tests/poker-join.bot-seed.behavior.test.mjs` locally and both completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f999585f48323b2c3ca03601e57ae)