### PR TITLE
Fix WS inactive cleanup imports to stay within release root

### DIFF
--- a/ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs
@@ -5,10 +5,10 @@ import { createInactiveCleanupExecutor } from './inactive-cleanup-adapter.mjs';
 
 test('inactive cleanup adapter uses module-relative shared loader urls and executes shared executor', async () => {
   const adapterSrc = fs.readFileSync(new URL('./inactive-cleanup-adapter.mjs', import.meta.url), 'utf8');
-  assert.match(adapterSrc, /\.\.\/\.\.\/\.\.\/shared\/poker-domain\/inactive-cleanup\.mjs/);
+  assert.match(adapterSrc, /\.\.\/\.\.\/shared\/poker-domain\/inactive-cleanup\.mjs/);
   assert.match(adapterSrc, /\.\.\/\.\.\/shared\/poker-domain\/inactive-cleanup-deps\.mjs/);
 
-  const sharedSrc = fs.readFileSync(new URL('../../../shared/poker-domain/inactive-cleanup.mjs', import.meta.url), 'utf8');
+  const sharedSrc = fs.readFileSync(new URL('../../shared/poker-domain/inactive-cleanup.mjs', import.meta.url), 'utf8');
   assert.doesNotMatch(sharedSrc, /netlify\/functions\/_shared\//, 'shared executor must not statically import netlify _shared modules');
   const wsDepsSrc = fs.readFileSync(new URL('../../shared/poker-domain/inactive-cleanup-deps.mjs', import.meta.url), 'utf8');
   assert.match(wsDepsSrc, /netlify\/functions\/_shared\/chips-ledger\.mjs/);

--- a/ws-server/poker/persistence/inactive-cleanup-adapter.mjs
+++ b/ws-server/poker/persistence/inactive-cleanup-adapter.mjs
@@ -3,8 +3,8 @@ async function beginSqlDefault(fn, { env = process.env } = {}) {
   return bootstrapDb.beginSqlWs(fn, { env });
 }
 
-const DEFAULT_INACTIVE_CLEANUP_MODULE_URL = new URL("../../../shared/poker-domain/inactive-cleanup.mjs", import.meta.url).href;
-const DEFAULT_INACTIVE_CLEANUP_DEPS_MODULE_URL = "../../shared/poker-domain/inactive-cleanup-deps.mjs";
+const DEFAULT_INACTIVE_CLEANUP_MODULE_URL = new URL("../../shared/poker-domain/inactive-cleanup.mjs", import.meta.url).href;
+const DEFAULT_INACTIVE_CLEANUP_DEPS_MODULE_URL = new URL("../../shared/poker-domain/inactive-cleanup-deps.mjs", import.meta.url).href;
 
 function isTerminalLoaderFailure(error) {
   const code = typeof error?.code === "string" ? error.code : "";


### PR DESCRIPTION
### Motivation
- The adapter was importing `../../../shared/poker-domain/inactive-cleanup.mjs`, which escaped the active release directory and caused `ERR_MODULE_NOT_FOUND` during disconnect cleanup; the change keeps module resolution inside the current release bundle while preserving existing behavior.

### Description
- Change `DEFAULT_INACTIVE_CLEANUP_MODULE_URL` to `new URL("../../shared/poker-domain/inactive-cleanup.mjs", import.meta.url).href` so the main cleanup module resolves to `<release>/shared/poker-domain/inactive-cleanup.mjs`.
- Change `DEFAULT_INACTIVE_CLEANUP_DEPS_MODULE_URL` to use `new URL("../../shared/poker-domain/inactive-cleanup-deps.mjs", import.meta.url).href` so deps are resolved from the same release-root model.
- Adjust the behavior test `ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs` to expect and load the corrected `../../shared/...` paths; all runtime patterns (dynamic `import()`), `klog` events, and error classification remain unchanged.

### Testing
- Ran `node --test ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs` and all tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81184347483239f7e7e75960a393a)