### PR TITLE
Implement WS 'act' command end-to-end with client promise API, UI integration, and tests

### DIFF
--- a/.github/workflows/ws-deploy.yml
+++ b/.github/workflows/ws-deploy.yml
@@ -60,6 +60,13 @@ jobs:
 
       - name: Run ws table manager behavior test
         run: node --test ws-server/poker/table/table-manager.behavior.test.mjs
+
+      - name: Run ws act handler behavior test
+        run: node --test ws-server/poker/handlers/act.behavior.test.mjs
+
+      - name: Run ws act handler invalid behavior test
+        run: node --test ws-server/poker/handlers/act.invalid.behavior.test.mjs
+
       - name: Run authoritative leave adapter behavior test
         run: node --test ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
 

--- a/.github/workflows/ws-pr-checks.yml
+++ b/.github/workflows/ws-pr-checks.yml
@@ -53,6 +53,13 @@ jobs:
 
       - name: Run ws table manager behavior test
         run: node --test ws-server/poker/table/table-manager.behavior.test.mjs
+
+      - name: Run ws act handler behavior test
+        run: node --test ws-server/poker/handlers/act.behavior.test.mjs
+
+      - name: Run ws act handler invalid behavior test
+        run: node --test ws-server/poker/handlers/act.invalid.behavior.test.mjs
+
       - name: Run authoritative leave adapter behavior test
         run: node --test ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
 

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -41,6 +41,7 @@
     var started = false;
     var authOk = false;
     var initialSnapshotDelivered = false;
+    var pendingCommandsByRequestId = new Map();
 
     function emitStatus(status, data){
       try { onStatus(status, data || {}); } catch (_err){}
@@ -50,19 +51,69 @@
       try { onProtocolError({ code: code, detail: detail || null }); } catch (_err){}
     }
 
-    function send(type, payload){
+    function send(type, payload, requestIdOverride){
       if (!ws || ws.readyState !== 1) return false;
       var roomId = tableId ? tableId : null;
+      var requestId = typeof requestIdOverride === 'string' && requestIdOverride.trim() ? requestIdOverride.trim() : buildRequestId();
       var envelope = {
         version: '1.0',
         type: type,
-        requestId: buildRequestId(),
+        requestId: requestId,
         ts: new Date().toISOString(),
         payload: payload || {}
       };
       if (roomId) envelope.roomId = roomId;
       ws.send(JSON.stringify(envelope));
-      return true;
+      return requestId;
+    }
+
+    function rejectPendingCommands(reasonCode){
+      var code = reasonCode || 'connection_closed';
+      pendingCommandsByRequestId.forEach(function(entry){
+        if (!entry || typeof entry.reject !== 'function') return;
+        var err = new Error(code);
+        err.code = code;
+        entry.reject(err);
+      });
+      pendingCommandsByRequestId.clear();
+    }
+
+    function sendAct(command){
+      var payload = command && typeof command === 'object' ? command : {};
+      var handId = typeof payload.handId === 'string' ? payload.handId.trim() : '';
+      var action = typeof payload.action === 'string' ? payload.action.trim().toUpperCase() : '';
+      var requestId = typeof payload.requestId === 'string' ? payload.requestId.trim() : '';
+      if (!authOk || !ws || ws.readyState !== 1){
+        var notReadyErr = new Error('ws_unavailable');
+        notReadyErr.code = 'ws_unavailable';
+        return Promise.reject(notReadyErr);
+      }
+      if (!requestId || !handId || !action){
+        var invalidErr = new Error('invalid_command');
+        invalidErr.code = 'invalid_command';
+        return Promise.reject(invalidErr);
+      }
+
+      return new Promise(function(resolve, reject){
+        var sentRequestId = send('act', {
+          tableId: tableId,
+          handId: handId,
+          action: action,
+          amount: payload.amount
+        }, requestId);
+
+        if (!sentRequestId){
+          var sendErr = new Error('ws_unavailable');
+          sendErr.code = 'ws_unavailable';
+          reject(sendErr);
+          return;
+        }
+
+        pendingCommandsByRequestId.set(sentRequestId, {
+          resolve: resolve,
+          reject: reject
+        });
+      });
     }
 
     function normalizeSnapshot(frame, initial){
@@ -135,6 +186,19 @@
         return;
       }
       if (frame.type === 'commandResult'){
+        var commandRequestId = typeof frame.requestId === 'string' && frame.requestId.trim() ? frame.requestId.trim() : (frame.payload && typeof frame.payload.requestId === 'string' ? frame.payload.requestId.trim() : '');
+        if (commandRequestId && pendingCommandsByRequestId.has(commandRequestId)){
+          var pending = pendingCommandsByRequestId.get(commandRequestId);
+          pendingCommandsByRequestId.delete(commandRequestId);
+          if (frame.payload && frame.payload.status === 'accepted'){
+            pending.resolve({ ok: true, status: 'accepted', reason: null, requestId: commandRequestId });
+          } else {
+            var rejectedCode = frame.payload && frame.payload.reason ? frame.payload.reason : 'command_rejected';
+            var rejectedErr = new Error(rejectedCode);
+            rejectedErr.code = rejectedCode;
+            pending.reject(rejectedErr);
+          }
+        }
         emitStatus('command_result', {
           status: frame.payload && frame.payload.status ? frame.payload.status : null,
           reason: frame.payload && frame.payload.reason ? frame.payload.reason : null
@@ -152,6 +216,14 @@
       }
       if (frame.type === 'error'){
         var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error';
+        var errorRequestId = typeof frame.requestId === 'string' && frame.requestId.trim() ? frame.requestId.trim() : '';
+        if (errorRequestId && pendingCommandsByRequestId.has(errorRequestId)){
+          var pendingError = pendingCommandsByRequestId.get(errorRequestId);
+          pendingCommandsByRequestId.delete(errorRequestId);
+          var commandErr = new Error(code);
+          commandErr.code = code;
+          pendingError.reject(commandErr);
+        }
         emitStatus('error', { code: code });
         emitProtocolError(code, frame.payload && frame.payload.message ? frame.payload.message : null);
       }
@@ -192,6 +264,7 @@
         emitStatus('failed', { stage: 'socket', code: 'socket_error' });
       };
       ws.onclose = function(evt){
+        rejectPendingCommands('connection_closed');
         emitStatus('closed', { code: evt && evt.code ? evt.code : null });
       };
     }
@@ -200,6 +273,7 @@
       destroyed = true;
       started = false;
       authOk = false;
+      rejectPendingCommands('client_shutdown');
       if (ws && ws.readyState <= 1){
         try { ws.close(1000, 'client_shutdown'); } catch (_err){}
       }
@@ -208,7 +282,8 @@
 
     return {
       start: start,
-      destroy: destroy
+      destroy: destroy,
+      sendAct: sendAct
     };
   }
 

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -2703,11 +2703,40 @@
           pendingActType = normalized;
         }
         var actRequestId = normalizeRequestId(resolved.requestId);
-        var result = await apiPost(ACT_URL, {
-          tableId: tableId,
-          requestId: actRequestId,
-          action: actionResult.action
-        });
+        var useWsAct = !!(wsStarted && wsClient && typeof wsClient.sendAct === 'function');
+        var completedTransport = useWsAct ? 'ws' : 'http';
+        var result = null;
+        if (useWsAct){
+          try {
+            await wsClient.sendAct({
+              tableId: tableId,
+              requestId: actRequestId,
+              handId: resolveCurrentHandId(),
+              action: actionResult.action.type,
+              amount: actionResult.action.amount
+            });
+            result = { ok: true };
+          } catch (wsErr){
+            var wsErrCode = wsErr && (wsErr.code || wsErr.message) ? String(wsErr.code || wsErr.message) : 'ws_unavailable';
+            if (wsErrCode === 'ws_unavailable' || wsErrCode === 'connection_closed' || wsErrCode === 'client_shutdown'){
+              klog('poker_ws_act_unavailable_fallback_http', { tableId: tableId, requestId: actRequestId, reason: wsErrCode });
+              result = await apiPost(ACT_URL, {
+                tableId: tableId,
+                requestId: actRequestId,
+                action: actionResult.action
+              });
+              completedTransport = 'http';
+            } else {
+              throw wsErr;
+            }
+          }
+        } else {
+          result = await apiPost(ACT_URL, {
+            tableId: tableId,
+            requestId: actRequestId,
+            action: actionResult.action
+          });
+        }
         if (isPendingResponse(result)){
           scheduleDevPendingRetry('act', retryAct);
           return;
@@ -2731,7 +2760,7 @@
         clearActPending();
         setInlineStatus(actStatusEl, t('pokerActOk', 'Action sent'), 'success');
         if (!isPageActive()) return;
-        loadTable(false);
+        if (completedTransport === 'http') loadTable(false);
       } catch (err){
         if (isAbortError(err)){
           pauseActPending();
@@ -2750,21 +2779,22 @@
           return;
         }
         clearActPending();
+        var errCode = err && (err.code || err.error || err.message) ? String(err.code || err.error || err.message) : '';
         var errMessage = err && (err.message || err.code) ? String(err.message || err.code) : '';
         var loweredMessage = errMessage.toLowerCase();
-        if (err && (err.status === 403 || err.code === 'not_your_turn' || loweredMessage.indexOf('not your turn') !== -1)){
+        if (err && (err.status === 403 || errCode === 'not_your_turn' || loweredMessage.indexOf('not your turn') !== -1)){
           setInlineStatus(actStatusEl, t('pokerErrNotYourTurn', 'Not your turn'), 'error');
           return;
         }
-        if (err && err.code === 'action_not_allowed'){
+        if (errCode === 'action_not_allowed'){
           setInlineStatus(actStatusEl, t('pokerErrActionNotAllowed', 'Action not allowed right now'), 'error');
           return;
         }
-        if (err && err.code === 'invalid_amount'){
+        if (errCode === 'invalid_amount'){
           setInlineStatus(actStatusEl, t('pokerErrActAmount', 'Invalid amount'), 'error');
           return;
         }
-        if (err && err.code === 'state_invalid'){
+        if (errCode === 'state_invalid'){
           setInlineStatus(actStatusEl, t('pokerErrStateChanged', 'State changed. Refreshing...'), 'error');
           if (isPageActive()) loadTable(false);
           return;

--- a/tests/helpers/poker-ui-table-harness.mjs
+++ b/tests/helpers/poker-ui-table-harness.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import vm from 'node:vm';
 
 function makeElement(id){
+  const listeners = new Map();
   return {
     id,
     hidden: false,
@@ -24,9 +25,25 @@ function makeElement(id){
     removeChild(child){ this.children = this.children.filter((it) => it !== child); },
     setAttribute(){},
     removeAttribute(){},
-    addEventListener(){},
-    removeEventListener(){},
+    addEventListener(type, handler){
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(handler);
+    },
+    removeEventListener(type, handler){
+      if (!listeners.has(type)) return;
+      if (!handler){ listeners.delete(type); return; }
+      listeners.set(type, listeners.get(type).filter((entry) => entry !== handler));
+    },
     querySelector(){ return null; },
+    click(){
+      const handlers = listeners.get('click') || [];
+      handlers.forEach((handler) => handler({
+        type: 'click',
+        target: this,
+        preventDefault(){},
+        stopPropagation(){}
+      }));
+    },
     focus(){},
     blur(){},
   };
@@ -39,6 +56,9 @@ export function createPokerTableHarness(options = {}){
   const fetchState = {
     getCalls: 0,
     heartbeatCalls: 0,
+    actCalls: 0,
+    actBodies: [],
+    urls: [],
     responses: options.responses || [
       {
         tableId,
@@ -112,8 +132,9 @@ export function createPokerTableHarness(options = {}){
     clearTimeout(id){ clearTimeoutCalls.push(id); timeouts.delete(id); },
     setInterval(){ return 999; },
     clearInterval(){},
-    fetch: async (url) => {
+    fetch: async (url, init) => {
       const text = String(url || '');
+      fetchState.urls.push(text);
       if (text.includes('/poker-get-table')){
         fetchState.getCalls += 1;
         const index = Math.min(fetchState.getCalls - 1, fetchState.responses.length - 1);
@@ -122,6 +143,16 @@ export function createPokerTableHarness(options = {}){
       if (text.includes('/poker-heartbeat')){
         fetchState.heartbeatCalls += 1;
         return { ok: true, json: async () => ({ ok: true }) };
+      }
+      if (text.includes('/poker-act')){
+        fetchState.actCalls += 1;
+        if (init && typeof init.body === 'string' && init.body){
+          try {
+            fetchState.actBodies.push(JSON.parse(init.body));
+          } catch (_err) {
+            fetchState.actBodies.push(null);
+          }
+        }
       }
       if (text.includes('/ws-mint-token')){
         return { ok: true, json: async () => ({ ok: true, token: 'mint' }) };

--- a/tests/poker-ui-ws-act-errors.behavior.test.mjs
+++ b/tests/poker-ui-ws-act-errors.behavior.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createPokerTableHarness } from './helpers/poker-ui-table-harness.mjs';
+
+const wsClientSource = fs.readFileSync(path.join(process.cwd(), 'poker/poker-ws-client.js'), 'utf8');
+const sentFrames = [];
+const sockets = [];
+
+class FakeWebSocket {
+  constructor(url){
+    this.url = url;
+    this.readyState = 0;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+    this.onerror = null;
+    sockets.push(this);
+  }
+  send(raw){ sentFrames.push(JSON.parse(raw)); }
+  close(){ this.readyState = 3; if (this.onclose) this.onclose({ code: 1000 }); }
+}
+
+function emitFrame(ws, frame){
+  ws.onmessage({ data: JSON.stringify(frame) });
+}
+
+function createRealWsFactory(){
+  return function wsFactory(createOptions){
+    const sandbox = {
+      window: {
+        WebSocket: FakeWebSocket,
+        __POKER_WS_URL: 'wss://example/ws',
+        KLog: { log: () => {} }
+      },
+      fetch: async () => ({ ok: true, json: async () => ({ ok: true, token: 'mint-token' }) }),
+      JSON,
+      Date,
+      Math,
+      setTimeout,
+      clearTimeout,
+      Promise,
+      Error,
+      Map
+    };
+    sandbox.window.fetch = sandbox.fetch;
+    vm.createContext(sandbox);
+    vm.runInContext(wsClientSource, sandbox, { filename: 'poker/poker-ws-client.js' });
+    return sandbox.window.PokerWsClient.create(createOptions);
+  };
+}
+
+const harness = createPokerTableHarness({
+  responses: [
+    {
+      tableId: 'table-1',
+      status: 'OPEN',
+      maxPlayers: 6,
+      seats: [
+        { seatNo: 0, userId: 'user-1', status: 'ACTIVE', stack: 100 },
+        { seatNo: 1, userId: 'user-2', status: 'ACTIVE', stack: 100 },
+      ],
+      legalActions: ['FOLD'],
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      state: { version: 4, state: { handId: 'h-err-1', phase: 'PREFLOP', turnUserId: 'user-1', pot: 10, community: [] } },
+    },
+    {
+      tableId: 'table-1',
+      status: 'OPEN',
+      maxPlayers: 6,
+      seats: [
+        { seatNo: 0, userId: 'user-1', status: 'ACTIVE', stack: 100 },
+        { seatNo: 1, userId: 'user-2', status: 'ACTIVE', stack: 100 },
+      ],
+      legalActions: ['FOLD'],
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      state: { version: 5, state: { handId: 'h-err-1', phase: 'FLOP', turnUserId: 'user-2', pot: 12, community: ['As', 'Kd', '3h'] } },
+    },
+  ],
+  wsFactory: createRealWsFactory()
+});
+
+harness.fireDomContentLoaded();
+await harness.flush();
+await harness.flush();
+await harness.flush();
+
+const ws = sockets[0];
+ws.readyState = 1;
+ws.onopen();
+emitFrame(ws, { version: '1.0', type: 'helloAck', payload: {} });
+await harness.flush();
+emitFrame(ws, { version: '1.0', type: 'authOk', payload: { roomId: 'table-1' } });
+await harness.flush();
+emitFrame(ws, {
+  version: '1.0',
+  type: 'table_state',
+  payload: {
+    tableId: 'table-1',
+    stateVersion: 5,
+    hand: { handId: 'h-err-1', status: 'PREFLOP' },
+    turn: { userId: 'user-1', deadlineAt: Date.now() + 30000 },
+    legalActions: { actions: ['FOLD'] },
+    actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+    authoritativeMembers: [
+      { userId: 'user-1', seat: 0 },
+      { userId: 'user-2', seat: 1 }
+    ]
+  }
+});
+await harness.flush();
+
+harness.elements.pokerActFoldBtn.click();
+await harness.flush();
+const firstAct = sentFrames.filter((frame) => frame.type === 'act').slice(-1)[0];
+assert.ok(firstAct && firstAct.requestId, 'first act should be sent over WS with requestId');
+emitFrame(ws, {
+  version: '1.0',
+  type: 'commandResult',
+  requestId: firstAct.requestId,
+  payload: { requestId: firstAct.requestId, status: 'rejected', reason: 'invalid_amount' }
+});
+await harness.flush();
+
+assert.equal(harness.elements.pokerActStatus.textContent, 'Invalid amount', 'WS invalid_amount should show specific invalid amount message');
+assert.notEqual(harness.elements.pokerActStatus.textContent, 'Failed to send action', 'WS invalid_amount should not show generic action error');
+
+const getCallsBeforeStateInvalid = harness.fetchState.getCalls;
+harness.elements.pokerActFoldBtn.click();
+await harness.flush();
+const secondAct = sentFrames.filter((frame) => frame.type === 'act').slice(-1)[0];
+assert.ok(secondAct && secondAct.requestId, 'second act should be sent over WS with requestId');
+emitFrame(ws, {
+  version: '1.0',
+  type: 'commandResult',
+  requestId: secondAct.requestId,
+  payload: { requestId: secondAct.requestId, status: 'rejected', reason: 'state_invalid' }
+});
+await harness.flush();
+await harness.flush();
+assert.notEqual(harness.elements.pokerActStatus.textContent, 'Failed to send action', 'WS state_invalid should not collapse to generic failure');
+assert.equal(harness.fetchState.getCalls > getCallsBeforeStateInvalid, true, 'WS state_invalid should trigger loadTable(false) refresh when active');

--- a/tests/poker-ui-ws-act-http-fallback-refresh.behavior.test.mjs
+++ b/tests/poker-ui-ws-act-http-fallback-refresh.behavior.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { createPokerTableHarness } from './helpers/poker-ui-table-harness.mjs';
+
+const wsActPayloads = [];
+
+const harness = createPokerTableHarness({
+  responses: [
+    {
+      tableId: 'table-1',
+      status: 'OPEN',
+      maxPlayers: 6,
+      seats: [
+        { seatNo: 0, userId: 'user-1', status: 'ACTIVE', stack: 100 },
+        { seatNo: 1, userId: 'user-2', status: 'ACTIVE', stack: 100 },
+      ],
+      legalActions: ['FOLD'],
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      state: { version: 4, state: { handId: 'h-http-1', phase: 'PREFLOP', turnUserId: 'user-1', pot: 10, community: [] } },
+    },
+    {
+      tableId: 'table-1',
+      status: 'OPEN',
+      maxPlayers: 6,
+      seats: [
+        { seatNo: 0, userId: 'user-1', status: 'ACTIVE', stack: 99 },
+        { seatNo: 1, userId: 'user-2', status: 'ACTIVE', stack: 100 },
+      ],
+      legalActions: [],
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      state: { version: 5, state: { handId: 'h-http-1', phase: 'FLOP', turnUserId: 'user-2', pot: 12, community: ['As', 'Kd', '3h'] } },
+    },
+  ],
+  wsFactory: function wsFactory(){
+    return {
+      start(){},
+      destroy(){},
+      sendAct(payload){
+        wsActPayloads.push(payload);
+        const err = new Error('connection_closed');
+        err.code = 'connection_closed';
+        return Promise.reject(err);
+      }
+    };
+  }
+});
+
+harness.fireDomContentLoaded();
+await harness.flush();
+
+assert.equal(harness.fetchState.getCalls, 1, 'bootstrap should fetch initial table state once');
+assert.equal(harness.fetchState.actCalls, 0);
+
+harness.elements.pokerActFoldBtn.click();
+await harness.flush();
+await harness.flush();
+
+assert.equal(wsActPayloads.length, 1, 'WS should still be attempted first');
+assert.equal(harness.fetchState.actCalls, 1, 'fallback should call HTTP poker-act once');
+assert.equal(harness.fetchState.getCalls, 2, 'successful HTTP fallback should refresh table via loadTable(false)');
+
+const wsRequestId = wsActPayloads[0] && wsActPayloads[0].requestId ? String(wsActPayloads[0].requestId) : '';
+const httpRequestId = harness.fetchState.actBodies[0] && harness.fetchState.actBodies[0].requestId ? String(harness.fetchState.actBodies[0].requestId) : '';
+assert.ok(wsRequestId.length > 0, 'WS attempt should include non-empty requestId');
+assert.equal(httpRequestId, wsRequestId, 'HTTP fallback should reuse the same requestId for idempotency');
+
+assert.equal(Number(harness.elements.pokerVersion.textContent), 5, 'UI should reflect refreshed authoritative version after fallback success');
+assert.equal(harness.elements.pokerPhase.textContent, 'FLOP', 'UI phase should come from refreshed HTTP state after fallback');

--- a/tests/poker-ui-ws-act-live-state.behavior.test.mjs
+++ b/tests/poker-ui-ws-act-live-state.behavior.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { createPokerTableHarness } from './helpers/poker-ui-table-harness.mjs';
+
+const wsClientSource = fs.readFileSync(path.join(process.cwd(), 'poker/poker-ws-client.js'), 'utf8');
+const sentFrames = [];
+const sockets = [];
+
+class FakeWebSocket {
+  constructor(url){
+    this.url = url;
+    this.readyState = 0;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+    this.onerror = null;
+    sockets.push(this);
+  }
+
+  send(raw){
+    sentFrames.push(JSON.parse(raw));
+  }
+
+  close(){
+    this.readyState = 3;
+    if (typeof this.onclose === 'function') this.onclose({ code: 1000 });
+  }
+}
+
+function emitFrame(ws, frame){
+  ws.onmessage({ data: JSON.stringify(frame) });
+}
+
+function createRealWsFactory(){
+  return function wsFactory(createOptions){
+    const sandbox = {
+      window: {
+        WebSocket: FakeWebSocket,
+        __POKER_WS_URL: 'wss://example/ws',
+        KLog: { log: () => {} }
+      },
+      fetch: async () => ({ ok: true, json: async () => ({ ok: true, token: 'mint-token' }) }),
+      JSON,
+      Date,
+      Math,
+      setTimeout,
+      clearTimeout,
+      Promise,
+      Error,
+      Map
+    };
+    sandbox.window.fetch = sandbox.fetch;
+    vm.createContext(sandbox);
+    vm.runInContext(wsClientSource, sandbox, { filename: 'poker/poker-ws-client.js' });
+    return sandbox.window.PokerWsClient.create(createOptions);
+  };
+}
+
+const harness = createPokerTableHarness({
+  responses: [
+    {
+      tableId: 'table-1',
+      status: 'OPEN',
+      maxPlayers: 6,
+      seats: [
+        { seatNo: 0, userId: 'user-1', status: 'ACTIVE', stack: 100 },
+        { seatNo: 1, userId: 'user-2', status: 'ACTIVE', stack: 100 },
+      ],
+      legalActions: ['FOLD'],
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      state: {
+        version: 4,
+        state: {
+          handId: 'h-ws-1',
+          phase: 'PREFLOP',
+          turnUserId: 'user-1',
+          pot: 10,
+          community: []
+        }
+      },
+    },
+  ],
+  wsFactory: createRealWsFactory()
+});
+
+harness.fireDomContentLoaded();
+await harness.flush();
+await harness.flush();
+await harness.flush();
+
+assert.equal(harness.fetchState.getCalls, 1, 'bootstrap should fetch table once');
+assert.equal(sockets.length, 1, 'real WS client should create one socket');
+
+const ws = sockets[0];
+ws.readyState = 1;
+ws.onopen();
+
+assert.equal(sentFrames[0].type, 'hello', 'socket should send hello frame first');
+emitFrame(ws, { version: '1.0', type: 'helloAck', payload: {} });
+await harness.flush();
+
+const authFrame = sentFrames.find((frame) => frame.type === 'auth');
+assert.ok(authFrame, 'socket should send auth frame after helloAck');
+emitFrame(ws, { version: '1.0', type: 'authOk', payload: { roomId: 'table-1' } });
+await harness.flush();
+
+const subFrame = sentFrames.find((frame) => frame.type === 'table_state_sub');
+assert.ok(subFrame, 'socket should request table_state_sub after authOk');
+
+emitFrame(ws, {
+  version: '1.0',
+  type: 'table_state',
+  payload: {
+    tableId: 'table-1',
+    stateVersion: 5,
+    hand: { handId: 'h-ws-1', status: 'PREFLOP' },
+    turn: { userId: 'user-1', deadlineAt: Date.now() + 30000 },
+    legalActions: { actions: ['FOLD'] },
+    actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+    authoritativeMembers: [
+      { userId: 'user-1', seat: 0 },
+      { userId: 'user-2', seat: 1 }
+    ]
+  }
+});
+await harness.flush();
+
+harness.elements.pokerActFoldBtn.click();
+await harness.flush();
+
+const actFrame = sentFrames.find((frame) => frame.type === 'act');
+assert.ok(actFrame, 'clicking action should emit ws act envelope');
+assert.equal(actFrame.payload.handId, 'h-ws-1', 'act envelope should include current handId');
+assert.equal(actFrame.payload.action, 'FOLD', 'act envelope should include normalized action');
+assert.equal(typeof actFrame.requestId, 'string');
+assert.ok(actFrame.requestId.length > 0, 'act envelope should include requestId');
+
+emitFrame(ws, {
+  version: '1.0',
+  type: 'commandResult',
+  requestId: actFrame.requestId,
+  payload: { requestId: actFrame.requestId, status: 'accepted', reason: null }
+});
+await harness.flush();
+
+emitFrame(ws, {
+  version: '1.0',
+  type: 'table_state',
+  payload: {
+    tableId: 'table-1',
+    stateVersion: 6,
+    hand: { handId: 'h-ws-1', status: 'FLOP' },
+    turn: { userId: 'user-2', deadlineAt: Date.now() + 30000 },
+    legalActions: { actions: [] },
+    actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+    authoritativeMembers: [
+      { userId: 'user-1', seat: 0 },
+      { userId: 'user-2', seat: 1 }
+    ]
+  }
+});
+await harness.flush();
+
+assert.equal(harness.fetchState.actCalls, 0, 'healthy WS success path must not call HTTP poker-act');
+assert.equal(harness.fetchState.getCalls, 1, 'healthy WS success should not force HTTP refresh loadTable(false)');
+assert.equal(Number(harness.elements.pokerVersion.textContent), 6, 'UI should update from WS table_state after commandResult');
+assert.equal(harness.elements.pokerPhase.textContent, 'FLOP', 'UI should render phase from WS table_state update');

--- a/tests/poker-ws-client-act.behavior.test.mjs
+++ b/tests/poker-ws-client-act.behavior.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const source = fs.readFileSync(path.join(process.cwd(), 'poker/poker-ws-client.js'), 'utf8');
+
+const sentFrames = [];
+const sockets = [];
+
+class FakeWebSocket {
+  constructor(url){
+    this.url = url;
+    this.readyState = 0;
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+    this.onerror = null;
+    sockets.push(this);
+  }
+
+  send(raw){
+    sentFrames.push(JSON.parse(raw));
+  }
+
+  close(){
+    this.readyState = 3;
+    if (this.onclose) this.onclose({ code: 1000 });
+  }
+}
+
+function emitFrame(ws, frame){
+  ws.onmessage({ data: JSON.stringify(frame) });
+}
+
+function createClient(){
+  const sandbox = {
+    window: {
+      WebSocket: FakeWebSocket,
+      __POKER_WS_URL: 'wss://example/ws',
+      KLog: { log: () => {} },
+    },
+    fetch: async () => ({ ok: true, json: async () => ({ ok: true, token: 'mint-token' }) }),
+    JSON,
+    Date,
+    Math,
+    Map,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    Error,
+  };
+  sandbox.window.fetch = sandbox.fetch;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: 'poker/poker-ws-client.js' });
+
+  const client = sandbox.window.PokerWsClient.create({
+    tableId: 'table-1',
+    getAccessToken: async () => 'access-token',
+  });
+
+  return client;
+}
+
+const client = createClient();
+client.start();
+
+assert.equal(sockets.length, 1);
+const ws = sockets[0];
+ws.readyState = 1;
+ws.onopen();
+emitFrame(ws, { type: 'helloAck', payload: {} });
+await new Promise((resolve) => setTimeout(resolve, 0));
+emitFrame(ws, { type: 'authOk', payload: { roomId: 'table-1' } });
+
+const acceptedPromise = client.sendAct({ requestId: 'req-accepted', handId: 'h-1', action: 'fold' });
+const actFrame = sentFrames.find((frame) => frame.type === 'act' && frame.requestId === 'req-accepted');
+assert.ok(actFrame);
+
+emitFrame(ws, { type: 'commandResult', requestId: 'req-accepted', payload: { requestId: 'req-accepted', status: 'accepted', reason: null } });
+const accepted = await acceptedPromise;
+assert.equal(accepted.ok, true);
+
+const rejectedPromise = client.sendAct({ requestId: 'req-rejected', handId: 'h-1', action: 'fold' });
+emitFrame(ws, { type: 'commandResult', requestId: 'req-rejected', payload: { requestId: 'req-rejected', status: 'rejected', reason: 'illegal_action' } });
+await assert.rejects(rejectedPromise, (err) => err && err.code === 'illegal_action');
+
+const invalidAmountPromise = client.sendAct({ requestId: 'req-invalid-amount', handId: 'h-1', action: 'raise', amount: 1 });
+emitFrame(ws, { type: 'commandResult', requestId: 'req-invalid-amount', payload: { requestId: 'req-invalid-amount', status: 'rejected', reason: 'invalid_amount' } });
+await assert.rejects(invalidAmountPromise, (err) => err && err.code === 'invalid_amount');
+
+const stateInvalidPromise = client.sendAct({ requestId: 'req-state-invalid', handId: 'h-1', action: 'fold' });
+emitFrame(ws, { type: 'commandResult', requestId: 'req-state-invalid', payload: { requestId: 'req-state-invalid', status: 'rejected', reason: 'state_invalid' } });
+await assert.rejects(stateInvalidPromise, (err) => err && err.code === 'state_invalid');
+
+const pendingClosePromise = client.sendAct({ requestId: 'req-close', handId: 'h-1', action: 'fold' });
+ws.close();
+await assert.rejects(pendingClosePromise, (err) => err && err.code === 'connection_closed');

--- a/ws-server/poker/handlers/act.behavior.test.mjs
+++ b/ws-server/poker/handlers/act.behavior.test.mjs
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleAct } from "./act.mjs";
+import { createTableManager } from "../table/table-manager.mjs";
+
+function fakeWs(id) {
+  return { id };
+}
+
+function createConnState(userId) {
+  return {
+    sessionId: `session_${userId}`,
+    session: { userId }
+  };
+}
+
+test("handleAct accepts legal action, broadcasts once, and is idempotent by requestId", async () => {
+  const tableManager = createTableManager();
+  const wsA = fakeWs("a");
+  const wsB = fakeWs("b");
+  const tableId = "table_act_handler_ok";
+
+  tableManager.join({ ws: wsA, userId: "user_a", tableId, requestId: "join-a", nowTs: 1000 });
+  tableManager.join({ ws: wsB, userId: "user_b", tableId, requestId: "join-b", nowTs: 1001 });
+  const boot = tableManager.bootstrapHand(tableId, { nowMs: 2000 });
+  assert.equal(boot.ok, true);
+  assert.equal(boot.changed, true);
+
+  const preSnapshot = tableManager.tableSnapshot(tableId, "user_a");
+  const handId = preSnapshot.hand?.handId;
+  assert.ok(handId, "expected handId in snapshot");
+
+  const connA = createConnState("user_a");
+  const sentCommandResults = [];
+  const broadcastCalls = [];
+  const persistedCalls = [];
+
+  const frame = {
+    requestId: "req-act-1",
+    ts: "2026-03-01T00:00:00Z",
+    payload: { tableId, handId, action: "FOLD" }
+  };
+
+  await handleAct({
+    frame,
+    ws: wsA,
+    connState: connA,
+    tableId,
+    tableManager,
+    sendError: () => assert.fail("did not expect sendError"),
+    sendCommandResult: (_ws, _connState, payload) => sentCommandResults.push(payload),
+    persistMutatedState: async (payload) => { persistedCalls.push(payload); return { ok: true }; },
+    restoreTableFromPersisted: async () => assert.fail("did not expect restore"),
+    broadcastResyncRequired: () => assert.fail("did not expect resync"),
+    broadcastStateSnapshots: (broadcastTableId) => broadcastCalls.push(broadcastTableId)
+  });
+
+  const postSnapshot = tableManager.tableSnapshot(tableId, "user_a");
+  assert.equal(sentCommandResults.length, 1);
+  assert.equal(sentCommandResults[0].status, "accepted");
+  assert.equal(persistedCalls.length, 1);
+  assert.equal(broadcastCalls.length, 1);
+  assert.equal(postSnapshot.stateVersion, preSnapshot.stateVersion + 1);
+
+  await handleAct({
+    frame,
+    ws: wsA,
+    connState: connA,
+    tableId,
+    tableManager,
+    sendError: () => assert.fail("did not expect sendError"),
+    sendCommandResult: (_ws, _connState, payload) => sentCommandResults.push(payload),
+    persistMutatedState: async () => { persistedCalls.push({ duplicate: true }); return { ok: true }; },
+    restoreTableFromPersisted: async () => assert.fail("did not expect restore"),
+    broadcastResyncRequired: () => assert.fail("did not expect resync"),
+    broadcastStateSnapshots: (broadcastTableId) => broadcastCalls.push(broadcastTableId)
+  });
+
+  const replaySnapshot = tableManager.tableSnapshot(tableId, "user_a");
+  assert.equal(sentCommandResults.length, 2);
+  assert.equal(sentCommandResults[1].status, "accepted");
+  assert.equal(persistedCalls.length, 1, "duplicate requestId must not persist again");
+  assert.equal(broadcastCalls.length, 1, "duplicate requestId must not broadcast again");
+  assert.equal(replaySnapshot.stateVersion, postSnapshot.stateVersion, "duplicate requestId must not mutate state");
+});

--- a/ws-server/poker/handlers/act.invalid.behavior.test.mjs
+++ b/ws-server/poker/handlers/act.invalid.behavior.test.mjs
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleAct } from "./act.mjs";
+import { createTableManager } from "../table/table-manager.mjs";
+
+function fakeWs(id) {
+  return { id };
+}
+
+function createConnState(userId) {
+  return {
+    sessionId: `session_${userId}`,
+    session: { userId }
+  };
+}
+
+async function setupTable() {
+  const tableManager = createTableManager();
+  const wsA = fakeWs("a");
+  const wsB = fakeWs("b");
+  const wsObserver = fakeWs("obs");
+  const tableId = "table_act_handler_invalid";
+
+  tableManager.join({ ws: wsA, userId: "user_a", tableId, requestId: "join-a", nowTs: 1 });
+  tableManager.join({ ws: wsB, userId: "user_b", tableId, requestId: "join-b", nowTs: 2 });
+  tableManager.subscribe({ ws: wsObserver, tableId });
+  tableManager.bootstrapHand(tableId, { nowMs: 3000 });
+
+  const snapshot = tableManager.tableSnapshot(tableId, "user_a");
+  return { tableManager, wsA, wsB, wsObserver, tableId, handId: snapshot.hand?.handId };
+}
+
+test("handleAct rejects malformed, wrong table, wrong user, and illegal actions without mutation", async () => {
+  const { tableManager, wsA, wsObserver, tableId, handId } = await setupTable();
+  assert.ok(handId);
+
+  const sendErrors = [];
+  const commandResults = [];
+  const broadcasts = [];
+
+  const beforeVersion = tableManager.tableSnapshot(tableId, "user_a").stateVersion;
+
+  const cases = [
+    {
+      name: "malformed payload",
+      ws: wsA,
+      connState: createConnState("user_a"),
+      tableId,
+      frame: { requestId: "bad-1", ts: "2026-03-01T00:00:00Z", payload: { tableId, action: "FOLD" } },
+      expect: "error"
+    },
+    {
+      name: "wrong table against active connection",
+      ws: wsObserver,
+      connState: createConnState("user_observer"),
+      tableId: "table_other",
+      frame: { requestId: "bad-2", ts: "2026-03-01T00:00:00Z", payload: { tableId: "table_other", handId, action: "FOLD" } },
+      expect: "result"
+    },
+    {
+      name: "not seated user",
+      ws: wsA,
+      connState: createConnState("intruder"),
+      tableId,
+      frame: { requestId: "bad-3", ts: "2026-03-01T00:00:00Z", payload: { tableId, handId, action: "CALL" } },
+      expect: "result"
+    },
+    {
+      name: "not your turn",
+      ws: wsA,
+      connState: createConnState("user_b"),
+      tableId,
+      frame: { requestId: "bad-4", ts: "2026-03-01T00:00:00Z", payload: { tableId, handId, action: "CHECK" } },
+      expect: "result"
+    },
+    {
+      name: "illegal action",
+      ws: wsA,
+      connState: createConnState("user_a"),
+      tableId,
+      frame: { requestId: "bad-5", ts: "2026-03-01T00:00:00Z", payload: { tableId, handId, action: "RAISE", amount: 1 } },
+      expect: "result"
+    }
+  ];
+
+  for (const testCase of cases) {
+    await handleAct({
+      frame: testCase.frame,
+      ws: testCase.ws,
+      connState: testCase.connState,
+      tableId: testCase.tableId,
+      tableManager,
+      sendError: (_ws, _conn, payload) => sendErrors.push({ name: testCase.name, payload }),
+      sendCommandResult: (_ws, _conn, payload) => commandResults.push({ name: testCase.name, payload }),
+      persistMutatedState: async () => assert.fail("invalid cases must not persist"),
+      restoreTableFromPersisted: async () => assert.fail("invalid cases must not restore"),
+      broadcastResyncRequired: () => assert.fail("invalid cases must not resync"),
+      broadcastStateSnapshots: (broadcastTableId) => broadcasts.push(broadcastTableId)
+    });
+  }
+
+  const afterVersion = tableManager.tableSnapshot(tableId, "user_a").stateVersion;
+  assert.equal(afterVersion, beforeVersion, "invalid acts must not mutate authoritative state");
+  assert.equal(broadcasts.length, 0, "invalid acts must not broadcast success snapshots");
+
+  const malformed = sendErrors.find((entry) => entry.name === "malformed payload");
+  assert.ok(malformed);
+  assert.equal(malformed.payload.code, "INVALID_COMMAND");
+
+  for (const name of ["wrong table against active connection", "not seated user", "not your turn", "illegal action"]) {
+    const rejection = commandResults.find((entry) => entry.name === name);
+    assert.ok(rejection, `expected commandResult for ${name}`);
+    assert.equal(rejection.payload.status, "rejected");
+  }
+});

--- a/ws-server/poker/handlers/act.mjs
+++ b/ws-server/poker/handlers/act.mjs
@@ -1,0 +1,110 @@
+function rejectMalformed(sendError, ws, connState, requestId, message) {
+  sendError(ws, connState, {
+    code: "INVALID_COMMAND",
+    message,
+    requestId
+  });
+}
+
+function normalizeAction(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().toUpperCase();
+}
+
+export async function handleAct({
+  frame,
+  ws,
+  connState,
+  tableId,
+  tableManager,
+  sendError,
+  sendCommandResult,
+  persistMutatedState,
+  restoreTableFromPersisted,
+  broadcastResyncRequired,
+  broadcastStateSnapshots
+}) {
+  const requestId = frame.requestId ?? null;
+  const handId = typeof frame.payload?.handId === "string" ? frame.payload.handId.trim() : "";
+  const action = normalizeAction(frame.payload?.action);
+  const amount = frame.payload?.amount;
+
+  if (!handId) {
+    rejectMalformed(sendError, ws, connState, requestId, "act requires payload.handId");
+    return;
+  }
+
+  if (!["FOLD", "CHECK", "CALL", "BET", "RAISE"].includes(action)) {
+    rejectMalformed(sendError, ws, connState, requestId, "act requires payload.action of fold/check/call/bet/raise");
+    return;
+  }
+
+  if ((action === "BET" || action === "RAISE") && !Number.isFinite(amount)) {
+    rejectMalformed(sendError, ws, connState, requestId, "act requires numeric payload.amount for bet/raise");
+    return;
+  }
+
+  const activeTableId = typeof tableManager.resolveConnectionTableId === "function"
+    ? tableManager.resolveConnectionTableId({ ws })
+    : null;
+  if (activeTableId && activeTableId !== tableId) {
+    sendCommandResult(ws, connState, {
+      requestId,
+      tableId,
+      status: "rejected",
+      reason: "wrong_table"
+    });
+    return;
+  }
+
+  const ensured = await tableManager.ensureTableLoaded(tableId);
+  if (!ensured.ok) {
+    sendCommandResult(ws, connState, {
+      requestId,
+      tableId,
+      status: "rejected",
+      reason: ensured.code
+    });
+    return;
+  }
+
+  const result = tableManager.applyAction({
+    tableId,
+    handId,
+    userId: connState.session.userId,
+    requestId,
+    action,
+    amount,
+    nowIso: frame.ts
+  });
+
+  if (result.accepted && !result.replayed && result.changed) {
+    const persisted = await persistMutatedState({
+      tableId,
+      expectedVersion: Number(result.stateVersion) - 1,
+      mutationKind: "act"
+    });
+    if (!persisted?.ok) {
+      await restoreTableFromPersisted(tableId);
+      sendCommandResult(ws, connState, {
+        requestId,
+        tableId,
+        status: "rejected",
+        reason: persisted?.reason || "persist_failed"
+      });
+      broadcastResyncRequired(tableId, "persistence_conflict");
+      return;
+    }
+  }
+
+  sendCommandResult(ws, connState, {
+    requestId,
+    tableId,
+    status: result.accepted ? "accepted" : "rejected",
+    reason: result.reason
+  });
+
+  if (result.accepted && !result.replayed && result.changed) {
+    broadcastStateSnapshots(tableId);
+  }
+}

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -964,6 +964,18 @@ export function createTableManager({
     return matches.length === 1 ? matches[0] : null;
   }
 
+  function resolveConnectionTableId({ ws }) {
+    const conn = connStateBySocket.get(ws);
+    if (!conn) return null;
+    if (typeof conn.joinedTableId === "string" && conn.joinedTableId) {
+      return conn.joinedTableId;
+    }
+    if (typeof conn.subscribedTableId === "string" && conn.subscribedTableId) {
+      return conn.subscribedTableId;
+    }
+    return null;
+  }
+
   const manager = {
     ensureTableLoaded,
     join,
@@ -981,6 +993,7 @@ export function createTableManager({
     cleanupConnection,
     orderedSubscribers,
     orderedConnectionsForTable,
+    resolveConnectionTableId,
     resolveImplicitLeaveTableId,
     sweepExpiredPresence,
     persistedPokerState,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -6,6 +6,7 @@ import { handleHello } from "./poker/handlers/hello.mjs";
 import { handlePing } from "./poker/handlers/ping.mjs";
 import { handleAuth } from "./poker/handlers/auth.mjs";
 import { handleProtectedEcho } from "./poker/handlers/protected-echo.mjs";
+import { handleAct } from "./poker/handlers/act.mjs";
 import { verifyToken } from "./poker/auth/verify-token.mjs";
 import { createConnState } from "./poker/runtime/conn-state.mjs";
 import { ackSessionSeq, touchSession } from "./poker/runtime/session.mjs";
@@ -1158,88 +1159,19 @@ wss.on("connection", (ws) => {
         return;
       }
 
-      const tableId = resolvedRoomId.roomId;
-      const handId = typeof frame.payload?.handId === "string" ? frame.payload.handId.trim() : "";
-      const action = typeof frame.payload?.action === "string" ? frame.payload.action.trim().toUpperCase() : "";
-      const amount = frame.payload?.amount;
-
-      if (!handId) {
-        sendError(ws, connState, {
-          code: "INVALID_COMMAND",
-          message: "act requires payload.handId",
-          requestId: frame.requestId ?? null
-        });
-        return;
-      }
-
-      if (!["FOLD", "CHECK", "CALL", "BET", "RAISE"].includes(action)) {
-        sendError(ws, connState, {
-          code: "INVALID_COMMAND",
-          message: "act requires payload.action of fold/check/call/bet/raise",
-          requestId: frame.requestId ?? null
-        });
-        return;
-      }
-
-      if ((action === "BET" || action === "RAISE") && !Number.isFinite(amount)) {
-        sendError(ws, connState, {
-          code: "INVALID_COMMAND",
-          message: "act requires numeric payload.amount for bet/raise",
-          requestId: frame.requestId ?? null
-        });
-        return;
-      }
-
-      const ensured = await tableManager.ensureTableLoaded(tableId);
-      if (!ensured.ok) {
-        sendCommandResult(ws, connState, {
-          requestId: frame.requestId ?? null,
-          tableId,
-          status: "rejected",
-          reason: ensured.code
-        });
-        return;
-      }
-
-      const result = tableManager.applyAction({
-        tableId,
-        handId,
-        userId: connState.session.userId,
-        requestId: frame.requestId,
-        action,
-        amount,
-        nowIso: frame.ts
+      await handleAct({
+        frame,
+        ws,
+        connState,
+        tableId: resolvedRoomId.roomId,
+        tableManager,
+        sendError,
+        sendCommandResult,
+        persistMutatedState,
+        restoreTableFromPersisted,
+        broadcastResyncRequired,
+        broadcastStateSnapshots
       });
-
-      if (result.accepted && !result.replayed && result.changed) {
-        const persisted = await persistMutatedState({
-          tableId,
-          expectedVersion: Number(result.stateVersion) - 1,
-          mutationKind: "act"
-        });
-        if (!persisted?.ok) {
-          await restoreTableFromPersisted(tableId);
-          sendCommandResult(ws, connState, {
-            requestId: frame.requestId ?? null,
-            tableId,
-            status: "rejected",
-            reason: persisted?.reason || "persist_failed"
-          });
-          broadcastResyncRequired(tableId, "persistence_conflict");
-          return;
-        }
-      }
-
-      sendCommandResult(ws, connState, {
-        requestId: frame.requestId ?? null,
-        tableId,
-        status: result.accepted ? "accepted" : "rejected",
-        reason: result.reason
-      });
-
-      if (result.accepted && !result.replayed && result.changed) {
-        broadcastStateSnapshots(tableId);
-      }
       return;
     }
 

--- a/ws-tests/ws-deploy-workflow.test.mjs
+++ b/ws-tests/ws-deploy-workflow.test.mjs
@@ -40,6 +40,10 @@ test("ws-deploy keeps ws-tests trigger surface and runs harness checks", () => {
   assert.match(text, /Run ws poker engine bootstrap behavior test/);
   assert.match(text, /node --test ws-server\/poker\/engine\/engine-bootstrap\.behavior\.test\.mjs/);
   assert.match(text, /Run ws poker engine act behavior test/);
+  assert.match(text, /Run ws act handler behavior test/);
+  assert.match(text, /node --test ws-server\/poker\/handlers\/act\.behavior\.test\.mjs/);
+  assert.match(text, /Run ws act handler invalid behavior test/);
+  assert.match(text, /node --test ws-server\/poker\/handlers\/act\.invalid\.behavior\.test\.mjs/);
   assert.match(text, /node --test ws-server\/poker\/engine\/engine-act\.behavior\.test\.mjs/);
   assert.match(text, /Run ws poker engine rollover behavior test/);
   assert.match(text, /node --test ws-server\/poker\/engine\/engine-rollover\.behavior\.test\.mjs/);

--- a/ws-tests/ws-pr-workflow.test.mjs
+++ b/ws-tests/ws-pr-workflow.test.mjs
@@ -76,6 +76,10 @@ function assertRequiredOrder(text) {
   assert.match(block, /node --test ws-server\/poker\/engine\/engine-rollover\.behavior\.test\.mjs/);
   assert.match(block, /Run ws poker engine timeout behavior test/);
   assert.match(block, /node --test ws-server\/poker\/engine\/engine-timeout\.behavior\.test\.mjs/);
+  assert.match(block, /Run ws act handler behavior test/);
+  assert.match(block, /node --test ws-server\/poker\/handlers\/act\.behavior\.test\.mjs/);
+  assert.match(block, /Run ws act handler invalid behavior test/);
+  assert.match(block, /node --test ws-server\/poker\/handlers\/act\.invalid\.behavior\.test\.mjs/);
 
   assert.equal(rootInstall, -1);
   assert.notEqual(install, -1);

--- a/ws-tests/ws-tests-suite-completeness.guard.test.mjs
+++ b/ws-tests/ws-tests-suite-completeness.guard.test.mjs
@@ -31,6 +31,11 @@ const REQUIRED_PERSISTED_BOOTSTRAP_BEHAVIOR_TESTS = [
   "ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs",
   "ws-server/poker/bootstrap/persisted-bootstrap-repository.behavior.test.mjs"
 ];
+
+const REQUIRED_WS_ACT_HANDLER_BEHAVIOR_TESTS = [
+  "ws-server/poker/handlers/act.behavior.test.mjs",
+  "ws-server/poker/handlers/act.invalid.behavior.test.mjs"
+];
 const EXCLUDED_FROM_PR = new Set([
   "ws-tests/ws-deploy-workflow.test.mjs",
   "ws-tests/ws-lockfile-integrity.test.mjs",
@@ -196,5 +201,16 @@ test("persisted bootstrap behavior tests are wired in both PR and deploy workflo
     const command = `node --test ${file}`;
     assert.ok(prWorkflow.includes(command), `Missing persisted bootstrap test in PR workflow: ${file}`);
     assert.ok(deployWorkflow.includes(command), `Missing persisted bootstrap test in deploy workflow: ${file}`);
+  }
+});
+
+test("WS act handler behavior tests are wired in both PR and deploy workflows", () => {
+  const prWorkflow = workflowText(".github/workflows/ws-pr-checks.yml");
+  const deployWorkflow = workflowText(".github/workflows/ws-deploy.yml");
+
+  for (const file of REQUIRED_WS_ACT_HANDLER_BEHAVIOR_TESTS) {
+    const command = `node --test ${file}`;
+    assert.ok(prWorkflow.includes(command), `Missing WS act handler test in PR workflow: ${file}`);
+    assert.ok(deployWorkflow.includes(command), `Missing WS act handler test in deploy workflow: ${file}`);
   }
 });


### PR DESCRIPTION
### Motivation

- Add first-class WebSocket handling for player actions (`act`) so commands are validated, idempotent by `requestId`, persisted, and broadcast without duplicating server logic in the main message processor.
- Provide a promise-based client API for `act` to allow the UI to await WS acknowledgements and fall back to HTTP when the WS path is unavailable while preserving idempotency.
- Improve test harness and CI workflows to cover the new WS paths and ensure behavior across client, UI, and server code.

### Description

- Added a new server-side handler `ws-server/poker/handlers/act.mjs` that validates frames, enforces allowed actions/amounts, applies actions via `tableManager`, persists mutations, replies via `sendCommandResult`, and broadcasts snapshots when appropriate.
- Wire `handleAct` into the main server flow by importing it in `ws-server/server.mjs` and delegating `act` frames to the handler instead of inlining logic there.
- Extended `ws-server/poker/table/table-manager.mjs` with `resolveConnectionTableId` to help validate if a connection is attached to the target table.
- Enhanced the browser WS client `poker/poker-ws-client.js` with a pending commands map, `sendAct` promise API, requestId reuse, `rejectPendingCommands` on close/shutdown, and resolution/rejection of pending promises when `commandResult`/`error` frames arrive.
- Updated the UI `poker/poker.js` to attempt WS `sendAct` first with fallback to HTTP `apiPost` when the WS attempt fails or the connection is unavailable, reusing the same `requestId` for idempotency and only forcing `loadTable(false)` when the HTTP transport completed the action.
- Improved the test harness in `tests/helpers/poker-ui-table-harness.mjs` with event listener support (`click`), fetch tracking for `/poker-act`, and other utilities to validate request bodies and URLs.
- Added a comprehensive set of automated tests for the new functionality: WS server handler tests (`ws-server/poker/handlers/act.behavior.test.mjs`, `act.invalid.behavior.test.mjs`), WS client tests (`tests/poker-ws-client-act.behavior.test.mjs`), and UI-level WS-act behavior tests (`tests/poker-ui-ws-act-live-state.behavior.test.mjs`, `tests/poker-ui-ws-act-http-fallback-refresh.behavior.test.mjs`, `tests/poker-ui-ws-act-errors.behavior.test.mjs`).
- Updated CI workflows (`.github/workflows/ws-deploy.yml`, `.github/workflows/ws-pr-checks.yml`) and ws-tests guard files to run the new tests and assert their presence in PR and deploy pipelines.

### Testing

- Ran the new server handler tests `node --test ws-server/poker/handlers/act.behavior.test.mjs` and `node --test ws-server/poker/handlers/act.invalid.behavior.test.mjs`, which passed.
- Executed WS client and UI behavior tests `node --test tests/poker-ws-client-act.behavior.test.mjs`, `node --test tests/poker-ui-ws-act-live-state.behavior.test.mjs`, `node --test tests/poker-ui-ws-act-http-fallback-refresh.behavior.test.mjs`, and `node --test tests/poker-ui-ws-act-errors.behavior.test.mjs`, all of which passed.
- Verified CI/workflow guard checks by running the updated ws-tests (`ws-tests/ws-deploy-workflow.test.mjs`, `ws-tests/ws-pr-workflow.test.mjs`, and `ws-tests/ws-tests-suite-completeness.guard.test.mjs`) which detect and assert the new tests are wired into the workflows and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72019bb3c832399dda8f054f7514a)