### PR TITLE
Refine trusted showdown state merging and fallback handling for bot autoplay

### DIFF
--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -234,7 +234,7 @@ test("accepted bot autoplay showdown uses trusted private hole cards even for pu
   assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_same_hand");
 });
 
-test("accepted bot autoplay rejects fallback when primary showdown hand identity is missing", async () => {
+test("accepted bot autoplay accepts fallback supplement when primary showdown hand identity is missing", async () => {
   const logs = [];
   const calls = { persist: 0, restore: 0, resync: 0 };
   const privateState = {
@@ -281,14 +281,13 @@ test("accepted bot autoplay rejects fallback when primary showdown hand identity
   });
 
   const result = await run({ tableId: "t-missing-handid", trigger: "act", requestId: "r-missing-handid" });
-  assert.equal(result.ok, false);
-  assert.equal(result.reason, "showdown_missing_private_inputs");
-  assert.equal(calls.persist, 0);
-  assert.equal(calls.restore, 1);
-  assert.equal(calls.resync, 1);
+  assert.equal(result.ok, true);
+  assert.equal(calls.persist, 1);
+  assert.equal(calls.restore, 0);
+  assert.equal(calls.resync, 0);
   const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
   assert.ok(preflightLog);
-  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_primary_identity_unknown_rejected");
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_primary_identity_unknown");
 });
 
 test("accepted bot autoplay preserves fresh showdown gameplay fields when fallback is stale", async () => {
@@ -618,6 +617,59 @@ test("accepted bot autoplay rejects cross-hand fallback for degraded showdown ru
   const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
   assert.ok(preflightLog);
   assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_hand_mismatch_rejected");
+});
+
+test("accepted bot autoplay does not treat untrusted fallback handId drift as trusted mismatch", async () => {
+  const logs = [];
+  const calls = { restore: 0, resync: 0 };
+  const privateState = {
+    tableId: "t-untrusted-fallback-mismatch",
+    handId: "h-current-1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    community: [{ r: "A", s: "S" }, { r: "K", s: "S" }, { r: "Q", s: "S" }, { r: "J", s: "S" }, { r: "2", s: "D" }],
+    stacks: { human_1: 100, bot_2: 100 },
+    foldedByUserId: [],
+    sitOutByUserId: {},
+    leftTableByUserId: {},
+    pot: 30,
+    sidePots: [],
+    contributionsByUserId: { human_1: 15, bot_2: 15 },
+    holeCardsByUserId: {
+      human_1: [{ r: "9", s: "S" }, { r: "8", s: "S" }],
+      bot_2: [{ r: "A", s: "H" }, { r: "A", s: "D" }]
+    }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...privateState, handId: "h-fallback-other-hand" }),
+    persistedStateVersion: () => 25,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 26 })
+  };
+  const moduleUrl = new URL("./fixtures/autoplay-showdown-public-state-mismatch-fixture.mjs", import.meta.url).href;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    broadcastResyncRequired: () => {
+      calls.resync += 1;
+    },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: (event, payload) => logs.push({ event, payload })
+  });
+
+  const result = await run({ tableId: "t-untrusted-fallback-mismatch", trigger: "act", requestId: "r-untrusted-fallback-mismatch" });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "showdown_missing_private_inputs");
+  assert.equal(calls.restore, 1);
+  assert.equal(calls.resync, 1);
+  const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
+  assert.ok(preflightLog);
+  assert.equal(preflightLog.payload.trustedStateSource, "fallback_private_untrusted_rejected");
 });
 
 test("accepted bot autoplay prefers trusted runtime private showdown source when available", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -128,14 +128,12 @@ function hasTrustedRuntimeShape(state) {
   if (!state || typeof state !== "object") return false;
   const isPlainMap = (value) => !!(value && typeof value === "object" && !Array.isArray(value));
   const hasEntries = (value) => isPlainMap(value) && Object.keys(value).length > 0;
-  const community = Array.isArray(state.community) ? state.community : [];
-  if (community.length !== 5) return false;
   const seats = Array.isArray(state.seats) ? state.seats : [];
   if (seats.length < 2) return false;
-  if (!hasEntries(state.stacks)) return false;
-  if (!hasEntries(state.contributionsByUserId)) return false;
   if (!hasEntries(state.holeCardsByUserId)) return false;
   if (!isPlainMap(state.foldedByUserId) || !isPlainMap(state.leftTableByUserId) || !isPlainMap(state.sitOutByUserId)) return false;
+  if (!isPlainMap(state.stacks) || !isPlainMap(state.contributionsByUserId)) return false;
+  if (state.community != null && !Array.isArray(state.community)) return false;
   return true;
 }
 
@@ -145,62 +143,65 @@ function resolveTrustedStateToMaterialize({
   trustedHoleCardsByUserId
 }) {
   const isPlainMap = (value) => !!(value && typeof value === "object" && !Array.isArray(value));
-  const mapSize = (value) => (isPlainMap(value) ? Object.keys(value).length : 0);
-  const mergeMap = (primaryMap, fallbackMap) => {
-    const safePrimary = isPlainMap(primaryMap) ? primaryMap : {};
-    const safeFallback = isPlainMap(fallbackMap) ? fallbackMap : {};
-    return { ...safeFallback, ...safePrimary };
+  const hasEntries = (value) => isPlainMap(value) && Object.keys(value).length > 0;
+  const mergeMapPrimaryFirst = (primaryMap, fallbackMap) => {
+    const primary = isPlainMap(primaryMap) ? primaryMap : {};
+    const fallback = isPlainMap(fallbackMap) ? fallbackMap : {};
+    if (!hasEntries(primary) && !hasEntries(fallback)) return undefined;
+    return { ...fallback, ...primary };
   };
-  const toArrayOrNull = (value) => (Array.isArray(value) ? value : null);
-  const mergeTrustedSupplementState = (primary, fallback, resolvedHoleCards) => {
+  const mergeSeatsPrimaryFirst = (primarySeats, fallbackSeats) => {
+    const primary = Array.isArray(primarySeats) ? primarySeats : [];
+    const fallback = Array.isArray(fallbackSeats) ? fallbackSeats : [];
+    if (primary.length === 0) return fallback.length > 0 ? fallback.slice() : undefined;
+    if (fallback.length === 0) return primary.slice();
+    const fallbackByUserId = new Map();
+    const fallbackBySeatNo = new Map();
+    for (const seat of fallback) {
+      const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
+      if (userId) fallbackByUserId.set(userId, seat);
+      if (Number.isInteger(Number(seat?.seatNo))) fallbackBySeatNo.set(Number(seat.seatNo), seat);
+    }
+    return primary.map((seat) => {
+      const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
+      const seatNo = Number.isInteger(Number(seat?.seatNo)) ? Number(seat.seatNo) : null;
+      const fallbackSeat = (userId && fallbackByUserId.get(userId)) || (seatNo != null ? fallbackBySeatNo.get(seatNo) : null);
+      return fallbackSeat ? { ...fallbackSeat, ...seat } : seat;
+    });
+  };
+  const mergePrimaryWithFallbackSupplement = (primary, fallback, resolvedHoleCards) => {
     const base = primary && typeof primary === "object" ? { ...primary } : {};
     const fb = fallback && typeof fallback === "object" ? fallback : {};
-    const baseCommunity = toArrayOrNull(base.community);
-    const fallbackCommunity = toArrayOrNull(fb.community);
-    if ((!baseCommunity || baseCommunity.length < 5) && fallbackCommunity && fallbackCommunity.length === 5) {
+    const primaryCommunity = Array.isArray(base.community) ? base.community : null;
+    const fallbackCommunity = Array.isArray(fb.community) ? fb.community : null;
+    if ((!primaryCommunity || primaryCommunity.length === 0) && fallbackCommunity && fallbackCommunity.length > 0) {
       base.community = fallbackCommunity.slice();
     }
-    if (!Number.isFinite(Number(base.pot)) && Number.isFinite(Number(fb.pot))) {
-      base.pot = Number(fb.pot);
+    if (!Array.isArray(base.seats) || base.seats.length === 0) {
+      if (Array.isArray(fb.seats) && fb.seats.length > 0) base.seats = fb.seats.slice();
+    } else {
+      const mergedSeats = mergeSeatsPrimaryFirst(base.seats, fb.seats);
+      if (Array.isArray(mergedSeats)) base.seats = mergedSeats;
     }
-    if ((!Array.isArray(base.sidePots) || (Array.isArray(base.sidePots) && base.sidePots.some((pot) => !pot || typeof pot !== "object"))) && Array.isArray(fb.sidePots)) {
-      base.sidePots = fb.sidePots.slice();
+    if (!Number.isFinite(Number(base.pot)) && Number.isFinite(Number(fb.pot))) base.pot = Number(fb.pot);
+    if (!Array.isArray(base.sidePots) && Array.isArray(fb.sidePots)) base.sidePots = fb.sidePots.slice();
+    const mapFields = ["stacks", "contributionsByUserId", "foldedByUserId", "leftTableByUserId", "sitOutByUserId"];
+    for (const key of mapFields) {
+      const merged = mergeMapPrimaryFirst(base[key], fb[key]);
+      if (merged) base[key] = merged;
     }
-    if ((!Array.isArray(base.seats) || base.seats.length < 2) && Array.isArray(fb.seats) && fb.seats.length >= 2) {
-      base.seats = fb.seats.slice();
-    }
-    if (Array.isArray(base.seats) && Array.isArray(fb.seats) && base.seats.length >= 2 && fb.seats.length >= 2) {
-      const byUserId = {};
-      for (const seat of fb.seats) {
-        const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
-        if (!userId) continue;
-        byUserId[userId] = seat;
-      }
-      base.seats = base.seats.map((seat) => {
-        const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
-        const fallbackSeat = userId ? byUserId[userId] : null;
-        if (!fallbackSeat) return seat;
-        return {
-          ...fallbackSeat,
-          ...seat
-        };
-      });
-    }
-    if (mapSize(base.stacks) > 0 || mapSize(fb.stacks) > 0) base.stacks = mergeMap(base.stacks, fb.stacks);
-    if (mapSize(base.contributionsByUserId) > 0 || mapSize(fb.contributionsByUserId) > 0) base.contributionsByUserId = mergeMap(base.contributionsByUserId, fb.contributionsByUserId);
-    if (mapSize(base.foldedByUserId) > 0 || mapSize(fb.foldedByUserId) > 0) base.foldedByUserId = mergeMap(base.foldedByUserId, fb.foldedByUserId);
-    if (mapSize(base.leftTableByUserId) > 0 || mapSize(fb.leftTableByUserId) > 0) base.leftTableByUserId = mergeMap(base.leftTableByUserId, fb.leftTableByUserId);
-    if (mapSize(base.sitOutByUserId) > 0 || mapSize(fb.sitOutByUserId) > 0) base.sitOutByUserId = mergeMap(base.sitOutByUserId, fb.sitOutByUserId);
     if ((typeof base.handId !== "string" || !base.handId.trim()) && typeof fb.handId === "string" && fb.handId.trim()) {
       base.handId = fb.handId.trim();
     }
     if ((!base.showdown || typeof base.showdown !== "object") && fb.showdown && typeof fb.showdown === "object") {
       base.showdown = { ...fb.showdown };
     }
-    if (resolvedHoleCards && typeof resolvedHoleCards === "object") {
-      base.holeCardsByUserId = resolvedHoleCards;
-    } else if (mapSize(base.holeCardsByUserId) === 0 && mapSize(fb.holeCardsByUserId) > 0) {
-      base.holeCardsByUserId = { ...fb.holeCardsByUserId };
+    if (resolvedHoleCards && isPlainMap(resolvedHoleCards) && Object.keys(resolvedHoleCards).length > 0) {
+      const merged = mergeMapPrimaryFirst(resolvedHoleCards, base.holeCardsByUserId);
+      if (merged) base.holeCardsByUserId = merged;
+    } else {
+      const merged = mergeMapPrimaryFirst(base.holeCardsByUserId, fb.holeCardsByUserId);
+      if (merged) base.holeCardsByUserId = merged;
     }
     return base;
   };
@@ -215,16 +216,14 @@ function resolveTrustedStateToMaterialize({
   const trustedMismatch = !!primaryComparableHandId && !!fallbackComparableHandId && primaryComparableHandId !== fallbackComparableHandId;
   let selectedState = null;
   let trustedStateSource = "runtime_public_like_rejected";
-  if (primaryTrusted) {
-    selectedState = mergeTrustedSupplementState(primary, null, trustedHoleCardsByUserId);
-    trustedStateSource = "runtime_private";
-  } else if (fallbackTrusted && trustedMismatch) {
+  if (trustedMismatch) {
     trustedStateSource = "fallback_private_hand_mismatch_rejected";
-  } else if (fallbackTrusted && sameHand) {
-    selectedState = mergeTrustedSupplementState(primary, fallback, trustedHoleCardsByUserId);
-    trustedStateSource = "fallback_private_same_hand";
+  } else if (primaryTrusted) {
+    selectedState = mergePrimaryWithFallbackSupplement(primary, fallbackTrusted ? fallback : null, trustedHoleCardsByUserId);
+    trustedStateSource = "runtime_private";
   } else if (fallbackTrusted) {
-    trustedStateSource = "fallback_private_primary_identity_unknown_rejected";
+    selectedState = mergePrimaryWithFallbackSupplement(primary, fallback, trustedHoleCardsByUserId);
+    trustedStateSource = sameHand ? "fallback_private_same_hand" : "fallback_private_primary_identity_unknown";
   } else if (fallback && !fallbackTrusted) {
     trustedStateSource = "fallback_private_untrusted_rejected";
   }

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -528,6 +528,46 @@ test("authoritative WS table_join can progress through human act and bot timeout
       timeoutMs: 5000
     });
     assert.equal(afterBotAutoplay.payload.stateVersion > afterHumanAction.payload.stateVersion, true);
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "join-act-snapshot-after-bot",
+      ts: "2026-02-28T06:20:03Z",
+      payload: { tableId, view: "snapshot" }
+    });
+    const postAutoplaySnapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(postAutoplaySnapshot.payload.stateVersion >= afterBotAutoplay.payload.stateVersion, true);
+    assert.equal(typeof postAutoplaySnapshot.payload.public.hand.handId, "string");
+    const postAutoplayHumanTurn = await waitForHumanTurn(ws, {
+      userId: "act_human",
+      baseline: postAutoplaySnapshot.payload,
+      timeoutMs: 6000
+    });
+    const followupAction = pickNonTerminalHumanAction(postAutoplayHumanTurn);
+    assert.ok(followupAction, "expected a legal human action after autoplay progression");
+    const followupActFrame = {
+      version: "1.0",
+      type: "act",
+      requestId: "act-runtime-human-followup",
+      ts: "2026-02-28T06:20:04Z",
+      payload: {
+        tableId,
+        handId: postAutoplayHumanTurn.public.hand.handId,
+        action: followupAction.action
+      }
+    };
+    if (Number.isFinite(followupAction.amount)) {
+      followupActFrame.payload.amount = followupAction.amount;
+    }
+    sendFrame(ws, followupActFrame);
+    const followupAck = await nextCommandResultForRequest(ws, "act-runtime-human-followup");
+    assert.equal(followupAck.payload.status, "accepted");
+    const afterFollowupAction = await nextStateUpdate(ws, {
+      baseline: postAutoplayHumanTurn,
+      timeoutMs: 5000
+    });
+    assert.equal(afterFollowupAction.payload.stateVersion > postAutoplayHumanTurn.stateVersion, true);
+    assert.equal(typeof afterFollowupAction.payload.public.hand.handId, "string");
 
     ws.close();
   } finally {


### PR DESCRIPTION
### Motivation

- Harden how runtime and persisted private state are merged for autoplay showdown resolution to avoid rejecting valid fallback supplements and to prevent stale or malformed fallback data from corrupting runtime state.
- Improve detection of trusted runtime shape and more robustly merge seat and map fields so primary (runtime) fields are preserved while supplementing missing data from fallback persisted state.

### Description

- Relaxed and corrected shape checks in `hasTrustedRuntimeShape` and allowed `community` to be optional while enforcing map-like fields for `stacks` and `contributionsByUserId`.
- Rewrote merging logic in `resolveTrustedStateToMaterialize` to prefer primary/runtime values, introduced `mergePrimaryWithFallbackSupplement` and `mergeSeatsPrimaryFirst` to merge seats by `userId` or `seatNo`, and unified map merging with a primary-first strategy.
- Adjusted community, pot, sidePots, seats, map fields, `handId`, `showdown`, and `holeCardsByUserId` merge semantics to supplement missing or empty primary fields from fallback rather than overwriting valid runtime data.
- Changed trusted-state selection flow and `trustedStateSource` labeling so that fallback trusted data can be used as a supplement when primary identity is unknown, and untrusted fallbacks are explicitly marked `fallback_private_untrusted_rejected`.
- Updated behavior tests to reflect new acceptance semantics and added a test `accepted bot autoplay does not treat untrusted fallback handId drift as trusted mismatch` to cover handId drift scenarios; extended `ws-join-runtime` test to validate post-autoplay snapshot and follow-up human action.

### Testing

- Ran the updated autoplay behavior tests in `ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs`, including the newly added handId-drift test, and they passed.
- Executed the `ws-tests/ws-join-runtime.behavior.test.mjs` scenario that was extended to assert post-autoplay snapshot consistency and subsequent human action, and it passed.
- Ran the relevant ws-server runtime test suite covering trusted-state merging and showdown preflight logging, and all modified assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfc1bf7b008323b1febee718da52be)