### PR TITLE
Support select-then-submit amount actions, restore amount mode on failures, and add DOM tests

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -438,6 +438,19 @@
     return { showActions: showActions, status: status };
   }
 
+  function resolveTurnActionClickOutcome(actionType, pendingType){
+    var normalized = normalizeActionTypeValue(actionType);
+    if (!normalized) return { kind: 'invalid', actionType: null, nextPendingActType: null };
+    if (normalized !== 'BET' && normalized !== 'RAISE'){
+      return { kind: 'submit', actionType: normalized, nextPendingActType: pendingType || null };
+    }
+    var normalizedPending = normalizeActionTypeValue(pendingType);
+    if (normalizedPending === normalized){
+      return { kind: 'submit', actionType: normalized, nextPendingActType: normalized };
+    }
+    return { kind: 'select_amount', actionType: normalized, nextPendingActType: normalized };
+  }
+
 
   if (window.__RUNNING_POKER_UI_TESTS__ === true){
     window.__POKER_UI_TEST_HOOKS__ = {
@@ -449,6 +462,7 @@
       sanitizeAllowedActions: sanitizeAllowedActions,
       validateAmountActionPayload: validateAmountActionPayload,
       resolveTurnActionUiState: resolveTurnActionUiState,
+      resolveTurnActionClickOutcome: resolveTurnActionClickOutcome,
       ensurePokerRecorder: ensurePokerRecorder,
       getPokerDumpText: getPokerDumpText,
       copyTextToClipboard: copyTextToClipboard,
@@ -2942,18 +2956,25 @@
     }
 
     async function sendAct(actionType, requestIdOverride){
-      if (!shouldEnableDevActions()) return;
+      if (!shouldEnableDevActions()) return { ok: false, code: 'disabled' };
       var normalized = normalizeActionType(actionType);
-      if (!normalized) return;
+      if (!normalized) return { ok: false, code: 'invalid_action' };
+      function restoreAmountModeOnFailure(){
+        if (normalized !== 'BET' && normalized !== 'RAISE') return;
+        pendingActType = normalized;
+        renderAllowedActionButtons();
+      }
       var allowedInfo = getAllowedActionsForUser(tableData, currentUserId);
       if (!allowedInfo.allowed.has(normalized)){
         setInlineStatus(actStatusEl, t('pokerErrActionNotAllowed', 'Action not allowed right now'), 'error');
-        return;
+        restoreAmountModeOnFailure();
+        return { ok: false, code: 'action_not_allowed' };
       }
       var actionResult = getActPayload(normalized);
       if (actionResult.error){
         setInlineStatus(actStatusEl, actionResult.error, 'error');
-        return;
+        restoreAmountModeOnFailure();
+        return { ok: false, code: 'invalid_amount' };
       }
       setInlineStatus(actStatusEl, null, null);
       setDevPendingState('act', true);
@@ -2961,14 +2982,10 @@
         var resolved = resolveRequestId(pendingActRequestId, requestIdOverride);
         if (resolved.nextPending){
           pendingActRequestId = normalizeRequestId(resolved.nextPending);
-          pendingActType = normalized;
           pendingActRetries = 0;
           pendingActStartedAt = null;
         } else if (!pendingActRequestId){
           pendingActRequestId = normalizeRequestId(resolved.requestId);
-          pendingActType = normalized;
-        } else if (!pendingActType){
-          pendingActType = normalized;
         }
         var actRequestId = normalizeRequestId(resolved.requestId);
         var wsActPayload = { handId: resolveCurrentHandId(), action: normalized };
@@ -2977,10 +2994,11 @@
         var result = await actSender(wsActPayload, actRequestId);
         if (isPendingResponse(result)){
           scheduleDevPendingRetry('act', retryAct);
-          return;
+          return { ok: false, code: 'pending' };
         }
         if (result && result.ok === false){
           clearActPending();
+          restoreAmountModeOnFailure();
           if (result.error === 'not_your_turn'){
             setInlineStatus(actStatusEl, t('pokerErrNotYourTurn', 'Not your turn'), 'error');
           } else if (result.error === 'action_not_allowed'){
@@ -2995,16 +3013,19 @@
           } else {
             setInlineStatus(actStatusEl, t('pokerErrAct', 'Failed to send action'), 'error');
           }
-          return;
+          return { ok: false, code: result.error || 'failed' };
         }
         clearActPending();
         setInlineStatus(actStatusEl, t('pokerActOk', 'Action sent'), 'success');
+        return { ok: true, code: 'ok' };
       } catch (err){
         if (isAbortError(err)){
+          restoreAmountModeOnFailure();
           pauseActPending();
-          return;
+          return { ok: false, code: 'aborted' };
         }
         if (isAuthError(err)){
+          restoreAmountModeOnFailure();
           stopPendingAll();
           handleTableAuthExpired({
             authMsg: authMsg,
@@ -3014,34 +3035,36 @@
             stopHeartbeat: stopHeartbeat,
             onAuthExpired: startAuthWatch
           });
-          return;
+          return { ok: false, code: 'unauthorized' };
         }
         clearActPending();
+        restoreAmountModeOnFailure();
         var errMessage = err && (err.message || err.code) ? String(err.message || err.code) : '';
         var loweredMessage = errMessage.toLowerCase();
         if (err && (err.status === 403 || err.code === 'not_your_turn' || loweredMessage.indexOf('not your turn') !== -1)){
           setInlineStatus(actStatusEl, t('pokerErrNotYourTurn', 'Not your turn'), 'error');
-          return;
+          return { ok: false, code: 'not_your_turn' };
         }
         if (err && err.code === 'action_not_allowed'){
           setInlineStatus(actStatusEl, t('pokerErrActionNotAllowed', 'Action not allowed right now'), 'error');
-          return;
+          return { ok: false, code: 'action_not_allowed' };
         }
         if (err && err.code === 'invalid_amount'){
           setInlineStatus(actStatusEl, t('pokerErrActAmount', 'Invalid amount'), 'error');
-          return;
+          return { ok: false, code: 'invalid_amount' };
         }
         if (err && err.code === 'state_invalid'){
           setInlineStatus(actStatusEl, t('pokerErrStateChanged', 'State changed. Refreshing...'), 'error');
           if (isPageActive()) loadTable(false);
-          return;
+          return { ok: false, code: 'state_invalid' };
         }
         if (err && err.code === 'hand_not_live'){
           setInlineStatus(actStatusEl, t('pokerErrHandNotLive', 'Hand is not live'), 'error');
-          return;
+          return { ok: false, code: 'hand_not_live' };
         }
         klog('poker_act_error', { tableId: tableId, error: err.message || err.code });
         setInlineStatus(actStatusEl, err.message || t('pokerErrAct', 'Failed to send action'), 'error');
+        return { ok: false, code: err && (err.code || err.message) ? err.code || err.message : 'failed' };
       }
     }
 
@@ -3301,20 +3324,40 @@
         setInlineStatus(actStatusEl, t('pokerErrActionNotAllowed', 'Action not allowed right now'), 'error');
         return;
       }
-      pendingActType = normalized;
-      updateActAmountConstraints(allowedInfo, pendingActType);
-      updateActAmountHint(allowedInfo, pendingActType);
+      var clickOutcome = resolveTurnActionClickOutcome(normalized, pendingActType);
+      if (clickOutcome.kind === 'select_amount'){
+        pendingActType = clickOutcome.nextPendingActType;
+        setInlineStatus(actStatusEl, null, null);
+        renderAllowedActionButtons();
+        if (actAmountInput && !actAmountInput.disabled){
+          try {
+            actAmountInput.focus();
+            if (typeof actAmountInput.select === 'function') actAmountInput.select();
+          } catch (_focusErr){}
+        }
+        return;
+      }
+      if (clickOutcome.kind === 'submit'){
+        pendingActType = null;
+        renderAllowedActionButtons();
+      }
       klog('poker_act_click', { tableId: tableId, hasToken: !!state.token, type: normalized });
       setInlineStatus(actStatusEl, null, null);
-      sendAct(normalized).catch(function(err){
-        if (isAbortError(err)){
-          pauseActPending();
-          return;
-        }
-        clearActPending();
-        klog('poker_act_click_error', { message: err && (err.message || err.code) ? err.message || err.code : 'unknown_error' });
-        setInlineStatus(actStatusEl, err && (err.message || err.code) ? err.message || err.code : t('pokerErrAct', 'Failed to send action'), 'error');
+      sendAct(normalized).then(function(_result){
+      }).catch(function(err){
+        klog('poker_act_click_unexpected_error', { message: err && (err.message || err.code) ? err.message || err.code : 'unknown_error' });
+        setInlineStatus(actStatusEl, t('pokerErrAct', 'Failed to send action'), 'error');
       });
+    }
+
+    function handleActAmountKeyDown(event){
+      if (!event || event.key !== 'Enter') return;
+      if (event.preventDefault) event.preventDefault();
+      if (event.stopPropagation) event.stopPropagation();
+      if (!pendingActType || actPending || !shouldEnableDevActions()) return;
+      var normalized = normalizeActionType(pendingActType);
+      if (normalized !== 'BET' && normalized !== 'RAISE') return;
+      handleActionClick(normalized, event);
     }
 
     function handleActCheckClick(event){
@@ -3347,6 +3390,7 @@
     if (actFoldBtn) actFoldBtn.addEventListener('click', handleActFoldClick);
     if (actBetBtn) actBetBtn.addEventListener('click', handleActBetClick);
     if (actRaiseBtn) actRaiseBtn.addEventListener('click', handleActRaiseClick);
+    if (actAmountInput) actAmountInput.addEventListener('keydown', handleActAmountKeyDown);
     if (jsonToggle){
       jsonToggle.addEventListener('click', function(){
         if (jsonBox) jsonBox.hidden = !jsonBox.hidden;

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -130,6 +130,7 @@ run("node", ["tests/poker-get-table.me-notSeated.db-shape.behavior.test.mjs"], "
 run("node", ["tests/poker-materialize-settlement.payouts.test.mjs"], "poker-materialize-settlement-payouts");
 
 run("node", ["tests/poker-ui.behavior.test.mjs"], "poker-ui-behavior");
+run("node", ["tests/poker-ui-amount-actions-dom.behavior.test.mjs"], "poker-ui-amount-actions-dom-behavior");
 run("node", ["tests/poker-ui-ws-join-smoke.behavior.test.mjs"], "poker-ui-ws-join-smoke-behavior");
 run("node", ["tests/poker-ui-ws-write-path.guard.test.mjs"], "poker-ui-ws-write-path-guard");
 run("node", ["tests/poker-ui-no-heartbeat.guard.test.mjs"], "poker-ui-no-heartbeat-guard");

--- a/tests/poker-ui-amount-actions-dom.behavior.test.mjs
+++ b/tests/poker-ui-amount-actions-dom.behavior.test.mjs
@@ -1,0 +1,409 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPokerTableHarness } from './helpers/poker-ui-table-harness.mjs';
+
+function makeActionableResponse(legalActions){
+  return {
+    tableId: 'table-1',
+    status: 'OPEN',
+    maxPlayers: 6,
+    seats: [
+      { seatNo: 1, userId: 'user-1', status: 'ACTIVE', stack: 150 },
+      { seatNo: 2, userId: 'bot-2', status: 'ACTIVE', stack: 150 }
+    ],
+    legalActions: legalActions,
+    actionConstraints: {},
+    state: {
+      version: 1,
+      state: {
+        phase: 'TURN',
+        pot: 15,
+        community: [],
+        stacks: { 'user-1': 150, 'bot-2': 150 },
+        turnUserId: 'user-1',
+        handId: 'hand-1'
+      }
+    }
+  };
+}
+
+function fireEnterOnAmountInput(harness){
+  const input = harness.elements.pokerActAmount;
+  const handlers = input._listeners.keydown || [];
+  handlers.forEach((fn) => fn({
+    key: 'Enter',
+    preventDefault(){},
+    stopPropagation(){},
+    target: input
+  }));
+}
+
+function getSubmittedActionType(payload){
+  if (!payload || typeof payload !== 'object') return null;
+  if (typeof payload.action === 'string') return payload.action;
+  if (payload.action && typeof payload.action.type === 'string') return payload.action.type;
+  return null;
+}
+
+function getSubmittedAmount(payload){
+  if (!payload || typeof payload !== 'object') return null;
+  if (Number.isFinite(Number(payload.amount))) return Number(payload.amount);
+  if (payload.action && Number.isFinite(Number(payload.action.amount))) return Number(payload.action.amount);
+  return null;
+}
+
+test('poker UI amount actions DOM flow supports select-first and submit-second without clearing value on harmless rerender', async () => {
+  var actCalls = [];
+  var snapshotHandler = null;
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CHECK', 'BET', 'RAISE'])],
+    wsFactory(createOptions){
+      snapshotHandler = createOptions.onSnapshot;
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload, requestId){
+          actCalls.push({ payload, requestId });
+          return Promise.resolve({ ok: true });
+        }
+      };
+    }
+  });
+
+  var amountInput = harness.elements.pokerActAmount;
+  var focusCalls = 0;
+  var selectCalls = 0;
+  amountInput.focus = function(){ focusCalls += 1; };
+  amountInput.select = function(){ selectCalls += 1; };
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+  assert.equal(actCalls.length, 0, 'first BET click should not submit immediately');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, false, 'first BET click should reveal amount input row');
+  assert.equal(amountInput.disabled, false, 'first BET click should enable amount input');
+  assert.ok(focusCalls >= 1, 'first BET click should focus amount input');
+  assert.ok(selectCalls >= 1, 'first BET click should select amount input text');
+
+  amountInput.value = '23';
+  snapshotHandler({
+    kind: 'table_state',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 2,
+      seats: [
+        { seatNo: 1, userId: 'user-1', status: 'ACTIVE' },
+        { seatNo: 2, userId: 'bot-2', status: 'ACTIVE' }
+      ],
+      stacks: { 'user-1': 150, 'bot-2': 150 },
+      hand: { status: 'TURN', handId: 'hand-1' },
+      turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+      board: { cards: ['As', 'Kd', '3h', '2c'] },
+      pot: { total: 20, sidePots: [] },
+      legalActions: { actions: ['CHECK', 'BET', 'RAISE'] },
+      actionConstraints: {}
+    }
+  });
+  await harness.flush();
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, false, 'harmless rerender should keep amount row visible when pending BET remains legal');
+  assert.equal(amountInput.disabled, false, 'harmless rerender should keep amount input editable');
+  assert.equal(amountInput.value, '23', 'harmless rerender should not clear current amount value');
+
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+  assert.equal(actCalls.length, 1, 'second BET click should submit exactly one action');
+  assert.equal(actCalls[0].payload.handId, 'hand-1', 'second BET click should submit current hand id');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'BET', 'second BET click should submit BET action');
+  assert.equal(getSubmittedAmount(actCalls[0].payload), 23, 'second BET click should submit entered amount');
+  assert.equal(typeof actCalls[0].requestId, 'string', 'second BET click should provide request id to ws sender');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'second BET click should clear amount mode immediately');
+  assert.equal(amountInput.disabled, true, 'second BET click should disable amount input immediately');
+  snapshotHandler({
+    kind: 'table_state',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 3,
+      seats: [
+        { seatNo: 1, userId: 'user-1', status: 'ACTIVE' },
+        { seatNo: 2, userId: 'bot-2', status: 'ACTIVE' }
+      ],
+      stacks: { 'user-1': 150, 'bot-2': 150 },
+      hand: { status: 'TURN', handId: 'hand-1' },
+      turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+      board: { cards: ['As', 'Kd', '3h', '2c'] },
+      pot: { total: 22, sidePots: [] },
+      legalActions: { actions: ['CHECK', 'BET', 'RAISE'] },
+      actionConstraints: {}
+    }
+  });
+  await harness.flush();
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'successful BET submit should stay out of amount mode after rerender');
+
+  harness.elements.pokerActRaiseBtn.click();
+  await harness.flush();
+  assert.equal(actCalls.length, 1, 'first RAISE click should switch pending mode without submitting');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, false, 'switching BET to RAISE should keep amount mode visible');
+  assert.equal(amountInput.disabled, false, 'switching BET to RAISE should keep input editable');
+
+  amountInput.value = '31';
+  fireEnterOnAmountInput(harness);
+  await harness.flush();
+  assert.equal(actCalls.length, 2, 'Enter key should submit selected pending RAISE exactly once');
+  assert.equal(actCalls[1].payload.handId, 'hand-1', 'Enter key should submit current hand id for RAISE');
+  assert.equal(getSubmittedActionType(actCalls[1].payload), 'RAISE', 'Enter key should submit RAISE after selecting it');
+  assert.equal(getSubmittedAmount(actCalls[1].payload), 31, 'Enter key should use entered RAISE amount');
+  assert.equal(typeof actCalls[1].requestId, 'string', 'Enter key submit should provide request id to ws sender');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'Enter submit should clear amount mode immediately');
+  assert.equal(amountInput.disabled, true, 'Enter submit should disable amount input immediately');
+  snapshotHandler({
+    kind: 'table_state',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 4,
+      seats: [
+        { seatNo: 1, userId: 'user-1', status: 'ACTIVE' },
+        { seatNo: 2, userId: 'bot-2', status: 'ACTIVE' }
+      ],
+      stacks: { 'user-1': 150, 'bot-2': 150 },
+      hand: { status: 'TURN', handId: 'hand-1' },
+      turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+      board: { cards: ['As', 'Kd', '3h', '2c'] },
+      pot: { total: 24, sidePots: [] },
+      legalActions: { actions: ['CHECK', 'BET', 'RAISE'] },
+      actionConstraints: {}
+    }
+  });
+  await harness.flush();
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'successful RAISE submit should stay out of amount mode after rerender');
+});
+
+test('poker UI CHECK remains one-click submit in DOM flow', async () => {
+  var actCalls = [];
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CHECK'])],
+    wsFactory(createOptions){
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload){
+          actCalls.push({ payload });
+          return Promise.resolve({ ok: true });
+        }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActCheckBtn.click();
+  await harness.flush();
+
+  assert.equal(actCalls.length, 1, 'CHECK should submit immediately on first click');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'CHECK', 'CHECK should submit CHECK action');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'CHECK click should not enter amount mode');
+});
+
+test('poker UI clears pending BET mode when switching to CHECK submit', async () => {
+  var actCalls = [];
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CHECK', 'BET', 'RAISE'])],
+    wsFactory(createOptions){
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload){
+          actCalls.push({ payload });
+          return Promise.resolve({ ok: true });
+        }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+  harness.elements.pokerActAmount.value = '22';
+  harness.elements.pokerActCheckBtn.click();
+  await harness.flush();
+
+  assert.equal(actCalls.length, 1, 'CHECK click from pending BET mode should submit exactly once');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'CHECK', 'CHECK click from pending BET mode should submit CHECK');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'CHECK click from pending BET mode should hide amount row');
+  assert.equal(harness.elements.pokerActAmount.disabled, true, 'CHECK click from pending BET mode should disable amount input');
+});
+
+test('poker UI clears pending RAISE mode when switching to FOLD submit', async () => {
+  var actCalls = [];
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CALL', 'RAISE', 'FOLD'])],
+    wsFactory(createOptions){
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload){
+          actCalls.push({ payload });
+          return Promise.resolve({ ok: true });
+        }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActRaiseBtn.click();
+  await harness.flush();
+  harness.elements.pokerActAmount.value = '30';
+  harness.elements.pokerActFoldBtn.click();
+  await harness.flush();
+
+  assert.equal(actCalls.length, 1, 'FOLD click from pending RAISE mode should submit exactly once');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'FOLD', 'FOLD click from pending RAISE mode should submit FOLD');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'FOLD click from pending RAISE mode should hide amount row');
+  assert.equal(harness.elements.pokerActAmount.disabled, true, 'FOLD click from pending RAISE mode should disable amount input');
+});
+
+test('poker UI clears pending amount mode when pending action becomes illegal on rerender', async () => {
+  var snapshotHandler = null;
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CHECK', 'BET'])],
+    wsFactory(createOptions){
+      snapshotHandler = createOptions.onSnapshot;
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(){ return Promise.resolve({ ok: true }); }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+  harness.elements.pokerActAmount.value = '29';
+  snapshotHandler({
+    kind: 'table_state',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 3,
+      seats: [
+        { seatNo: 1, userId: 'user-1', status: 'ACTIVE' },
+        { seatNo: 2, userId: 'bot-2', status: 'ACTIVE' }
+      ],
+      stacks: { 'user-1': 150, 'bot-2': 150 },
+      hand: { status: 'TURN', handId: 'hand-1' },
+      turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+      board: { cards: ['As', 'Kd', '3h', '2c'] },
+      pot: { total: 20, sidePots: [] },
+      legalActions: { actions: ['CHECK'] },
+      actionConstraints: {}
+    }
+  });
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, true, 'illegal pending action rerender should hide amount row');
+  assert.equal(harness.elements.pokerActAmount.disabled, true, 'illegal pending action rerender should disable amount input');
+  assert.equal(harness.elements.pokerActAmount.value, '', 'illegal pending action rerender should clear stale amount value');
+});
+
+test('poker UI restores BET amount mode and value after failed BET submit', async () => {
+  var actCalls = [];
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CHECK', 'BET'])],
+    wsFactory(createOptions){
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload){
+          actCalls.push({ payload });
+          return Promise.reject(new Error('send_failed'));
+        }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+  harness.elements.pokerActAmount.value = '27';
+  harness.elements.pokerActBetBtn.click();
+  await harness.flush();
+
+  assert.equal(actCalls.length, 1, 'failed BET submit should still attempt one submit');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'BET', 'failed BET submit should send BET action');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, false, 'failed BET submit should restore amount mode');
+  assert.equal(harness.elements.pokerActAmount.disabled, false, 'failed BET submit should restore editable amount input');
+  assert.equal(harness.elements.pokerActAmount.value, '27', 'failed BET submit should preserve typed amount');
+  assert.equal(typeof harness.elements.pokerActStatus.textContent, 'string', 'failed BET submit should set an error status');
+});
+
+test('poker UI restores RAISE amount mode and value after failed Enter submit', async () => {
+  var actCalls = [];
+  var harness = createPokerTableHarness({
+    responses: [makeActionableResponse(['CALL', 'RAISE', 'FOLD'])],
+    wsFactory(createOptions){
+      return {
+        start(){
+          Promise.resolve().then(function(){
+            if (typeof createOptions.onStatus === 'function') createOptions.onStatus('auth_ok', { roomId: 'table-1' });
+          });
+        },
+        destroy(){},
+        isReady(){ return true; },
+        sendAct(payload){
+          actCalls.push({ payload });
+          return Promise.reject(new Error('send_failed'));
+        }
+      };
+    }
+  });
+
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerActRaiseBtn.click();
+  await harness.flush();
+  harness.elements.pokerActAmount.value = '33';
+  fireEnterOnAmountInput(harness);
+  await harness.flush();
+
+  assert.equal(actCalls.length, 1, 'failed RAISE Enter submit should still attempt one submit');
+  assert.equal(getSubmittedActionType(actCalls[0].payload), 'RAISE', 'failed RAISE Enter submit should send RAISE action');
+  assert.equal(harness.elements.pokerActAmountWrap.hidden, false, 'failed RAISE submit should restore amount mode');
+  assert.equal(harness.elements.pokerActAmount.disabled, false, 'failed RAISE submit should restore editable amount input');
+  assert.equal(harness.elements.pokerActAmount.value, '33', 'failed RAISE submit should preserve typed amount');
+  assert.equal(typeof harness.elements.pokerActStatus.textContent, 'string', 'failed RAISE submit should set an error status');
+});

--- a/tests/poker-ui-bet-raise-contract.behavior.test.mjs
+++ b/tests/poker-ui-bet-raise-contract.behavior.test.mjs
@@ -65,6 +65,8 @@ assert.ok(hooks, 'expected poker UI test hooks');
     availableActions: ['CHECK', 'BET'],
   });
   assert.equal(uiState.showActions, true, 'action row should be visible with CHECK/BET legal actions');
+  const invalidZero = hooks.validateAmountActionPayload('BET', '0', allowedInfo);
+  assert.equal(typeof invalidZero.error, 'string', 'BET amount should reject zero');
 }
 
 {
@@ -82,4 +84,18 @@ assert.ok(hooks, 'expected poker UI test hooks');
     availableActions: ['CALL', 'RAISE', 'FOLD'],
   });
   assert.equal(uiState.showActions, true, 'action row should be visible with CALL/RAISE/FOLD legal actions');
+  const invalidNegative = hooks.validateAmountActionPayload('RAISE', '-3', allowedInfo);
+  assert.equal(typeof invalidNegative.error, 'string', 'RAISE amount should reject negatives');
+}
+
+{
+  const allowedInfo = hooks.sanitizeAllowedActions(new Set(['BET', 'RAISE']), { maxBetAmount: 25, minRaiseTo: 20, maxRaiseTo: 40 });
+  const betTooHigh = hooks.validateAmountActionPayload('BET', '26', allowedInfo);
+  assert.equal(typeof betTooHigh.error, 'string', 'BET should reject values above valid max');
+  const betInRange = hooks.validateAmountActionPayload('BET', '25', allowedInfo);
+  assert.equal(betInRange.error, undefined, 'BET should accept values at valid max');
+  const raiseTooLow = hooks.validateAmountActionPayload('RAISE', '19', allowedInfo);
+  assert.equal(typeof raiseTooLow.error, 'string', 'RAISE should reject values below valid min');
+  const raiseInRange = hooks.validateAmountActionPayload('RAISE', '32', allowedInfo);
+  assert.equal(raiseInRange.error, undefined, 'RAISE should accept values inside valid bounds');
 }

--- a/tests/poker-ui-turn-actions.test.mjs
+++ b/tests/poker-ui-turn-actions.test.mjs
@@ -57,6 +57,7 @@ assert.ok(hooks, 'poker UI should expose test hooks when explicitly enabled');
 assert.equal(typeof hooks.sanitizeAllowedActions, 'function', 'sanitizeAllowedActions hook should be exposed');
 assert.equal(typeof hooks.validateAmountActionPayload, 'function', 'validateAmountActionPayload hook should be exposed');
 assert.equal(typeof hooks.resolveTurnActionUiState, 'function', 'resolveTurnActionUiState hook should be exposed');
+assert.equal(typeof hooks.resolveTurnActionClickOutcome, 'function', 'resolveTurnActionClickOutcome hook should be exposed');
 
 const countdown = hooks.computeRemainingTurnSeconds(Date.now() + 30000, Date.now());
 assert.ok(countdown > 0, 'countdown should be positive for future deadline in ms');
@@ -99,3 +100,20 @@ const raiseUiState = hooks.resolveTurnActionUiState({
   availableActions: ['RAISE', 'CALL', 'FOLD'],
 });
 assert.equal(raiseUiState.showActions, true, 'turn actions should remain visible when raw legal actions include RAISE');
+
+const firstBetClick = hooks.resolveTurnActionClickOutcome('BET', null);
+assert.equal(firstBetClick.kind, 'select_amount', 'first BET click should enter amount selection mode');
+assert.equal(firstBetClick.nextPendingActType, 'BET', 'first BET click should set pending action to BET');
+
+const secondBetClick = hooks.resolveTurnActionClickOutcome('BET', 'BET');
+assert.equal(secondBetClick.kind, 'submit', 'second BET click should submit the selected amount action');
+
+const firstRaiseClick = hooks.resolveTurnActionClickOutcome('RAISE', null);
+assert.equal(firstRaiseClick.kind, 'select_amount', 'first RAISE click should enter amount selection mode');
+
+const switchToRaiseClick = hooks.resolveTurnActionClickOutcome('RAISE', 'BET');
+assert.equal(switchToRaiseClick.kind, 'select_amount', 'switching from BET to RAISE should stay in amount selection mode');
+assert.equal(switchToRaiseClick.nextPendingActType, 'RAISE', 'switching amount actions should update pending action type');
+
+const checkClick = hooks.resolveTurnActionClickOutcome('CHECK', 'BET');
+assert.equal(checkClick.kind, 'submit', 'CHECK should remain a one-click submit action');

--- a/tests/test-all.runner-registration.guard.test.mjs
+++ b/tests/test-all.runner-registration.guard.test.mjs
@@ -6,6 +6,7 @@ const root = process.cwd();
 const source = await readFile(path.join(root, "scripts", "test-all.mjs"), "utf8");
 
 assert.match(source, /run\("node", \["tests\/poker-ui\.behavior\.test\.mjs"\],/, "runner should include poker-ui.behavior test");
+assert.match(source, /run\("node", \["tests\/poker-ui-amount-actions-dom\.behavior\.test\.mjs"\],/, "runner should include poker-ui amount-actions DOM behavior test");
 assert.match(source, /run\("node", \["tests\/poker-ui-ws-join-smoke\.behavior\.test\.mjs"\],/, "runner should include poker-ui ws join smoke test");
 assert.doesNotMatch(source, /run\("node", \["tests\/poker-ui-ws-act-smoke\.behavior\.test\.mjs"\],/, "runner should not include poker-ui ws act smoke test after canonical coverage trim");
 assert.match(source, /run\("node", \["tests\/poker-ui-ws-write-path\.guard\.test\.mjs"\],/, "runner should include poker-ui ws write-path guard test");


### PR DESCRIPTION
### Motivation
- Ensure BET/RAISE actions follow a two-step DOM flow (select amount first, submit second) and keep typed values across harmless rerenders.
- Restore amount-selection mode and preserve input value when a submit fails so the user can retry without retyping.
- Make the amount-action click decision logic testable and add coverage for DOM interactions and validation.

### Description
- Added `resolveTurnActionClickOutcome` to centralize click behavior for amount vs non-amount actions and exported it to the test hooks as `resolveTurnActionClickOutcome`.
- Updated `handleActionClick` to use the new click outcome logic so first `BET`/`RAISE` clicks enter amount-selection mode while subsequent clicks submit, and non-amount actions submit immediately.
- Modified `sendAct` to return structured result objects on early exits and failures, and introduced `restoreAmountModeOnFailure` to re-enable pending amount mode and preserve the typed amount when submits fail.
- Added an `Enter` key handler `handleActAmountKeyDown` to allow submitting a pending `BET`/`RAISE` via the keyboard, and wired it to the amount input.
- Added comprehensive tests: new DOM behavior tests in `tests/poker-ui-amount-actions-dom.behavior.test.mjs`, updated unit hooks checks in `tests/poker-ui-turn-actions.test.mjs` and amount validation assertions in `tests/poker-ui-bet-raise-contract.behavior.test.mjs`, and registered the new test in `scripts/test-all.mjs` with a guard update in `tests/test-all.runner-registration.guard.test.mjs`.

### Testing
- Ran the poker UI unit and behavior tests including `tests/poker-ui-amount-actions-dom.behavior.test.mjs`, `tests/poker-ui-turn-actions.test.mjs`, and `tests/poker-ui-bet-raise-contract.behavior.test.mjs`, and they succeeded.
- Verified the test runner includes the new DOM behavior test by updating `scripts/test-all.mjs` and confirmed the guard `tests/test-all.runner-registration.guard.test.mjs` reflects the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0a59b37483239774438a9d051573)