### PR TITLE
Run full tests workflow for every pull request target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Motivation
- PRs targeting non-`main` branches were not running the full test workflow (including Playwright), causing CI coverage drift between PR and post-merge contexts; the intent is to ensure identical test coverage for all PR targets.

### Description
- Removed the `pull_request.branches: [ main ]` restriction from `.github/workflows/tests.yml` while keeping `push` limited to `main`, and preserved the existing `PLAYWRIGHT=1 npm test` step so Playwright remains part of the same `tests` job.

### Testing
- Verified the change and workflow triggers by inspecting the file with `sed -n '1,120p' .github/workflows/tests.yml` and searching workflows with `rg -n "pull_request|push|schedule|workflow_dispatch|branches|paths" .github/workflows/*.yml`, and committed the update with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cee8470dc483238133395550c2e849)