### PR TITLE
Add infra VPS Caddy deployment workflow and smoke tests

### DIFF
--- a/.github/workflows/infra-vps.yml
+++ b/.github/workflows/infra-vps.yml
@@ -19,6 +19,8 @@ jobs:
   validate:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/infra-vps.yml
+++ b/.github/workflows/infra-vps.yml
@@ -1,0 +1,248 @@
+name: Infra VPS
+
+on:
+  pull_request:
+    paths:
+      - "infra/vps/**"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "infra/vps/**"
+  workflow_dispatch:
+
+concurrency:
+  group: infra-vps-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate infra VPS structure
+        run: |
+          set -euo pipefail
+          test -f infra/vps/Caddyfile
+
+  apply:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure Caddyfile exists
+        run: |
+          set -euo pipefail
+          test -f infra/vps/Caddyfile
+
+      - name: Upload Caddyfile to VPS temp path
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: infra/vps/Caddyfile
+          target: /tmp/arcadeplatform-infra
+          strip_components: 2
+
+      - name: Backup, validate, reload and smoke-check Caddy config
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -eu
+            if ! command -v bash >/dev/null 2>&1; then
+              echo "bash is required on VPS"
+              exit 1
+            fi
+
+            bash <<'BASH'
+            set -Eeuo pipefail
+            CADDY_PATH="/etc/caddy/Caddyfile"
+            BACKUP_PATH="${CADDY_PATH}.bak.$(date +%Y%m%d%H%M%S)"
+            TMP_PATH="/tmp/arcadeplatform-infra/Caddyfile"
+            HAVE_BACKUP=0
+            APPLIED=0
+            ROLLED_BACK=0
+
+            rollback() {
+              if [ "$HAVE_BACKUP" != "1" ] || [ "$ROLLED_BACK" = "1" ]; then
+                return 0
+              fi
+              ROLLED_BACK=1
+              sudo -n cp "$BACKUP_PATH" "$CADDY_PATH" || true
+              sudo -n systemctl reload caddy || true
+            }
+
+            on_error() {
+              rc=$?
+              if [ "$APPLIED" = "1" ]; then
+                rollback
+              fi
+              exit "$rc"
+            }
+
+            trap 'on_error' ERR
+
+            test -f "$TMP_PATH"
+            sudo -n cp "$CADDY_PATH" "$BACKUP_PATH"
+            sudo -n test -f "$BACKUP_PATH"
+            HAVE_BACKUP=1
+
+            sudo -n cp "$TMP_PATH" "$CADDY_PATH"
+            APPLIED=1
+
+            sudo -n caddy validate --config /etc/caddy/Caddyfile
+            sudo -n systemctl reload caddy
+
+            HEALTHZ_BODY="$(curl -fsS https://ws.kcswh.pl/healthz | tr -d '\r\n')"
+            test "$HEALTHZ_BODY" = "ok"
+
+            if command -v node >/dev/null 2>&1; then
+              timeout 12s node <<'NODE'
+const tls = require('tls');
+const crypto = require('crypto');
+
+const host = 'ws.kcswh.pl';
+const path = '/ws';
+const wsKey = crypto.randomBytes(16).toString('base64');
+const expectedAccept = crypto.createHash('sha1').update(`${wsKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest('base64');
+const helloPayload = JSON.stringify({ version: '1.0', type: 'hello', ts: new Date().toISOString(), payload: { supportedVersions: ['1.0'] } });
+
+function maskedTextFrame(payload) {
+  const data = Buffer.from(payload, 'utf8');
+  const mask = crypto.randomBytes(4);
+  let header;
+  if (data.length < 126) {
+    header = Buffer.from([0x81, 0x80 | data.length]);
+  } else if (data.length < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(data.length, 2);
+  } else {
+    process.exit(1);
+  }
+  const masked = Buffer.alloc(data.length);
+  for (let i = 0; i < data.length; i += 1) masked[i] = data[i] ^ mask[i % 4];
+  return Buffer.concat([header, mask, masked]);
+}
+
+function unmask(payload, mask) {
+  const out = Buffer.alloc(payload.length);
+  for (let i = 0; i < payload.length; i += 1) out[i] = payload[i] ^ mask[i % 4];
+  return out;
+}
+
+const socket = tls.connect({ host, port: 443, servername: host }, () => {
+  const req = [
+    `GET ${path} HTTP/1.1`,
+    `Host: ${host}`,
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Key: ${wsKey}`,
+    'Sec-WebSocket-Version: 13',
+    '',
+    ''
+  ].join('\r\n');
+  socket.write(req);
+});
+
+let done = false;
+let stage = 'handshake';
+let buffer = Buffer.alloc(0);
+const timer = setTimeout(() => finish(1), 5000);
+
+function finish(code) {
+  if (done) return;
+  done = true;
+  clearTimeout(timer);
+  socket.destroy();
+  process.exit(code);
+}
+
+function parseFrames() {
+  while (buffer.length >= 2) {
+    const b1 = buffer[0];
+    const b2 = buffer[1];
+    const opcode = b1 & 0x0f;
+    const masked = (b2 & 0x80) !== 0;
+    let offset = 2;
+    let length = b2 & 0x7f;
+
+    if (length === 126) {
+      if (buffer.length < offset + 2) return;
+      length = buffer.readUInt16BE(offset);
+      offset += 2;
+    } else if (length === 127) {
+      return finish(1);
+    }
+
+    const maskBytes = masked ? 4 : 0;
+    if (buffer.length < offset + maskBytes + length) return;
+    const mask = masked ? buffer.subarray(offset, offset + 4) : null;
+    offset += maskBytes;
+    let payload = buffer.subarray(offset, offset + length);
+    buffer = buffer.subarray(offset + length);
+
+    if (masked && mask) payload = unmask(payload, mask);
+    if (opcode === 0x1) {
+      const msg = payload.toString('utf8');
+      if (msg.includes('"type":"helloAck"')) return finish(0);
+    }
+  }
+}
+
+socket.on('data', (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+
+  if (stage === 'handshake') {
+    const idx = buffer.indexOf('\r\n\r\n');
+    if (idx === -1) return;
+
+    const head = buffer.subarray(0, idx).toString('utf8');
+    const lines = head.split('\r\n');
+    const status = lines[0] || '';
+    const headers = new Map();
+    for (let i = 1; i < lines.length; i += 1) {
+      const pos = lines[i].indexOf(':');
+      if (pos > 0) headers.set(lines[i].slice(0, pos).trim().toLowerCase(), lines[i].slice(pos + 1).trim());
+    }
+
+    if (!status.includes('101')) return finish(1);
+    if ((headers.get('sec-websocket-accept') || '') !== expectedAccept) return finish(1);
+
+    buffer = buffer.subarray(idx + 4);
+    stage = 'frames';
+    socket.write(maskedTextFrame(helloPayload));
+  }
+
+  if (stage === 'frames') parseFrames();
+});
+
+socket.on('error', () => finish(1));
+socket.on('end', () => finish(1));
+NODE
+            else
+              curl -sS -o /dev/null -D - --http1.1 https://ws.kcswh.pl/ws \
+                -H 'Connection: Upgrade' \
+                -H 'Upgrade: websocket' \
+                -H 'Sec-WebSocket-Version: 13' \
+                -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' | grep -q ' 101 '
+            fi
+
+            trap - ERR
+            BASH
+            rc=$?
+            if [ "$rc" != "0" ]; then
+              exit "$rc"
+            fi

--- a/.github/workflows/ws-deploy.yml
+++ b/.github/workflows/ws-deploy.yml
@@ -60,6 +60,21 @@ jobs:
       - name: Run ws tests suite completeness guard
         run: node --test ws-tests/ws-tests-suite-completeness.guard.test.mjs
 
+      - name: Run infra VPS workflow guard test
+        run: node --test ws-tests/infra-vps-workflow.guard.test.mjs
+
+      - name: Run infra VPS smoke-check structure behavior test
+        run: node --test ws-tests/infra-vps-workflow.smokecheck-structure.behavior.test.mjs
+
+      - name: Run infra VPS WS smoke-check deps guard test
+        run: node --test ws-tests/infra-vps-workflow.ws-smokecheck-deps.guard.test.mjs
+
+      - name: Run infra VPS concurrency guard test
+        run: node --test ws-tests/infra-vps-workflow.concurrency.guard.test.mjs
+
+      - name: Run infra VPS bash exit propagation guard test
+        run: node --test ws-tests/infra-vps-workflow.bash-exit-propagation.guard.test.mjs
+
       - name: Run lockfile integrity test
         run: node --test ws-tests/ws-lockfile-integrity.test.mjs
 

--- a/.github/workflows/ws-pr-checks.yml
+++ b/.github/workflows/ws-pr-checks.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Run ws tests suite completeness guard
         run: node --test ws-tests/ws-tests-suite-completeness.guard.test.mjs
 
+      - name: Run infra VPS workflow guard test
+        run: node --test ws-tests/infra-vps-workflow.guard.test.mjs
+
+      - name: Run infra VPS smoke-check structure behavior test
+        run: node --test ws-tests/infra-vps-workflow.smokecheck-structure.behavior.test.mjs
+
+      - name: Run infra VPS WS smoke-check deps guard test
+        run: node --test ws-tests/infra-vps-workflow.ws-smokecheck-deps.guard.test.mjs
+
+      - name: Run infra VPS concurrency guard test
+        run: node --test ws-tests/infra-vps-workflow.concurrency.guard.test.mjs
+
+      - name: Run infra VPS bash exit propagation guard test
+        run: node --test ws-tests/infra-vps-workflow.bash-exit-propagation.guard.test.mjs
+
       - name: Run ws poker protocol doc test
         run: node --test ws-tests/ws-poker-protocol-doc.test.mjs
 

--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -1,0 +1,15 @@
+ws.kcswh.pl {
+  @healthz path /healthz
+  handle @healthz {
+    reverse_proxy 127.0.0.1:3000
+  }
+
+  @ws path /ws*
+  handle @ws {
+    reverse_proxy 127.0.0.1:3000
+  }
+
+  handle {
+    respond "OK" 200
+  }
+}

--- a/ws-tests/infra-vps-workflow.bash-exit-propagation.guard.test.mjs
+++ b/ws-tests/infra-vps-workflow.bash-exit-propagation.guard.test.mjs
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const WORKFLOW_PATH = ".github/workflows/infra-vps.yml";
+
+function workflowText() {
+  return fs.readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+function heredocBounds(text) {
+  const bashStartIndex = text.indexOf("bash <<'BASH'");
+  assert.notEqual(bashStartIndex, -1);
+
+  const lines = text.split("\n");
+  let offset = 0;
+  let startLine = -1;
+  let endLineStart = -1;
+  let endLineEnd = -1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const lineStart = offset;
+    const lineEnd = lineStart + line.length;
+
+    if (startLine === -1 && bashStartIndex >= lineStart && bashStartIndex <= lineEnd) {
+      startLine = i;
+    } else if (startLine !== -1 && i > startLine && line.trim() === "BASH") {
+      endLineStart = lineStart;
+      endLineEnd = lineEnd;
+      break;
+    }
+
+    offset = lineEnd + 1;
+  }
+
+  assert.notEqual(startLine, -1);
+  assert.notEqual(endLineStart, -1);
+  assert.equal(endLineStart > bashStartIndex, true);
+
+  return {
+    bashStartIndex,
+    heredocEndLineStart: endLineStart,
+    heredocEndOffset: endLineEnd
+  };
+}
+
+test("infra VPS workflow POSIX outer fail-fast is set -eu and precedes bash heredoc", () => {
+  const text = workflowText();
+  const outerSetIndex = text.indexOf("set -eu");
+  const bashCheckIndex = text.indexOf("command -v bash >/dev/null 2>&1", outerSetIndex);
+  const bashStartIndex = text.indexOf("bash <<'BASH'", bashCheckIndex);
+
+  assert.notEqual(outerSetIndex, -1);
+  assert.notEqual(bashCheckIndex, -1);
+  assert.notEqual(bashStartIndex, -1);
+  assert.equal(outerSetIndex < bashCheckIndex, true);
+  assert.equal(bashCheckIndex < bashStartIndex, true);
+});
+
+test("infra VPS workflow heredoc boundary is robust and post-heredoc content is outside body", () => {
+  const text = workflowText();
+  const { bashStartIndex, heredocEndLineStart, heredocEndOffset } = heredocBounds(text);
+
+  const overwriteIndex = text.indexOf('sudo -n cp "$TMP_PATH" "$CADDY_PATH"', bashStartIndex);
+  const trapClearIndex = text.indexOf("trap - ERR", bashStartIndex);
+
+  assert.notEqual(overwriteIndex, -1);
+  assert.notEqual(trapClearIndex, -1);
+  assert.equal(overwriteIndex > bashStartIndex, true);
+  assert.equal(overwriteIndex < heredocEndLineStart, true);
+  assert.equal(trapClearIndex > bashStartIndex, true);
+  assert.equal(trapClearIndex < heredocEndLineStart, true);
+
+  const afterTerminator = text.slice(heredocEndOffset, heredocEndOffset + 200);
+  const rcIndex = afterTerminator.indexOf("rc=$?");
+  const exitIndex = afterTerminator.indexOf('exit "$rc"');
+  assert.notEqual(rcIndex, -1);
+  assert.notEqual(exitIndex, -1);
+  assert.equal(rcIndex < exitIndex, true);
+});
+
+test("heredoc bounds ignore incidental BASH token before terminator", () => {
+  const text = workflowText();
+  const marker = "            HAVE_BACKUP=0";
+  const idx = text.indexOf(marker);
+  assert.notEqual(idx, -1);
+
+  const injected = `${text.slice(0, idx)}            console.log("BASH");\n${text.slice(idx)}`;
+  const { bashStartIndex, heredocEndLineStart, heredocEndOffset } = heredocBounds(injected);
+  const injectedIndex = injected.indexOf('console.log("BASH")');
+
+  assert.notEqual(injectedIndex, -1);
+  assert.equal(bashStartIndex < injectedIndex, true);
+  assert.equal(injectedIndex < heredocEndLineStart, true);
+  assert.equal(heredocEndOffset > heredocEndLineStart, true);
+});

--- a/ws-tests/infra-vps-workflow.concurrency.guard.test.mjs
+++ b/ws-tests/infra-vps-workflow.concurrency.guard.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const WORKFLOW_PATH = ".github/workflows/infra-vps.yml";
+
+test("infra VPS workflow has top-level concurrency settings", () => {
+  const text = fs.readFileSync(WORKFLOW_PATH, "utf8");
+  const concurrencyIndex = text.indexOf("concurrency:");
+  const groupIndex = text.indexOf("group:", concurrencyIndex);
+  const cancelIndex = text.indexOf("cancel-in-progress: false", concurrencyIndex);
+  const jobsIndex = text.indexOf("jobs:");
+
+  assert.notEqual(concurrencyIndex, -1);
+  assert.notEqual(groupIndex, -1);
+  assert.notEqual(cancelIndex, -1);
+  assert.notEqual(jobsIndex, -1);
+  assert.equal(concurrencyIndex < jobsIndex, true);
+});

--- a/ws-tests/infra-vps-workflow.guard.test.mjs
+++ b/ws-tests/infra-vps-workflow.guard.test.mjs
@@ -1,0 +1,221 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const WORKFLOW_PATH = ".github/workflows/infra-vps.yml";
+const CADDYFILE_PATH = "infra/vps/Caddyfile";
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function heredocEndOffset(text) {
+  const start = text.indexOf("bash <<'BASH'");
+  if (start === -1) return -1;
+
+  const lines = text.split("\n");
+  let offset = 0;
+  let startLine = -1;
+  let endLine = -1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const lineStart = offset;
+    const lineEnd = lineStart + line.length;
+
+    if (startLine === -1 && start >= lineStart && start <= lineEnd) {
+      startLine = i;
+    } else if (startLine !== -1 && i > startLine && line.trim() === "BASH") {
+      endLine = i;
+      return lineEnd;
+    }
+
+    offset = lineEnd + 1;
+  }
+
+  if (startLine !== -1 && endLine <= startLine) return -1;
+  return -1;
+}
+
+test("infra VPS workflow exists and is scoped to infra/vps path filters", () => {
+  assert.ok(fs.existsSync(WORKFLOW_PATH), `${WORKFLOW_PATH} should exist`);
+
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("pull_request:"));
+  assert.ok(text.includes("push:"));
+  assert.ok(text.includes('"infra/vps/**"'));
+});
+
+test("infra VPS Caddyfile preserves explicit /healthz, /ws*, and root OK routing", () => {
+  const text = read(CADDYFILE_PATH);
+  assert.match(text, /path\s+\/healthz/);
+  assert.match(text, /path\s+\/ws\*/);
+  assert.match(text, /reverse_proxy\s+127\.0\.0\.1:3000/);
+  assert.match(text, /respond\s+"OK"\s+200/);
+});
+
+test("infra VPS workflow uses trap-based rollback after overwrite", () => {
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("trap 'on_error' ERR"));
+  assert.ok(text.includes("HAVE_BACKUP=0"));
+  assert.ok(text.includes("HAVE_BACKUP=1"));
+  assert.ok(text.includes("APPLIED=1"));
+  assert.ok(text.includes("ROLLED_BACK=0"));
+});
+
+
+
+test("infra VPS workflow captures heredoc boundary with whitespace-robust scan", () => {
+  const text = read(WORKFLOW_PATH);
+  const bashStartIndex = text.indexOf("bash <<'BASH'");
+  const bashEndOffset = heredocEndOffset(text);
+
+  assert.notEqual(bashStartIndex, -1);
+  assert.notEqual(bashEndOffset, -1);
+  assert.equal(bashStartIndex < bashEndOffset, true);
+  const afterTerminator = text.slice(bashEndOffset, bashEndOffset + 200);
+  const rcIndex = afterTerminator.indexOf("rc=$?");
+  const exitIndex = afterTerminator.indexOf('exit "$rc"');
+  assert.notEqual(rcIndex, -1);
+  assert.notEqual(exitIndex, -1);
+  assert.equal(rcIndex < exitIndex, true);
+});
+
+
+
+
+test("infra VPS workflow defines infra deploy concurrency guard", () => {
+  const text = read(WORKFLOW_PATH);
+  const concurrencyIndex = text.indexOf("concurrency:");
+  const groupIndex = text.indexOf("group:", concurrencyIndex);
+  const cancelIndex = text.indexOf("cancel-in-progress: false", concurrencyIndex);
+  const jobsIndex = text.indexOf("jobs:");
+
+  assert.notEqual(concurrencyIndex, -1);
+  assert.notEqual(groupIndex, -1);
+  assert.notEqual(cancelIndex, -1);
+  assert.notEqual(jobsIndex, -1);
+  assert.equal(concurrencyIndex < jobsIndex, true);
+});
+
+
+test("infra VPS workflow POSIX outer fail-fast is set -eu before bash invocation", () => {
+  const text = read(WORKFLOW_PATH);
+  const outerSetIndex = text.indexOf("set -eu");
+  const bashCheckIndex = text.indexOf("command -v bash >/dev/null 2>&1");
+
+  assert.notEqual(outerSetIndex, -1);
+  assert.notEqual(bashCheckIndex, -1);
+  assert.equal(outerSetIndex < bashCheckIndex, true);
+});
+
+test("infra VPS workflow explicitly executes remote script with bash", () => {
+  const text = read(WORKFLOW_PATH);
+  const bashCheckIndex = text.indexOf("command -v bash >/dev/null 2>&1");
+  const bashInvokeIndex = text.indexOf("bash <<'BASH'", bashCheckIndex);
+  const overwriteIndex = text.indexOf('sudo -n cp "$TMP_PATH" "$CADDY_PATH"', bashInvokeIndex);
+
+  assert.notEqual(bashCheckIndex, -1);
+  assert.notEqual(bashInvokeIndex, -1);
+  assert.notEqual(overwriteIndex, -1);
+  assert.equal(bashCheckIndex < bashInvokeIndex, true);
+  assert.equal(bashInvokeIndex < overwriteIndex, true);
+});
+
+test("infra VPS workflow uses non-interactive sudo", () => {
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("sudo -n caddy validate"));
+  assert.ok(text.includes("sudo -n systemctl reload caddy"));
+  assert.equal(text.includes("sudo caddy validate"), false);
+  assert.equal(text.includes("sudo systemctl reload caddy"), false);
+});
+
+test("infra VPS workflow verifies backup exists before proceeding", () => {
+  const text = read(WORKFLOW_PATH);
+  const backupCopyIndex = text.indexOf('sudo -n cp "$CADDY_PATH" "$BACKUP_PATH"');
+  const backupExistsIndex = text.indexOf('sudo -n test -f "$BACKUP_PATH"');
+  const overwriteIndex = text.indexOf('sudo -n cp "$TMP_PATH" "$CADDY_PATH"');
+
+  assert.notEqual(backupCopyIndex, -1);
+  assert.notEqual(backupExistsIndex, -1);
+  assert.notEqual(overwriteIndex, -1);
+  assert.equal(backupCopyIndex < backupExistsIndex, true);
+  assert.equal(backupExistsIndex < overwriteIndex, true);
+});
+
+test("infra VPS workflow validates Caddy config before reloading Caddy", () => {
+  const text = read(WORKFLOW_PATH);
+  const validateIndex = text.indexOf("sudo -n caddy validate");
+  const reloadIndex = text.indexOf("sudo -n systemctl reload caddy", validateIndex);
+  const healthzIndex = text.indexOf("HEALTHZ_BODY=", reloadIndex);
+
+  assert.notEqual(validateIndex, -1, "Workflow must run caddy validate");
+  assert.notEqual(reloadIndex, -1, "Workflow must reload caddy");
+  assert.notEqual(healthzIndex, -1, "Workflow must define healthz smoke check");
+  assert.equal(validateIndex < reloadIndex, true, "caddy validate must run before reload");
+  assert.equal(reloadIndex < healthzIndex, true, "reload must run before healthz smoke check");
+});
+
+test("infra VPS workflow ordering assertions use stable tokens (whitespace-robust)", () => {
+  const text = read(WORKFLOW_PATH);
+  const validateIndex = text.indexOf("sudo -n caddy validate");
+  const reloadIndex = text.indexOf("sudo -n systemctl reload caddy", validateIndex);
+  const healthzIndex = text.indexOf("HEALTHZ_BODY=", reloadIndex);
+
+  assert.notEqual(validateIndex, -1);
+  assert.notEqual(reloadIndex, -1);
+  assert.notEqual(healthzIndex, -1);
+  assert.equal(validateIndex < reloadIndex, true);
+  assert.equal(reloadIndex < healthzIndex, true);
+});
+
+test("infra VPS workflow uses errtrace for trap-based rollback", () => {
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("set -Eeuo pipefail"));
+  assert.ok(text.includes("trap 'on_error' ERR"));
+});
+
+test("infra VPS workflow WS smoke-check uses node built-ins and curl fallback", () => {
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("if command -v node >/dev/null 2>&1; then"));
+  assert.ok(text.includes("timeout 12s node <<'NODE'"));
+  assert.ok(text.includes("require('tls')"));
+  assert.ok(text.includes("require('crypto')"));
+  assert.ok(text.includes("Sec-WebSocket-Key"));
+  assert.ok(text.includes("sec-websocket-accept"));
+  assert.ok(text.includes("helloAck"));
+  assert.ok(text.includes("--http1.1 https://ws.kcswh.pl/ws"));
+  assert.ok(text.includes("Connection: Upgrade"));
+  assert.ok(text.includes("Upgrade: websocket"));
+  assert.ok(text.includes("grep -q ' 101 '"));
+  assert.equal(text.includes("require('ws')"), false);
+});
+
+test("infra VPS workflow healthz check is tolerant to newline/CRLF", () => {
+  const text = read(WORKFLOW_PATH);
+  assert.ok(text.includes("tr -d '\\r\\n'"));
+  assert.ok(text.includes('test "$HEALTHZ_BODY" = "ok"'));
+});
+
+test("heredocEndOffset advances offsets and finds terminator after start", () => {
+  const synthetic = [
+    "prelude",
+    "  bash <<'BASH'",
+    "    line-1",
+    "      line-2",
+    "   BASH   ",
+    "POST"
+  ].join("\n");
+
+  const offset1 = heredocEndOffset(synthetic);
+  const postIndex1 = synthetic.indexOf("\nPOST");
+
+  assert.notEqual(offset1, -1);
+  assert.equal(offset1 <= postIndex1, true);
+
+  const syntheticWithExtraBody = synthetic.replace("    line-1", "    line-1\n    extra-line");
+  const offset2 = heredocEndOffset(syntheticWithExtraBody);
+
+  assert.notEqual(offset2, -1);
+  assert.equal(offset2 > offset1, true);
+});

--- a/ws-tests/infra-vps-workflow.smokecheck-structure.behavior.test.mjs
+++ b/ws-tests/infra-vps-workflow.smokecheck-structure.behavior.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const WORKFLOW_PATH = ".github/workflows/infra-vps.yml";
+
+function workflowText() {
+  return fs.readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+test("infra VPS smoke check structure keeps rollback-safe ordering", () => {
+  const text = workflowText();
+
+  const appliedIndex = text.indexOf("APPLIED=1");
+  const reloadIndex = text.indexOf("sudo -n systemctl reload caddy", appliedIndex);
+  const healthzIndex = text.indexOf("HEALTHZ_BODY=", reloadIndex);
+  const nodeSmokeIndex = text.indexOf("timeout 12s node <<'NODE'", healthzIndex);
+  const trapClearIndex = text.indexOf("trap - ERR", nodeSmokeIndex);
+
+  assert.notEqual(appliedIndex, -1);
+  assert.notEqual(reloadIndex, -1);
+  assert.notEqual(healthzIndex, -1);
+  assert.notEqual(nodeSmokeIndex, -1);
+  assert.notEqual(trapClearIndex, -1);
+
+  assert.equal(appliedIndex < reloadIndex, true);
+  assert.equal(reloadIndex < healthzIndex, true);
+  assert.equal(healthzIndex < nodeSmokeIndex, true);
+  assert.equal(nodeSmokeIndex < trapClearIndex, true);
+});
+
+test("infra VPS smoke checks are standalone commands and trap remains active", () => {
+  const text = workflowText();
+
+  assert.ok(text.includes("trap 'on_error' ERR"));
+  assert.ok(text.includes("rollback()"));
+  assert.ok(text.includes("HEALTHZ_BODY=\"$(curl -fsS https://ws.kcswh.pl/healthz"));
+  assert.ok(text.includes("timeout 12s node <<'NODE'"));
+  assert.ok(text.includes("curl -sS -o /dev/null -D - --http1.1 https://ws.kcswh.pl/ws"));
+  assert.equal(text.includes("WS_RESPONSE=\"$("), false);
+});

--- a/ws-tests/infra-vps-workflow.ws-smokecheck-deps.guard.test.mjs
+++ b/ws-tests/infra-vps-workflow.ws-smokecheck-deps.guard.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const WORKFLOW_PATH = ".github/workflows/infra-vps.yml";
+
+test("infra VPS WS smoke-check does not depend on globally installed ws tooling", () => {
+  const text = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+  assert.equal(text.includes("command -v wscat"), false);
+  assert.equal(text.includes("docker run"), false);
+  assert.equal(text.includes("npm i ws"), false);
+  assert.equal(text.includes("require('ws')"), false);
+  assert.equal(text.includes("require('node:tls')"), false);
+  assert.equal(text.includes("require('node:crypto')"), false);
+
+  assert.ok(text.includes("require('tls')"));
+  assert.ok(text.includes("require('crypto')"));
+  assert.ok(text.includes("if command -v node >/dev/null 2>&1; then"));
+});


### PR DESCRIPTION
### Motivation

- Provide an automated deployment workflow for VPS Caddy configuration with validation, rollback and smoke checks to safely deploy `infra/vps/Caddyfile`.
- Ensure repository-level guards prevent regressions by adding tests that verify workflow structure, concurrency, heredoc safety, and smoke-check behavior.

### Description

- Add a new GitHub Actions workflow ` .github/workflows/infra-vps.yml` that validates the `infra/vps` structure on PRs and on push or `workflow_dispatch` uploads the `Caddyfile`, backs up the existing file, validates the config, reloads Caddy, and runs health and WebSocket smoke checks with a Node-based probe and a `curl` fallback.
- Add `infra/vps/Caddyfile` with explicit `/healthz`, `/ws*` and a root `respond "OK" 200` routing pointing to `127.0.0.1:3000`.
- Add a suite of guard and behavior tests under `ws-tests/` (`infra-vps-workflow.guard.test.mjs`, `infra-vps-workflow.smokecheck-structure.behavior.test.mjs`, `infra-vps-workflow.ws-smokecheck-deps.guard.test.mjs`, `infra-vps-workflow.concurrency.guard.test.mjs`, and `infra-vps-workflow.bash-exit-propagation.guard.test.mjs`) that assert workflow ordering, heredoc robustness, non-interactive `sudo`, concurrency settings, and WS/health smoke-check structure.
- Update existing CI matrices in ` .github/workflows/ws-deploy.yml` and ` .github/workflows/ws-pr-checks.yml` to run the new infra VPS tests as part of PR and deploy pipelines.

### Testing

- New automated tests were added and wired into CI: the `ws-tests/*infra-vps*` test files and existing `node --test` invocations were updated in `ws-deploy.yml` and `ws-pr-checks.yml` to execute them.
- No CI run results are included in this change (the workflow and tests are present and will run when the CI executes); test outcomes are not reported in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4550b1758832380f0ec514d079c4f)