### PR TITLE
Add PR5 `stateSnapshot` read-model and snapshot view support (server, docs, tests)

### DIFF
--- a/docs/ws-poker-protocol.md
+++ b/docs/ws-poker-protocol.md
@@ -64,7 +64,7 @@ Example envelope:
 | `helloAck` | `{ "version": "1.0", "sessionId": string, "heartbeatMs": integer }` | Confirms negotiated version and returns initial session id. |
 | `authOk` | `{ "userId": string, "roomId": string, "permissions": string[] }` | Auth success event. |
 | `pong` | `{ "clientTime": string, "serverTime": string }` | Ping response. |
-| `stateSnapshot` | `{ "stateVersion": integer, "table": object, "you": object }` | Full room state snapshot (private data scoped to authenticated seat only). |
+| `stateSnapshot` | `{ "stateVersion": integer, "table": object, "you": object }` | Full room state snapshot (canonical PR5 read-model contract; private data scoped to authenticated seat only). |
 | `statePatch` | `{ "stateVersion": integer, "patch": object }` | Incremental room state update. |
 | `commandResult` | `{ "requestId": string, "status": "accepted"|"rejected", "reason": string|null }` | Deterministic outcome for a client command. |
 | `resync` | `{ "mode": "required", "reason": string, "expectedSeq": integer }` | Signals that client must request/accept full snapshot. |
@@ -137,6 +137,56 @@ Example `table_state` frame:
       { "userId": "user_1", "seat": 1 },
       { "userId": "user_2", "seat": 2 }
     ]
+  }
+}
+```
+
+### State snapshot read-model (PR5 runtime contract)
+
+For read-only room projection, runtime currently supports `table_state_sub` with `payload.view = "snapshot"`.
+When this view is requested after successful auth, server emits `stateSnapshot` with canonical payload branch:
+
+- Snapshot view is a one-shot response for that request; it does not implicitly subscribe the socket to legacy `table_state` broadcast updates.
+
+- `payload.stateVersion: integer`
+- `payload.table: object`
+- `payload.you: object`
+
+Initial PR5 snapshot projection fields:
+
+- `payload.table.tableId: string`
+- `payload.table.members: Array<{ userId: string, seat: number }>` (stable sorted as above)
+- `payload.table.memberCount: number`
+- `payload.table.maxSeats: number` (when configured/runtime-known)
+- `payload.you.userId: string` (authenticated user)
+- `payload.you.seat: number | null` (null when authenticated observer is not seated)
+
+Example `stateSnapshot` frame:
+
+```json
+{
+  "version": "1.0",
+  "type": "stateSnapshot",
+  "requestId": "req-sub-snapshot-1",
+  "roomId": "table_100_200",
+  "sessionId": "sess_01JZ9VYQH8R9M8M5TQ2J4K8H3Z",
+  "seq": 43,
+  "ts": "2026-02-28T10:16:08Z",
+  "payload": {
+    "stateVersion": 7,
+    "table": {
+      "tableId": "table_100_200",
+      "members": [
+        { "userId": "user_1", "seat": 1 },
+        { "userId": "user_2", "seat": 2 }
+      ],
+      "memberCount": 2,
+      "maxSeats": 10
+    },
+    "you": {
+      "userId": "user_1",
+      "seat": 1
+    }
   }
 }
 ```

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createTableManager } from "../table/table-manager.mjs";
+import { buildStateSnapshotPayload } from "./state-snapshot.mjs";
+
+test("buildStateSnapshotPayload returns canonical payload for seated authenticated user", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const wsA = {};
+  const wsB = {};
+
+  const joinB = tableManager.join({ ws: wsB, userId: "user_b", tableId: "table_A", requestId: "join-b" });
+  assert.equal(joinB.ok, true);
+  const joinA = tableManager.join({ ws: wsA, userId: "user_a", tableId: "table_A", requestId: "join-a" });
+  assert.equal(joinA.ok, true);
+
+  const tableSnapshot = tableManager.tableSnapshot("table_A", "user_a");
+  const payload = buildStateSnapshotPayload({ tableSnapshot, userId: "user_a" });
+
+  assert.equal(Number.isInteger(payload.stateVersion), true);
+  assert.equal(typeof payload.table, "object");
+  assert.equal(typeof payload.you, "object");
+  assert.deepEqual(payload.table.members, [
+    { userId: "user_b", seat: 1 },
+    { userId: "user_a", seat: 2 }
+  ]);
+  assert.equal(payload.you.userId, "user_a");
+  assert.equal(payload.you.seat, 2);
+});
+
+test("buildStateSnapshotPayload keeps user scope and null seat for non-seated authenticated user", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const wsA = {};
+  const wsB = {};
+
+  assert.equal(tableManager.join({ ws: wsA, userId: "user_a", tableId: "table_B", requestId: "join-a" }).ok, true);
+  assert.equal(tableManager.join({ ws: wsB, userId: "user_b", tableId: "table_B", requestId: "join-b" }).ok, true);
+
+  const tableSnapshot = tableManager.tableSnapshot("table_B", "observer_user");
+  const payload = buildStateSnapshotPayload({ tableSnapshot, userId: "observer_user" });
+
+  assert.equal(payload.you.userId, "observer_user");
+  assert.equal(payload.you.seat, null);
+  assert.equal("private" in payload, false);
+  assert.equal("players" in payload.you, false);
+});

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -1,0 +1,44 @@
+function normalizeSeat(value) {
+  return Number.isInteger(value) ? value : null;
+}
+
+function stableMembers(members) {
+  const rows = Array.isArray(members) ? members : [];
+  return rows
+    .filter((member) => member && typeof member.userId === "string" && Number.isInteger(member.seat))
+    .map((member) => ({ userId: member.userId, seat: member.seat }))
+    .sort((a, b) => {
+      if (a.seat !== b.seat) {
+        return a.seat - b.seat;
+      }
+      return a.userId.localeCompare(b.userId);
+    });
+}
+
+export function buildStateSnapshotPayload({ tableSnapshot, userId }) {
+  const tableId = typeof tableSnapshot?.tableId === "string" ? tableSnapshot.tableId : "";
+  const stateVersion = Number.isInteger(tableSnapshot?.stateVersion) ? tableSnapshot.stateVersion : 0;
+  const maxSeats = Number.isInteger(tableSnapshot?.maxSeats) ? tableSnapshot.maxSeats : null;
+  const members = stableMembers(tableSnapshot?.members);
+  const youSeat = normalizeSeat(tableSnapshot?.youSeat);
+
+  const table = {
+    tableId,
+    members,
+    memberCount: members.length
+  };
+
+  if (maxSeats !== null) {
+    table.maxSeats = maxSeats;
+  }
+
+  return {
+    stateVersion,
+    table,
+    you: {
+      userId,
+      seat: youSeat
+    }
+  };
+}
+

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -66,6 +66,30 @@ export function createTableManager({
     };
   }
 
+  function tableSnapshot(tableId, userId) {
+    const table = tables.get(tableId);
+    if (!table) {
+      return {
+        tableId,
+        stateVersion: 0,
+        members: [],
+        maxSeats,
+        youSeat: null
+      };
+    }
+
+    const seatedValue = table.coreState.seats[userId];
+    const youSeat = Number.isInteger(seatedValue) ? seatedValue : null;
+
+    return {
+      tableId,
+      stateVersion: table.coreState.version,
+      members: normalizeMembers(table),
+      maxSeats: table.coreState.maxSeats,
+      youSeat
+    };
+  }
+
   function markConnected(member, nowMs) {
     member.connected = true;
     member.lastSeenAt = nowMs;
@@ -370,6 +394,7 @@ export function createTableManager({
     resync,
     touchPresence,
     tableState,
+    tableSnapshot,
     cleanupConnection,
     orderedSubscribers,
     sweepExpiredPresence

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -100,6 +100,41 @@ function nextMessage(ws, timeoutMs = 5000) {
   });
 }
 
+function attemptMessage(ws, timeoutMs = 300) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+
+    const onMessage = (data) => {
+      cleanup();
+      resolve(JSON.parse(String(data)));
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onClose = () => {
+      cleanup();
+      resolve(null);
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
+}
+
 function sendFrame(ws, frame) {
   ws.send(JSON.stringify(frame));
 }
@@ -122,6 +157,17 @@ async function hello(ws) {
     requestId: "req-hello",
     ts: "2026-02-28T00:00:00Z",
     payload: { supportedVersions: ["1.0"] }
+  });
+  return nextMessage(ws);
+}
+
+async function auth(ws, token, requestId = "req-auth") {
+  sendFrame(ws, {
+    version: "1.0",
+    type: "auth",
+    requestId,
+    ts: "2026-02-28T00:00:01Z",
+    payload: { token }
   });
   return nextMessage(ws);
 }
@@ -209,6 +255,141 @@ test("resync message requires auth", async () => {
     assert.equal(ws.readyState, WebSocket.OPEN);
 
     ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("table_state_sub snapshot view requires auth and does not leak stateSnapshot", async () => {
+  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: "test-secret" } });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "req-sub-unauth",
+      ts: "2026-02-28T00:00:01Z",
+      payload: { tableId: "table_A", view: "snapshot" }
+    });
+
+    const frame = await nextMessage(ws);
+    assert.equal(frame.type, "error");
+    assert.equal(frame.payload.code, "auth_required");
+    assert.notEqual(frame.type, "stateSnapshot");
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("authenticated snapshot view emits stateSnapshot with canonical payload shape", async () => {
+  const secret = "test-secret";
+  const token = makeHs256Jwt({ secret, sub: "user_123" });
+  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret } });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    const authOk = await auth(ws, token, "req-auth-snapshot");
+    assert.equal(authOk.type, "authOk");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "req-join-snapshot",
+      ts: "2026-02-28T00:00:02Z",
+      payload: { tableId: "table_A" }
+    });
+    const join = await nextMessage(ws);
+    assert.equal(join.type, "table_state");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "req-sub-snapshot",
+      ts: "2026-02-28T00:00:03Z",
+      payload: { tableId: "table_A", view: "snapshot" }
+    });
+    const snapshot = await nextMessage(ws);
+    assert.equal(snapshot.type, "stateSnapshot");
+    assert.equal(snapshot.payload.table.tableId, "table_A");
+    assert.equal(Number.isInteger(snapshot.payload.stateVersion), true);
+    assert.equal(typeof snapshot.payload.table, "object");
+    assert.equal(typeof snapshot.payload.you, "object");
+    assert.deepEqual(snapshot.payload.table.members, [{ userId: "user_123", seat: 1 }]);
+    assert.equal(snapshot.payload.you.userId, "user_123");
+    assert.equal(snapshot.payload.you.seat, 1);
+    assert.equal(typeof snapshot.sessionId, "string");
+    assert.equal(typeof snapshot.ts, "string");
+    assert.equal(snapshot.version, "1.0");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "req-sub-snapshot-2",
+      ts: "2026-02-28T00:00:04Z",
+      payload: { tableId: "table_A", view: "snapshot" }
+    });
+    const snapshot2 = await nextMessage(ws);
+    assert.equal(snapshot2.type, "stateSnapshot");
+    assert.deepEqual(snapshot2.payload, snapshot.payload);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("snapshot-view subscription is one-shot and does not receive later legacy table_state broadcasts", async () => {
+  const secret = "test-secret";
+  const snapshotToken = makeHs256Jwt({ secret, sub: "snapshot_user" });
+  const actorToken = makeHs256Jwt({ secret, sub: "actor_user" });
+  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret } });
+
+  try {
+    await waitForListening(child, 5000);
+    const snapshotClient = await connectClient(port);
+    const actorClient = await connectClient(port);
+
+    await hello(snapshotClient);
+    await hello(actorClient);
+    assert.equal((await auth(snapshotClient, snapshotToken, "req-auth-snapshot-oneshot")).type, "authOk");
+    assert.equal((await auth(actorClient, actorToken, "req-auth-actor-oneshot")).type, "authOk");
+
+    sendFrame(snapshotClient, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "req-sub-snapshot-oneshot",
+      ts: "2026-02-28T00:00:05Z",
+      payload: { tableId: "table_oneshot", view: "snapshot" }
+    });
+    const snapshot = await nextMessage(snapshotClient);
+    assert.equal(snapshot.type, "stateSnapshot");
+
+    sendFrame(actorClient, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "req-join-actor-oneshot",
+      ts: "2026-02-28T00:00:06Z",
+      payload: { tableId: "table_oneshot" }
+    });
+    const actorJoin = await nextMessage(actorClient);
+    assert.equal(actorJoin.type, "table_state");
+
+    const snapshotFollowup = await attemptMessage(snapshotClient, 350);
+    assert.equal(snapshotFollowup, null);
+
+    snapshotClient.close();
+    actorClient.close();
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -12,6 +12,7 @@ import { recordReplayFrame, resolveReplay, touchSession } from "./poker/runtime/
 import { recordProtocolViolation, shouldClose } from "./poker/runtime/conn-guards.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 import { createSessionStore } from "./poker/runtime/session-store.mjs";
+import { buildStateSnapshotPayload } from "./poker/read-model/state-snapshot.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -178,6 +179,31 @@ function sendTableState(ws, connState, { requestId = null, tableState }) {
   const frame = recordReplayFrame({
     session: connState.session,
     tableId: tableState.tableId,
+    frame: baseFrame
+  });
+  sendFrame(ws, frame);
+}
+
+function sendStateSnapshot(ws, connState, { requestId = null, tableSnapshot }) {
+  const baseFrame = {
+    version: "1.0",
+    type: "stateSnapshot",
+    ts: nowTs(),
+    roomId: tableSnapshot.tableId,
+    sessionId: connState.sessionId,
+    payload: buildStateSnapshotPayload({
+      tableSnapshot,
+      userId: connState.session.userId
+    })
+  };
+
+  if (requestId) {
+    baseFrame.requestId = requestId;
+  }
+
+  const frame = recordReplayFrame({
+    session: connState.session,
+    tableId: tableSnapshot.tableId,
     frame: baseFrame
   });
   sendFrame(ws, frame);
@@ -552,6 +578,13 @@ wss.on("connection", (ws) => {
         return;
       }
       const tableId = resolvedRoomId.roomId;
+
+      const wantsSnapshot = frame.payload?.view === "snapshot" || frame.payload?.mode === "snapshot";
+      if (wantsSnapshot) {
+        const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
+        sendStateSnapshot(ws, connState, { requestId: frame.requestId ?? null, tableSnapshot });
+        return;
+      }
 
       const subscribed = tableManager.subscribe({ ws, tableId });
       if (!subscribed.ok) {

--- a/ws-tests/ws-poker-protocol-doc.test.mjs
+++ b/ws-tests/ws-poker-protocol-doc.test.mjs
@@ -8,6 +8,11 @@ function docText() {
   return fs.readFileSync(DOC_PATH, "utf8");
 }
 
+function serverMessageTypesSection(text) {
+  const match = text.match(/### Server → Client\n\n([\s\S]*?)(\n### |\n## |$)/);
+  return match ? match[1] : "";
+}
+
 test("ws poker protocol document exists and is non-empty", () => {
   assert.ok(fs.existsSync(DOC_PATH));
   const text = docText();
@@ -29,8 +34,22 @@ test("ws poker protocol document defines required message type names", () => {
   assert.match(text, /^\|\s*`hello`\s*\|/m);
   assert.match(text, /^\|\s*`auth`\s*\|/m);
   assert.match(text, /^\|\s*`ping`\s*\|/m);
-  assert.match(text, /^\|\s*`error`\s*\|/m);
-  assert.match(text, /^\|\s*`resync`\s*\|/m);
+
+  const serverTypes = serverMessageTypesSection(text);
+  assert.ok(serverTypes.length > 0);
+  assert.match(serverTypes, /^\|\s*`error`\s*\|/m);
+  assert.match(serverTypes, /^\|\s*`resync`\s*\|/m);
+  assert.match(serverTypes, /^\|\s*`stateSnapshot`\s*\|/m);
+});
+
+test("ws poker protocol document defines canonical stateSnapshot payload fields", () => {
+  const text = docText();
+  const serverTypes = serverMessageTypesSection(text);
+
+  assert.match(serverTypes, /^\|\s*`stateSnapshot`\s*\|[^\n]*"stateVersion"\s*:\s*integer[^\n]*"table"\s*:\s*object[^\n]*"you"\s*:\s*object/m);
+  assert.match(text, /"stateVersion"\s*:\s*\d+/);
+  assert.match(text, /"table"\s*:\s*\{/);
+  assert.match(text, /"you"\s*:\s*\{/);
 });
 
 test("ws poker protocol document contains envelope JSON markers", () => {


### PR DESCRIPTION
### Motivation

- Introduce a canonical, read-only snapshot view for room state (PR5 runtime contract) so clients can request a one-shot `stateSnapshot` without subscribing to legacy broadcasts.
- Provide a stable payload shape that scopes private data to the authenticated seat and supports read-model consumers.
- Ensure server enforces auth for snapshot requests and that the snapshot view does not implicitly subscribe sockets to `table_state` broadcasts.

### Description

- Add a read-model builder `buildStateSnapshotPayload` in `ws-server/poker/read-model/state-snapshot.mjs` which normalizes members, computes `memberCount`, optional `maxSeats`, and scopes `you` with `seat` or `null`.
- Add `tableSnapshot(tableId, userId)` to `table-manager` to return table-level metadata including `stateVersion`, `members`, `maxSeats`, and the actor's seat as `youSeat`.
- Wire a new `sendStateSnapshot` in `server.mjs` and return a `stateSnapshot` frame when `table_state_sub` is requested with `view: "snapshot"`, using `recordReplayFrame` for replayability and preserving `requestId` when present.
- Update protocol docs `docs/ws-poker-protocol.md` to document the `stateSnapshot` message, its canonical fields, and the one-shot semantics for the `snapshot` view.
- Add and update tests: unit tests for the payload builder and behavior tests exercising auth gating, canonical payload shape, and one-shot semantics, plus doc assertions in `ws-tests/ws-poker-protocol-doc.test.mjs` and small helper additions in `ws-server/server.behavior.test.mjs`.

### Testing

- Ran `ws-server/poker/read-model/state-snapshot.behavior.test.mjs` which verifies canonical payload for seated and non-seated authenticated users and it passed.
- Ran updated `ws-server/server.behavior.test.mjs` tests that cover unauthenticated snapshot requests, authenticated snapshot payload emission, and one-shot semantics, and they passed.
- Ran the updated documentation checks in `ws-tests/ws-poker-protocol-doc.test.mjs` which assert the `stateSnapshot` type and payload fields and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab019d90548323b63692a1defac7de)