### PR TITLE
Validate and merge trusted showdown hole-cards for bot autoplay; add fixtures and behavior tests

### DIFF
--- a/shared/poker-domain/poker-autoplay.mjs
+++ b/shared/poker-domain/poker-autoplay.mjs
@@ -120,9 +120,15 @@ export const runBotAutoplayLoop = async ({
         ? botNextState.showdown.handId.trim()
         : "";
     const botShowdownMaterialized = !!botHandId && !!botShowdownHandId && botShowdownHandId === botHandId;
-    const botNeedsShowdown = !botShowdownMaterialized && (botEligibleUserIds.length <= 1 || botNextState.phase === "SHOWDOWN");
-    if (botNeedsShowdown && typeof materializeShowdownState === "function") {
-      botNextState = materializeShowdownState(botNextState, seatUserIdsInOrder);
+    const botNeedsSingleWinnerResolution = !botShowdownMaterialized && botEligibleUserIds.length <= 1;
+    const botNeedsFullShowdownResolution = !botShowdownMaterialized && botEligibleUserIds.length > 1 && botNextState.phase === "SHOWDOWN";
+    if ((botNeedsSingleWinnerResolution || botNeedsFullShowdownResolution) && typeof materializeShowdownState === "function") {
+      botNextState = materializeShowdownState(
+        botNextState,
+        seatUserIdsInOrder,
+        loopPrivateState?.holeCardsByUserId,
+        { requiresShowdownComparison: botNeedsFullShowdownResolution }
+      );
     }
 
     const botPersistedState = buildPersistedFromPrivateState(botNextState, botTurnUserId, botRequestId);

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -2,6 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { createAcceptedBotAutoplayExecutor } from "./accepted-bot-autoplay-adapter.mjs";
+import { initHandState, applyAction as applyRuntimeAction, advanceIfNeeded } from "../snapshot-runtime/poker-reducer.mjs";
+import { runAdvanceLoop } from "../../../shared/poker-domain/poker-autoplay.mjs";
+import { materializeShowdownAndPayout } from "../snapshot-runtime/poker-materialize-showdown.mjs";
+import { computeShowdown } from "../snapshot-runtime/poker-showdown.mjs";
+import { awardPotsAtShowdown } from "../snapshot-runtime/poker-payout.mjs";
 
 test("autoplay adapter resolves shared autoplay from neutral shared module path", () => {
   const source = fs.readFileSync(new URL("./accepted-bot-autoplay-adapter.mjs", import.meta.url), "utf8");
@@ -173,4 +178,409 @@ test("accepted bot autoplay unavailable shared helper returns safe non-fatal res
   assert.equal(result.reason, "autoplay_unavailable");
   assert.equal(result.changed, false);
   assert.equal(result.noop, true);
+});
+
+test("accepted bot autoplay showdown uses trusted private hole cards even for public showdown state", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0 };
+  const privateState = {
+    tableId: "t-showdown",
+    handId: "h-showdown-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 40,
+    sidePots: [],
+    contributionsByUserId: { human_1: 20, bot_2: 20 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 4,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 5 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-public-state-fixture.mjs", import.meta.url).href;
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {},
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-showdown", trigger: "act", requestId: "r-showdown" });
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+});
+
+test("accepted bot autoplay reloads trusted private showdown hole cards after boundary", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0 };
+  const privateState = {
+    tableId: "t-reload",
+    handId: "h-reload-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 50,
+    sidePots: [],
+    contributionsByUserId: { human_1: 25, bot_2: 25 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 7,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 8 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-reload-private-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {},
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-reload", trigger: "act", requestId: "r-reload" });
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+});
+
+test("accepted bot autoplay merges partial loop-private showdown cards with persisted trusted cards", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-partial-merge",
+    handId: "h-partial-merge-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 45,
+    sidePots: [],
+    contributionsByUserId: { human_1: 22, bot_2: 23 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 9,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 10 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-partial-loop-private-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-partial-merge", trigger: "act", requestId: "r-partial-merge" });
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+});
+
+test("accepted bot autoplay ignores malformed fallback showdown hole-card arrays", async () => {
+  const logs = [];
+  const calls = { restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-fallback-invalid",
+    handId: "h-fallback-invalid-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 35,
+    sidePots: [],
+    contributionsByUserId: { human_1: 17, bot_2: 18 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 10,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 11 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-reload-private-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-fallback-invalid", trigger: "act", requestId: "r-fallback-invalid" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "showdown_missing_private_inputs");
+  assert.equal(calls.restore, 1);
+  assert.equal(calls.resync, 1);
+  const focusedLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing");
+  assert.ok(focusedLog);
+  assert.deepEqual(focusedLog.payload.missingHoleCardsUserIds, ["human_1"]);
+});
+
+test("accepted bot autoplay emits focused showdown-input log and restores on missing trusted hole cards", async () => {
+  const logs = [];
+  const calls = { restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-missing",
+    handId: "h-missing-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 30,
+    sidePots: [],
+    contributionsByUserId: { human_1: 15, bot_2: 15 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 11,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 12 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-public-state-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-missing", trigger: "act", requestId: "r-missing" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "showdown_missing_private_inputs");
+  assert.equal(calls.restore, 1);
+  assert.equal(calls.resync, 1);
+  const focusedLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing");
+  assert.ok(focusedLog);
+  assert.deepEqual(focusedLog.payload.missingHoleCardsUserIds, ["human_1"]);
+});
+
+test("accepted bot autoplay resolves single-winner terminal hands without showdown-only input validation", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-single",
+    handId: "h-single-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: true, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 20,
+    sidePots: [],
+    contributionsByUserId: { human_1: 10, bot_2: 10 },
+    holeCardsByUserId: {
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 13,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 14 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-single-winner-terminal-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-single", trigger: "act", requestId: "r-single" });
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+});
+
+test("accepted bot autoplay settles showdown and allows next hand to continue", async () => {
+  const seats = [{ userId: "bot_1", seatNo: 1, isBot: true }, { userId: "bot_2", seatNo: 2, isBot: true }];
+  const stacks = { bot_1: 100, bot_2: 100 };
+  let state = initHandState({ tableId: "t-next-hand", seats, stacks }).state;
+
+  while (state.phase !== "RIVER") {
+    if (state.phase === "HAND_DONE" || state.phase === "SHOWDOWN" || state.phase === "SETTLED") {
+      break;
+    }
+    const acted = applyRuntimeAction(state, { type: "CHECK", userId: state.turnUserId });
+    const advanced = runAdvanceLoop(acted.state, [], [], advanceIfNeeded);
+    state = advanced.nextState;
+  }
+
+  if (state.phase !== "RIVER") {
+    throw new Error(`expected_river_phase:${state.phase}`);
+  }
+
+  let persistedState = { ...state, handId: "h-next-1", turnUserId: "bot_1" };
+  let persistedVersion = 20;
+  const calls = { persist: 0, restore: 0, resync: 0 };
+
+  const seatOrder = seats.slice().sort((a, b) => a.seatNo - b.seatNo).map((seat) => seat.userId);
+  const maybeMaterialize = (privateState) => {
+    const eligible = seatOrder.filter((userId) => !privateState.foldedByUserId?.[userId] && !privateState.leftTableByUserId?.[userId] && !privateState.sitOutByUserId?.[userId]);
+    const handId = typeof privateState.handId === "string" ? privateState.handId : "";
+    const showdownHandId = typeof privateState.showdown?.handId === "string" ? privateState.showdown.handId : "";
+    const alreadyMaterialized = !!handId && !!showdownHandId && handId === showdownHandId;
+    if (alreadyMaterialized || (eligible.length > 1 && privateState.phase !== "SHOWDOWN")) return privateState;
+    return materializeShowdownAndPayout({
+      state: privateState,
+      seatUserIdsInOrder: seatOrder,
+      holeCardsByUserId: privateState.holeCardsByUserId,
+      computeShowdown,
+      awardPotsAtShowdown,
+      klog: () => {}
+    }).nextState;
+  };
+
+  const tableManager = {
+    persistedPokerState: () => persistedState,
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: () => ({ seats }),
+    applyAction: ({ userId, action, amount }) => {
+      const applied = applyRuntimeAction(persistedState, { type: action, userId, amount });
+      const advanced = runAdvanceLoop(applied.state, [], [], advanceIfNeeded);
+      persistedState = maybeMaterialize(advanced.nextState);
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    klog: () => {}
+  });
+
+  const showdownRun = await run({ tableId: "t-next-hand", trigger: "act", requestId: "r-next-hand-1" });
+  assert.equal(showdownRun.ok, true);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  assert.equal(persistedState.phase, "SETTLED");
+  assert.ok(persistedState.showdown);
+
+  persistedState = advanceIfNeeded(persistedState).state;
+  persistedVersion += 1;
+  for (let i = 0; i < 6 && !["PREFLOP", "FLOP", "TURN", "RIVER"].includes(persistedState.phase); i += 1) {
+    persistedState = advanceIfNeeded(persistedState).state;
+    persistedVersion += 1;
+  }
+
+  const nextHandRun = await run({ tableId: "t-next-hand", trigger: "act", requestId: "r-next-hand-2" });
+  assert.equal(nextHandRun.ok, true);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  assert.equal(nextHandRun.reason === "turn_not_bot" || nextHandRun.actionCount > 0 || nextHandRun.reason === "not_action_phase", true);
 });

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -98,11 +98,89 @@ function buildPersistedFromPrivateState(privateStateInput, actorUserId, actionRe
   return { ...withActionMap, turnStartedAt: null, turnDeadlineAt: null };
 }
 
-function materializeShowdownState(stateToMaterialize, seatOrder, nowIso, klog) {
+function resolveTrustedHoleCardsByUserId({
+  primaryState,
+  fallbackState
+}) {
+  const primary = primaryState?.holeCardsByUserId && typeof primaryState.holeCardsByUserId === "object" && !Array.isArray(primaryState.holeCardsByUserId)
+    ? primaryState.holeCardsByUserId
+    : {};
+  const fallback = fallbackState?.holeCardsByUserId && typeof fallbackState.holeCardsByUserId === "object" && !Array.isArray(fallbackState.holeCardsByUserId)
+    ? fallbackState.holeCardsByUserId
+    : {};
+  const out = {};
+  const userIds = new Set([...Object.keys(fallback), ...Object.keys(primary)]);
+  for (const userId of userIds) {
+    const primaryCards = primary[userId];
+    const fallbackCards = fallback[userId];
+    if (Array.isArray(primaryCards) && primaryCards.length === 2) {
+      out[userId] = primaryCards;
+      continue;
+    }
+    if (Array.isArray(fallbackCards) && fallbackCards.length === 2) {
+      out[userId] = fallbackCards;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function validateTrustedShowdownInputs({
+  stateToMaterialize,
+  seatOrder,
+  holeCardsByUserId
+}) {
+  const community = Array.isArray(stateToMaterialize?.community) ? stateToMaterialize.community : [];
+  const seats = Array.isArray(seatOrder) ? seatOrder : [];
+  const eligibleUserIds = seats.filter((userId) =>
+    typeof userId === "string"
+    && !stateToMaterialize?.foldedByUserId?.[userId]
+    && !stateToMaterialize?.leftTableByUserId?.[userId]
+    && !stateToMaterialize?.sitOutByUserId?.[userId]
+  );
+  const trustedHoleCards = holeCardsByUserId && typeof holeCardsByUserId === "object" && !Array.isArray(holeCardsByUserId)
+    ? holeCardsByUserId
+    : {};
+  const missingHoleCardsUserIds = [];
+  for (const userId of eligibleUserIds) {
+    const cards = trustedHoleCards?.[userId];
+    if (!Array.isArray(cards) || cards.length !== 2) {
+      missingHoleCardsUserIds.push(userId);
+    }
+  }
+  return {
+    communityLen: community.length,
+    eligibleUserIds,
+    eligibleCount: eligibleUserIds.length,
+    missingHoleCardsUserIds
+  };
+}
+
+function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUserId, nowIso, klog, options = {}) {
+  if (options?.requiresShowdownComparison === true) {
+    const showdownInputs = validateTrustedShowdownInputs({
+      stateToMaterialize,
+      seatOrder,
+      holeCardsByUserId
+    });
+    if (showdownInputs.communityLen !== 5 || showdownInputs.missingHoleCardsUserIds.length > 0) {
+      const error = new Error("showdown_missing_private_inputs");
+      error.code = "showdown_missing_private_inputs";
+      if (typeof klog === "function") {
+        klog("ws_bot_autoplay_showdown_input_missing", {
+          handId: typeof stateToMaterialize?.handId === "string" ? stateToMaterialize.handId : null,
+          phase: typeof stateToMaterialize?.phase === "string" ? stateToMaterialize.phase : null,
+          communityLen: showdownInputs.communityLen,
+          eligibleCount: showdownInputs.eligibleCount,
+          missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds
+        });
+      }
+      throw error;
+    }
+  }
   return materializeShowdownAndPayout({
     state: stateToMaterialize,
     seatUserIdsInOrder: seatOrder,
-    holeCardsByUserId: stateToMaterialize?.holeCardsByUserId,
+    holeCardsByUserId,
     computeShowdown,
     awardPotsAtShowdown,
     klog,
@@ -221,7 +299,22 @@ export function createAcceptedBotAutoplayExecutor({
         isActionPhase,
         advanceIfNeeded,
         buildPersistedFromPrivateState,
-        materializeShowdownState: (nextState, seatOrder) => materializeShowdownState(nextState, seatOrder, frameTs || new Date().toISOString(), klog),
+        materializeShowdownState: (nextState, seatOrder, loopPrivateHoleCardsByUserId, options = {}) => {
+          const trustedHoleCardsByUserId = options?.requiresShowdownComparison === true
+            ? resolveTrustedHoleCardsByUserId({
+                primaryState: { holeCardsByUserId: loopPrivateHoleCardsByUserId },
+                fallbackState: tableManager.persistedPokerState(tableId)
+              })
+            : null;
+          return materializeShowdownState(
+            nextState,
+            seatOrder,
+            trustedHoleCardsByUserId,
+            frameTs || new Date().toISOString(),
+            klog,
+            options
+          );
+        },
         computeLegalActions: ({ statePublic, userId }) => {
           const legal = computeLegalActions({ statePublic, userId });
           const legalSummary = summarizeLegalActions(legal?.actions);

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-partial-loop-private-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-partial-loop-private-fixture.mjs
@@ -1,0 +1,32 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const showdownSource = withoutPrivateState(initialPrivateState);
+  const firstSeatUserId = Array.isArray(seatUserIdsInOrder) ? seatUserIdsInOrder[0] : null;
+  const partialLoopPrivate = firstSeatUserId
+    ? { [firstSeatUserId]: initialPrivateState?.holeCardsByUserId?.[firstSeatUserId] }
+    : {};
+  const nextState = materializeShowdownState(showdownSource, seatUserIdsInOrder, partialLoopPrivate, { requiresShowdownComparison: true });
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:partial-loop-private:1",
+    fromState: showdownSource,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-fixture.mjs
@@ -1,0 +1,33 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const showdownSource = withoutPrivateState(initialPrivateState);
+  const nextState = materializeShowdownState(
+    showdownSource,
+    seatUserIdsInOrder,
+    initialPrivateState?.holeCardsByUserId,
+    { requiresShowdownComparison: true }
+  );
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:1",
+    fromState: showdownSource,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-reload-private-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-reload-private-fixture.mjs
@@ -1,0 +1,28 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const showdownSource = withoutPrivateState(initialPrivateState);
+  const nextState = materializeShowdownState(showdownSource, seatUserIdsInOrder, null, { requiresShowdownComparison: true });
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:reload:1",
+    fromState: showdownSource,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-single-winner-terminal-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-single-winner-terminal-fixture.mjs
@@ -1,0 +1,28 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const showdownSource = withoutPrivateState(initialPrivateState);
+  const nextState = materializeShowdownState(showdownSource, seatUserIdsInOrder, null, { requiresShowdownComparison: false });
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:single-winner:1",
+    fromState: showdownSource,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};


### PR DESCRIPTION
### Motivation
- Ensure bot autoplay can resolve showdowns securely by using trusted persisted private hole-cards when required and by validating inputs before computing showdown outcomes.
- Prevent autoplay from proceeding with incomplete or malformed private inputs for multi-player showdowns while allowing single-winner terminal hands to be resolved without additional showdown-only validation.

### Description
- Add `resolveTrustedHoleCardsByUserId` to merge loop-private (`primaryState`) and persisted (`fallbackState`) hole-cards and return a trusted map or `null` when none present.  
- Add `validateTrustedShowdownInputs` to check community length and that all eligible players have two trusted hole-cards, returning a diagnostic object and list of missing user ids.  
- Update `materializeShowdownState` to accept `holeCardsByUserId` and an `options.requiresShowdownComparison` flag, to validate inputs and emit a `ws_bot_autoplay_showdown_input_missing` log and throw an error with code `showdown_missing_private_inputs` when required inputs are missing or malformed, otherwise call `materializeShowdownAndPayout`.  
- Update autoplay loop caller to distinguish single-winner terminal resolution from full showdown comparison and pass `loopPrivateState` hole-cards plus the `requiresShowdownComparison` option to the materializer; use persisted state as fallback trusted source when needed.  
- Replace older single `materializeShowdownState` call-site with a wrapper that resolves trusted hole-cards from loop-private and persisted state before materializing.  
- Add multiple fixtures under `ws-server/poker/runtime/fixtures/` to simulate showdown scenarios used by autoplay fixtures and tests (`autoplay-showdown-public-state-fixture`, `autoplay-showdown-reload-private-fixture`, `autoplay-showdown-partial-loop-private-fixture`, `autoplay-single-winner-terminal-fixture`).  
- Extend `accepted-bot-autoplay-adapter.behavior.test.mjs` with tests covering: public-showdown input usage, reload of private showdown inputs after boundary, merging partial loop-private with persisted trusted cards, ignoring malformed fallback arrays, emitting focused logs and restoring on missing trusted inputs, single-winner terminal resolution without showdown-only validation, and settling showdowns then continuing to next hand.  

### Testing
- Ran the `accepted-bot-autoplay-adapter` behavior tests including the newly added showdown-related tests in `ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs`, and they completed successfully.  
- Verified fixtures exercise the new trusted-hole-card merge and validation paths including the logging of `ws_bot_autoplay_showdown_input_missing` and restore/resync behavior for missing inputs.  
- Confirmed single-winner terminal-case test allows resolution without requiring full showdown private inputs and that settling a showdown allows the next hand to continue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf529ee9348323afb75699df5ecb29)