### PR TITLE
Fix bot-only poker sweep timestamp fallback and add regression test guard

### DIFF
--- a/netlify/functions/poker-sweep.mjs
+++ b/netlify/functions/poker-sweep.mjs
@@ -385,7 +385,7 @@ with bot_only_tables as (
   where t.status = 'OPEN'
     and coalesce(
       (
-        select max(coalesce(hs.last_seen_at, hs.updated_at))
+        select max(coalesce(hs.last_seen_at, hs.joined_at, hs.created_at))
         from public.poker_seats hs
         where hs.table_id = t.id
           and coalesce(hs.is_bot, false) = false

--- a/tests/poker-sweep.close-bot-only-table.behavior.test.mjs
+++ b/tests/poker-sweep.close-bot-only-table.behavior.test.mjs
@@ -161,7 +161,12 @@ const run = async () => {
   const botOnlyCloseQuery = old.queries.find((entry) => entry.text.includes("with bot_only_tables as"));
   assert.ok(botOnlyCloseQuery, "expected bot-only close candidate query");
   assert.equal(botOnlyCloseQuery.text.includes("t.last_activity_at < now()"), false);
-  assert.equal(botOnlyCloseQuery.text.includes("select max(coalesce(hs.last_seen_at, hs.updated_at))\n        from public.poker_seats hs\n        where hs.table_id = t.id\n          and hs.status = 'active'\n          and coalesce(hs.is_bot, false) = false"), false);
+  assert.equal(botOnlyCloseQuery.text.includes("hs.updated_at"), false, "bot-only close query must not reference missing poker_seats.updated_at");
+  assert.equal(
+    botOnlyCloseQuery.text.includes("hs.joined_at") || botOnlyCloseQuery.text.includes("hs.created_at"),
+    true,
+    "bot-only close query should use existing poker_seats timestamps as fallback"
+  );
 
   assertBotCashoutOrdering(old.queries);
 


### PR DESCRIPTION
### Motivation

- The bot-only table closure SQL referenced a non-existent column `hs.updated_at` on `public.poker_seats`, causing Postgres error `42703` and leaving bot-only OPEN tables as zombies. 
- The runtime error prevented the sweep handler from closing bot-only tables while bots remained active. 
- The behavior test suite did not guard against reintroducing the missing-column regression. 

### Description

- Updated the bot-only closure query in `netlify/functions/poker-sweep.mjs` to compute last human activity using only existing seat timestamp columns by replacing `max(coalesce(hs.last_seen_at, hs.updated_at))` with `max(coalesce(hs.last_seen_at, hs.joined_at, hs.created_at))`. 
- Strengthened `tests/poker-sweep.close-bot-only-table.behavior.test.mjs` to assert the captured `bot_only_tables` SQL does not contain `hs.updated_at`. 
- Added a positive assertion in the test that the query includes at least one real fallback timestamp (`hs.joined_at` or `hs.created_at`) so the regression would fail if real columns are removed or `hs.updated_at` is reintroduced. 

### Testing

- Ran the updated behavior test `node tests/poker-sweep.close-bot-only-table.behavior.test.mjs` and it completed successfully (test passed). 
- The test captures generated SQL and confirms absence of `hs.updated_at` and presence of `hs.joined_at`/`hs.created_at` as intended. 
- No other automated test changes were made and no schema or ledger behavior was modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69946791cad48323b782cd50a5ea323a)