### PR TITLE
Sanitize amount-based actions, validate bet/raise payloads, and improve turn-action UI state

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -282,6 +282,11 @@
     return n;
   }
 
+  function normalizeActionTypeValue(value){
+    if (typeof value !== 'string') return '';
+    return value.trim().toUpperCase();
+  }
+
   function normalizeDeadlineMs(deadline){
     if (deadline == null) return null;
     var num = Number(deadline);
@@ -324,6 +329,74 @@
     };
   }
 
+  function normalizeActionConstraints(constraints){
+    var source = isPlainObject(constraints) ? constraints : null;
+    return {
+      toCall: toFiniteOrNull(source ? source.toCall : null),
+      minRaiseTo: toFiniteOrNull(source ? source.minRaiseTo : null),
+      maxRaiseTo: toFiniteOrNull(source ? source.maxRaiseTo : null),
+      maxBetAmount: toFiniteOrNull(source ? source.maxBetAmount : null)
+    };
+  }
+
+  function sanitizeAllowedActions(allowedSet, constraints){
+    var sanitized = new Set();
+    if (allowedSet && typeof allowedSet.forEach === 'function'){
+      allowedSet.forEach(function(type){
+        var normalizedType = normalizeActionTypeValue(type);
+        if (normalizedType) sanitized.add(normalizedType);
+      });
+    }
+    var normalizedConstraints = normalizeActionConstraints(constraints);
+    var betMax = normalizedConstraints.maxBetAmount;
+    var betAllowed = betMax != null && betMax >= 1;
+    if (sanitized.has('BET') && !betAllowed){
+      sanitized.delete('BET');
+    }
+    var raiseMin = normalizedConstraints.minRaiseTo;
+    var raiseMax = normalizedConstraints.maxRaiseTo;
+    var raiseRangeValid = raiseMin != null && raiseMax != null && raiseMax >= raiseMin;
+    var raiseActionable = raiseRangeValid && raiseMax >= 1;
+    if (sanitized.has('RAISE') && !raiseActionable){
+      sanitized.delete('RAISE');
+    }
+    return {
+      allowed: sanitized,
+      needsAmount: sanitized.has('BET') || sanitized.has('RAISE'),
+      constraints: normalizedConstraints
+    };
+  }
+
+  function validateAmountActionPayload(actionType, amountValue, allowedInfo){
+    var normalizedType = normalizeActionTypeValue(actionType);
+    if (normalizedType !== 'BET' && normalizedType !== 'RAISE'){
+      return { ok: true, amount: null };
+    }
+    if (!allowedInfo || !allowedInfo.allowed || !allowedInfo.allowed.has(normalizedType)){
+      return { error: t('pokerErrActionNotAllowed', 'Action not allowed right now') };
+    }
+    var amount = parseInt(amountValue, 10);
+    if (!isFinite(amount) || amount <= 0){
+      return { error: t('pokerActAmountRequired', 'Enter an amount for bet/raise') };
+    }
+    var constraints = normalizeActionConstraints(allowedInfo.constraints);
+    if (normalizedType === 'BET'){
+      if (constraints.maxBetAmount == null || constraints.maxBetAmount < 1 || amount > constraints.maxBetAmount){
+        return { error: t('pokerErrActAmount', 'Invalid amount') };
+      }
+    } else if (normalizedType === 'RAISE'){
+      var raiseMin = constraints.minRaiseTo;
+      var raiseMax = constraints.maxRaiseTo;
+      if (raiseMin == null || raiseMax == null || raiseMax < raiseMin || raiseMax < 1){
+        return { error: t('pokerErrActAmount', 'Invalid amount') };
+      }
+      if (amount < raiseMin || amount > raiseMax){
+        return { error: t('pokerErrActAmount', 'Invalid amount') };
+      }
+    }
+    return { ok: true, amount: Math.trunc(amount) };
+  }
+
   function getSeatDisplayName(seat){
     if (!seat) return '';
     return seat.displayName || seat.name || seat.username || seat.userName || seat.handle || '';
@@ -362,6 +435,24 @@
     };
   }
 
+  function resolveTurnActionUiState(params){
+    var info = params || {};
+    var sanitizedAllowedActions = Array.isArray(info.sanitizedAllowedActions) ? info.sanitizedAllowedActions : [];
+    var rawLegalActions = Array.isArray(info.rawLegalActions) ? info.rawLegalActions : [];
+    var showActions = shouldShowTurnActions({
+      phase: info.phase,
+      turnUserId: info.turnUserId,
+      currentUserId: info.currentUserId,
+      legalActions: sanitizedAllowedActions
+    });
+    var isUsersTurn = !!info.isUsersTurn;
+    var status = null;
+    if (isUsersTurn && sanitizedAllowedActions.length === 0){
+      status = rawLegalActions.length > 0 ? 'no_actionable_moves' : 'contract_mismatch';
+    }
+    return { showActions: showActions, status: status };
+  }
+
 
   if (window.__RUNNING_POKER_UI_TESTS__ === true){
     window.__POKER_UI_TEST_HOOKS__ = {
@@ -370,6 +461,9 @@
       shouldShowTurnActions: shouldShowTurnActions,
       getConstraintsFromResponse: getConstraintsFromResponse,
       getLegalActionsFromResponse: getLegalActionsFromResponse,
+      sanitizeAllowedActions: sanitizeAllowedActions,
+      validateAmountActionPayload: validateAmountActionPayload,
+      resolveTurnActionUiState: resolveTurnActionUiState,
       ensurePokerRecorder: ensurePokerRecorder,
       getPokerDumpText: getPokerDumpText,
       copyTextToClipboard: copyTextToClipboard,
@@ -1747,7 +1841,7 @@
     }
 
     function getAllowedActionsForUser(data, userId){
-      var info = { allowed: new Set(), needsAmount: false, phase: null, turnUserId: null, isUsersTurn: false, legalActions: [] };
+      var info = { allowed: new Set(), needsAmount: false, phase: null, turnUserId: null, isUsersTurn: false, legalActions: [], constraints: normalizeActionConstraints(null) };
       if (!data || !userId) return info;
       var stateObj = data && data.state ? data.state : null;
       var gameState = stateObj && stateObj.state ? stateObj.state : {};
@@ -1761,7 +1855,11 @@
         var type = normalizeActionType(list[i]);
         if (type) allowed.add(type);
       }
-      info.needsAmount = allowed.has('BET') || allowed.has('RAISE');
+      var sourceConstraints = data && data._actionConstraints ? data._actionConstraints : getConstraintsFromResponse(data);
+      var sanitized = sanitizeAllowedActions(allowed, sourceConstraints);
+      info.allowed = sanitized.allowed;
+      info.needsAmount = sanitized.needsAmount;
+      info.constraints = sanitized.constraints;
       return info;
     }
 
@@ -1769,16 +1867,23 @@
       var allowedInfo = getAllowedActionsForUser(tableData, currentUserId);
       var allowed = allowedInfo.allowed;
       var enabled = shouldEnableDevActions();
-      var dumpEnabled = shouldEnableDumpLogs();
-      var copyEnabled = shouldEnableCopyLog();
-      var hasActions = shouldShowTurnActions({
+      var uiState = resolveTurnActionUiState({
         phase: allowedInfo.phase,
         turnUserId: allowedInfo.turnUserId,
         currentUserId: currentUserId,
-        legalActions: allowedInfo.legalActions
+        isUsersTurn: allowedInfo.isUsersTurn,
+        rawLegalActions: allowedInfo.legalActions,
+        sanitizedAllowedActions: Array.from(allowedInfo.allowed)
       });
+      var hasActions = uiState.showActions;
       toggleHidden(actRow, !hasActions);
       toggleHidden(actAmountWrap, !hasActions || !allowedInfo.needsAmount);
+      if (pendingActType && !allowed.has(pendingActType)){
+        pendingActType = null;
+        if (actAmountInput){
+          actAmountInput.value = '';
+        }
+      }
       var actions = [
         { type: 'CHECK', el: actCheckBtn },
         { type: 'CALL', el: actCallBtn },
@@ -1797,8 +1902,7 @@
           actCallBtn.dataset.baseLabel = actCallBtn.textContent || t('pokerActCall', 'CALL');
         }
         var baseLabel = actCallBtn.dataset.baseLabel || t('pokerActCall', 'CALL');
-        var constraints = tableData && tableData._actionConstraints ? tableData._actionConstraints : null;
-        var toCall = constraints ? toFiniteOrNull(constraints.toCall) : null;
+        var toCall = allowedInfo.constraints ? allowedInfo.constraints.toCall : null;
         var callAllowed = allowed.has('CALL');
         if (callAllowed && toCall != null && toCall > 0){
           var callTemplate = t('pokerCallWithAmount', 'CALL ({amount})');
@@ -1813,8 +1917,10 @@
       }
       updateActAmountHint(allowedInfo, pendingActType);
       if (actStatusEl){
-        if (allowedInfo.isUsersTurn && allowed.size === 0){
+        if (uiState.status === 'contract_mismatch'){
           setInlineStatus(actStatusEl, t('pokerContractMismatch', 'No legal actions computed. Client/server contract mismatch.'), 'error');
+        } else if (uiState.status === 'no_actionable_moves'){
+          setInlineStatus(actStatusEl, t('pokerNoActionableMoves', 'No actionable moves available right now'), null);
         } else if (!allowedInfo.isUsersTurn && isActionablePhase(allowedInfo.phase) && !!allowedInfo.turnUserId){
           setInlineStatus(actStatusEl, t('pokerWaitingForOpponent', 'Waiting for opponent'), null);
         } else if (actStatusEl.dataset.authRequired !== '1') {
@@ -1827,21 +1933,20 @@
       if (!actAmountInput) return;
       actAmountInput.removeAttribute('min');
       actAmountInput.removeAttribute('max');
-      var constraints = tableData && tableData._actionConstraints ? tableData._actionConstraints : null;
+      var constraints = allowedInfo && allowedInfo.constraints ? allowedInfo.constraints : null;
       if (!constraints || !selectedType || !allowedInfo || !allowedInfo.allowed) return;
       var normalized = normalizeActionType(selectedType);
       if (!normalized) return;
       if (!allowedInfo.allowed.has(normalized)) return;
       if (normalized === 'RAISE'){
-        if (constraints.minRaiseTo != null){
+        if (constraints.minRaiseTo != null && constraints.maxRaiseTo != null && constraints.maxRaiseTo >= constraints.minRaiseTo && constraints.maxRaiseTo >= 1){
           actAmountInput.setAttribute('min', String(constraints.minRaiseTo));
-        }
-        if (constraints.maxRaiseTo != null){
           actAmountInput.setAttribute('max', String(constraints.maxRaiseTo));
         }
         return;
       }
-      if (normalized === 'BET' && constraints.maxBetAmount != null){
+      if (normalized === 'BET' && constraints.maxBetAmount != null && constraints.maxBetAmount >= 1){
+        actAmountInput.setAttribute('min', '1');
         actAmountInput.setAttribute('max', String(constraints.maxBetAmount));
       }
     }
@@ -1853,7 +1958,7 @@
         actAmountHintEl.hidden = true;
         return;
       }
-      var constraints = tableData && tableData._actionConstraints ? tableData._actionConstraints : null;
+      var constraints = allowedInfo && allowedInfo.constraints ? allowedInfo.constraints : null;
       var normalized = normalizeActionType(selectedType);
       if (!constraints || !normalized || !allowedInfo.allowed){
         actAmountHintEl.textContent = '';
@@ -1867,21 +1972,21 @@
       }
       var hint = '';
       if (normalized === 'RAISE'){
-        var minRaiseTo = toFiniteOrNull(constraints.minRaiseTo);
-        var maxRaiseTo = toFiniteOrNull(constraints.maxRaiseTo);
-        if (minRaiseTo != null && maxRaiseTo != null){
+        var minRaiseTo = constraints.minRaiseTo;
+        var maxRaiseTo = constraints.maxRaiseTo;
+        if (minRaiseTo != null && maxRaiseTo != null && maxRaiseTo >= minRaiseTo && maxRaiseTo >= 1){
           var rangeTemplate = t('pokerRaiseRange', 'Raise-to range: {min}–{max}');
           hint = rangeTemplate.replace('{min}', String(minRaiseTo)).replace('{max}', String(maxRaiseTo));
-        } else if (minRaiseTo != null){
+        } else if (minRaiseTo != null && minRaiseTo >= 1){
           var minTemplate = t('pokerRaiseMin', 'Raise-to min: {min}');
           hint = minTemplate.replace('{min}', String(minRaiseTo));
-        } else if (maxRaiseTo != null){
+        } else if (maxRaiseTo != null && maxRaiseTo >= 1){
           var maxTemplate = t('pokerRaiseMax', 'Raise-to max: {max}');
           hint = maxTemplate.replace('{max}', String(maxRaiseTo));
         }
       } else if (normalized === 'BET'){
-        var maxBetAmount = toFiniteOrNull(constraints.maxBetAmount);
-        if (maxBetAmount != null){
+        var maxBetAmount = constraints.maxBetAmount;
+        if (maxBetAmount != null && maxBetAmount >= 1){
           var betTemplate = t('pokerBetMax', 'Bet max: {max}');
           hint = betTemplate.replace('{max}', String(maxBetAmount));
         }
@@ -2827,25 +2932,10 @@
     function getActPayload(actionType){
       var payload = { type: actionType };
       if (actionType === 'BET' || actionType === 'RAISE'){
-        var amount = parseInt(actAmountInput ? actAmountInput.value : '', 10);
-        if (!isFinite(amount) || amount <= 0){
-          return { error: t('pokerActAmountRequired', 'Enter an amount for bet/raise') };
-        }
-        var constraints = tableData && tableData._actionConstraints ? tableData._actionConstraints : null;
-        if (constraints){
-          if (actionType === 'BET' && constraints.maxBetAmount != null && amount > constraints.maxBetAmount){
-            return { error: t('pokerErrActAmount', 'Invalid amount') };
-          }
-          if (actionType === 'RAISE'){
-            if (constraints.minRaiseTo != null && amount < constraints.minRaiseTo){
-              return { error: t('pokerErrActAmount', 'Invalid amount') };
-            }
-            if (constraints.maxRaiseTo != null && amount > constraints.maxRaiseTo){
-              return { error: t('pokerErrActAmount', 'Invalid amount') };
-            }
-          }
-        }
-        payload.amount = Math.trunc(amount);
+        var allowedInfo = getAllowedActionsForUser(tableData, currentUserId);
+        var validation = validateAmountActionPayload(actionType, actAmountInput ? actAmountInput.value : '', allowedInfo);
+        if (validation.error) return { error: validation.error };
+        payload.amount = validation.amount;
       }
       return { action: payload };
     }

--- a/tests/poker-ui-amount-actions-sanitization.test.mjs
+++ b/tests/poker-ui-amount-actions-sanitization.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const root = process.cwd();
+const source = fs.readFileSync(path.join(root, 'poker/poker.js'), 'utf8');
+
+const sandbox = {
+  Buffer,
+  window: {
+    location: { pathname: '/poker/table.html', search: '' },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    __RUNNING_POKER_UI_TESTS__: true,
+  },
+  document: {
+    readyState: 'loading',
+    addEventListener: () => {},
+    getElementById: () => null,
+    body: { innerHTML: '' },
+    visibilityState: 'visible',
+  },
+  URLSearchParams,
+  Date,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  navigator: { userAgent: 'node' },
+  localStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+  fetch: async () => { throw new Error('fetch not available in unit test'); },
+  atob: (value) => Buffer.from(String(value), 'base64').toString('binary'),
+  btoa: (value) => Buffer.from(String(value), 'binary').toString('base64'),
+};
+
+sandbox.window.document = sandbox.document;
+sandbox.window.navigator = sandbox.navigator;
+sandbox.window.localStorage = sandbox.localStorage;
+sandbox.window.fetch = sandbox.fetch;
+sandbox.window.atob = sandbox.atob;
+sandbox.window.btoa = sandbox.btoa;
+
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'poker/poker.js' });
+const hooks = sandbox.window.__POKER_UI_TEST_HOOKS__;
+
+assert.ok(hooks && hooks.sanitizeAllowedActions && hooks.validateAmountActionPayload && hooks.resolveTurnActionUiState, 'expected poker UI sanitization hooks');
+
+// Test case 1 — BET hidden when numeric max is zero.
+{
+  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET', 'CHECK']), { maxBetAmount: 0, toCall: 0 });
+  assert.equal(sanitized.allowed.has('BET'), false, 'BET should be removed when maxBetAmount is zero');
+  const showActions = hooks.shouldShowTurnActions({
+    phase: 'PREFLOP',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    legalActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(showActions, true, 'row should stay visible when a sanitized non-amount action (CHECK) remains');
+  assert.equal(sanitized.needsAmount, false, 'amount input should not be required when impossible amount action is removed');
+}
+
+// Test case 2 — BET shown when numeric max is valid.
+{
+  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 20, toCall: 0 });
+  assert.equal(sanitized.allowed.has('BET'), true, 'BET should remain available with positive maxBetAmount');
+  const payload = hooks.validateAmountActionPayload('BET', '12', sanitized);
+  assert.equal(payload.error, undefined, 'valid bet amount should pass payload validation');
+  assert.equal(payload.amount, 12, 'validated payload amount should be normalized to integer');
+}
+
+// Test case 3 — RAISE hidden when raise range is impossible.
+{
+  const sanitized = hooks.sanitizeAllowedActions(new Set(['RAISE']), { minRaiseTo: 10, maxRaiseTo: 5 });
+  assert.equal(sanitized.allowed.has('RAISE'), false, 'RAISE should be removed when minRaiseTo exceeds maxRaiseTo');
+  assert.equal(sanitized.needsAmount, false, 'amount input should not remain required when impossible raise is removed');
+  const showActions = hooks.shouldShowTurnActions({
+    phase: 'TURN',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    legalActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(showActions, false, 'row should be hidden when sanitization removes all actions');
+}
+
+// Test case 4 — stale selected BET cleared after snapshot update (modeled via validation).
+{
+  const initial = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 15 });
+  assert.equal(initial.allowed.has('BET'), true, 'BET is initially allowed');
+  const updated = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 0 });
+  assert.equal(updated.allowed.has('BET'), false, 'BET is removed after constraints update');
+  const payload = hooks.validateAmountActionPayload('BET', '5', updated);
+  assert.equal(payload.error, 'Action not allowed right now', 'stale BET selection should fail as not allowed after sanitization update');
+}
+
+// Test case 5 — submission path uses sanitized action availability.
+{
+  const rawLegalButImpossible = hooks.sanitizeAllowedActions(new Set(['BET', 'CALL']), { maxBetAmount: 0, toCall: 0 });
+  const payload = hooks.validateAmountActionPayload('BET', '1', rawLegalButImpossible);
+  assert.equal(payload.error, 'Action not allowed right now', 'payload validation should reject impossible BET even if legalActions included BET');
+}
+
+// Regression — sanitized-empty actions hide turn actions row when driven by sanitized model.
+{
+  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 0, toCall: 0 });
+  assert.equal(sanitized.allowed.has('BET'), false, 'sanitization should remove impossible BET');
+  const showActions = hooks.shouldShowTurnActions({
+    phase: 'RIVER',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    legalActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(showActions, false, 'turn actions should be hidden when sanitized actions are empty');
+  const uiState = hooks.resolveTurnActionUiState({
+    isUsersTurn: true,
+    phase: 'RIVER',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    rawLegalActions: ['BET'],
+    sanitizedAllowedActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(uiState.showActions, false, 'resolved UI state should hide row when sanitized actions are empty');
+  assert.equal(uiState.status, 'no_actionable_moves', 'resolved UI state should indicate non-mismatch no-actionable state');
+  const payload = hooks.validateAmountActionPayload('BET', '1', sanitized);
+  assert.equal(payload.error, 'Action not allowed right now', 'sanitized-empty state should block impossible BET submission');
+}
+
+// Regression happy path — valid positive BET keeps turn actions visible.
+{
+  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 20, toCall: 0 });
+  assert.equal(sanitized.allowed.has('BET'), true, 'BET should remain allowed when maxBetAmount is positive');
+  const showActions = hooks.shouldShowTurnActions({
+    phase: 'FLOP',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    legalActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(showActions, true, 'turn actions should stay visible for valid sanitized BET');
+  const uiState = hooks.resolveTurnActionUiState({
+    isUsersTurn: true,
+    phase: 'FLOP',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    rawLegalActions: ['BET'],
+    sanitizedAllowedActions: Array.from(sanitized.allowed)
+  });
+  assert.equal(uiState.showActions, true, 'resolved UI state should keep row visible for valid sanitized BET');
+  assert.equal(uiState.status, null, 'resolved UI state should not show empty-state status when sanitized action exists');
+}
+
+// Regression — raw-empty user-turn state remains contract mismatch.
+{
+  const uiState = hooks.resolveTurnActionUiState({
+    isUsersTurn: true,
+    phase: 'TURN',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    rawLegalActions: [],
+    sanitizedAllowedActions: []
+  });
+  assert.equal(uiState.showActions, false, 'resolved UI state should hide row when no raw/sanitized actions exist');
+  assert.equal(uiState.status, 'contract_mismatch', 'raw-empty user-turn state should preserve contract mismatch status');
+}

--- a/tests/poker-ui-turn-actions.test.mjs
+++ b/tests/poker-ui-turn-actions.test.mjs
@@ -54,6 +54,9 @@ vm.runInContext(source, sandbox, { filename: 'poker/poker.js' });
 
 const hooks = sandbox.window.__POKER_UI_TEST_HOOKS__;
 assert.ok(hooks, 'poker UI should expose test hooks when explicitly enabled');
+assert.equal(typeof hooks.sanitizeAllowedActions, 'function', 'sanitizeAllowedActions hook should be exposed');
+assert.equal(typeof hooks.validateAmountActionPayload, 'function', 'validateAmountActionPayload hook should be exposed');
+assert.equal(typeof hooks.resolveTurnActionUiState, 'function', 'resolveTurnActionUiState hook should be exposed');
 
 const countdown = hooks.computeRemainingTurnSeconds(Date.now() + 30000, Date.now());
 assert.ok(countdown > 0, 'countdown should be positive for future deadline in ms');


### PR DESCRIPTION
### Motivation

- Prevent impossible amount-based actions (BET/RAISE) from being displayed or submitted when server-provided constraints make them infeasible.
- Normalize and centralize constraint handling and action-type normalization to avoid client/server contract mismatches and stale selections.

### Description

- Added `normalizeActionTypeValue`, `normalizeActionConstraints`, `sanitizeAllowedActions`, `validateAmountActionPayload`, and `resolveTurnActionUiState` helpers to normalize inputs, sanitize action lists against numeric constraints, validate bet/raise payloads, and compute turn-action UI state.
- Updated `getAllowedActionsForUser` to apply sanitization and store normalized `constraints` and `needsAmount` on the returned info object.
- Updated UI rendering and input helpers (`renderAllowedActionButtons`, `updateActAmountConstraints`, `updateActAmountHint`, and `getActPayload`) to use sanitized action sets and normalized constraints; this includes clearing stale `pendingActType` selections when they become invalid and switching status labels between `contract_mismatch` and `no_actionable_moves` appropriately.
- Exposed the new helpers on the test hooks when `window.__RUNNING_POKER_UI_TESTS__` is enabled.
- Added comprehensive unit tests in `tests/poker-ui-amount-actions-sanitization.test.mjs` and updated `tests/poker-ui-turn-actions.test.mjs` to cover sanitization, validation, and UI-state resolution behaviors.

### Testing

- Ran the poker UI unit tests including `poker-ui-turn-actions.test.mjs` and the new `poker-ui-amount-actions-sanitization.test.mjs` under the Node VM sandbox harness, and all assertions passed.
- Verified the test hooks expose `sanitizeAllowedActions`, `validateAmountActionPayload`, and `resolveTurnActionUiState` and that the added test cases for hidden/visible actions, validation rejections, and status labels succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc242868e88323a64fb19894136974)