### PR TITLE
Guard WS snapshot helpers to avoid ReferenceError when currentUserId is out of scope

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1683,6 +1683,7 @@
     function applyWsSnapshotNow(snapshotPayload, options){
       if (!snapshotPayload || typeof snapshotPayload !== 'object') return false;
       var opts = options && typeof options === 'object' ? options : {};
+      var activeCurrentUserId = typeof currentUserId === 'string' && currentUserId ? currentUserId : '';
       if (!shouldApplyWsSnapshot(snapshotPayload, opts)) return false;
       if (!tableData || typeof tableData !== 'object'){
         if (!opts.allowWhenNoBaseline) return false;
@@ -1702,12 +1703,12 @@
         tableId: tableId,
         snapshotKind: opts.snapshotKind || null,
         stateVersion: resolveTableDataVersion(tableData),
-        currentUserId: currentUserId || null,
+        currentUserId: activeCurrentUserId || null,
         isSeated: isSeated === true,
         youSeat: Number.isInteger(snapshotPayload.youSeat) ? snapshotPayload.youSeat : null,
         currentUserSeatNo: seatFacts.seatNo,
         stacksKeys: Object.keys(stacks),
-        currentUserStackValue: currentUserId ? stacks[currentUserId] : null,
+        currentUserStackValue: activeCurrentUserId ? stacks[activeCurrentUserId] : null,
         seatsCount: Array.isArray(tableData.seats) ? tableData.seats.length : 0,
         seatUserSeatMap: buildSeatUserSeatMap(tableData.seats || [])
       });
@@ -1725,6 +1726,7 @@
 
     function applyWsSnapshot(snapshot){
       if (!snapshot || !snapshot.payload) return;
+      var activeCurrentUserId = typeof currentUserId === 'string' && currentUserId ? currentUserId : '';
       var normalized = normalizeWsSnapshotPayload(snapshot);
       var payload = normalized.payload || {};
       var snapshotKind = normalized.kind || snapshot.kind || snapshot.rawType || null;
@@ -1732,7 +1734,7 @@
       var currentVersion = resolveTableDataVersion(tableData);
       var rawStacks = normalizeSnapshotStacks(payload) || {};
       var payloadSeatSnapshot = buildWsPayloadSeatSnapshot(payload);
-      var currentUserSeatNo = payloadSeatSnapshot.seatMap[currentUserId || ''];
+      var currentUserSeatNo = payloadSeatSnapshot.seatMap[activeCurrentUserId];
       var youSeatPresent = Number.isInteger(payload.youSeat);
       klog('poker_ws_snapshot_received', {
         tableId: tableId,
@@ -1745,12 +1747,12 @@
         tableId: tableId,
         snapshotKind: snapshotKind,
         stateVersion: incomingVersion,
-        currentUserId: currentUserId || null,
+        currentUserId: activeCurrentUserId || null,
         isSeated: isSeated === true,
         youSeat: Number.isInteger(payload.youSeat) ? payload.youSeat : null,
         currentUserSeatNo: Number.isInteger(currentUserSeatNo) ? currentUserSeatNo : null,
         stacksKeys: Object.keys(rawStacks),
-        currentUserStackValue: currentUserId ? rawStacks[currentUserId] : null,
+        currentUserStackValue: activeCurrentUserId ? rawStacks[activeCurrentUserId] : null,
         seatsCount: payloadSeatSnapshot.seatRows.length,
         seatUserSeatMap: payloadSeatSnapshot.seatMap,
         seatUserIds: payloadSeatSnapshot.seatRows,


### PR DESCRIPTION
### Motivation
- Recent WS snapshot logging/normalization changes introduced bare `currentUserId` reads inside helper functions that may run inside isolated/eval harnesses, causing a `ReferenceError` and hard test failures.
- The intent is to harden those snapshot helpers and diagnostics so logging never becomes a source of runtime failure while preserving the new stack normalization and diagnostic payloads.

### Description
- Introduced a guarded local `activeCurrentUserId` (`var activeCurrentUserId = typeof currentUserId === 'string' && currentUserId ? currentUserId : ''`) at the top of both `applyWsSnapshotNow(...)` and `applyWsSnapshot(...)`.
- Replaced direct `currentUserId` uses in WS diagnostic payloads and helper reads with `activeCurrentUserId` (affecting fields such as `currentUserId`, `currentUserStackValue`, and seat lookups) so missing global bindings do not throw.
- Preserved existing stack normalization, merge/version gating, and other snapshot behavior; only scope-safety access paths for diagnostics and helper reads were changed.
- File modified: `poker/poker.js` (no gameplay, protocol, idempotency, persistence, or fallback behavior was changed).

### Testing
- Ran `node --test tests/poker-ws-presence-race.behavior.test.mjs tests/poker-ui-ws-live-state-page.behavior.test.mjs tests/poker-ws-presence-mapping.test.mjs`; `tests/poker-ui-ws-live-state-page.behavior.test.mjs` and the version-gating subtest passed, and the previous hard `ReferenceError` no longer occurs.
- `tests/poker-ws-presence-race.behavior.test.mjs` still reports one failing assertion in the "deferred snapshot apply preserves baseline constraints when WS omits them" subtest (the assertion expects `h.getSeen() === false` but observed `true`), which appears unrelated to the scope crash fix.
- Re-ran `node --test tests/poker-ws-presence-race.behavior.test.mjs` to confirm regression behavior; the `ReferenceError` is resolved but the single assertion failure remains and requires closer inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee166b8788323ae177c539834b7af)