### PR TITLE
Trust server legalActions for BET/RAISE availability in poker UI

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -347,23 +347,10 @@
         if (normalizedType) sanitized.add(normalizedType);
       });
     }
-    var normalizedConstraints = normalizeActionConstraints(constraints);
-    var betMax = normalizedConstraints.maxBetAmount;
-    var betAllowed = betMax != null && betMax >= 1;
-    if (sanitized.has('BET') && !betAllowed){
-      sanitized.delete('BET');
-    }
-    var raiseMin = normalizedConstraints.minRaiseTo;
-    var raiseMax = normalizedConstraints.maxRaiseTo;
-    var raiseRangeValid = raiseMin != null && raiseMax != null && raiseMax >= raiseMin;
-    var raiseActionable = raiseRangeValid && raiseMax >= 1;
-    if (sanitized.has('RAISE') && !raiseActionable){
-      sanitized.delete('RAISE');
-    }
     return {
       allowed: sanitized,
       needsAmount: sanitized.has('BET') || sanitized.has('RAISE'),
-      constraints: normalizedConstraints
+      constraints: normalizeActionConstraints(constraints)
     };
   }
 
@@ -381,16 +368,14 @@
     }
     var constraints = normalizeActionConstraints(allowedInfo.constraints);
     if (normalizedType === 'BET'){
-      if (constraints.maxBetAmount == null || constraints.maxBetAmount < 1 || amount > constraints.maxBetAmount){
+      if (constraints.maxBetAmount != null && constraints.maxBetAmount >= 1 && amount > constraints.maxBetAmount){
         return { error: t('pokerErrActAmount', 'Invalid amount') };
       }
     } else if (normalizedType === 'RAISE'){
       var raiseMin = constraints.minRaiseTo;
       var raiseMax = constraints.maxRaiseTo;
-      if (raiseMin == null || raiseMax == null || raiseMax < raiseMin || raiseMax < 1){
-        return { error: t('pokerErrActAmount', 'Invalid amount') };
-      }
-      if (amount < raiseMin || amount > raiseMax){
+      var hasValidRaiseRange = raiseMin != null && raiseMax != null && raiseMax >= raiseMin && raiseMax >= 1;
+      if (hasValidRaiseRange && (amount < raiseMin || amount > raiseMax)){
         return { error: t('pokerErrActAmount', 'Invalid amount') };
       }
     }
@@ -437,17 +422,17 @@
 
   function resolveTurnActionUiState(params){
     var info = params || {};
-    var sanitizedAllowedActions = Array.isArray(info.sanitizedAllowedActions) ? info.sanitizedAllowedActions : [];
+    var availableActions = Array.isArray(info.availableActions) ? info.availableActions : [];
     var rawLegalActions = Array.isArray(info.rawLegalActions) ? info.rawLegalActions : [];
     var showActions = shouldShowTurnActions({
       phase: info.phase,
       turnUserId: info.turnUserId,
       currentUserId: info.currentUserId,
-      legalActions: sanitizedAllowedActions
+      legalActions: availableActions
     });
     var isUsersTurn = !!info.isUsersTurn;
     var status = null;
-    if (isUsersTurn && sanitizedAllowedActions.length === 0){
+    if (isUsersTurn && availableActions.length === 0){
       status = rawLegalActions.length > 0 ? 'no_actionable_moves' : 'contract_mismatch';
     }
     return { showActions: showActions, status: status };
@@ -1856,10 +1841,9 @@
         if (type) allowed.add(type);
       }
       var sourceConstraints = data && data._actionConstraints ? data._actionConstraints : getConstraintsFromResponse(data);
-      var sanitized = sanitizeAllowedActions(allowed, sourceConstraints);
-      info.allowed = sanitized.allowed;
-      info.needsAmount = sanitized.needsAmount;
-      info.constraints = sanitized.constraints;
+      info.allowed = allowed;
+      info.needsAmount = allowed.has('BET') || allowed.has('RAISE');
+      info.constraints = normalizeActionConstraints(sourceConstraints);
       return info;
     }
 
@@ -1873,17 +1857,18 @@
         currentUserId: currentUserId,
         isUsersTurn: allowedInfo.isUsersTurn,
         rawLegalActions: allowedInfo.legalActions,
-        sanitizedAllowedActions: Array.from(allowedInfo.allowed)
+        availableActions: Array.from(allowedInfo.allowed)
       });
       var hasActions = uiState.showActions;
       toggleHidden(actRow, !hasActions);
-      toggleHidden(actAmountWrap, !hasActions || !allowedInfo.needsAmount);
       if (pendingActType && !allowed.has(pendingActType)){
         pendingActType = null;
         if (actAmountInput){
           actAmountInput.value = '';
         }
       }
+      var selectedNeedsAmount = pendingActType === 'BET' || pendingActType === 'RAISE';
+      toggleHidden(actAmountWrap, !hasActions || !selectedNeedsAmount);
       var actions = [
         { type: 'CHECK', el: actCheckBtn },
         { type: 'CALL', el: actCallBtn },
@@ -1912,7 +1897,7 @@
         }
       }
       if (actAmountInput){
-        setDisabled(actAmountInput, !enabled || actPending || !allowedInfo.needsAmount);
+        setDisabled(actAmountInput, !enabled || actPending || !selectedNeedsAmount);
         updateActAmountConstraints(allowedInfo, pendingActType);
       }
       updateActAmountHint(allowedInfo, pendingActType);

--- a/tests/poker-ui-amount-actions-sanitization.test.mjs
+++ b/tests/poker-ui-amount-actions-sanitization.test.mjs
@@ -49,111 +49,63 @@ vm.createContext(sandbox);
 vm.runInContext(source, sandbox, { filename: 'poker/poker.js' });
 const hooks = sandbox.window.__POKER_UI_TEST_HOOKS__;
 
-assert.ok(hooks && hooks.sanitizeAllowedActions && hooks.validateAmountActionPayload && hooks.resolveTurnActionUiState, 'expected poker UI sanitization hooks');
+assert.ok(hooks && hooks.sanitizeAllowedActions && hooks.validateAmountActionPayload && hooks.resolveTurnActionUiState, 'expected poker UI amount-action hooks');
 
-// Test case 1 — BET hidden when numeric max is zero.
+// Contract: legalActions availability is server-authoritative even when constraints are missing.
 {
-  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET', 'CHECK']), { maxBetAmount: 0, toCall: 0 });
-  assert.equal(sanitized.allowed.has('BET'), false, 'BET should be removed when maxBetAmount is zero');
-  const showActions = hooks.shouldShowTurnActions({
-    phase: 'PREFLOP',
-    turnUserId: 'user-1',
-    currentUserId: 'user-1',
-    legalActions: Array.from(sanitized.allowed)
-  });
-  assert.equal(showActions, true, 'row should stay visible when a sanitized non-amount action (CHECK) remains');
-  assert.equal(sanitized.needsAmount, false, 'amount input should not be required when impossible amount action is removed');
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['BET']), null);
+  assert.equal(allowedInfo.allowed.has('BET'), true, 'BET should remain available when constraints are missing');
+  const payload = hooks.validateAmountActionPayload('BET', '20', allowedInfo);
+  assert.equal(payload.error, undefined, 'positive BET should pass local validation when maxBetAmount is absent');
+  assert.equal(payload.amount, 20, 'validated payload amount should be normalized to integer');
 }
 
-// Test case 2 — BET shown when numeric max is valid.
 {
-  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 20, toCall: 0 });
-  assert.equal(sanitized.allowed.has('BET'), true, 'BET should remain available with positive maxBetAmount');
-  const payload = hooks.validateAmountActionPayload('BET', '12', sanitized);
-  assert.equal(payload.error, undefined, 'valid bet amount should pass payload validation');
-  assert.equal(payload.amount, 12, 'validated payload amount should be normalized to integer');
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['RAISE']), { minRaiseTo: null, maxRaiseTo: null });
+  assert.equal(allowedInfo.allowed.has('RAISE'), true, 'RAISE should remain available when raise range constraints are absent');
+  const payload = hooks.validateAmountActionPayload('RAISE', '20', allowedInfo);
+  assert.equal(payload.error, undefined, 'positive RAISE should pass local validation when raise range is absent');
+  assert.equal(payload.amount, 20, 'validated raise payload should normalize to integer');
 }
 
-// Test case 3 — RAISE hidden when raise range is impossible.
+// Invalid non-positive amount is still rejected.
 {
-  const sanitized = hooks.sanitizeAllowedActions(new Set(['RAISE']), { minRaiseTo: 10, maxRaiseTo: 5 });
-  assert.equal(sanitized.allowed.has('RAISE'), false, 'RAISE should be removed when minRaiseTo exceeds maxRaiseTo');
-  assert.equal(sanitized.needsAmount, false, 'amount input should not remain required when impossible raise is removed');
-  const showActions = hooks.shouldShowTurnActions({
-    phase: 'TURN',
-    turnUserId: 'user-1',
-    currentUserId: 'user-1',
-    legalActions: Array.from(sanitized.allowed)
-  });
-  assert.equal(showActions, false, 'row should be hidden when sanitization removes all actions');
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['BET']), null);
+  const zeroPayload = hooks.validateAmountActionPayload('BET', '0', allowedInfo);
+  assert.equal(zeroPayload.error, 'Enter an amount for bet/raise', 'zero bet amount should fail local validation');
+  const negativePayload = hooks.validateAmountActionPayload('RAISE', '-4', hooks.sanitizeAllowedActions(new Set(['RAISE']), null));
+  assert.equal(negativePayload.error, 'Enter an amount for bet/raise', 'negative raise amount should fail local validation');
 }
 
-// Test case 4 — stale selected BET cleared after snapshot update (modeled via validation).
+// When constraints are present and valid they still enforce ranges.
 {
-  const initial = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 15 });
-  assert.equal(initial.allowed.has('BET'), true, 'BET is initially allowed');
-  const updated = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 0 });
-  assert.equal(updated.allowed.has('BET'), false, 'BET is removed after constraints update');
-  const payload = hooks.validateAmountActionPayload('BET', '5', updated);
-  assert.equal(payload.error, 'Action not allowed right now', 'stale BET selection should fail as not allowed after sanitization update');
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 20 });
+  const payload = hooks.validateAmountActionPayload('BET', '21', allowedInfo);
+  assert.equal(payload.error, 'Invalid amount', 'BET should enforce maxBetAmount when present');
 }
 
-// Test case 5 — submission path uses sanitized action availability.
 {
-  const rawLegalButImpossible = hooks.sanitizeAllowedActions(new Set(['BET', 'CALL']), { maxBetAmount: 0, toCall: 0 });
-  const payload = hooks.validateAmountActionPayload('BET', '1', rawLegalButImpossible);
-  assert.equal(payload.error, 'Action not allowed right now', 'payload validation should reject impossible BET even if legalActions included BET');
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['RAISE']), { minRaiseTo: 10, maxRaiseTo: 20 });
+  const low = hooks.validateAmountActionPayload('RAISE', '9', allowedInfo);
+  assert.equal(low.error, 'Invalid amount', 'RAISE should enforce minRaiseTo when valid range is present');
+  const inRange = hooks.validateAmountActionPayload('RAISE', '15', allowedInfo);
+  assert.equal(inRange.error, undefined, 'RAISE should accept value inside valid range');
 }
 
-// Regression — sanitized-empty actions hide turn actions row when driven by sanitized model.
+// Turn actions visibility is computed from available legal actions.
 {
-  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 0, toCall: 0 });
-  assert.equal(sanitized.allowed.has('BET'), false, 'sanitization should remove impossible BET');
-  const showActions = hooks.shouldShowTurnActions({
-    phase: 'RIVER',
-    turnUserId: 'user-1',
-    currentUserId: 'user-1',
-    legalActions: Array.from(sanitized.allowed)
-  });
-  assert.equal(showActions, false, 'turn actions should be hidden when sanitized actions are empty');
   const uiState = hooks.resolveTurnActionUiState({
     isUsersTurn: true,
     phase: 'RIVER',
     turnUserId: 'user-1',
     currentUserId: 'user-1',
     rawLegalActions: ['BET'],
-    sanitizedAllowedActions: Array.from(sanitized.allowed)
+    availableActions: ['BET']
   });
-  assert.equal(uiState.showActions, false, 'resolved UI state should hide row when sanitized actions are empty');
-  assert.equal(uiState.status, 'no_actionable_moves', 'resolved UI state should indicate non-mismatch no-actionable state');
-  const payload = hooks.validateAmountActionPayload('BET', '1', sanitized);
-  assert.equal(payload.error, 'Action not allowed right now', 'sanitized-empty state should block impossible BET submission');
+  assert.equal(uiState.showActions, true, 'BET should keep action row visible');
+  assert.equal(uiState.status, null, 'status should be clear when available legal actions exist');
 }
 
-// Regression happy path — valid positive BET keeps turn actions visible.
-{
-  const sanitized = hooks.sanitizeAllowedActions(new Set(['BET']), { maxBetAmount: 20, toCall: 0 });
-  assert.equal(sanitized.allowed.has('BET'), true, 'BET should remain allowed when maxBetAmount is positive');
-  const showActions = hooks.shouldShowTurnActions({
-    phase: 'FLOP',
-    turnUserId: 'user-1',
-    currentUserId: 'user-1',
-    legalActions: Array.from(sanitized.allowed)
-  });
-  assert.equal(showActions, true, 'turn actions should stay visible for valid sanitized BET');
-  const uiState = hooks.resolveTurnActionUiState({
-    isUsersTurn: true,
-    phase: 'FLOP',
-    turnUserId: 'user-1',
-    currentUserId: 'user-1',
-    rawLegalActions: ['BET'],
-    sanitizedAllowedActions: Array.from(sanitized.allowed)
-  });
-  assert.equal(uiState.showActions, true, 'resolved UI state should keep row visible for valid sanitized BET');
-  assert.equal(uiState.status, null, 'resolved UI state should not show empty-state status when sanitized action exists');
-}
-
-// Regression — raw-empty user-turn state remains contract mismatch.
 {
   const uiState = hooks.resolveTurnActionUiState({
     isUsersTurn: true,
@@ -161,8 +113,7 @@ assert.ok(hooks && hooks.sanitizeAllowedActions && hooks.validateAmountActionPay
     turnUserId: 'user-1',
     currentUserId: 'user-1',
     rawLegalActions: [],
-    sanitizedAllowedActions: []
+    availableActions: []
   });
-  assert.equal(uiState.showActions, false, 'resolved UI state should hide row when no raw/sanitized actions exist');
-  assert.equal(uiState.status, 'contract_mismatch', 'raw-empty user-turn state should preserve contract mismatch status');
+  assert.equal(uiState.status, 'contract_mismatch', 'empty raw legal actions on user turn should still report contract mismatch');
 }

--- a/tests/poker-ui-bet-raise-contract.behavior.test.mjs
+++ b/tests/poker-ui-bet-raise-contract.behavior.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const root = process.cwd();
+const source = fs.readFileSync(path.join(root, 'poker/poker.js'), 'utf8');
+
+const sandbox = {
+  Buffer,
+  window: {
+    location: { pathname: '/poker/table.html', search: '' },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    __RUNNING_POKER_UI_TESTS__: true,
+  },
+  document: {
+    readyState: 'loading',
+    addEventListener: () => {},
+    getElementById: () => null,
+    body: { innerHTML: '' },
+    visibilityState: 'visible',
+  },
+  URLSearchParams,
+  Date,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  navigator: { userAgent: 'node' },
+  localStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+  fetch: async () => { throw new Error('fetch not available in unit test'); },
+  atob: (value) => Buffer.from(String(value), 'base64').toString('binary'),
+  btoa: (value) => Buffer.from(String(value), 'binary').toString('base64'),
+};
+
+sandbox.window.document = sandbox.document;
+sandbox.window.navigator = sandbox.navigator;
+sandbox.window.localStorage = sandbox.localStorage;
+sandbox.window.fetch = sandbox.fetch;
+sandbox.window.atob = sandbox.atob;
+sandbox.window.btoa = sandbox.btoa;
+
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'poker/poker.js' });
+const hooks = sandbox.window.__POKER_UI_TEST_HOOKS__;
+
+assert.ok(hooks, 'expected poker UI test hooks');
+
+{
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['CHECK', 'BET']), { maxBetAmount: null });
+  assert.equal(allowedInfo.allowed.has('BET'), true, 'BET should stay in UI model when maxBetAmount is missing');
+  const payload = hooks.validateAmountActionPayload('BET', '20', allowedInfo);
+  assert.equal(payload.error, undefined, 'BET payload should accept positive amount when maxBetAmount is missing');
+  const uiState = hooks.resolveTurnActionUiState({
+    isUsersTurn: true,
+    phase: 'FLOP',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    rawLegalActions: ['CHECK', 'BET'],
+    availableActions: ['CHECK', 'BET'],
+  });
+  assert.equal(uiState.showActions, true, 'action row should be visible with CHECK/BET legal actions');
+}
+
+{
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['CALL', 'RAISE', 'FOLD']), { minRaiseTo: null, maxRaiseTo: null });
+  assert.equal(allowedInfo.allowed.has('RAISE'), true, 'RAISE should stay in UI model when raise range is missing');
+  const payload = hooks.validateAmountActionPayload('RAISE', '20', allowedInfo);
+  assert.equal(payload.error, undefined, 'RAISE payload should accept positive amount when range is missing');
+  assert.notEqual(payload.error, 'Action not allowed right now', 'RAISE should not fail with action-availability error when legal');
+  const uiState = hooks.resolveTurnActionUiState({
+    isUsersTurn: true,
+    phase: 'TURN',
+    turnUserId: 'user-1',
+    currentUserId: 'user-1',
+    rawLegalActions: ['CALL', 'RAISE', 'FOLD'],
+    availableActions: ['CALL', 'RAISE', 'FOLD'],
+  });
+  assert.equal(uiState.showActions, true, 'action row should be visible with CALL/RAISE/FOLD legal actions');
+}

--- a/tests/poker-ui-turn-actions.test.mjs
+++ b/tests/poker-ui-turn-actions.test.mjs
@@ -79,3 +79,23 @@ const hideActions = hooks.shouldShowTurnActions({
   legalActions: ['FOLD', 'CALL'],
 });
 assert.equal(hideActions, false, 'actions should be hidden for the non-acting player');
+
+const betUiState = hooks.resolveTurnActionUiState({
+  isUsersTurn: true,
+  phase: 'TURN',
+  turnUserId: 'user-1',
+  currentUserId: 'user-1',
+  rawLegalActions: ['BET'],
+  availableActions: ['BET'],
+});
+assert.equal(betUiState.showActions, true, 'turn actions should remain visible when raw legal actions include BET');
+
+const raiseUiState = hooks.resolveTurnActionUiState({
+  isUsersTurn: true,
+  phase: 'RIVER',
+  turnUserId: 'user-1',
+  currentUserId: 'user-1',
+  rawLegalActions: ['RAISE', 'CALL', 'FOLD'],
+  availableActions: ['RAISE', 'CALL', 'FOLD'],
+});
+assert.equal(raiseUiState.showActions, true, 'turn actions should remain visible when raw legal actions include RAISE');


### PR DESCRIPTION
### Motivation
- The UI was removing or blocking legal BET/RAISE actions based on client-side sanitization of `actionConstraints`, producing states like “CHECK only + Amount 0”.
- The server `legalActions` is the authoritative source of which actions are available and the UI must not remove BET/RAISE when constraints are missing/partial.
- Changes must be minimal, JSP-safe plain JavaScript localized to the poker turn-actions UI and keep backend rules and protocol unchanged.

### Description
- `getAllowedActionsForUser()` now preserves normalized server `legalActions` in `info.allowed` and stores constraints only as metadata; it no longer removes BET/RAISE based on incomplete constraints (`poker/poker.js`).
- `sanitizeAllowedActions()` was reduced to a normalization helper that does not filter availability and continues to return normalized `constraints` for UX hints (`poker/poker.js`).
- `validateAmountActionPayload()` enforces positive-integer amounts always but applies upper-bound/range checks only when the relevant constraint values are present and valid (`maxBetAmount` for BET, both `minRaiseTo` and `maxRaiseTo` for RAISE) (`poker/poker.js`).
- Amount input visibility/enablement in `renderAllowedActionButtons()` now depends on the selected action (`pendingActType === 'BET' || 'RAISE'`) and stale pending selections are cleared on refresh; `resolveTurnActionUiState()` and `shouldShowTurnActions()` compute visibility from the real available actions rather than a constraints-sanitized subset (`poker/poker.js`).
- Tests updated and added to reflect contract-first semantics: modified `tests/poker-ui-amount-actions-sanitization.test.mjs`, `tests/poker-ui-turn-actions.test.mjs`, and added `tests/poker-ui-bet-raise-contract.behavior.test.mjs` to cover missing-constraint BET/RAISE behavior.

### Testing
- Ran `node tests/poker-ui-turn-actions.test.mjs` and it passed.
- Ran `node tests/poker-ui-amount-actions-sanitization.test.mjs` and it passed.
- Ran `node tests/poker-ui-bet-raise-contract.behavior.test.mjs` (new regression behavior test) and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd03fef0f8832390b6a08ae0e7df32)