### PR TITLE
Normalize WS snapshot stacks, improve UI stack rendering, and harden bot-autoplay with diagnostics

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1233,6 +1233,9 @@
       var payload = snapshotPayload && typeof snapshotPayload === 'object' ? snapshotPayload : {};
       if (snapshotKind === 'stateSnapshot') return true;
       if (isPlainObject(payload.public) || isPlainObject(payload.private) || isPlainObject(payload.you)) return true;
+      if (isPlainObject(payload.hand) || isPlainObject(payload.turn) || isPlainObject(payload.pot) || isPlainObject(payload.board)) return true;
+      if (isPlainObject(payload.stacks) || (isPlainObject(payload.public) && isPlainObject(payload.public.stacks))) return true;
+      if (Array.isArray(payload.seats) || Array.isArray(payload.authoritativeMembers)) return true;
       return isPlainObject(payload.table);
     }
 
@@ -1292,6 +1295,10 @@
       if (!normalized.hand && isPlainObject(pub.hand)) normalized.hand = pub.hand;
       if (!normalized.pot && isPlainObject(pub.pot)) normalized.pot = pub.pot;
       if (!normalized.turn && isPlainObject(pub.turn)) normalized.turn = pub.turn;
+      if (!normalized.stacks || typeof normalized.stacks !== 'object' || Array.isArray(normalized.stacks)){
+        var normalizedStacks = normalizeSnapshotStacks(payload);
+        if (normalizedStacks) normalized.stacks = normalizedStacks;
+      }
       if (!normalized.legalActions && pub.legalActions != null) normalized.legalActions = pub.legalActions;
       if (!normalized.actionConstraints && isPlainObject(pub.actionConstraints)) normalized.actionConstraints = pub.actionConstraints;
       if (!normalized.board && pub.board != null){
@@ -1310,6 +1317,15 @@
         }
       }
       return { kind: kind, payload: normalized };
+    }
+
+    function normalizeSnapshotStacks(payload){
+      var safePayload = payload && typeof payload === 'object' ? payload : {};
+      if (isPlainObject(safePayload.stacks)) return Object.assign({}, safePayload.stacks);
+      var publicPayload = isPlainObject(safePayload.public) ? safePayload.public : {};
+      if (isPlainObject(publicPayload.stacks)) return Object.assign({}, publicPayload.stacks);
+      if (isPlainObject(safePayload.state) && isPlainObject(safePayload.state.stacks)) return Object.assign({}, safePayload.state.stacks);
+      return null;
     }
 
     function mapTableStateToSeatUpdates(snapshotPayload){
@@ -1430,7 +1446,7 @@
         potTotal: Number.isFinite(Number(potPayload.total)) ? Number(potPayload.total) : 0,
         sidePots: Array.isArray(potPayload.sidePots) ? potPayload.sidePots.slice() : [],
         community: communityCards,
-        stacks: isPlainObject(payload.stacks) ? Object.assign({}, payload.stacks) : {}
+        stacks: normalizeSnapshotStacks(payload) || {}
       };
       var resolvedMaxPlayers = null;
       if (Number.isInteger(tablePayload.maxPlayers) && tablePayload.maxPlayers > 1){
@@ -1497,8 +1513,9 @@
         }
         if (Array.isArray(payload.pot.sidePots)) nextState.sidePots = payload.pot.sidePots.slice();
       }
-      if (payload.stacks && typeof payload.stacks === 'object' && !Array.isArray(payload.stacks)){
-        nextState.stacks = Object.assign({}, baselineInner.stacks && typeof baselineInner.stacks === 'object' ? baselineInner.stacks : {}, payload.stacks);
+      var normalizedStacks = normalizeSnapshotStacks(payload);
+      if (normalizedStacks){
+        nextState.stacks = Object.assign({}, baselineInner.stacks && typeof baselineInner.stacks === 'object' ? baselineInner.stacks : {}, normalizedStacks);
       }
       baselineState.state = nextState;
       merged.state = baselineState;
@@ -1563,6 +1580,51 @@
         return facts;
       }
       return facts;
+    }
+
+    function buildSeatUserSeatMap(seats){
+      var map = {};
+      if (!Array.isArray(seats)) return map;
+      for (var i = 0; i < seats.length; i++){
+        var seat = seats[i];
+        if (!seat || typeof seat.userId !== 'string') continue;
+        var userId = seat.userId.trim();
+        if (!userId) continue;
+        map[userId] = Number.isInteger(seat.seatNo) ? seat.seatNo : null;
+      }
+      return map;
+    }
+
+    function buildWsPayloadSeatSnapshot(payload){
+      var seatMap = {};
+      var seatRows = [];
+      if (Array.isArray(payload.authoritativeMembers)){
+        for (var i = 0; i < payload.authoritativeMembers.length; i++){
+          var member = payload.authoritativeMembers[i];
+          if (!member || typeof member.userId !== 'string') continue;
+          var memberUserId = member.userId.trim();
+          if (!memberUserId) continue;
+          var memberSeatNo = Number.isInteger(member.seat) ? member.seat : null;
+          seatMap[memberUserId] = memberSeatNo;
+          seatRows.push(memberUserId + ':' + (memberSeatNo != null ? memberSeatNo : 'null'));
+        }
+      }
+      if (Array.isArray(payload.seats)){
+        for (var j = 0; j < payload.seats.length; j++){
+          var seat = payload.seats[j];
+          if (!seat || typeof seat.userId !== 'string') continue;
+          var seatUserId = seat.userId.trim();
+          if (!seatUserId) continue;
+          if (seatMap[seatUserId] != null) continue;
+          var seatNo = Number.isInteger(seat.seatNo) ? seat.seatNo : null;
+          seatMap[seatUserId] = seatNo;
+          seatRows.push(seatUserId + ':' + (seatNo != null ? seatNo : 'null'));
+        }
+      }
+      return {
+        seatMap: seatMap,
+        seatRows: seatRows
+      };
     }
 
     function hasTurnMetadata(state){
@@ -1632,6 +1694,23 @@
         tableData = mergedData;
       }
       isSeated = isCurrentUserSeated(tableData);
+      var stateObj = tableData && typeof tableData.state === 'object' ? tableData.state : {};
+      var gameState = stateObj && typeof stateObj.state === 'object' ? stateObj.state : {};
+      var stacks = gameState && typeof gameState.stacks === 'object' && !Array.isArray(gameState.stacks) ? gameState.stacks : {};
+      var seatFacts = findCurrentUserSeatFacts(tableData);
+      klog('poker_ws_snapshot_runtime_normalized', {
+        tableId: tableId,
+        snapshotKind: opts.snapshotKind || null,
+        stateVersion: resolveTableDataVersion(tableData),
+        currentUserId: currentUserId || null,
+        isSeated: isSeated === true,
+        youSeat: Number.isInteger(snapshotPayload.youSeat) ? snapshotPayload.youSeat : null,
+        currentUserSeatNo: seatFacts.seatNo,
+        stacksKeys: Object.keys(stacks),
+        currentUserStackValue: currentUserId ? stacks[currentUserId] : null,
+        seatsCount: Array.isArray(tableData.seats) ? tableData.seats.length : 0,
+        seatUserSeatMap: buildSeatUserSeatMap(tableData.seats || [])
+      });
       renderTable(tableData);
       var seatedCount = getSeatedCount(tableData);
       if (isSeated && seatedCount !== lastAutoStartSeatCount){
@@ -1651,12 +1730,31 @@
       var snapshotKind = normalized.kind || snapshot.kind || snapshot.rawType || null;
       var incomingVersion = resolveSnapshotVersion(payload);
       var currentVersion = resolveTableDataVersion(tableData);
+      var rawStacks = normalizeSnapshotStacks(payload) || {};
+      var payloadSeatSnapshot = buildWsPayloadSeatSnapshot(payload);
+      var currentUserSeatNo = payloadSeatSnapshot.seatMap[currentUserId || ''];
+      var youSeatPresent = Number.isInteger(payload.youSeat);
       klog('poker_ws_snapshot_received', {
         tableId: tableId,
         kind: snapshotKind,
         initial: snapshot.initial === true,
         members: Array.isArray(payload.members) ? payload.members.length : 0,
         stateVersion: incomingVersion
+      });
+      klog('poker_ws_snapshot_apply_input', {
+        tableId: tableId,
+        snapshotKind: snapshotKind,
+        stateVersion: incomingVersion,
+        currentUserId: currentUserId || null,
+        isSeated: isSeated === true,
+        youSeat: Number.isInteger(payload.youSeat) ? payload.youSeat : null,
+        currentUserSeatNo: Number.isInteger(currentUserSeatNo) ? currentUserSeatNo : null,
+        stacksKeys: Object.keys(rawStacks),
+        currentUserStackValue: currentUserId ? rawStacks[currentUserId] : null,
+        seatsCount: payloadSeatSnapshot.seatRows.length,
+        seatUserSeatMap: payloadSeatSnapshot.seatMap,
+        seatUserIds: payloadSeatSnapshot.seatRows,
+        youSeatPresent: youSeatPresent
       });
 
       if (applyWsSnapshotNow(payload, {
@@ -2665,7 +2763,7 @@
           } else {
             seatStatusEl.className += ' poker-seat-status--active';
             seatStatusEl.textContent = t('pokerSeatActive', 'Active');
-            var activeStack = seat.userId && stacks[seat.userId] != null ? formatChips(stacks[seat.userId]) : '0';
+            var activeStack = seat.userId && stacks[seat.userId] != null ? formatChips(stacks[seat.userId]) : '-';
             seatStackEl.textContent = t('pokerSeatStack', 'Stack') + ': ' + activeStack;
           }
           div.appendChild(seatNoEl);
@@ -2678,12 +2776,30 @@
 
       var hasCurrentUserStack = !!(currentUserId && stacks[currentUserId] != null);
       var yourStack = hasCurrentUserStack ? formatChips(stacks[currentUserId]) : '-';
+      var seatFacts = findCurrentUserSeatFacts(data);
+      klog('poker_render_your_stack_pre', {
+        tableId: tableId,
+        stateVersion: Number.isInteger(stateObj.version) ? stateObj.version : null,
+        currentUserId: currentUserId || null,
+        isSeated: isSeated === true,
+        currentUserSeatNo: seatFacts.seatNo,
+        hasCurrentUserStack: hasCurrentUserStack,
+        rawCurrentUserStack: currentUserId ? stacks[currentUserId] : null,
+        stacksKeys: Object.keys(stacks || {})
+      });
       if (isSeated && currentUserId && !hasCurrentUserStack){
-        yourStack = '0';
         klog('poker_stack_missing_for_seated_user', {
           tableId: tableId,
-          userId: currentUserId,
-          stacksKeys: Object.keys(stacks || {})
+          stateVersion: Number.isInteger(stateObj.version) ? stateObj.version : null,
+          snapshotKind: wsSnapshotSeen ? 'ws_runtime' : 'non_ws_or_initial',
+          currentUserId: currentUserId,
+          isSeated: isSeated === true,
+          currentUserSeatNo: seatFacts.seatNo,
+          stacksKeys: Object.keys(stacks || {}),
+          hasCurrentUserStack: hasCurrentUserStack,
+          rawCurrentUserStack: currentUserId ? stacks[currentUserId] : null,
+          seatUserIds: Array.isArray(data.seats) ? data.seats.filter(function(seat){ return seat && typeof seat.userId === 'string' && seat.userId; }).map(function(seat){ return seat.userId; }) : [],
+          youSeatPresent: Number.isInteger(seatFacts.seatNo)
         });
       }
       if (yourStackEl) yourStackEl.textContent = yourStack;

--- a/tests/poker-ui-ws-live-state-page.behavior.test.mjs
+++ b/tests/poker-ui-ws-live-state-page.behavior.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { createPokerTableHarness } from './helpers/poker-ui-table-harness.mjs';
 
+function seatCardFor(seatsGrid, seatNo){
+  if (!seatsGrid || !Array.isArray(seatsGrid.children)) return null;
+  var index = Number(seatNo) - 1;
+  if (!Number.isInteger(index) || index < 0) return null;
+  return seatsGrid.children[index] || null;
+}
+
 const harness = createPokerTableHarness();
 
 harness.fireDomContentLoaded();
@@ -21,14 +28,16 @@ ws.onSnapshot({
   payload: {
     tableId: 'table-1',
     stateVersion: 2,
-    table: { tableId: 'table-1', status: 'OPEN', maxSeats: 9, members: [{ userId: 'u1', seat: 1 }] },
+    table: { tableId: 'table-1', status: 'OPEN', maxSeats: 9, members: [{ userId: 'user-1', seat: 1 }] },
     public: {
       hand: { handId: 'h-2', status: 'TURN' },
       turn: { userId: 'u1', deadlineAt: Date.now() + 5000 },
       board: ['As', 'Kd', '3h', '2c'],
       pot: { total: 42, sidePots: [] },
-      legalActions: ['CHECK']
-    }
+      legalActions: ['CHECK'],
+      stacks: { 'user-1': 250 }
+    },
+    you: { seat: 1 }
   },
 });
 await harness.flush();
@@ -36,7 +45,48 @@ await harness.flush();
 assert.equal(Number(harness.elements.pokerVersion.textContent), 2, 'WS snapshot should drive rendered table version');
 assert.equal(harness.elements.pokerPhase.textContent, 'TURN', 'WS snapshot should drive rendered phase');
 assert.equal(harness.elements.pokerSeatsGrid.children.length, 9, 'WS maxSeats bootstrap should set table capacity without HTTP baseline');
+assert.equal(harness.elements.pokerYourStack.textContent, '250', 'WS snapshot should normalize public.stacks and render current user stack');
+assert.equal(
+  harness.logs.some((entry) => entry.kind === 'poker_stack_missing_for_seated_user'),
+  false,
+  'stack missing log should not fire when stack exists in payload.public.stacks'
+);
+
 assert.ok(
   harness.clearTimeoutCalls.length > clearTimeoutBeforeSnapshot,
   'stopPolling should be triggered after a valid WS snapshot is applied'
+);
+
+const missingHarness = createPokerTableHarness();
+missingHarness.fireDomContentLoaded();
+await missingHarness.flush();
+assert.equal(missingHarness.fetchState.getCalls, 0, 'missing-stack scenario should remain WS-only');
+const missingWs = missingHarness.wsCreates[0].options;
+missingWs.onSnapshot({
+  kind: 'stateSnapshot',
+  payload: {
+    tableId: 'table-1',
+    stateVersion: 2,
+    table: { tableId: 'table-1', status: 'OPEN', maxSeats: 9, members: [{ userId: 'user-1', seat: 1 }] },
+    public: {
+      hand: { handId: 'h-3', status: 'TURN' },
+      turn: { userId: 'u2', deadlineAt: Date.now() + 5000 },
+      board: ['As', 'Kd', '3h', '2c'],
+      pot: { total: 22, sidePots: [] },
+      legalActions: ['CHECK']
+    },
+    you: { seat: 1 }
+  },
+});
+await missingHarness.flush();
+
+assert.equal(missingHarness.elements.pokerYourStack.textContent, '-', 'missing stack for seated user should render placeholder and never fake zero');
+const seatOneCard = seatCardFor(missingHarness.elements.pokerSeatsGrid, 1);
+const seatOneStackNode = seatOneCard && seatOneCard.children
+  ? seatOneCard.children[3]
+  : null;
+assert.equal(
+  seatOneStackNode && seatOneStackNode.textContent ? seatOneStackNode.textContent.indexOf(': -') !== -1 : false,
+  true,
+  'active seat with missing stack should render placeholder, not zero'
 );

--- a/ws-server/poker/handlers/act.behavior.test.mjs
+++ b/ws-server/poker/handlers/act.behavior.test.mjs
@@ -93,6 +93,28 @@ test('handleActCommand does not autoplay for replayed, rejected, or conflicted a
   assert.deepEqual(autoplayCalls, []);
 });
 
+test('handleActCommand skips broadcast when autoplay returns failure but still sends accepted commandResult', async () => {
+  const calls = { command: [], snapshots: 0 };
+  await handleActCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'r7', ts: new Date().toISOString(), payload: { handId: 'h1', action: 'CHECK' } },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: { ensureTableLoaded: async () => ({ ok: true }), applyAction: () => ({ accepted: true, replayed: false, changed: true, stateVersion: 2, reason: null }) },
+    ensureTableLoadedErrorMapper: (x) => x,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _cs, payload) => calls.command.push(payload),
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    broadcastStateSnapshots: () => { calls.snapshots += 1; },
+    runAcceptedBotAutoplay: async () => ({ ok: false, reason: 'invalid_state' })
+  });
+
+  assert.equal(calls.command.length, 1);
+  assert.equal(calls.command[0].status, 'accepted');
+  assert.equal(calls.snapshots, 0);
+});
+
 
 test('handleActCommand rejects ensureTableLoaded failure with mapped stable code', async () => {
   const calls = [];

--- a/ws-server/poker/handlers/act.mjs
+++ b/ws-server/poker/handlers/act.mjs
@@ -87,23 +87,25 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
   });
 
   if (result.accepted && !result.replayed && result.changed) {
+    let autoplayResult = { ok: true };
     try {
-      await runAcceptedBotAutoplay({
+      autoplayResult = await runAcceptedBotAutoplay({
         tableId,
         trigger: "act",
         requestId: frame.requestId ?? null,
         frameTs: frame.ts
       });
     } catch (error) {
+      autoplayResult = { ok: false, reason: error?.message || "autoplay_failed" };
       klog("ws_act_bot_autoplay_failed", {
         tableId,
         requestId: frame.requestId ?? null,
         message: error?.message || "unknown"
       });
     }
-  }
-
-  if (result.accepted && !result.replayed && result.changed) {
+    if (autoplayResult?.ok === false) {
+      return;
+    }
     broadcastStateSnapshots(tableId);
   }
 }

--- a/ws-server/poker/handlers/start-hand.behavior.test.mjs
+++ b/ws-server/poker/handlers/start-hand.behavior.test.mjs
@@ -131,3 +131,31 @@ test('handleStartHandCommand rejects ensureTableLoaded failure with stable comma
   assert.equal(calls.persist, 0);
   assert.equal(calls.snapshots, 0);
 });
+
+test('handleStartHandCommand skips broadcast when autoplay returns failure but still sends accepted commandResult', async () => {
+  const calls = { command: [], snapshots: 0, persist: 0 };
+  await handleStartHandCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'r6' },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: {
+      ensureTableLoaded: async () => ({ ok: true }),
+      tableSnapshot: () => ({ youSeat: 1 }),
+      persistedStateVersion: () => 2,
+      bootstrapHand: () => ({ ok: true, changed: true, bootstrap: 'started' })
+    },
+    ensureTableLoadedErrorMapper: (x) => x,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _cs, payload) => calls.command.push(payload),
+    persistMutatedState: async () => { calls.persist += 1; return { ok: true }; },
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    broadcastStateSnapshots: () => { calls.snapshots += 1; },
+    runAcceptedBotAutoplay: async () => ({ ok: false, reason: 'invalid_state' })
+  });
+
+  assert.equal(calls.command.length, 1);
+  assert.equal(calls.command[0].status, 'accepted');
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.snapshots, 0);
+});

--- a/ws-server/poker/handlers/start-hand.mjs
+++ b/ws-server/poker/handlers/start-hand.mjs
@@ -74,19 +74,25 @@ export async function handleStartHandCommand({ frame, ws, connState, tableManage
     reason: null
   });
 
+  let autoplayResult = { ok: true };
   try {
-    await runAcceptedBotAutoplay({
+    autoplayResult = await runAcceptedBotAutoplay({
       tableId,
       trigger: "start_hand",
       requestId: frame.requestId ?? null,
       frameTs: frame.ts
     });
   } catch (error) {
+    autoplayResult = { ok: false, reason: error?.message || "autoplay_failed" };
     klog("ws_start_hand_bot_autoplay_failed", {
       tableId,
       requestId: frame.requestId ?? null,
       message: error?.message || "unknown"
     });
+  }
+
+  if (autoplayResult?.ok === false) {
+    return;
   }
 
   broadcastStateSnapshots(tableId);

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -110,6 +110,44 @@ function materializeShowdownState(stateToMaterialize, seatOrder, nowIso, klog) {
   }).nextState;
 }
 
+function buildDiagnosticSnapshot(state) {
+  const seats = Array.isArray(state?.seats) ? state.seats : [];
+  const seatUserIds = seats
+    .filter((seat) => typeof seat?.userId === "string" && seat.userId.trim())
+    .sort((a, b) => Number(a?.seatNo ?? 0) - Number(b?.seatNo ?? 0))
+    .map((seat) => seat.userId.trim());
+  const stacks = state?.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks) ? state.stacks : {};
+  const communityCards = Array.isArray(state?.community) ? state.community : [];
+  return {
+    phase: typeof state?.phase === "string" ? state.phase : null,
+    handId: typeof state?.handId === "string" ? state.handId : null,
+    turnUserId: typeof state?.turnUserId === "string" ? state.turnUserId : null,
+    pot: Number.isFinite(Number(state?.pot)) ? Number(state.pot) : 0,
+    communityDealt: state?.communityDealt === true || state?.communityDealt === false ? state.communityDealt : (communityCards.length > 0),
+    communityLen: communityCards.length,
+    seatsCount: seats.length,
+    seatUserIds,
+    stacksKeys: Object.keys(stacks),
+    stackCount: Object.keys(stacks).length
+  };
+}
+
+function summarizeLegalActions(legalActions) {
+  const actions = Array.isArray(legalActions) ? legalActions : [];
+  const types = [];
+  for (const item of actions) {
+    if (typeof item === "string") {
+      types.push(item);
+    } else if (item && typeof item === "object" && typeof item.type === "string") {
+      types.push(item.type);
+    }
+  }
+  return {
+    count: actions.length,
+    types: [...new Set(types)].slice(0, 8)
+  };
+}
+
 export function createAcceptedBotAutoplayExecutor({
   tableManager,
   persistMutatedState,
@@ -119,12 +157,25 @@ export function createAcceptedBotAutoplayExecutor({
   klog = () => {}
 } = {}) {
   return async function runAcceptedBotAutoplay({ tableId, trigger, requestId, frameTs }) {
+    const baseLog = {
+      tableId,
+      trigger: trigger || null,
+      requestId: requestId || null
+    };
+    let lastKnown = {
+      stage: "init",
+      state: null,
+      actionType: null,
+      actionAmount: null,
+      legalActionSummary: null
+    };
     const privateState = tableManager.persistedPokerState(tableId);
     if (!privateState || typeof privateState !== "object") {
       return { ok: true, changed: false, actionCount: 0, reason: "missing_state" };
     }
 
     const state = withoutPrivateState(privateState);
+    lastKnown.state = state;
     if (!isActionPhase(state?.phase) || !state?.turnUserId) {
       return { ok: true, changed: false, actionCount: 0, reason: "not_action_phase" };
     }
@@ -148,80 +199,214 @@ export function createAcceptedBotAutoplayExecutor({
     const seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
     const seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
     const cfg = getBotAutoplayConfig(env);
-
-    const botLoop = await runBotAutoplayLoop({
-      tableId,
-      requestId: `${trigger || "ws"}:${requestId || "no-request-id"}`,
-      initialState: state,
-      initialPrivateState: privateState,
-      initialVersion: Number(tableManager.persistedStateVersion(tableId) || 0),
-      seatBotMap,
-      seatUserIdsInOrder,
-      maxActions: cfg.maxActionsPerRequest,
-      botsOnlyHandCompletionHardCap: cfg.botsOnlyHandCompletionHardCap,
-      policyVersion: cfg.policyVersion,
-      klog,
-      isActionPhase,
-      advanceIfNeeded,
-      buildPersistedFromPrivateState,
-      materializeShowdownState: (nextState, seatOrder) => materializeShowdownState(nextState, seatOrder, frameTs || new Date().toISOString(), klog),
-      computeLegalActions,
-      withoutPrivateState,
-      chooseBotActionTrivial,
-      isBotTurn,
-      applyAction: applyRuntimeAction,
-      persistStep: async ({ botTurnUserId, botAction, botRequestId, fromState }) => {
-        const applied = tableManager.applyAction({
-          tableId,
-          handId: fromState?.handId,
-          userId: botTurnUserId,
-          requestId: botRequestId,
-          action: botAction?.type,
-          amount: botAction?.amount,
-          nowIso: frameTs || new Date().toISOString()
-        });
-
-        if (!applied?.accepted || applied?.replayed || !applied?.changed) {
-          return { ok: false, reason: applied?.reason || "bot_action_rejected" };
-        }
-
-        const persisted = await persistMutatedState({
-          tableId,
-          expectedVersion: Number(applied.stateVersion) - 1,
-          mutationKind: "act"
-        });
-
-        if (!persisted?.ok) {
-          await restoreTableFromPersisted(tableId);
-          broadcastResyncRequired(tableId, "persistence_conflict");
-          return { ok: false, reason: persisted?.reason || "persist_failed" };
-        }
-
-        const latestPrivateState = tableManager.persistedPokerState(tableId);
-        return {
-          ok: true,
-          loopVersion: Number(applied.stateVersion),
-          responseFinalState: withoutPrivateState(latestPrivateState),
-          loopPrivateState: latestPrivateState
-        };
-      }
+    klog("ws_bot_autoplay_loop_start", {
+      ...baseLog,
+      ...buildDiagnosticSnapshot(state),
+      stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0),
+      maxActions: cfg.maxActionsPerRequest
     });
-
-    if (botLoop?.botActionCount > 0 || botLoop?.botStopReason) {
-      klog("ws_bot_autoplay_stop", {
+    try {
+      const botLoop = await runBotAutoplayLoop({
         tableId,
-        requestId: requestId || null,
-        trigger: trigger || null,
-        botActionCount: botLoop?.botActionCount || 0,
-        reason: botLoop?.botStopReason || "not_attempted"
-      });
-    }
+        requestId: `${trigger || "ws"}:${requestId || "no-request-id"}`,
+        initialState: state,
+        initialPrivateState: privateState,
+        initialVersion: Number(tableManager.persistedStateVersion(tableId) || 0),
+        seatBotMap,
+        seatUserIdsInOrder,
+        maxActions: cfg.maxActionsPerRequest,
+        botsOnlyHandCompletionHardCap: cfg.botsOnlyHandCompletionHardCap,
+        policyVersion: cfg.policyVersion,
+        klog,
+        isActionPhase,
+        advanceIfNeeded,
+        buildPersistedFromPrivateState,
+        materializeShowdownState: (nextState, seatOrder) => materializeShowdownState(nextState, seatOrder, frameTs || new Date().toISOString(), klog),
+        computeLegalActions: ({ statePublic, userId }) => {
+          const legal = computeLegalActions({ statePublic, userId });
+          const legalSummary = summarizeLegalActions(legal?.actions);
+          lastKnown = { ...lastKnown, stage: "turn_snapshot", state: statePublic, legalActionSummary: legalSummary };
+          klog("ws_bot_autoplay_turn_snapshot", {
+            ...baseLog,
+            botTurnUserId: userId || null,
+            legalActionSummary: legalSummary,
+            ...buildDiagnosticSnapshot(statePublic),
+            stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
+          });
+          return legal;
+        },
+        withoutPrivateState,
+        chooseBotActionTrivial: (legalActions) => {
+          const action = chooseBotActionTrivial(legalActions);
+          lastKnown = { ...lastKnown, stage: "action_chosen", actionType: action?.type || null, actionAmount: action?.amount ?? null };
+          klog("ws_bot_autoplay_action_chosen", {
+            ...baseLog,
+            botTurnUserId: typeof lastKnown?.state?.turnUserId === "string" ? lastKnown.state.turnUserId : null,
+            actionType: action?.type || null,
+            amount: action?.amount ?? null
+          });
+          return action;
+        },
+        isBotTurn,
+        applyAction: (loopPrivateState, botAction) => {
+          const safeState = withoutPrivateState(loopPrivateState);
+          lastKnown = { ...lastKnown, stage: "apply_start", state: safeState, actionType: botAction?.type || null, actionAmount: botAction?.amount ?? null };
+          klog("ws_bot_autoplay_apply_start", {
+            ...baseLog,
+            botTurnUserId: typeof safeState?.turnUserId === "string" ? safeState.turnUserId : null,
+            actionType: botAction?.type || null,
+            amount: botAction?.amount ?? null,
+            ...buildDiagnosticSnapshot(safeState),
+            legalActionSummary: lastKnown.legalActionSummary,
+            stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
+          });
+          const applied = applyRuntimeAction(loopPrivateState, botAction);
+          const nextState = withoutPrivateState(applied?.state);
+          lastKnown = { ...lastKnown, stage: "apply_result", state: nextState };
+          klog("ws_bot_autoplay_apply_result", {
+            ...baseLog,
+            botTurnUserId: typeof safeState?.turnUserId === "string" ? safeState.turnUserId : null,
+            actionType: botAction?.type || null,
+            amount: botAction?.amount ?? null,
+            ...buildDiagnosticSnapshot(nextState),
+            legalActionSummary: lastKnown.legalActionSummary,
+            stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
+          });
+          return applied;
+        },
+        persistStep: async ({ botTurnUserId, botAction, botRequestId, fromState }) => {
+          klog("ws_bot_autoplay_persist_start", {
+            ...baseLog,
+            botTurnUserId: botTurnUserId || null,
+            actionType: botAction?.type || null,
+            amount: botAction?.amount ?? null,
+            ...buildDiagnosticSnapshot(fromState),
+            legalActionSummary: lastKnown.legalActionSummary,
+            stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
+          });
+          const applied = tableManager.applyAction({
+            tableId,
+            handId: fromState?.handId,
+            userId: botTurnUserId,
+            requestId: botRequestId,
+            action: botAction?.type,
+            amount: botAction?.amount,
+            nowIso: frameTs || new Date().toISOString()
+          });
 
-    return {
-      ok: true,
-      changed: (botLoop?.botActionCount || 0) > 0,
-      actionCount: botLoop?.botActionCount || 0,
-      reason: botLoop?.botStopReason || "not_attempted"
-    };
+          if (!applied?.accepted || applied?.replayed || !applied?.changed) {
+            klog("ws_bot_autoplay_persist_result", {
+              ...baseLog,
+              botTurnUserId: botTurnUserId || null,
+              actionType: botAction?.type || null,
+              amount: botAction?.amount ?? null,
+              ok: false,
+              reason: applied?.reason || "bot_action_rejected"
+            });
+            return { ok: false, reason: applied?.reason || "bot_action_rejected" };
+          }
+
+          const persisted = await persistMutatedState({
+            tableId,
+            expectedVersion: Number(applied.stateVersion) - 1,
+            mutationKind: "act"
+          });
+
+          if (!persisted?.ok) {
+            await restoreTableFromPersisted(tableId);
+            broadcastResyncRequired(tableId, "persistence_conflict");
+            klog("ws_bot_autoplay_persist_result", {
+              ...baseLog,
+              botTurnUserId: botTurnUserId || null,
+              actionType: botAction?.type || null,
+              amount: botAction?.amount ?? null,
+              ok: false,
+              reason: persisted?.reason || "persist_failed"
+            });
+            return { ok: false, reason: persisted?.reason || "persist_failed" };
+          }
+
+          const latestPrivateState = tableManager.persistedPokerState(tableId);
+          const latestState = withoutPrivateState(latestPrivateState);
+          lastKnown = { ...lastKnown, stage: "state_after_step", state: latestState };
+          klog("ws_bot_autoplay_persist_result", {
+            ...baseLog,
+            botTurnUserId: botTurnUserId || null,
+            actionType: botAction?.type || null,
+            amount: botAction?.amount ?? null,
+            ok: true,
+            stateVersion: Number(applied.stateVersion)
+          });
+          klog("ws_bot_autoplay_state_after_step", {
+            ...baseLog,
+            botTurnUserId: botTurnUserId || null,
+            actionType: botAction?.type || null,
+            amount: botAction?.amount ?? null,
+            ...buildDiagnosticSnapshot(latestState),
+            legalActionSummary: lastKnown.legalActionSummary,
+            stateVersion: Number(applied.stateVersion)
+          });
+          return {
+            ok: true,
+            loopVersion: Number(applied.stateVersion),
+            responseFinalState: latestState,
+            loopPrivateState: latestPrivateState
+          };
+        }
+      });
+
+      if (botLoop?.botActionCount > 0 || botLoop?.botStopReason) {
+        klog("ws_bot_autoplay_loop_stop", {
+          ...baseLog,
+          botActionCount: botLoop?.botActionCount || 0,
+          reason: botLoop?.botStopReason || "not_attempted",
+          ...buildDiagnosticSnapshot(botLoop?.responseFinalState || lastKnown.state),
+          stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
+        });
+      }
+
+      return {
+        ok: true,
+        changed: (botLoop?.botActionCount || 0) > 0,
+        actionCount: botLoop?.botActionCount || 0,
+        reason: botLoop?.botStopReason || "not_attempted"
+      };
+    } catch (error) {
+      const lastState = lastKnown.state;
+      const diagnostic = buildDiagnosticSnapshot(lastState);
+      const failureReason = error?.code || error?.name || "autoplay_failed";
+      let restoreOk = false;
+      let restoreReason = null;
+      try {
+        await restoreTableFromPersisted(tableId);
+        restoreOk = true;
+      } catch (restoreError) {
+        restoreReason = restoreError?.message || "restore_failed";
+      }
+      try {
+        broadcastResyncRequired(tableId, restoreOk ? "autoplay_failed_resync" : "autoplay_restore_failed");
+      } catch (_broadcastError) {}
+      klog("ws_bot_autoplay_failed", {
+        ...baseLog,
+        stage: lastKnown.stage,
+        reason: failureReason,
+        errorMessage: error?.message || "unknown",
+        errorStackShort: error?.stack ? String(error.stack).slice(0, 500) : null,
+        lastKnownPhase: diagnostic.phase,
+        lastKnownTurnUserId: diagnostic.turnUserId,
+        lastKnownStateVersion: Number(tableManager.persistedStateVersion(tableId) || 0) || null,
+        lastKnownStacksKeys: diagnostic.stacksKeys,
+        lastKnownSeatUserIds: diagnostic.seatUserIds,
+        restoreOk,
+        restoreReason
+      });
+      return {
+        ok: false,
+        changed: false,
+        actionCount: 0,
+        reason: failureReason,
+        restoreOk
+      };
+    }
   };
 }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -249,6 +249,16 @@ function nowTs() {
   return new Date().toISOString();
 }
 
+function buildAutoplayStartSnapshot(tableId) {
+  const state = tableManager.persistedPokerState(tableId);
+  const stateVersion = Number(tableManager.persistedStateVersion(tableId) || 0);
+  return {
+    stateVersionBeforeAutoplay: stateVersion || null,
+    turnUserIdBeforeAutoplay: typeof state?.turnUserId === "string" ? state.turnUserId : null,
+    phaseBeforeAutoplay: typeof state?.phase === "string" ? state.phase : null
+  };
+}
+
 function sendFrame(ws, frame) {
   if (ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify(frame));
@@ -1210,7 +1220,19 @@ wss.on("connection", (ws) => {
         return;
       }
       frame.__resolvedTableId = resolvedRoomId.roomId;
-      const runAcceptedBotAutoplay = await loadAcceptedBotAutoplayExecutor();
+      const acceptedBotAutoplayExecutor = await loadAcceptedBotAutoplayExecutor();
+      const runAcceptedBotAutoplay = async ({ tableId, trigger, requestId, frameTs }) => {
+        const startSnapshot = buildAutoplayStartSnapshot(tableId);
+        klogSafe("ws_bot_autoplay_start", {
+          tableId,
+          requestId: requestId || null,
+          trigger: trigger || null,
+          stateVersion_before_autoplay: startSnapshot.stateVersionBeforeAutoplay,
+          turnUserId_before_autoplay: startSnapshot.turnUserIdBeforeAutoplay,
+          phase_before_autoplay: startSnapshot.phaseBeforeAutoplay
+        });
+        return acceptedBotAutoplayExecutor({ tableId, trigger, requestId, frameTs });
+      };
       await handleActCommand({
         frame,
         ws,
@@ -1240,7 +1262,19 @@ wss.on("connection", (ws) => {
         return;
       }
       frame.__resolvedTableId = resolvedRoomId.roomId;
-      const runAcceptedBotAutoplay = await loadAcceptedBotAutoplayExecutor();
+      const acceptedBotAutoplayExecutor = await loadAcceptedBotAutoplayExecutor();
+      const runAcceptedBotAutoplay = async ({ tableId, trigger, requestId, frameTs }) => {
+        const startSnapshot = buildAutoplayStartSnapshot(tableId);
+        klogSafe("ws_bot_autoplay_start", {
+          tableId,
+          requestId: requestId || null,
+          trigger: trigger || null,
+          stateVersion_before_autoplay: startSnapshot.stateVersionBeforeAutoplay,
+          turnUserId_before_autoplay: startSnapshot.turnUserIdBeforeAutoplay,
+          phase_before_autoplay: startSnapshot.phaseBeforeAutoplay
+        });
+        return acceptedBotAutoplayExecutor({ tableId, trigger, requestId, frameTs });
+      };
       await handleStartHandCommand({
         frame,
         ws,


### PR DESCRIPTION
### Motivation
- Ensure stacks provided in various WS snapshot shapes are normalized and surfaced to the client so seated users' stacks render correctly without faking zeros. 
- Improve observability and safety of server-side bot autoplay by adding detailed diagnostics, robust error handling, and preventing broadcasts when autoplay fails. 
- Add coverage for the new stack normalization and autoplay failure behavior in unit tests.

### Description
- Enhanced WS snapshot detection in `poker.js` to consider `hand`, `turn`, `pot`, `board`, `stacks`, `seats`, and `authoritativeMembers` as rich gameplay snapshots. 
- Added `normalizeSnapshotStacks` to canonicalize stacks from `payload.stacks`, `payload.public.stacks`, or `payload.state.stacks`, and integrated it into `normalizeWsSnapshotPayload`, state merge logic, and render paths. 
- Added utilities `buildSeatUserSeatMap` and `buildWsPayloadSeatSnapshot` and expanded runtime logging (`klog`) around snapshot application and rendering, including stack keys and current user stack values. 
- Changed seat and your-stack rendering to show placeholder `-` when a stack is missing instead of emitting a fake `0`, and augmented missing-stack diagnostic logs with richer context. 
- On the server side, wrapped bot-autoplay invocation with try/catch and short-circuited broadcasting when `runAcceptedBotAutoplay` returns a non-OK result in both `act` and `start_hand` handlers. 
- Replaced inline autoplay loader wiring to log a pre-autoplay snapshot via `buildAutoplayStartSnapshot` in `ws-server/server.mjs`. 
- Substantially extended the accepted-bot-autoplay adapter with diagnostic helpers (`buildDiagnosticSnapshot`, `summarizeLegalActions`), detailed lifecycle logging, persisted-step logging, improved return shapes, and error recovery that attempts table restore and broadcasts resync on failure.
- Updated tests and added helpers: adjusted poker UI WS test payloads to include `public.stacks`, added assertions for stack rendering and missing-stack behavior, and added server-side tests asserting broadcasts are skipped when autoplay fails but command results are still sent.

### Testing
- Ran updated UI behavior tests in `tests/poker-ui-ws-live-state-page.behavior.test.mjs`, which assert stack normalization and placeholder rendering, and they passed. 
- Ran server behavior tests in `ws-server/poker/handlers/act.behavior.test.mjs` and `ws-server/poker/handlers/start-hand.behavior.test.mjs` that cover the new autoplay-failure-short-circuiting behavior, and they passed. 
- Existing unit test suite covering autoplay adapter was executed with the new diagnostics and error paths and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ced4cdb520832389c89788be8a60c0)