### PR TITLE
Persist inert closed state on inactive cleanup and skip closed tables during timeout sweeps

### DIFF
--- a/shared/poker-domain/inactive-cleanup.mjs
+++ b/shared/poker-domain/inactive-cleanup.mjs
@@ -43,6 +43,30 @@ function hasAnyActiveHuman(seats) {
   return (seats || []).some((row) => row?.is_bot !== true && row?.status === "ACTIVE");
 }
 
+function toClosedInertState({ state, stacks }) {
+  return {
+    ...state,
+    phase: "HAND_DONE",
+    handId: "",
+    handSeed: "",
+    showdown: null,
+    community: [],
+    communityDealt: 0,
+    pot: 0,
+    potTotal: 0,
+    sidePots: [],
+    turnUserId: null,
+    turnStartedAt: null,
+    turnDeadlineAt: null,
+    lastAggressorUserId: null,
+    currentBet: 0,
+    toCallByUserId: {},
+    betThisRoundByUserId: {},
+    actedThisRoundByUserId: {},
+    stacks
+  };
+}
+
 async function postCashout({ postTransaction, tx, tableId, userId, amount, idempotencyKey, createdBy, reason }) {
   if (!postTransaction || typeof postTransaction !== "function") {
     throw new Error("post_transaction_missing");
@@ -143,7 +167,7 @@ export async function executeInactiveCleanup({
     }
 
     if (stateRow) {
-      const finalState = { ...state, stacks };
+      const finalState = toClosedInertState({ state, stacks });
       await tx.unsafe("update public.poker_state set state = $2 where table_id = $1;", [tableId, JSON.stringify(finalState)]);
     }
 

--- a/tests/poker-inactive-cleanup.behavior.test.mjs
+++ b/tests/poker-inactive-cleanup.behavior.test.mjs
@@ -108,6 +108,24 @@ test('singleton human disconnect closes table, ignores bots keep-alive, and clos
   assert.equal(closeUser4.idempotencyKey, 'poker:inactive_cleanup_close:table-3:user-4');
   const holeCardDelete = ctx.updates.find((u) => String(u.query).includes('delete from public.poker_hole_cards'));
   assert.ok(holeCardDelete, 'close path should clear hole cards');
+  const closedState = ctx.updates.filter((u) => u.kind === 'state').at(-1)?.value;
+  assert.ok(closedState, 'close path should persist closed inert state');
+  assert.equal(closedState.phase, 'HAND_DONE');
+  assert.equal(closedState.handId, '');
+  assert.equal(closedState.handSeed, '');
+  assert.equal(closedState.showdown, null);
+  assert.deepEqual(closedState.community, []);
+  assert.equal(closedState.communityDealt, 0);
+  assert.equal(closedState.pot, 0);
+  assert.equal(closedState.potTotal, 0);
+  assert.deepEqual(closedState.sidePots, []);
+  assert.equal(closedState.turnUserId, null);
+  assert.equal(closedState.turnStartedAt, null);
+  assert.equal(closedState.turnDeadlineAt, null);
+  assert.equal(closedState.currentBet, 0);
+  assert.deepEqual(closedState.toCallByUserId, {});
+  assert.deepEqual(closedState.betThisRoundByUserId, {});
+  assert.deepEqual(closedState.actedThisRoundByUserId, {});
 });
 
 test('idempotent no-op when seat is already inactive', async () => {
@@ -129,5 +147,49 @@ test('idempotent no-op when seat is already inactive', async () => {
   });
 
   assert.equal(result.ok, true);
+  assert.equal(ctx.ledgerCalls.length, 0);
+});
+
+test('repeated cleanup against already closed inert table remains stable and no-op', async () => {
+  const inertState = {
+    phase: 'HAND_DONE',
+    handId: '',
+    handSeed: '',
+    showdown: null,
+    community: [],
+    communityDealt: 0,
+    pot: 0,
+    potTotal: 0,
+    sidePots: [],
+    turnUserId: null,
+    turnStartedAt: null,
+    turnDeadlineAt: null,
+    stacks: {}
+  };
+  const ctx = makeTx({
+    seat: { table_id: 'table-5', user_id: 'user-5', seat_no: 5, status: 'INACTIVE', is_bot: false, stack: 0 },
+    state: inertState,
+    allSeats: [{ user_id: 'user-5', status: 'INACTIVE', is_bot: false, stack: 0 }],
+    tableStatus: 'CLOSED'
+  });
+
+  const result = await executeInactiveCleanup({
+    tableId: 'table-5',
+    userId: 'user-5',
+    requestId: 'req-5',
+    env: {},
+    beginSql: async (fn) => fn(ctx.tx),
+    postTransaction: async (payload) => ctx.ledgerCalls.push(payload),
+    isHoleCardsTableMissing: () => false
+  });
+
+  assert.equal(result.status, 'already_closed');
+  assert.equal(result.changed, false);
+  const finalState = ctx.updates.filter((u) => u.kind === 'state').at(-1)?.value;
+  assert.equal(finalState.phase, inertState.phase);
+  assert.equal(finalState.turnUserId, inertState.turnUserId);
+  assert.equal(finalState.turnStartedAt, inertState.turnStartedAt);
+  assert.equal(finalState.turnDeadlineAt, inertState.turnDeadlineAt);
+  assert.deepEqual(finalState.stacks, inertState.stacks);
   assert.equal(ctx.ledgerCalls.length, 0);
 });

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -65,6 +65,14 @@ function normalizeStateVersion(rawVersion) {
   return parsed;
 }
 
+function normalizeTableStatus(rawStatus) {
+  if (typeof rawStatus !== "string") {
+    return "OPEN";
+  }
+  const normalized = rawStatus.trim().toUpperCase();
+  return normalized || "OPEN";
+}
+
 function normalizePublicStacks(seatRows) {
   if (!Array.isArray(seatRows)) {
     return {};
@@ -215,6 +223,7 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
     ok: true,
     table: {
       tableId,
+      tableStatus: normalizeTableStatus(tableRow.status),
       coreState: {
         roomId: tableId,
         maxSeats,

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -64,6 +64,12 @@ function normalizeAuthoritativeMembers(table) {
   });
 }
 
+function normalizeTableStatus(value) {
+  if (typeof value !== "string") return "OPEN";
+  const normalized = value.trim().toUpperCase();
+  return normalized || "OPEN";
+}
+
 export function createTableManager({
   presenceTtlMs = DEFAULT_PRESENCE_TTL_MS,
   maxSeats = DEFAULT_MAX_SEATS,
@@ -141,6 +147,7 @@ export function createTableManager({
       const initialCoreState = createInitialCoreState({ roomId: tableId, maxSeats });
       tables.set(tableId, {
         tableId,
+        tableStatus: "OPEN",
         coreState: initialCoreState,
         persistedStateVersion: Number.isInteger(initialCoreState.version) ? initialCoreState.version : 0,
         presenceByUserId: new Map(),
@@ -183,6 +190,7 @@ export function createTableManager({
       }
 
       const loadedTable = loaded.table;
+      loadedTable.tableStatus = normalizeTableStatus(loadedTable.tableStatus);
       const loadedVersion = Number(loadedTable?.coreState?.version);
       loadedTable.persistedStateVersion = Number.isInteger(loadedVersion) && loadedVersion >= 0 ? loadedVersion : 0;
       tables.set(tableId, loadedTable);
@@ -399,9 +407,12 @@ export function createTableManager({
     };
   }
 
-  function sweepTurnTimeouts({ nowMs = Date.now() } = {}) {
+  function sweepTurnTimeouts({ nowMs = Date.now(), shouldProcessTable = null } = {}) {
     const updates = [];
     for (const [tableId] of tables.entries()) {
+      if (typeof shouldProcessTable === "function" && shouldProcessTable(tableId) !== true) {
+        continue;
+      }
       const timeoutResult = maybeApplyTurnTimeout({ tableId, nowMs });
       if (timeoutResult.ok && timeoutResult.changed) {
         updates.push({ tableId, stateVersion: timeoutResult.stateVersion });
@@ -941,6 +952,7 @@ export function createTableManager({
     }
 
     table.coreState = restoredCoreState;
+    table.tableStatus = normalizeTableStatus(restoredTable?.tableStatus);
     table.persistedStateVersion = Number.isInteger(restoredCoreState.version) && restoredCoreState.version >= 0
       ? restoredCoreState.version
       : table.persistedStateVersion;
@@ -960,6 +972,11 @@ export function createTableManager({
     }
 
     return { ...table.coreState.pokerState };
+  }
+
+  function isTableClosed(tableId) {
+    const table = tables.get(tableId);
+    return normalizeTableStatus(table?.tableStatus) === "CLOSED";
   }
 
   function __debugCore(tableId) {
@@ -1036,7 +1053,8 @@ export function createTableManager({
     persistedPokerState,
     persistedStateVersion,
     setPersistedStateVersion,
-    restoreTableFromPersisted
+    restoreTableFromPersisted,
+    isTableClosed
   };
 
   if (enableDebugCore && nodeEnv !== "production") {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2844,6 +2844,123 @@ export function createInactiveCleanupExecutor({ env }) {
   }
 });
 
+test("disconnect cleanup close rewrite restores inert state and blocks repeated timeout sweeps", async () => {
+  const secret = "disconnect-cleanup-closed-inert";
+  const tableId = "table_disconnect_closed_inert";
+  const store = {
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "active" },
+        seatRows: [{ user_id: "seat_user_closed", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 500 }],
+        stateRow: {
+          version: 17,
+          state: {
+            handId: "h17",
+            phase: "PREFLOP",
+            turnUserId: "seat_user_closed",
+            turnStartedAt: Date.now() - 30_000,
+            turnDeadlineAt: Date.now() - 20_000,
+            stacks: { seat_user_closed: 500 }
+          }
+        }
+      }
+    }
+  };
+  const { dir, filePath } = await writePersistedFile(store);
+  const cleanupModule = await writeTestModule(`
+import fs from "node:fs/promises";
+export function createInactiveCleanupExecutor({ env }) {
+  return async ({ tableId, userId }) => {
+    const raw = await fs.readFile(env.WS_PERSISTED_STATE_FILE, "utf8");
+    const doc = JSON.parse(raw || "{}");
+    const table = doc?.tables?.[tableId];
+    if (!table) return { ok: true, changed: false, status: "seat_missing", retryable: false };
+    table.tableRow = { ...(table.tableRow || {}), status: "CLOSED" };
+    table.seatRows = (Array.isArray(table.seatRows) ? table.seatRows : []).map((row) =>
+      row?.user_id === userId ? { ...row, status: "INACTIVE", stack: 0 } : row
+    );
+    const state = table?.stateRow?.state && typeof table.stateRow.state === "object" ? table.stateRow.state : {};
+    const nextStacks = { ...(state.stacks || {}) };
+    delete nextStacks[userId];
+    table.stateRow = {
+      ...(table.stateRow || { version: 0 }),
+      state: {
+        ...state,
+        phase: "HAND_DONE",
+        handId: "",
+        handSeed: "",
+        showdown: null,
+        community: [],
+        communityDealt: 0,
+        pot: 0,
+        potTotal: 0,
+        sidePots: [],
+        turnUserId: null,
+        turnStartedAt: null,
+        turnDeadlineAt: null,
+        currentBet: 0,
+        toCallByUserId: {},
+        betThisRoundByUserId: {},
+        actedThisRoundByUserId: {},
+        stacks: nextStacks
+      }
+    };
+    await fs.writeFile(env.WS_PERSISTED_STATE_FILE, JSON.stringify(doc) + "\\n", "utf8");
+    return { ok: true, changed: true, status: "cleaned_closed", closed: true, retryable: false };
+  };
+}
+`, "inactive-cleanup-test-adapter-closed.mjs");
+
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_DISCONNECT_CLEANUP_SWEEP_MS: "25",
+      WS_TIMEOUT_SWEEP_MS: "20",
+      WS_INACTIVE_CLEANUP_ADAPTER_MODULE_PATH: `file://${cleanupModule.filePath}`
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const seated = await connectClient(port);
+    const observer = await connectClient(port);
+    await hello(seated);
+    await hello(observer);
+    await auth(seated, makeHs256Jwt({ secret, sub: "seat_user_closed" }), "auth-seat-cleanup-closed");
+    await auth(observer, makeHs256Jwt({ secret, sub: "observer_user_closed" }), "auth-observer-cleanup-closed");
+
+    sendFrame(seated, { version: "1.0", type: "table_join", requestId: "join-cleanup-closed-seat", ts: "2026-03-01T00:05:01Z", payload: { tableId } });
+    await nextMessageOfType(seated, "commandResult");
+    await nextMessageOfType(seated, "table_state");
+
+    sendFrame(observer, { version: "1.0", type: "table_state_sub", requestId: "sub-cleanup-closed-observer", ts: "2026-03-01T00:05:02Z", payload: { tableId, view: "snapshot" } });
+    await nextMessageOfType(observer, "stateSnapshot");
+
+    seated.close();
+    await waitForStdoutLine(child, "ws_disconnect_cleanup_restore_success", 5000);
+    sendFrame(observer, { version: "1.0", type: "table_state_sub", requestId: "sub-cleanup-closed-observer-post", ts: "2026-03-01T00:05:03Z", payload: { tableId, view: "snapshot" } });
+    const afterCleanup = await nextMessageOfType(observer, "stateSnapshot");
+    assert.equal(afterCleanup.payload.public.turn.userId, null);
+
+    const versionAfterCleanup = afterCleanup.payload.stateVersion;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const persistedAfterSweep = await readPersistedFile(filePath);
+    assert.equal(persistedAfterSweep.tables[tableId].stateRow.state.phase, "HAND_DONE");
+    assert.equal(persistedAfterSweep.tables[tableId].stateRow.version, versionAfterCleanup);
+    sendFrame(observer, { version: "1.0", type: "table_state_sub", requestId: "sub-cleanup-closed-observer-final", ts: "2026-03-01T00:05:04Z", payload: { tableId, view: "snapshot" } });
+    const finalSnapshot = await nextMessageOfType(observer, "stateSnapshot");
+    assert.equal(finalSnapshot.payload.public.turn.userId, null);
+    assert.equal(finalSnapshot.payload.stateVersion, versionAfterCleanup);
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(cleanupModule.dir, { recursive: true, force: true });
+  }
+});
+
 test("disconnect cleanup restore failure does not broadcast stale success", async () => {
   const secret = "disconnect-cleanup-failure";
   const tableId = "table_disconnect_restore_fail";

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -697,7 +697,10 @@ async function sweepDisconnectCleanupAndBroadcast() {
 
 async function sweepTurnTimeoutsAndBroadcast() {
   const nowMs = Date.now();
-  const timeoutUpdates = tableManager.sweepTurnTimeouts({ nowMs });
+  const timeoutUpdates = tableManager.sweepTurnTimeouts({
+    nowMs,
+    shouldProcessTable: (tableId) => tableManager.isTableClosed(tableId) !== true
+  });
   for (const update of timeoutUpdates) {
     const persisted = await persistMutatedState({
       tableId: update.tableId,


### PR DESCRIPTION
### Motivation

- Ensure that when an inactive human-only table is closed by the inactive cleanup flow the poker state is rewritten to an inert `HAND_DONE` state so subsequent timeout sweeps and restores don't revive turn deadlines or active hands.
- Normalize and consistently track table status across bootstrap/restore/code paths and avoid applying turn timeouts to tables already closed.

### Description

- Add `toClosedInertState` in `shared/poker-domain/inactive-cleanup.mjs` to produce a canonical inert `HAND_DONE` state (clears hand fields, community, pots, turn metadata and preserves `stacks`).
- Replace inline final-state rewrite with a call to `toClosedInertState` when persisting the closed table state in the cleanup flow and clear seat stacks accordingly in the same transaction.
- Add `normalizeTableStatus` to `ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs` and to `ws-server/poker/table/table-manager.mjs` to normalize missing/invalid statuses to `OPEN` and persist normalized `tableStatus` into loaded/restored tables; set default `tableStatus` for newly created tables.
- Add `isTableClosed` to the table manager and extend `sweepTurnTimeouts` with a `shouldProcessTable` hook so callers can skip processing closed tables; the server now calls `sweepTurnTimeouts` with a predicate to skip `CLOSED` tables.
- Add tests and assertions to verify the closed inert state is persisted and that repeated cleanup on already-closed inert state is a no-op; add an integration-like behavior test that ensures a disconnect cleanup rewrite restores an inert state and prevents further timeout sweeps from changing state.

### Testing

- Ran the poker inactive-cleanup behavior tests in `tests/poker-inactive-cleanup.behavior.test.mjs`, including the new checks that the inert `HAND_DONE` state is persisted and that repeated cleanup is a no-op; all assertions passed.
- Ran the websocket server behavior suite updates in `ws-server/server.behavior.test.mjs`, including the new `disconnect cleanup close rewrite` scenario that verifies restore persistence and that timeout sweeps are blocked for closed tables; the new test passed.
- End-to-end integration scenarios exercising `sweepTurnTimeouts` with the `shouldProcessTable` predicate and the disconnect cleanup broadcast/restore flows were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc10dbd6d483238198de3a6b535ed2)