### PR TITLE
Fix production WS bot autoplay loader

### DIFF
--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -5,17 +5,17 @@ import { createAcceptedBotAutoplayExecutor } from "./accepted-bot-autoplay-adapt
 import { initHandState, applyAction as applyRuntimeAction, advanceIfNeeded } from "../snapshot-runtime/poker-reducer.mjs";
 import { buildBootstrappedPokerState, applyCoreStateAction } from "../engine/poker-engine.mjs";
 import { computeSharedLegalActions } from "../shared/poker-primitives.mjs";
-import { runAdvanceLoop } from "../../../shared/poker-domain/poker-autoplay.mjs";
+import { runAdvanceLoop } from "../../shared/poker-domain/poker-autoplay.mjs";
 import { materializeShowdownAndPayout } from "../snapshot-runtime/poker-materialize-showdown.mjs";
 import { computeShowdown } from "../snapshot-runtime/poker-showdown.mjs";
 import { awardPotsAtShowdown } from "../snapshot-runtime/poker-payout.mjs";
 
 test("autoplay adapter resolves shared autoplay from neutral shared module path", () => {
   const source = fs.readFileSync(new URL("./accepted-bot-autoplay-adapter.mjs", import.meta.url), "utf8");
-  assert.match(source, /\.\.\/\.\.\/\.\.\/shared\/poker-domain\/poker-autoplay\.mjs/);
+  assert.match(source, /\.\.\/\.\.\/shared\/poker-domain\/poker-autoplay\.mjs/);
   assert.doesNotMatch(source, /netlify\/functions\/_shared/);
 
-  const sharedSource = fs.readFileSync(new URL("../../../shared/poker-domain/poker-autoplay.mjs", import.meta.url), "utf8");
+  const sharedSource = fs.readFileSync(new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url), "utf8");
   assert.doesNotMatch(sharedSource, /netlify\/functions\/_shared/);
 });
 

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -14,7 +14,7 @@ import { awardPotsAtShowdown as awardLegacyPotsAtShowdown } from "../snapshot-ru
 import { withoutPrivateState as withoutLegacyPrivateState } from "../snapshot-runtime/poker-state-utils.mjs";
 import { computeLegalActions as computeLegacyLegalActions } from "../snapshot-runtime/poker-legal-actions.mjs";
 
-const DEFAULT_SHARED_AUTOPLAY_MODULE_URL = new URL("../../../shared/poker-domain/poker-autoplay.mjs", import.meta.url).href;
+const DEFAULT_SHARED_AUTOPLAY_MODULE_URL = new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url).href;
 const sharedAutoplayModulePromiseByUrl = new Map();
 
 const isActionPhase = (phase) => phase === "PREFLOP" || phase === "FLOP" || phase === "TURN" || phase === "RIVER";

--- a/ws-server/shared/poker-domain/poker-autoplay.mjs
+++ b/ws-server/shared/poker-domain/poker-autoplay.mjs
@@ -1,0 +1,1 @@
+export { hasParticipatingHumanInHand, runAdvanceLoop, runBotAutoplayLoop } from "../../../shared/poker-domain/poker-autoplay.mjs";

--- a/ws-tests/ws-ws-dependency.guard.test.mjs
+++ b/ws-tests/ws-ws-dependency.guard.test.mjs
@@ -287,6 +287,22 @@ test("ws-local join wrapper is the only allowed bridge to repo-root shared join 
   }
 });
 
+test("ws-local poker autoplay wrapper is the only allowed bridge to repo-root shared autoplay module", () => {
+  const wrapperFile = "ws-server/shared/poker-domain/poker-autoplay.mjs";
+  const wrapperText = fs.readFileSync(wrapperFile, "utf8");
+  assert.match(wrapperText, /export\s*\{\s*hasParticipatingHumanInHand,\s*runAdvanceLoop,\s*runBotAutoplayLoop\s*\}\s*from\s*["']\.\.\/\.\.\/\.\.\/shared\/poker-domain\/poker-autoplay\.mjs["']/);
+
+  const wsFiles = fs.readdirSync("ws-server", { recursive: true })
+    .filter((entry) => typeof entry === "string" && entry.endsWith('.mjs'))
+    .map((entry) => `ws-server/${entry.replaceAll('\\', '/')}`);
+
+  for (const file of wsFiles) {
+    if (file === wrapperFile) continue;
+    const text = fs.readFileSync(file, "utf8");
+    assert.doesNotMatch(text, /\.\.\/\.\.\/\.\.\/shared\/poker-domain\/poker-autoplay\.mjs/, `Only ${wrapperFile} may bridge to repo-root shared autoplay module`);
+  }
+});
+
 
 test("ws dependency guard detects forbidden bridge import", async () => {
   const forbiddenFile = "ws-server/tmp-forbidden-import.mjs";


### PR DESCRIPTION
## Summary
- fix WS bot autoplay adapter to load through the ws-server shared wrapper path used by release artifacts
- add ws-server autoplay wrapper for release layout parity
- extend guard/runtime tests to lock the contract

## Testing
- node --test ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
- node --test ws-tests/ws-ws-dependency.guard.test.mjs
- node scripts/syntax-check.mjs