### PR TITLE
[codex] Fix poker quick seat numbering for auto-join

### DIFF
--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -39,19 +39,18 @@ const pickSeatNo = (rows, maxPlayers) => {
 };
 
 const toUiSeatNo = (seatNoDb, maxPlayers) => {
-  const maxUi = Number.isInteger(maxPlayers) && maxPlayers >= 2 ? maxPlayers - 1 : 0;
-  if (!Number.isInteger(seatNoDb)) return 0;
-  const seatNoUi = seatNoDb - 1;
-  if (seatNoUi < 0) return 0;
-  if (seatNoUi > maxUi) return maxUi;
-  return seatNoUi;
+  const maxUi = Number.isInteger(maxPlayers) && maxPlayers >= 2 ? maxPlayers : DEFAULT_MAX_PLAYERS;
+  if (!Number.isInteger(seatNoDb)) return 1;
+  if (seatNoDb < 1) return 1;
+  if (seatNoDb > maxUi) return maxUi;
+  return seatNoDb;
 };
 
 const createAndRecommend = async (tx, { userId, maxPlayers, stakesJson }) => {
   const created = await createPokerTableWithState(tx, { userId, maxPlayers, stakesJson });
   const tableId = created.tableId;
   await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-  const seatNoUi = 0;
+  const seatNoUi = 1;
   return { tableId, seatNo: seatNoUi, strategy: "create" };
 };
 

--- a/tests/poker-quick-seat.behavior.test.mjs
+++ b/tests/poker-quick-seat.behavior.test.mjs
@@ -87,8 +87,8 @@ const run = async () => {
     const body = JSON.parse(res.body);
     assert.equal(body.ok, true);
     assert.equal(body.tableId, "table-human");
-    assert.equal(body.seatNo, 2);
-    assert.ok(body.seatNo >= 0 && body.seatNo <= 5);
+    assert.equal(body.seatNo, 3);
+    assert.ok(body.seatNo >= 1 && body.seatNo <= 6);
     assert.ok(
       queries.some((entry) => entry.query.toLowerCase().includes("coalesce(hs.is_bot, false) = false")),
       "quick seat should prefer tables with at least one human"
@@ -112,8 +112,8 @@ const run = async () => {
     const body = JSON.parse(res.body);
     assert.equal(body.ok, true);
     assert.equal(body.tableId, "table-any");
-    assert.equal(body.seatNo, 1);
-    assert.ok(body.seatNo >= 0 && body.seatNo <= 5);
+    assert.equal(body.seatNo, 2);
+    assert.ok(body.seatNo >= 1 && body.seatNo <= 6);
     assertCanonicalLockKey(queries, "quickseat:6:1:2");
     assert.ok(
       queries.some((entry) => entry.query.toLowerCase().includes("where table_id = $1 and status = 'active' order by seat_no asc")),
@@ -133,7 +133,7 @@ const run = async () => {
     const body = JSON.parse(res.body);
     assert.equal(body.ok, true);
     assert.equal(body.tableId, "table-human");
-    assert.equal(body.seatNo, 1);
+    assert.equal(body.seatNo, 2);
     assertCanonicalLockKey(queries, "quickseat:6:1:2");
     assert.ok(
       queries.some((entry) => entry.query.toLowerCase().includes("where table_id = $1 and user_id = $2 limit 1")),
@@ -153,8 +153,8 @@ const run = async () => {
     const body = JSON.parse(res.body);
     assert.equal(body.ok, true);
     assert.equal(body.tableId, "table-new");
-    assert.equal(body.seatNo, 0);
-    assert.ok(body.seatNo >= 0 && body.seatNo <= 5);
+    assert.equal(body.seatNo, 1);
+    assert.ok(body.seatNo >= 1 && body.seatNo <= 6);
     assertCanonicalLockKey(queries, "quickseat:6:1:2");
     assert.ok(
       queries.some((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables")),


### PR DESCRIPTION
## What changed
- changed `poker-quick-seat` to return recommended seat numbers in the same 1-based numbering used by both poker table UIs
- updated quick-seat behavior tests to match the corrected contract

## Why
`Play now` was opening `table-v2` with `autoJoin=1`, but the quick-seat function could return `seatNo=0` for a fresh table. The V2 auto-join flow expects normal UI seat numbering, so the recommendation could be ignored or interpreted incorrectly, leaving the user in the table lobby instead of seated.

## Impact
- `Play now` should now create/open a table and auto-join the recommended seat consistently on production
- the seat recommendation contract is now aligned across the lobby flow and both poker table UIs

## Validation
- `node tests/poker-quick-seat.behavior.test.mjs`
- `node tests/poker-ui.behavior.test.mjs`
- `node tests/poker-v2-live.behavior.test.mjs`
- `node scripts/syntax-check.mjs`
