### PR TITLE
Ensure inactive-cleanup preserves valid turn holders and add behavior tests

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -77,6 +77,7 @@ run("node", ["tests/poker-handSeats-reset.behavior.test.mjs"], "poker-handseats-
 run("node", ["tests/poker-legal-actions.left-player.invalid-player.behavior.test.mjs"], "poker-legal-actions-left-player-invalid-player-behavior");
 run("node", ["tests/poker-leave.test.mjs"], "poker-leave");
 run("node", ["shared/poker-domain/leave.behavior.test.mjs"], "poker-domain-leave-behavior");
+run("node", ["shared/poker-domain/inactive-cleanup.behavior.test.mjs"], "poker-domain-inactive-cleanup-behavior");
 run("node", ["tests/poker-join-http-retired.test.mjs"], "poker-join-http-retired");
 run("node", ["tests/poker-leave.instant-detach.midhand.behavior.test.mjs"], "poker-leave-instant-detach-midhand-behavior");
 run("node", ["tests/poker-leave.instant-detach.replay-preserves-left-flag.behavior.test.mjs"], "poker-leave-instant-detach-replay-preserves-left-flag-behavior");

--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { executeInactiveCleanup } from "./inactive-cleanup.mjs";
+
+function createCleanupHarness({ seatRows, state, tableStatus = "OPEN" }) {
+  const seatState = seatRows.map((row) => ({ ...row }));
+  const tableState = {
+    stateRow: { state: { ...state } },
+    tableStatus
+  };
+  const cashouts = [];
+
+  const tx = {
+    unsafe: async (sql, params = []) => {
+      if (sql.includes("where table_id = $1 and user_id = $2 limit 1 for update")) {
+        const [, userId] = params;
+        const seat = seatState.find((row) => row.user_id === userId) || null;
+        return seat ? [{ ...seat }] : [];
+      }
+      if (sql.includes("select state from public.poker_state")) {
+        return [{ state: { ...tableState.stateRow.state } }];
+      }
+      if (sql.includes("update public.poker_seats set status = 'INACTIVE', stack = 0 where table_id = $1 and user_id = $2")) {
+        const [, userId] = params;
+        for (let i = 0; i < seatState.length; i += 1) {
+          if (seatState[i].user_id === userId) {
+            seatState[i] = { ...seatState[i], status: "INACTIVE", stack: 0 };
+          }
+        }
+        return [];
+      }
+      if (sql.includes("select user_id, status, is_bot, stack from public.poker_seats")) {
+        return seatState.map((row) => ({ ...row }));
+      }
+      if (sql.includes("update public.poker_state set state = $2 where table_id = $1")) {
+        tableState.stateRow = { state: JSON.parse(params[1]) };
+        return [];
+      }
+      if (sql.includes("select status from public.poker_tables")) {
+        return [{ status: tableState.tableStatus }];
+      }
+      if (sql.includes("update public.poker_tables set status = 'CLOSED'")) {
+        tableState.tableStatus = "CLOSED";
+        return [];
+      }
+      if (sql.includes("delete from public.poker_hole_cards")) {
+        return [];
+      }
+      if (sql.includes("update public.poker_seats set status = 'INACTIVE', stack = 0 where table_id = $1 and is_bot = false")) {
+        for (let i = 0; i < seatState.length; i += 1) {
+          if (seatState[i].is_bot !== true) {
+            seatState[i] = { ...seatState[i], status: "INACTIVE", stack: 0 };
+          }
+        }
+        return [];
+      }
+      throw new Error(`Unhandled SQL in test harness: ${sql}`);
+    }
+  };
+
+  return {
+    seatState,
+    tableState,
+    cashouts,
+    run: () => executeInactiveCleanup({
+      beginSql: async (fn) => fn(tx),
+      tableId: "table_1",
+      userId: "human_1",
+      requestId: "req-1",
+      postTransaction: async (entry) => {
+        cashouts.push(entry);
+        return { ok: true };
+      }
+    })
+  };
+}
+
+test("inactive cleanup preserves valid bot turn holder", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", status: "ACTIVE", is_bot: false, stack: 500 },
+      { user_id: "human_2", status: "ACTIVE", is_bot: false, stack: 600 },
+      { user_id: "bot_1", status: "ACTIVE", is_bot: true, stack: 400 }
+    ],
+    state: {
+      turnUserId: "bot_1",
+      stacks: { human_1: 500, human_2: 600, bot_1: 400 }
+    }
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_1")?.status, "INACTIVE");
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_2")?.status, "ACTIVE");
+  assert.equal(harness.seatState.find((row) => row.user_id === "bot_1")?.status, "ACTIVE");
+  assert.equal(harness.tableState.stateRow.state.turnUserId, "bot_1");
+  assert.deepEqual(harness.tableState.stateRow.state.stacks, { human_2: 600, bot_1: 400 });
+});
+
+test("inactive cleanup clears removed disconnected turn holder", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", status: "ACTIVE", is_bot: false, stack: 500 }
+    ],
+    state: {
+      turnUserId: "human_1",
+      stacks: { human_1: 500 }
+    }
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(harness.tableState.stateRow.state.turnUserId, null);
+  assert.deepEqual(harness.tableState.stateRow.state.stacks, {});
+});

--- a/shared/poker-domain/inactive-cleanup.mjs
+++ b/shared/poker-domain/inactive-cleanup.mjs
@@ -43,6 +43,17 @@ function hasAnyActiveHuman(seats) {
   return (seats || []).some((row) => row?.is_bot !== true && row?.status === "ACTIVE");
 }
 
+function activeSeatUserIdSet(seats) {
+  const ids = new Set();
+  for (const row of seats || []) {
+    if (row?.status !== "ACTIVE") continue;
+    if (typeof row?.user_id === "string" && row.user_id.length > 0) {
+      ids.add(row.user_id);
+    }
+  }
+  return ids;
+}
+
 function toClosedInertState({ state, stacks }) {
   return {
     ...state,
@@ -133,15 +144,19 @@ export async function executeInactiveCleanup({
       await tx.unsafe("update public.poker_seats set status = 'INACTIVE', stack = 0 where table_id = $1 and user_id = $2;", [tableId, userId]);
     }
 
-    if (stateRow) {
-      const nextState = { ...state, stacks };
-      await tx.unsafe("update public.poker_state set state = $2 where table_id = $1;", [tableId, JSON.stringify(nextState)]);
-    }
-
     const allSeatRows = await tx.unsafe(
       "select user_id, status, is_bot, stack from public.poker_seats where table_id = $1 for update;",
       [tableId]
     );
+
+    if (stateRow) {
+      const nextState = { ...state, stacks };
+      const turnUserId = typeof nextState.turnUserId === "string" ? nextState.turnUserId : null;
+      if (turnUserId && !activeSeatUserIdSet(allSeatRows).has(turnUserId)) {
+        nextState.turnUserId = null;
+      }
+      await tx.unsafe("update public.poker_state set state = $2 where table_id = $1;", [tableId, JSON.stringify(nextState)]);
+    }
 
     if (hasAnyActiveHuman(allSeatRows)) {
       return { ok: true, changed: seatWasActive, status: seatWasActive ? "cleaned" : "already_inactive", closed: false, retryable: false };

--- a/tests/test-all.runner-registration.guard.test.mjs
+++ b/tests/test-all.runner-registration.guard.test.mjs
@@ -21,6 +21,7 @@ assert.match(source, /run\("node", \["tests\/poker-ui-no-heartbeat\.guard\.test\
 assert.match(source, /run\("node", \["ws-server\/poker\/persistence\/inactive-cleanup-adapter\.behavior\.test\.mjs"\],/, "runner should include ws inactive cleanup adapter behavior test");
 assert.match(source, /run\("node", \["ws-server\/poker\/runtime\/disconnect-cleanup\.behavior\.test\.mjs"\],/, "runner should include ws disconnect cleanup runtime behavior test");
 assert.match(source, /run\("node", \["ws-server\/poker\/runtime\/accepted-bot-autoplay-adapter\.behavior\.test\.mjs"\],/, "runner should include ws accepted bot autoplay adapter behavior test");
+assert.match(source, /run\("node", \["shared\/poker-domain\/inactive-cleanup\.behavior\.test\.mjs"\],/, "runner should include shared poker-domain inactive cleanup behavior test");
 assert.doesNotMatch(source, /poker-heartbeat\.behavior\.test\.mjs/, "runner should not include removed heartbeat behavior tests");
 assert.doesNotMatch(source, /tests\/poker-sweep\.behavior\.test\.mjs/, "runner should not include removed legacy sweep behavior test");
 assert.doesNotMatch(source, /tests\/poker-sweep\..*\.behavior\.test\.mjs/, "runner should not include removed sweep behavior tests");

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2666,7 +2666,16 @@ export function createInactiveCleanupExecutor({ env }) {
     const state = table?.stateRow?.state && typeof table.stateRow.state === "object" ? table.stateRow.state : {};
     const nextStacks = { ...(state.stacks || {}) };
     delete nextStacks[userId];
-    table.stateRow = { ...(table.stateRow || { version: 0 }), state: { ...state, turnUserId: null, stacks: nextStacks } };
+    const activeSeatUserIds = new Set(
+      table.seatRows
+        .filter((row) => String(row?.status || "").toUpperCase() === "ACTIVE")
+        .map((row) => row?.user_id)
+        .filter((id) => typeof id === "string" && id.length > 0)
+    );
+    const nextTurnUserId = typeof state?.turnUserId === "string" && activeSeatUserIds.has(state.turnUserId)
+      ? state.turnUserId
+      : null;
+    table.stateRow = { ...(table.stateRow || { version: 0 }), state: { ...state, turnUserId: nextTurnUserId, stacks: nextStacks } };
     await fs.writeFile(env.WS_PERSISTED_STATE_FILE, JSON.stringify(doc) + "\\n", "utf8");
     return { ok: true, changed, status: changed ? "cleaned" : "already_inactive", retryable: false };
   };
@@ -2708,14 +2717,24 @@ export function createInactiveCleanupExecutor({ env }) {
       5000
     );
     assert.equal(afterCleanup.payload.members.some((member) => member.userId === "seat_user"), false);
+
     let restoredSnapshot = null;
     const snapshotDeadline = Date.now() + 5000;
     while (Date.now() < snapshotDeadline) {
       sendFrame(observer, { version: "1.0", type: "table_state_sub", requestId: `sub-cleanup-observer-snapshot-${Date.now()}`, ts: "2026-03-01T00:00:03Z", payload: { tableId, view: "snapshot" } });
       restoredSnapshot = await nextMessageOfType(observer, "stateSnapshot");
-      if (restoredSnapshot?.payload?.public?.turn?.userId === null) break;
+      const restoredTurnUserId = restoredSnapshot?.payload?.public?.turn?.userId ?? null;
+      const restoredSeatUserIds = Object.keys(restoredSnapshot?.payload?.public?.seats || {});
+      const seatRemoved = restoredSeatUserIds.includes("seat_user") === false;
+      const validTurn = restoredTurnUserId === null || restoredSeatUserIds.includes(restoredTurnUserId);
+      if (seatRemoved && validTurn) {
+        break;
+      }
     }
-    assert.equal(restoredSnapshot?.payload?.public?.turn?.userId, null);
+    const restoredTurnUserId = restoredSnapshot?.payload?.public?.turn?.userId ?? null;
+    const restoredSeatUserIds = Object.keys(restoredSnapshot?.payload?.public?.seats || {});
+    assert.equal(restoredSeatUserIds.includes("seat_user"), false);
+    assert.equal(restoredTurnUserId === null || restoredSeatUserIds.includes(restoredTurnUserId), true);
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);


### PR DESCRIPTION
### Motivation

- Ensure the inactive-cleanup routine does not leave a stale `turnUserId` pointing at a user that is no longer an active seat, while preserving a valid bot turn holder when appropriate.
- Add coverage for the inactive cleanup logic in the shared domain and register the new behavior test in the test runner.

### Description

- Added `activeSeatUserIdSet` helper to `shared/poker-domain/inactive-cleanup.mjs` to compute active seat user IDs.
- Moved the state update to occur after reading all seat rows and added logic to clear `turnUserId` when the referenced user is no longer an active seat; left valid turn holders intact.
- Added `shared/poker-domain/inactive-cleanup.behavior.test.mjs` to cover preserving bot turn holders and clearing removed disconnected turn holders.
- Registered the new behavior test in `scripts/test-all.mjs` and updated `tests/test-all.runner-registration.guard.test.mjs` to assert the runner includes the new test; updated `ws-server/server.behavior.test.mjs` assertions to validate restored snapshots allow a retained valid turn or null when appropriate.

### Testing

- Ran the integrated test runner via the project test suite (`scripts/test-all.mjs`) which includes the new `shared/poker-domain/inactive-cleanup.behavior.test.mjs`; tests succeeded.
- Updated guard and server behavior tests (`tests/test-all.runner-registration.guard.test.mjs`, `ws-server/server.behavior.test.mjs`) were run as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd28a7dc088323ae997228097dd111)