### PR TITLE
Fix production poker WS join mode

### DIFF
--- a/shared/poker-domain/inactive-cleanup-deps.mjs
+++ b/shared/poker-domain/inactive-cleanup-deps.mjs
@@ -1,0 +1,2 @@
+export { postTransaction } from "../../netlify/functions/_shared/chips-ledger.mjs";
+export { isHoleCardsTableMissing } from "../../netlify/functions/_shared/poker-hole-cards-store.mjs";

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -96,10 +96,24 @@ function resolveObserveOnlyJoin(rawValue) {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-const persistedBootstrapEnabled = Boolean(process.env.SUPABASE_DB_URL || process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON || process.env.WS_PERSISTED_STATE_FILE);
+function resolveAuthoritativeJoinEnabled(rawValue, { hasSupabaseDbUrl = false, observeOnlyJoinEnabled = false } = {}) {
+  if (rawValue === undefined || rawValue === null || String(rawValue).trim() === "") {
+    return Boolean(hasSupabaseDbUrl && !observeOnlyJoinEnabled);
+  }
+  const normalized = String(rawValue).trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return Boolean(hasSupabaseDbUrl && !observeOnlyJoinEnabled);
+}
+
+const hasSupabaseDbUrl = Boolean(process.env.SUPABASE_DB_URL);
+const persistedBootstrapEnabled = Boolean(hasSupabaseDbUrl || process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON || process.env.WS_PERSISTED_STATE_FILE);
 const persistedStateWriteEnabled = Boolean(process.env.SUPABASE_DB_URL || process.env.WS_PERSISTED_STATE_FILE);
 const observeOnlyJoinEnabled = resolveObserveOnlyJoin(process.env.WS_OBSERVE_ONLY_JOIN);
-const authoritativeJoinEnabled = String(process.env.WS_AUTHORITATIVE_JOIN_ENABLED || "").trim() === "1";
+const authoritativeJoinEnabled = resolveAuthoritativeJoinEnabled(process.env.WS_AUTHORITATIVE_JOIN_ENABLED, {
+  hasSupabaseDbUrl,
+  observeOnlyJoinEnabled
+});
 
 function createPersistedBootstrapLoader({ env = process.env } = {}) {
   let repositoryPromise = null;

--- a/ws-tests/ws-ws-dependency.guard.test.mjs
+++ b/ws-tests/ws-ws-dependency.guard.test.mjs
@@ -89,6 +89,18 @@ test("shared authoritative join core avoids static netlify adapter imports", () 
   assert.match(joinText, /await\s+import\(["']\.\.\/\.\.\/netlify\/functions\/_shared\/chips-ledger\.mjs["']\)/);
 });
 
+test("shared inactive cleanup deps wrapper exists for production ws release layout", () => {
+  const depsText = fs.readFileSync("shared/poker-domain/inactive-cleanup-deps.mjs", "utf8");
+  assert.match(depsText, /netlify\/functions\/_shared\/chips-ledger\.mjs/);
+  assert.match(depsText, /netlify\/functions\/_shared\/poker-hole-cards-store\.mjs/);
+});
+
+test("ws server defaults authoritative join only for db-backed runtime when env flag is missing", () => {
+  const serverText = fs.readFileSync("ws-server/server.mjs", "utf8");
+  assert.match(serverText, /const hasSupabaseDbUrl = Boolean\(process\.env\.SUPABASE_DB_URL\)/);
+  assert.match(serverText, /return Boolean\(hasSupabaseDbUrl && !observeOnlyJoinEnabled\)/);
+});
+
 test("ws-server package declares postgres dependency for db-backed bootstrap runtime", () => {
   const packageJson = JSON.parse(fs.readFileSync("ws-server/package.json", "utf8"));
   assert.equal(packageJson.dependencies?.postgres, "^3.4.5");


### PR DESCRIPTION
## Root cause
Production  was running with  set but without . In that configuration  degraded to local in-memory membership, so  showed a fake seated player without a persisted seat or seeded bots.

Production also missed , which caused repeated  loader failures.

## What this changes
- default WS authoritative join on for DB-backed runtime when the explicit env flag is missing
- add the missing root  wrapper used by the production release layout
- add guard coverage so both contracts stay locked

## Validation
- ✔ authoritative join branch rehydrates from persisted source before attach (285.213828ms)
✔ authoritative join missing state row returns protocol-safe state_missing (263.724922ms)
✔ authoritative WS table_join seeds two bots once and returns authoritative bot seat snapshot (279.434961ms)
ℹ tests 3
ℹ suites 0
ℹ pass 3
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1043.953789
- ✔ ws dependency resolves from global WebSocket or root/ws-server dependency graph (51.50293ms)
✔ guard passes when globalThis.WebSocket exists even if ws resolve fails (0.244179ms)
✔ guard reports explicit diagnostics when neither globalThis.WebSocket nor ws is available (1.413359ms)
✔ persisted bootstrap repository stays within ws-server runtime boundary (0.20379ms)
✔ shared authoritative join core avoids static netlify adapter imports (0.263164ms)
✔ shared inactive cleanup deps wrapper exists for production ws release layout (0.123516ms)
✔ ws server defaults authoritative join only for db-backed runtime when env flag is missing (0.173555ms)
✔ ws-server package declares postgres dependency for db-backed bootstrap runtime (0.120157ms)
✔ ws snapshot runtime helper chain stays within ws-server boundary (0.449375ms)
✔ ws server leave path avoids static shared/netlify runtime imports (0.763828ms)
✔ ws authoritative leave adapter imports with ws-server dependency graph (111.832539ms)
✔ ws deploy artifact contract includes authoritative leave runtime files (0.52207ms)
✔ ws authoritative leave executor non-override path resolves real module loader contract (5.370429ms)
✔ ws authoritative leave adapter default loader resolves in artifact-shaped layout (24.759258ms)
✔ ws-local leave wrapper is the only allowed bridge to repo-root shared leave module (11.784023ms)
✔ ws dependency guard detects forbidden bridge import (12.762695ms)
✔ workflow trigger boundary includes shared join and netlify helper surfaces (0.490742ms)
ℹ tests 17
ℹ suites 0
ℹ pass 17
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 408.35039
- ✔ Syntax OK (153 files)