### PR TITLE
Preserve stacks on equal-version WS snapshots and strengthen autoplay showdown state selection and validation

### DIFF
--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1232,6 +1232,18 @@
     function isRichGameplaySnapshot(snapshotPayload, snapshotKind){
       var payload = snapshotPayload && typeof snapshotPayload === 'object' ? snapshotPayload : {};
       if (snapshotKind === 'stateSnapshot') return true;
+      if (snapshotKind === 'table_state'){
+        return !!(
+          isPlainObject(payload.stacks)
+          || Array.isArray(payload.authoritativeMembers)
+          || Array.isArray(payload.seats)
+          || isPlainObject(payload.hand)
+          || isPlainObject(payload.turn)
+          || isPlainObject(payload.pot)
+          || isPlainObject(payload.board)
+          || Array.isArray(payload.board)
+        );
+      }
       if (isPlainObject(payload.public) || isPlainObject(payload.private) || isPlainObject(payload.you)) return true;
       return isPlainObject(payload.table);
     }
@@ -1634,26 +1646,61 @@
       return constraints.toCall != null || constraints.minRaiseTo != null || constraints.maxRaiseTo != null || constraints.maxBetAmount != null;
     }
 
+    function hasStackEntries(stacks){
+      return !!(stacks && typeof stacks === 'object' && !Array.isArray(stacks) && Object.keys(stacks).length > 0);
+    }
+
+    function resolveCurrentUserStackStatus(data){
+      var status = {
+        currentUserId: null,
+        seated: false,
+        hasStack: false,
+        stackValue: null
+      };
+      var activeCurrentUserId = typeof currentUserId === 'string' && currentUserId ? currentUserId : null;
+      if (!activeCurrentUserId) return status;
+      status.currentUserId = activeCurrentUserId;
+      var seatFacts = findCurrentUserSeatFacts(data);
+      status.seated = seatFacts.hasCurrentUserSeat === true;
+      status.hasStack = seatFacts.hasCurrentUserStack === true;
+      var stateObj = data && typeof data.state === 'object' ? data.state : null;
+      var gameState = stateObj && typeof stateObj.state === 'object' ? stateObj.state : null;
+      var stacks = gameState && typeof gameState.stacks === 'object' && !Array.isArray(gameState.stacks) ? gameState.stacks : null;
+      if (status.currentUserId && stacks && stacks[status.currentUserId] != null) status.stackValue = stacks[status.currentUserId];
+      return status;
+    }
+
     function materiallyImprovesRichSnapshot(currentData, snapshotPayload){
       if (!currentData || typeof currentData !== 'object') return false;
       if (!snapshotPayload || typeof snapshotPayload !== 'object') return false;
+      var currentStateBeforeMerge = currentData.state && currentData.state.state && typeof currentData.state.state === 'object' ? currentData.state.state : {};
+      var hadHoleCards = Array.isArray(currentData.myHoleCards) && currentData.myHoleCards.length > 0;
+      var hadCommunity = Array.isArray(currentStateBeforeMerge.community) && currentStateBeforeMerge.community.length > 0;
+      var hadLegalActions = Array.isArray(currentData.legalActions) && currentData.legalActions.length > 0;
+      var hadConstraints = hasConstraintsData(currentData.actionConstraints);
+      var hadTurnMetadata = hasTurnMetadata(currentStateBeforeMerge);
+      var hadStacks = hasStackEntries(currentStateBeforeMerge.stacks);
+      var currentStackKeys = hadStacks ? Object.keys(currentStateBeforeMerge.stacks) : [];
+      var currentUserStackStatusBefore = resolveCurrentUserStackStatus(currentData);
       var mergedData = mergeWsStateIntoTableData(currentData, snapshotPayload);
       if (!mergedData) return false;
-      var currentState = currentData.state && currentData.state.state && typeof currentData.state.state === 'object' ? currentData.state.state : {};
       var mergedState = mergedData.state && mergedData.state.state && typeof mergedData.state.state === 'object' ? mergedData.state.state : {};
-      var hadHoleCards = Array.isArray(currentData.myHoleCards) && currentData.myHoleCards.length > 0;
       var hasHoleCards = Array.isArray(mergedData.myHoleCards) && mergedData.myHoleCards.length > 0;
       if (!hadHoleCards && hasHoleCards) return true;
-      var hadCommunity = Array.isArray(currentState.community) && currentState.community.length > 0;
       var hasCommunity = Array.isArray(mergedState.community) && mergedState.community.length > 0;
       if (!hadCommunity && hasCommunity) return true;
-      var hadLegalActions = Array.isArray(currentData.legalActions) && currentData.legalActions.length > 0;
       var hasLegalActions = Array.isArray(mergedData.legalActions) && mergedData.legalActions.length > 0;
       if (!hadLegalActions && hasLegalActions) return true;
-      var hadConstraints = hasConstraintsData(currentData.actionConstraints);
       var hasConstraints = hasConstraintsData(mergedData.actionConstraints);
       if (!hadConstraints && hasConstraints) return true;
-      if (!hasTurnMetadata(currentState) && hasTurnMetadata(mergedState)) return true;
+      if (!hadTurnMetadata && hasTurnMetadata(mergedState)) return true;
+      var hasStacks = hasStackEntries(mergedState.stacks);
+      if (!hadStacks && hasStacks) return true;
+      var mergedStackKeys = hasStackEntries(mergedState.stacks) ? Object.keys(mergedState.stacks) : [];
+      if (mergedStackKeys.length > currentStackKeys.length) return true;
+      var currentUserStackStatusAfter = resolveCurrentUserStackStatus(mergedData);
+      if (currentUserStackStatusBefore.seated && !currentUserStackStatusBefore.hasStack && currentUserStackStatusAfter.hasStack) return true;
+      if (currentUserStackStatusBefore.seated && currentUserStackStatusBefore.hasStack && currentUserStackStatusAfter.hasStack && currentUserStackStatusBefore.stackValue !== currentUserStackStatusAfter.stackValue) return true;
       return false;
     }
 

--- a/tests/poker-ui-ws-snapshot-merge.behavior.test.mjs
+++ b/tests/poker-ui-ws-snapshot-merge.behavior.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPokerTableHarness } from "./helpers/poker-ui-table-harness.mjs";
+
+test("same-version snapshots preserve and upgrade stack maps instead of dropping seated stack", async () => {
+  const harness = createPokerTableHarness({
+    initialToken: "aaa." + Buffer.from(JSON.stringify({ sub: "u-seat" })).toString("base64") + ".zzz"
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.wsCreates[0].options;
+  ws.onSnapshot({
+    kind: "table_state",
+    payload: {
+      tableId: "table-1",
+      stateVersion: 9,
+      hand: { handId: "h9", status: "PREFLOP" },
+      authoritativeMembers: [{ userId: "u-seat", seat: 0 }, { userId: "u-bot", seat: 1 }],
+      stacks: { "u-seat": 125 }
+    }
+  });
+  await harness.flush();
+  assert.match(harness.elements.pokerYourStack.textContent, /125/, "baseline same-version table_state should render seated user stack");
+
+  ws.onSnapshot({
+    kind: "stateSnapshot",
+    payload: {
+      table: { tableId: "table-1", members: [{ userId: "u-seat", seat: 0 }, { userId: "u-bot", seat: 1 }] },
+      version: 9,
+      you: { seat: 0 },
+      public: {
+        hand: { handId: "h9", status: "PREFLOP" },
+        stacks: {}
+      }
+    }
+  });
+  await harness.flush();
+  assert.match(harness.elements.pokerYourStack.textContent, /125/, "equal-version stateSnapshot with empty stacks must not wipe known seated stack");
+
+  ws.onSnapshot({
+    kind: "table_state",
+    payload: {
+      tableId: "table-1",
+      stateVersion: 9,
+      authoritativeMembers: [{ userId: "u-seat", seat: 0 }, { userId: "u-bot", seat: 1 }],
+      stacks: { "u-seat": 130 }
+    }
+  });
+  await harness.flush();
+  assert.match(harness.elements.pokerYourStack.textContent, /130/, "same-version table_state with same keys but changed seated stack value should apply");
+
+  ws.onSnapshot({
+    kind: "table_state",
+    payload: {
+      tableId: "table-1",
+      stateVersion: 9,
+      authoritativeMembers: [{ userId: "u-seat", seat: 0 }, { userId: "u-bot", seat: 1 }],
+      stacks: { "u-seat": 130, "u-bot": 138 }
+    }
+  });
+  await harness.flush();
+  assert.match(harness.elements.pokerYourStack.textContent, /130/, "same-version richer stack map should still apply after same-key stack upgrade");
+
+  const seatedStackMissingLogs = harness.logs.filter((entry) => entry.kind === "poker_stack_missing_for_seated_user");
+  assert.equal(seatedStackMissingLogs.length, 0, "no seated-user stack-missing warning expected after same-version merge");
+});

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -224,12 +224,131 @@ test("accepted bot autoplay showdown uses trusted private hole cards even for pu
     env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
     klog: (event, payload) => logs.push({ event, payload })
   });
-
   const result = await run({ tableId: "t-showdown", trigger: "act", requestId: "r-showdown" });
   assert.equal(result.ok, true);
   assert.equal(calls.persist, 1);
   assert.equal(calls.restore, 0);
   assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_same_hand");
+});
+
+test("accepted bot autoplay rejects fallback when primary showdown hand identity is missing", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-missing-handid",
+    handId: "h-missing-handid-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 40,
+    sidePots: [],
+    contributionsByUserId: { human_1: 20, bot_2: 20 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 19,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 20 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-public-state-missing-handid-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-missing-handid", trigger: "act", requestId: "r-missing-handid" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "showdown_missing_private_inputs");
+  assert.equal(calls.persist, 0);
+  assert.equal(calls.restore, 1);
+  assert.equal(calls.resync, 1);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_primary_identity_unknown_rejected");
+});
+
+test("accepted bot autoplay preserves fresh showdown gameplay fields when fallback is stale", async () => {
+  const logs = [];
+  const calls = { persist: 0, restore: 0, resync: 0 };
+  const stalePersisted = {
+    tableId: "t-stale-overlay",
+    handId: "h-stale-overlay-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 40,
+    sidePots: [],
+    contributionsByUserId: { human_1: 20, bot_2: 20 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...stalePersisted }),
+    persistedStateVersion: () => 21,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 22 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-stale-fallback-overlay-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-stale-overlay", trigger: "act", requestId: "r-stale-overlay" });
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_same_hand");
+  const overlayLog = logs.find((entry) => entry.event === "ws_bot_autoplay_fixture_overlay_materialized");
+  assert.ok(overlayLog);
+  assert.equal(overlayLog.payload.bot2Contribution, 45);
+  assert.equal(overlayLog.payload.humanContribution, 20);
 });
 
 test("accepted bot autoplay reloads trusted private showdown hole cards after boundary", async () => {
@@ -441,6 +560,108 @@ test("accepted bot autoplay emits focused showdown-input log and restores on mis
   const focusedLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing");
   assert.ok(focusedLog);
   assert.deepEqual(focusedLog.payload.missingHoleCardsUserIds, ["human_1"]);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.deepEqual(preflightLog.payload.eligibleUserIds, ["human_1", "bot_2"]);
+  assert.deepEqual(preflightLog.payload.showdownComparedUserIds, ["bot_2"]);
+  assert.equal(preflightLog.payload.communityLen, 5);
+});
+
+test("accepted bot autoplay rejects cross-hand fallback for degraded showdown runtime state", async () => {
+  const logs = [];
+  const calls = { restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-mismatch",
+    handId: "h-current-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 30,
+    sidePots: [],
+    contributionsByUserId: { human_1: 15, bot_2: 15 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState, handId: "h-fallback-other-hand" }),
+    persistedStateVersion: () => 15,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 16 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-public-state-mismatch-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-mismatch", trigger: "act", requestId: "r-mismatch" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "showdown_missing_private_inputs");
+  assert.equal(calls.restore, 1);
+  assert.equal(calls.resync, 1);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_hand_mismatch_rejected");
+});
+
+test("accepted bot autoplay prefers trusted runtime private showdown source when available", async () => {
+  const logs = [];
+  const privateState = {
+    tableId: "t-runtime-source",
+    handId: "h-runtime-source-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: { human_1: false, bot_2: false },
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 40,
+    sidePots: [],
+    contributionsByUserId: { human_1: 20, bot_2: 20 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState }),
+    persistedStateVersion: () => 17,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 18 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-runtime-private-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-runtime-source", trigger: "act", requestId: "r-runtime-source" });
+  assert.equal(result.ok, true);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "runtime_private");
 });
 
 test("accepted bot autoplay resolves single-winner terminal hands without showdown-only input validation", async () => {
@@ -494,6 +715,98 @@ test("accepted bot autoplay resolves single-winner terminal hands without showdo
   assert.equal(calls.restore, 0);
   assert.equal(calls.resync, 0);
   assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing"), false);
+});
+
+test("accepted bot autoplay handles mixed human+bot runtime path through showdown and next hand", async () => {
+  const seats = [
+    { userId: "bot_2", seatNo: 1, isBot: true },
+    { userId: "human_1", seatNo: 2, isBot: false }
+  ];
+  const stacks = { human_1: 100, bot_2: 100 };
+  let persistedState = initHandState({ tableId: "t-mixed-runtime", seats, stacks }).state;
+  persistedState = { ...persistedState, handId: "h-mixed-runtime-1" };
+  let persistedVersion = 40;
+  const calls = { persist: 0, restore: 0, resync: 0 };
+
+  const logs = [];
+  const seatOrder = seats.slice().sort((a, b) => a.seatNo - b.seatNo).map((seat) => seat.userId);
+  const maybeMaterialize = (privateState) => {
+    const eligible = seatOrder.filter((userId) => !privateState.foldedByUserId?.[userId] && !privateState.leftTableByUserId?.[userId] && !privateState.sitOutByUserId?.[userId]);
+    const handId = typeof privateState.handId === "string" ? privateState.handId : "";
+    const showdownHandId = typeof privateState.showdown?.handId === "string" ? privateState.showdown.handId : "";
+    const alreadyMaterialized = !!handId && !!showdownHandId && handId === showdownHandId;
+    if (alreadyMaterialized || (eligible.length > 1 && privateState.phase !== "SHOWDOWN")) return privateState;
+    return materializeShowdownAndPayout({
+      state: privateState,
+      seatUserIdsInOrder: seatOrder,
+      holeCardsByUserId: privateState.holeCardsByUserId,
+      computeShowdown,
+      awardPotsAtShowdown,
+      klog: () => {}
+    }).nextState;
+  };
+
+  const tableManager = {
+    persistedPokerState: () => persistedState,
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: () => ({ seats }),
+    applyAction: ({ userId, action, amount }) => {
+      const applied = applyRuntimeAction(persistedState, { type: action, userId, amount });
+      const advanced = runAdvanceLoop(applied.state, [], [], advanceIfNeeded);
+      persistedState = maybeMaterialize(advanced.nextState);
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => {
+      calls.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+  let guard = 0;
+  while (persistedState.phase !== "SETTLED" && guard < 40) {
+    if (persistedState.phase === "PREFLOP" || persistedState.phase === "FLOP" || persistedState.phase === "TURN" || persistedState.phase === "RIVER") {
+      if (persistedState.turnUserId === "human_1") {
+        tableManager.applyAction({ userId: "human_1", action: "CHECK" });
+      } else {
+        const result = await run({ tableId: "t-mixed-runtime", trigger: "act", requestId: "r-mixed-runtime-" + guard });
+        assert.equal(result.ok, true);
+      }
+    } else {
+      persistedState = advanceIfNeeded(persistedState).state;
+      persistedVersion += 1;
+    }
+    guard += 1;
+  }
+
+  assert.equal(persistedState.phase, "SETTLED");
+  assert.ok(persistedState.showdown);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
+  assert.equal(logs.some((entry) => entry.event === "ws_bot_autoplay_showdown_preflight"), true);
+
+  persistedState = advanceIfNeeded(persistedState).state;
+  persistedVersion += 1;
+  for (let i = 0; i < 6 && !["PREFLOP", "FLOP", "TURN", "RIVER"].includes(persistedState.phase); i += 1) {
+    persistedState = advanceIfNeeded(persistedState).state;
+    persistedVersion += 1;
+  }
+
+  const nextHandResult = await run({ tableId: "t-mixed-runtime", trigger: "act", requestId: "r-mixed-runtime-next" });
+  assert.equal(nextHandResult.ok, true);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
 });
 
 test("accepted bot autoplay settles showdown and allows next hand to continue", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -124,34 +124,180 @@ function resolveTrustedHoleCardsByUserId({
   return Object.keys(out).length > 0 ? out : null;
 }
 
+function hasTrustedRuntimeShape(state) {
+  if (!state || typeof state !== "object") return false;
+  const isPlainMap = (value) => !!(value && typeof value === "object" && !Array.isArray(value));
+  const hasEntries = (value) => isPlainMap(value) && Object.keys(value).length > 0;
+  const community = Array.isArray(state.community) ? state.community : [];
+  if (community.length !== 5) return false;
+  const seats = Array.isArray(state.seats) ? state.seats : [];
+  if (seats.length < 2) return false;
+  if (!hasEntries(state.stacks)) return false;
+  if (!hasEntries(state.contributionsByUserId)) return false;
+  if (!hasEntries(state.holeCardsByUserId)) return false;
+  if (!isPlainMap(state.foldedByUserId) || !isPlainMap(state.leftTableByUserId) || !isPlainMap(state.sitOutByUserId)) return false;
+  return true;
+}
+
+function resolveTrustedStateToMaterialize({
+  primaryState,
+  fallbackState,
+  trustedHoleCardsByUserId
+}) {
+  const isPlainMap = (value) => !!(value && typeof value === "object" && !Array.isArray(value));
+  const mapSize = (value) => (isPlainMap(value) ? Object.keys(value).length : 0);
+  const mergeMap = (primaryMap, fallbackMap) => {
+    const safePrimary = isPlainMap(primaryMap) ? primaryMap : {};
+    const safeFallback = isPlainMap(fallbackMap) ? fallbackMap : {};
+    return { ...safeFallback, ...safePrimary };
+  };
+  const toArrayOrNull = (value) => (Array.isArray(value) ? value : null);
+  const mergeTrustedSupplementState = (primary, fallback, resolvedHoleCards) => {
+    const base = primary && typeof primary === "object" ? { ...primary } : {};
+    const fb = fallback && typeof fallback === "object" ? fallback : {};
+    const baseCommunity = toArrayOrNull(base.community);
+    const fallbackCommunity = toArrayOrNull(fb.community);
+    if ((!baseCommunity || baseCommunity.length < 5) && fallbackCommunity && fallbackCommunity.length === 5) {
+      base.community = fallbackCommunity.slice();
+    }
+    if (!Number.isFinite(Number(base.pot)) && Number.isFinite(Number(fb.pot))) {
+      base.pot = Number(fb.pot);
+    }
+    if ((!Array.isArray(base.sidePots) || (Array.isArray(base.sidePots) && base.sidePots.some((pot) => !pot || typeof pot !== "object"))) && Array.isArray(fb.sidePots)) {
+      base.sidePots = fb.sidePots.slice();
+    }
+    if ((!Array.isArray(base.seats) || base.seats.length < 2) && Array.isArray(fb.seats) && fb.seats.length >= 2) {
+      base.seats = fb.seats.slice();
+    }
+    if (Array.isArray(base.seats) && Array.isArray(fb.seats) && base.seats.length >= 2 && fb.seats.length >= 2) {
+      const byUserId = {};
+      for (const seat of fb.seats) {
+        const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
+        if (!userId) continue;
+        byUserId[userId] = seat;
+      }
+      base.seats = base.seats.map((seat) => {
+        const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
+        const fallbackSeat = userId ? byUserId[userId] : null;
+        if (!fallbackSeat) return seat;
+        return {
+          ...fallbackSeat,
+          ...seat
+        };
+      });
+    }
+    if (mapSize(base.stacks) > 0 || mapSize(fb.stacks) > 0) base.stacks = mergeMap(base.stacks, fb.stacks);
+    if (mapSize(base.contributionsByUserId) > 0 || mapSize(fb.contributionsByUserId) > 0) base.contributionsByUserId = mergeMap(base.contributionsByUserId, fb.contributionsByUserId);
+    if (mapSize(base.foldedByUserId) > 0 || mapSize(fb.foldedByUserId) > 0) base.foldedByUserId = mergeMap(base.foldedByUserId, fb.foldedByUserId);
+    if (mapSize(base.leftTableByUserId) > 0 || mapSize(fb.leftTableByUserId) > 0) base.leftTableByUserId = mergeMap(base.leftTableByUserId, fb.leftTableByUserId);
+    if (mapSize(base.sitOutByUserId) > 0 || mapSize(fb.sitOutByUserId) > 0) base.sitOutByUserId = mergeMap(base.sitOutByUserId, fb.sitOutByUserId);
+    if ((typeof base.handId !== "string" || !base.handId.trim()) && typeof fb.handId === "string" && fb.handId.trim()) {
+      base.handId = fb.handId.trim();
+    }
+    if ((!base.showdown || typeof base.showdown !== "object") && fb.showdown && typeof fb.showdown === "object") {
+      base.showdown = { ...fb.showdown };
+    }
+    if (resolvedHoleCards && typeof resolvedHoleCards === "object") {
+      base.holeCardsByUserId = resolvedHoleCards;
+    } else if (mapSize(base.holeCardsByUserId) === 0 && mapSize(fb.holeCardsByUserId) > 0) {
+      base.holeCardsByUserId = { ...fb.holeCardsByUserId };
+    }
+    return base;
+  };
+  const readHandId = (state) => (typeof state?.handId === "string" && state.handId.trim() ? state.handId.trim() : "");
+  const primary = primaryState && typeof primaryState === "object" ? primaryState : null;
+  const fallback = fallbackState && typeof fallbackState === "object" ? fallbackState : null;
+  const primaryTrusted = hasTrustedRuntimeShape(primary);
+  const fallbackTrusted = hasTrustedRuntimeShape(fallback);
+  const primaryComparableHandId = readHandId(primary);
+  const fallbackComparableHandId = fallbackTrusted ? readHandId(fallback) : "";
+  const sameHand = !!primaryComparableHandId && !!fallbackComparableHandId && primaryComparableHandId === fallbackComparableHandId;
+  const trustedMismatch = !!primaryComparableHandId && !!fallbackComparableHandId && primaryComparableHandId !== fallbackComparableHandId;
+  let selectedState = null;
+  let trustedStateSource = "runtime_public_like_rejected";
+  if (primaryTrusted) {
+    selectedState = mergeTrustedSupplementState(primary, null, trustedHoleCardsByUserId);
+    trustedStateSource = "runtime_private";
+  } else if (fallbackTrusted && trustedMismatch) {
+    trustedStateSource = "fallback_private_hand_mismatch_rejected";
+  } else if (fallbackTrusted && sameHand) {
+    selectedState = mergeTrustedSupplementState(primary, fallback, trustedHoleCardsByUserId);
+    trustedStateSource = "fallback_private_same_hand";
+  } else if (fallbackTrusted) {
+    trustedStateSource = "fallback_private_primary_identity_unknown_rejected";
+  } else if (fallback && !fallbackTrusted) {
+    trustedStateSource = "fallback_private_untrusted_rejected";
+  }
+  return {
+    state: selectedState,
+    trustedStateSource,
+    sameHand,
+    trustedMismatch,
+    primaryTrusted,
+    fallbackTrusted
+  };
+}
+
 function validateTrustedShowdownInputs({
   stateToMaterialize,
   seatOrder,
-  holeCardsByUserId
+  holeCardsByUserId,
+  trustedStateSource = "trusted_private"
 }) {
   const community = Array.isArray(stateToMaterialize?.community) ? stateToMaterialize.community : [];
   const seats = Array.isArray(seatOrder) ? seatOrder : [];
-  const eligibleUserIds = seats.filter((userId) =>
-    typeof userId === "string"
-    && !stateToMaterialize?.foldedByUserId?.[userId]
-    && !stateToMaterialize?.leftTableByUserId?.[userId]
-    && !stateToMaterialize?.sitOutByUserId?.[userId]
-  );
   const trustedHoleCards = holeCardsByUserId && typeof holeCardsByUserId === "object" && !Array.isArray(holeCardsByUserId)
     ? holeCardsByUserId
     : {};
+  const validSeatUserIds = [];
+  const invalidSeatUserIds = [];
+  for (const userId of seats) {
+    if (typeof userId !== "string" || !userId.trim()) {
+      invalidSeatUserIds.push(userId ?? null);
+      continue;
+    }
+    validSeatUserIds.push(userId.trim());
+  }
+  const eligibleUserIds = validSeatUserIds.filter((userId) =>
+    !stateToMaterialize?.foldedByUserId?.[userId]
+    && !stateToMaterialize?.leftTableByUserId?.[userId]
+    && !stateToMaterialize?.sitOutByUserId?.[userId]
+  );
   const missingHoleCardsUserIds = [];
+  const invalidHoleCardsUserIds = [];
+  const showdownComparedUserIds = [];
   for (const userId of eligibleUserIds) {
     const cards = trustedHoleCards?.[userId];
-    if (!Array.isArray(cards) || cards.length !== 2) {
+    if (!Array.isArray(cards)) {
       missingHoleCardsUserIds.push(userId);
+      continue;
     }
+    if (cards.length !== 2) {
+      invalidHoleCardsUserIds.push(userId);
+      continue;
+    }
+    showdownComparedUserIds.push(userId);
   }
+  const eligibleMissingFromShowdownUserIds = eligibleUserIds.filter((userId) => !showdownComparedUserIds.includes(userId));
+  const hasInvalidInput = (
+    community.length !== 5
+    || eligibleUserIds.length < 2
+    || invalidSeatUserIds.length > 0
+    || eligibleMissingFromShowdownUserIds.length > 0
+    || invalidHoleCardsUserIds.length > 0
+  );
   return {
+    trustedStateSource,
     communityLen: community.length,
     eligibleUserIds,
+    showdownComparedUserIds,
     eligibleCount: eligibleUserIds.length,
-    missingHoleCardsUserIds
+    showdownComparedCount: showdownComparedUserIds.length,
+    invalidSeatUserIds,
+    missingHoleCardsUserIds,
+    invalidHoleCardsUserIds,
+    eligibleMissingFromShowdownUserIds,
+    hasInvalidInput
   };
 }
 
@@ -160,9 +306,24 @@ function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUser
     const showdownInputs = validateTrustedShowdownInputs({
       stateToMaterialize,
       seatOrder,
-      holeCardsByUserId
+      holeCardsByUserId,
+      trustedStateSource: typeof options?.trustedStateSource === "string" ? options.trustedStateSource : "trusted_private"
     });
-    if (showdownInputs.communityLen !== 5 || showdownInputs.missingHoleCardsUserIds.length > 0) {
+    if (typeof klog === "function") {
+      klog("ws_bot_autoplay_showdown_preflight", {
+        handId: typeof stateToMaterialize?.handId === "string" ? stateToMaterialize.handId : null,
+        phase: typeof stateToMaterialize?.phase === "string" ? stateToMaterialize.phase : null,
+        communityLen: showdownInputs.communityLen,
+        eligibleUserIds: showdownInputs.eligibleUserIds,
+        showdownComparedUserIds: showdownInputs.showdownComparedUserIds,
+        missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds,
+        invalidHoleCardsUserIds: showdownInputs.invalidHoleCardsUserIds,
+        invalidSeatUserIds: showdownInputs.invalidSeatUserIds,
+        eligibleMissingFromShowdownUserIds: showdownInputs.eligibleMissingFromShowdownUserIds,
+        trustedStateSource: showdownInputs.trustedStateSource
+      });
+    }
+    if (showdownInputs.hasInvalidInput) {
       const error = new Error("showdown_missing_private_inputs");
       error.code = "showdown_missing_private_inputs";
       if (typeof klog === "function") {
@@ -171,7 +332,14 @@ function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUser
           phase: typeof stateToMaterialize?.phase === "string" ? stateToMaterialize.phase : null,
           communityLen: showdownInputs.communityLen,
           eligibleCount: showdownInputs.eligibleCount,
-          missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds
+          showdownComparedCount: showdownInputs.showdownComparedCount,
+          eligibleUserIds: showdownInputs.eligibleUserIds,
+          showdownComparedUserIds: showdownInputs.showdownComparedUserIds,
+          missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds,
+          invalidHoleCardsUserIds: showdownInputs.invalidHoleCardsUserIds,
+          invalidSeatUserIds: showdownInputs.invalidSeatUserIds,
+          eligibleMissingFromShowdownUserIds: showdownInputs.eligibleMissingFromShowdownUserIds,
+          trustedStateSource: showdownInputs.trustedStateSource
         });
       }
       throw error;
@@ -300,19 +468,34 @@ export function createAcceptedBotAutoplayExecutor({
         advanceIfNeeded,
         buildPersistedFromPrivateState,
         materializeShowdownState: (nextState, seatOrder, loopPrivateHoleCardsByUserId, options = {}) => {
-          const trustedHoleCardsByUserId = options?.requiresShowdownComparison === true
+          const requiresShowdownComparison = options?.requiresShowdownComparison === true;
+          const trustedHoleCardsByUserId = requiresShowdownComparison
             ? resolveTrustedHoleCardsByUserId({
                 primaryState: { holeCardsByUserId: loopPrivateHoleCardsByUserId },
                 fallbackState: tableManager.persistedPokerState(tableId)
               })
             : null;
+          let stateToMaterialize = nextState;
+          let trustedStateSource = "runtime_state_no_showdown_compare";
+          if (requiresShowdownComparison) {
+            const trustedStateResolution = resolveTrustedStateToMaterialize({
+              primaryState: nextState,
+              fallbackState: tableManager.persistedPokerState(tableId),
+              trustedHoleCardsByUserId
+            });
+            stateToMaterialize = trustedStateResolution.state;
+            trustedStateSource = trustedStateResolution.trustedStateSource;
+          }
           return materializeShowdownState(
-            nextState,
+            stateToMaterialize,
             seatOrder,
             trustedHoleCardsByUserId,
             frameTs || new Date().toISOString(),
             klog,
-            options
+            {
+              ...options,
+              trustedStateSource
+            }
           );
         },
         computeLegalActions: ({ statePublic, userId }) => {

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-mismatch-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-mismatch-fixture.mjs
@@ -1,0 +1,36 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const showdownSource = {
+    ...withoutPrivateState(initialPrivateState),
+    handId: "h-mismatch-fixture"
+  };
+  const nextState = materializeShowdownState(
+    showdownSource,
+    seatUserIdsInOrder,
+    initialPrivateState?.holeCardsByUserId,
+    { requiresShowdownComparison: true }
+  );
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:mismatch:1",
+    fromState: showdownSource,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-missing-handid-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-public-state-missing-handid-fixture.mjs
@@ -1,0 +1,34 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const publicLikeState = withoutPrivateState(initialPrivateState);
+  delete publicLikeState.handId;
+  const nextState = materializeShowdownState(
+    publicLikeState,
+    seatUserIdsInOrder,
+    initialPrivateState?.holeCardsByUserId,
+    { requiresShowdownComparison: true }
+  );
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:missing-hand:1",
+    fromState: publicLikeState,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-runtime-private-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-runtime-private-fixture.mjs
@@ -1,0 +1,32 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep
+}) => {
+  const nextState = materializeShowdownState(
+    initialPrivateState,
+    seatUserIdsInOrder,
+    initialPrivateState?.holeCardsByUserId,
+    { requiresShowdownComparison: true }
+  );
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:runtime-private:1",
+    fromState: withoutPrivateState(initialPrivateState),
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};

--- a/ws-server/poker/runtime/fixtures/autoplay-showdown-stale-fallback-overlay-fixture.mjs
+++ b/ws-server/poker/runtime/fixtures/autoplay-showdown-stale-fallback-overlay-fixture.mjs
@@ -1,0 +1,65 @@
+export const runBotAutoplayLoop = async ({
+  initialPrivateState,
+  seatUserIdsInOrder,
+  withoutPrivateState,
+  materializeShowdownState,
+  persistStep,
+  klog
+}) => {
+  const updatedPrivateState = {
+    ...initialPrivateState,
+    pot: Number(initialPrivateState?.pot || 0) + 25,
+    contributionsByUserId: {
+      ...(initialPrivateState?.contributionsByUserId || {}),
+      bot_2: Number(initialPrivateState?.contributionsByUserId?.bot_2 || 0) + 25
+    },
+    phase: "SHOWDOWN",
+    stacks: {
+      ...(initialPrivateState?.stacks || {}),
+      bot_2: Number(initialPrivateState?.stacks?.bot_2 || 0) - 25
+    },
+    foldedByUserId: {
+      ...(initialPrivateState?.foldedByUserId || {}),
+      bot_2: false
+    }
+  };
+  const degradedPrimary = withoutPrivateState(updatedPrivateState);
+  if (degradedPrimary?.contributionsByUserId && typeof degradedPrimary.contributionsByUserId === "object") {
+    delete degradedPrimary.contributionsByUserId.human_1;
+  }
+  if (degradedPrimary?.stacks && typeof degradedPrimary.stacks === "object") {
+    delete degradedPrimary.stacks.human_1;
+  }
+  const nextState = materializeShowdownState(
+    degradedPrimary,
+    seatUserIdsInOrder,
+    updatedPrivateState?.holeCardsByUserId,
+    { requiresShowdownComparison: true }
+  );
+  if (typeof klog === "function") {
+    klog("ws_bot_autoplay_fixture_overlay_materialized", {
+      pot: Number(nextState?.pot || 0),
+      bot2Contribution: Number(nextState?.contributionsByUserId?.bot_2 || 0),
+      humanContribution: Number(nextState?.contributionsByUserId?.human_1 || 0),
+      humanStack: Number(nextState?.stacks?.human_1 || 0)
+    });
+  }
+  await persistStep({
+    botTurnUserId: typeof initialPrivateState?.turnUserId === "string" ? initialPrivateState.turnUserId : null,
+    botAction: { type: "CHECK" },
+    botRequestId: "bot:fixture:stale-overlay:1",
+    fromState: degradedPrimary,
+    persistedState: withoutPrivateState(nextState),
+    privateState: nextState,
+    events: [],
+    loopVersion: 1
+  });
+  return {
+    responseFinalState: withoutPrivateState(nextState),
+    loopPrivateState: nextState,
+    loopVersion: 2,
+    botActionCount: 1,
+    botStopReason: "completed",
+    responseEvents: []
+  };
+};


### PR DESCRIPTION
### Motivation

- Ensure WS snapshot merges do not drop or regress known seated player stacks when receiving same-version or mixed-format snapshots. 
- Improve detection of rich gameplay snapshots from `table_state` payloads so UI applies meaningful updates. 
- Make the bot autoplay showdown flow more robust by selecting and validating trusted private/runtime state sources before materializing showdowns. 

### Description

- Extend `isRichGameplaySnapshot` to treat `table_state` payloads as rich when they contain `stacks`, `authoritativeMembers`, `seats`, `hand`, `turn`, `pot`, or `board` fields. 
- Add `hasStackEntries` and `resolveCurrentUserStackStatus` helpers and update `materiallyImprovesRichSnapshot` to consider stack presence, stack key growth, and per-user stack value changes when deciding whether an equal-version snapshot is an improvement. 
- Add logic to preserve/merge stack maps across merges so same-version `stateSnapshot` with empty stacks does not wipe previously known seated stacks. 
- In `ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs` add `hasTrustedRuntimeShape` and `resolveTrustedStateToMaterialize` to pick/merge a trusted runtime or fallback private state and produce a `trustedStateSource` diagnostic. 
- Enhance `validateTrustedShowdownInputs` and `materializeShowdownState` to log a `ws_bot_autoplay_showdown_preflight` diagnostic with detailed eligibility and hole-card validation info, and to reject invalid inputs with richer diagnostics. 
- Wire the trusted-state resolution into the autoplay executor so fixtures and the runtime may require showdown comparison using resolved/trusted hole cards. 
- Add multiple new behavior tests and fixtures: `tests/poker-ui-ws-snapshot-merge.behavior.test.mjs`, several `ws-server/poker/runtime/*.behavior.test.mjs` additions/updates, and new autoplay fixture modules in `ws-server/poker/runtime/fixtures/` to exercise fallback, mismatch, missing-hand-id, stale overlays, runtime-private, and mixed runtime+next-hand scenarios. 

### Testing

- Added and ran `tests/poker-ui-ws-snapshot-merge.behavior.test.mjs` which verifies same-version merges preserve and upgrade seated stacks; the test passed. 
- Added multiple `ws-server/poker/runtime` behavior tests exercising autoplay showdown preflight, fallback selection, rejection cases, stale overlay overlays, and mixed human+bot runtime paths; these new tests passed in the automated run. 
- New fixture modules under `ws-server/poker/runtime/fixtures` were used by the tests to simulate the various trusted/fallback scenarios, and all related tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8a38f1288323937298ea0d4981ea)