### PR TITLE
Allow null userId for escrow-only TABLE_BUY_IN in chips ledger and add regression tests

### DIFF
--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -871,12 +871,14 @@ from inserted i;
       throw mismatch;
     }
 
-    const accountRows = await sqlTx`
+    const accountRows = userAccount?.id
+      ? await sqlTx`
       select id, balance, next_entry_seq
       from public.chips_accounts
       where id = ${userAccount.id}
       limit 1;
-    `;
+    `
+      : [];
 
     return {
       transaction: transactionRow,

--- a/tests/chips-ledger.escrow-only.null-user.unit.test.mjs
+++ b/tests/chips-ledger.escrow-only.null-user.unit.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const loadPostTransaction = ({ beginSql, executeSql, klog }) => {
+  const source = fs.readFileSync(path.join(process.cwd(), "netlify/functions/_shared/chips-ledger.mjs"), "utf8");
+  const strippedImports = source.replace(/^\s*import[^;]+;\s*$/gm, "");
+  const rewrittenExports = strippedImports.replace(/export\s*\{[\s\S]*?\};?\s*$/m, "");
+  const factory = new Function("crypto", "beginSql", "executeSql", "klog", `"use strict";\n${rewrittenExports}\nreturn { postTransaction };`);
+  return factory(crypto, beginSql, executeSql, klog).postTransaction;
+};
+
+const run = async () => {
+  const state = {
+    accounts: new Map([
+      ["acct-system", { id: "acct-system", account_type: "SYSTEM", system_key: "TREASURY", status: "active", balance: 10000 }],
+      ["acct-escrow", { id: "acct-escrow", account_type: "ESCROW", system_key: "POKER_TABLE:test", status: "active", balance: 0 }],
+    ]),
+    transactions: [],
+    entries: [],
+    nextTxId: 1,
+    userLookups: 0,
+  };
+
+  const executeSql = async (query, params = []) => {
+    const text = String(query).toLowerCase();
+    if (text.includes("system_key = any")) {
+      const keys = params[0] || [];
+      return [...state.accounts.values()].filter((a) => keys.includes(a.system_key));
+    }
+    if (text.includes("from public.chips_transactions") && text.includes("idempotency_key")) {
+      const existing = state.transactions.find((tx) => tx.idempotency_key === params[0]);
+      return existing ? [existing] : [];
+    }
+    return [];
+  };
+
+  const beginSql = async (fn) => {
+    const sqlTx = async (strings, ...values) => {
+      const text = String(strings).toLowerCase();
+      if (text.includes("insert into public.chips_transactions")) {
+        const row = { id: `tx-${state.nextTxId++}`, tx_type: values[5], user_id: values[6], idempotency_key: values[3] };
+        state.transactions.push(row);
+        return [row];
+      }
+      if (text.includes("where id =")) return [];
+      throw new Error(`Unhandled sql template: ${text}`);
+    };
+    sqlTx.unsafe = async (query, params = []) => {
+      const text = String(query).toLowerCase();
+      if (text.includes("account_type = 'user'") && text.includes("for update")) {
+        state.userLookups += 1;
+        throw new Error("user account lookup should not run for null user");
+      }
+      if (text.includes("apply_balance")) {
+        const records = JSON.parse(params[0]);
+        const deltas = new Map();
+        for (const rec of records) deltas.set(rec.account_id, (deltas.get(rec.account_id) || 0) + Number(rec.amount));
+        for (const [accountId, delta] of deltas.entries()) {
+          const account = state.accounts.get(accountId);
+          account.balance += delta;
+        }
+        return [{ updated_accounts: deltas.size, expected_accounts: deltas.size, guard_ok: true, guard_check: true }];
+      }
+      if (text.includes("insert into public.chips_entries")) {
+        const [transactionId, payload] = params;
+        const inserted = JSON.parse(payload).map((rec, index) => ({ transaction_id: transactionId, account_id: rec.account_id, amount: rec.amount, metadata: rec.metadata || {}, entry_seq: index + 1 }));
+        state.entries.push(...inserted);
+        return [{ entries: inserted }];
+      }
+      throw new Error(`Unhandled sqlTx.unsafe: ${text}`);
+    };
+    return fn(sqlTx);
+  };
+
+  const postTransaction = loadPostTransaction({ beginSql, executeSql, klog: () => {} });
+  const result = await postTransaction({
+    userId: null,
+    txType: "TABLE_BUY_IN",
+    idempotencyKey: "null-user-escrow-only-1",
+    createdBy: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    entries: [
+      { accountType: "SYSTEM", systemKey: "TREASURY", amount: -200 },
+      { accountType: "ESCROW", systemKey: "POKER_TABLE:test", amount: 200 },
+    ],
+  });
+
+  assert.equal(result.transaction.tx_type, "TABLE_BUY_IN");
+  assert.equal(result.transaction.user_id, null);
+  assert.equal(state.userLookups, 0);
+  assert.equal(result.entries.length, 2);
+  assert.deepEqual(result.entries.map((entry) => entry.account_id).sort(), ["acct-escrow", "acct-system"]);
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/chips-ledger.human.buyin.unit.test.mjs
+++ b/tests/chips-ledger.human.buyin.unit.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const loadPostTransaction = ({ beginSql, executeSql, klog }) => {
+  const source = fs.readFileSync(path.join(process.cwd(), "netlify/functions/_shared/chips-ledger.mjs"), "utf8");
+  const strippedImports = source.replace(/^\s*import[^;]+;\s*$/gm, "");
+  const rewrittenExports = strippedImports.replace(/export\s*\{[\s\S]*?\};?\s*$/m, "");
+  const factory = new Function("crypto", "beginSql", "executeSql", "klog", `"use strict";\n${rewrittenExports}\nreturn { postTransaction };`);
+  return factory(crypto, beginSql, executeSql, klog).postTransaction;
+};
+
+const run = async () => {
+  const userId = "11111111-1111-4111-8111-111111111111";
+  const state = {
+    accounts: new Map([
+      ["acct-escrow", { id: "acct-escrow", account_type: "ESCROW", system_key: "POKER_TABLE:test", status: "active", balance: 0 }],
+    ]),
+    userAccountsCreated: 0,
+    nextTxId: 1,
+  };
+
+  const ensureUser = (id) => {
+    const key = `acct-user-${id}`;
+    if (!state.accounts.has(key)) {
+      state.userAccountsCreated += 1;
+      state.accounts.set(key, { id: key, account_type: "USER", user_id: id, status: "active", balance: 500, next_entry_seq: 1 });
+    }
+    return state.accounts.get(key);
+  };
+
+  const executeSql = async (query, params = []) => {
+    const text = String(query).toLowerCase();
+    if (text.includes("system_key = any")) {
+      const keys = params[0] || [];
+      return [...state.accounts.values()].filter((a) => keys.includes(a.system_key));
+    }
+    return [];
+  };
+
+  const beginSql = async (fn) => {
+    const sqlTx = async (strings, ...values) => {
+      const text = String(strings).toLowerCase();
+      if (text.includes("insert into public.chips_transactions")) {
+        return [{ id: `tx-${state.nextTxId++}`, tx_type: values[5], user_id: values[6], idempotency_key: values[3] }];
+      }
+      if (text.includes("where id =")) {
+        const account = state.accounts.get(values[0]);
+        return account ? [{ id: account.id, balance: account.balance, next_entry_seq: account.next_entry_seq || 1 }] : [];
+      }
+      throw new Error(`Unhandled sql template: ${text}`);
+    };
+    sqlTx.unsafe = async (query, params = []) => {
+      const text = String(query).toLowerCase();
+      if (text.includes("account_type = 'user'") && text.includes("for update")) {
+        return [{ account: ensureUser(params[0]) }];
+      }
+      if (text.includes("apply_balance")) {
+        const records = JSON.parse(params[0]);
+        const deltas = new Map();
+        for (const rec of records) deltas.set(rec.account_id, (deltas.get(rec.account_id) || 0) + Number(rec.amount));
+        for (const [accountId, delta] of deltas.entries()) {
+          const account = state.accounts.get(accountId);
+          account.balance += delta;
+        }
+        return [{ updated_accounts: deltas.size, expected_accounts: deltas.size, guard_ok: true, guard_check: true }];
+      }
+      if (text.includes("insert into public.chips_entries")) {
+        const [, payload] = params;
+        const inserted = JSON.parse(payload).map((rec, index) => ({ account_id: rec.account_id, amount: rec.amount, entry_seq: index + 1, metadata: rec.metadata || {} }));
+        return [{ entries: inserted }];
+      }
+      throw new Error(`Unhandled sqlTx.unsafe: ${text}`);
+    };
+    return fn(sqlTx);
+  };
+
+  const postTransaction = loadPostTransaction({ beginSql, executeSql, klog: () => {} });
+  const result = await postTransaction({
+    userId,
+    txType: "TABLE_BUY_IN",
+    idempotencyKey: "human-buyin-1",
+    createdBy: userId,
+    entries: [
+      { accountType: "USER", amount: -100 },
+      { accountType: "ESCROW", systemKey: "POKER_TABLE:test", amount: 100 },
+    ],
+  });
+
+  assert.equal(result.transaction.user_id, userId);
+  assert.equal(state.userAccountsCreated, 1);
+  assert.equal(result.entries.length, 2);
+  assert.equal(result.entries.some((entry) => entry.account_id === `acct-user-${userId}` && entry.amount === -100), true);
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/poker-join.bot-seed.behavior.test.mjs
+++ b/tests/poker-join.bot-seed.behavior.test.mjs
@@ -18,6 +18,7 @@ const makeJoinHandler = ({
 }) => {
   const queries = [];
   const ledgerCalls = [];
+  const logs = [];
   const seats = [];
   const requestStore = existingRequestStore;
   const stateHolder = {
@@ -141,11 +142,11 @@ const makeJoinHandler = ({
       ledgerCalls.push(payload);
       return { transaction: { id: `tx-${ledgerCalls.length}` } };
     },
-    klog: () => {},
+    klog: (event, payload) => { logs.push({ event, payload }); },
     HEARTBEAT_INTERVAL_SEC: 15,
   });
 
-  return { handler, seats, ledgerCalls, stateHolder, queries };
+  return { handler, seats, ledgerCalls, logs, stateHolder, queries };
 };
 
 const callJoin = (handler, requestId = "join-1") =>
@@ -197,6 +198,7 @@ const run = async () => {
         true
       );
     }
+    assert.equal(ctx.logs.some((entry) => entry.event === "poker_join_bot_seed_failed"), false);
   }
 
   {


### PR DESCRIPTION
### Motivation
- Bot seat seeding posts escrow-only `TABLE_BUY_IN` with `userId: null` but `postTransaction` could dereference a null user account and throw `Cannot read properties of null (reading 'id')`.
- The ledger helper must support SYSTEM→ESCROW transactions without any USER legs while preserving idempotency and human buy-in behavior.

### Description
- Guarded the final user account snapshot read in `postTransaction` so the `SELECT ... WHERE id = ${userAccount.id}` only runs when `userAccount?.id` is present, avoiding `.id` dereference on `null` (`netlify/functions/_shared/chips-ledger.mjs`).
- Added a unit test `tests/chips-ledger.escrow-only.null-user.unit.test.mjs` that simulates escrow-only `TABLE_BUY_IN` with `userId: null` and asserts no USER lookup and correct SYSTEM/ESCROW entries.
- Added a unit test `tests/chips-ledger.human.buyin.unit.test.mjs` that verifies normal human `TABLE_BUY_IN` resolves/creates a USER account and posts USER→ESCROW entries unchanged.
- Updated `tests/poker-join.bot-seed.behavior.test.mjs` to capture `klog` events and assert no `poker_join_bot_seed_failed` is emitted during bot seeding.

### Testing
- Ran `node tests/chips-ledger.escrow-only.null-user.unit.test.mjs` which passed and confirms no USER lookup and correct inserted entries.
- Ran `node tests/chips-ledger.human.buyin.unit.test.mjs` which passed and confirms USER resolution and entries for human buy-in.
- Ran `node tests/poker-join.bot-seed.behavior.test.mjs` which passed and confirms bot-seed flows emit no `poker_join_bot_seed_failed` and ledger payloads use `userId: null` as intended.
- Attempted to run the test suite via `npx vitest` but it failed due to `npm` registry permissions (403), so full `vitest`-driven CI was not executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa47b2bfc8323870044f0f8d1e99b)