### PR TITLE
Add poker v2 active turn clock overlay

### DIFF
--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -24,7 +24,15 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
-.poker-seat-avatar{width:76px; height:76px; margin:0 auto 7px; border-radius:50%; border:2px solid rgba(255,202,127,0.6); background:radial-gradient(circle at 50% 24%, rgba(255,235,214,0.22), rgba(26,25,30,0.74) 42%, rgba(7,8,10,0.98) 78%), linear-gradient(155deg, rgba(23,26,34,0.95), rgba(8,9,13,0.99)); box-shadow:0 8px 18px rgba(0,0,0,0.48); display:flex; align-items:flex-end; justify-content:center; font-size:0.8rem; letter-spacing:0.04em; color:#ebf2ff; padding-bottom:8px;}
+.poker-seat-avatar{position:relative; overflow:hidden; isolation:isolate; width:76px; height:76px; margin:0 auto 7px; border-radius:50%; border:2px solid rgba(255,202,127,0.6); background:radial-gradient(circle at 50% 24%, rgba(255,235,214,0.22), rgba(26,25,30,0.74) 42%, rgba(7,8,10,0.98) 78%), linear-gradient(155deg, rgba(23,26,34,0.95), rgba(8,9,13,0.99)); box-shadow:0 8px 18px rgba(0,0,0,0.48); display:flex; align-items:flex-end; justify-content:center; font-size:0.8rem; letter-spacing:0.04em; color:#ebf2ff; padding-bottom:8px;}
+
+.poker-seat-turn-clock{position:absolute; inset:-2px; border-radius:50%; pointer-events:none; z-index:1; opacity:0.88; background:conic-gradient(from -90deg, transparent 0turn, transparent calc((1 - var(--turn-progress, 0)) * 1turn), rgba(19,24,34,0.62) calc((1 - var(--turn-progress, 0)) * 1turn), rgba(19,24,34,0.62) 1turn); transform:scaleX(-1);}
+
+.poker-seat-turn-clock::after{content:""; position:absolute; inset:10px; border-radius:50%; border:1px solid rgba(255,255,255,0.06); background:transparent;}
+
+.poker-seat-turn-clock--warning{background:conic-gradient(from -90deg, transparent 0turn, transparent calc((1 - var(--turn-progress, 0)) * 1turn), rgba(133,28,28,0.48) calc((1 - var(--turn-progress, 0)) * 1turn), rgba(133,28,28,0.48) 1turn); animation:poker-turn-clock-pulse 0.95s ease-in-out infinite;}
+
+.poker-seat-avatar > :not(.poker-seat-turn-clock){position:relative; z-index:2;}
 
 .poker-seat-stack{display:inline-flex; align-items:center; justify-content:center; min-width:80px; padding:6px 12px; border-radius:18px; border:1px solid rgba(255,220,177,0.25); background:linear-gradient(180deg, rgba(7,13,24,0.88), rgba(2,5,11,0.95)); box-shadow:0 6px 14px rgba(0,0,0,0.42), inset 0 1px 1px rgba(255,255,255,0.12); font-size:1.05rem; font-weight:700; color:#fef7e5;}
 
@@ -149,3 +157,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
 
 .poker-v2-xp-badge{position:absolute; top:14px; right:12px; z-index:20; min-width:58px; padding:8px 10px; border-radius:14px; border:1px solid rgba(255,223,180,0.34); background:linear-gradient(180deg, rgba(16,24,37,0.88), rgba(7,10,15,0.96)); color:#e8eefb; text-decoration:none; font-size:0.88rem; font-weight:700; text-align:center; box-shadow:0 9px 17px rgba(0,0,0,0.48), inset 0 1px 1px rgba(255,255,255,0.2);} 
+
+@keyframes poker-turn-clock-pulse{
+  0%,100%{box-shadow:0 0 0 0 rgba(220,38,38,0.08);}
+  50%{box-shadow:0 0 0 7px rgba(220,38,38,0.22);}
+}

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -73,6 +73,7 @@
   var wsClient = null;
   var currentAccessToken = null;
   var authWatchTimer = null;
+  var turnClockTimer = null;
   var authUnsubscribe = null;
   var renderedSeatAnchors = {};
   var renderedSeatSlots = {};
@@ -99,6 +100,7 @@
       communityCards: [],
       heroCards: [],
       turnUserId: null,
+      turnStartedAt: null,
       turnDeadlineAt: null,
       phase: 'LOBBY',
       handId: null,
@@ -539,7 +541,11 @@
     else if (Number.isInteger(handObj.dealerSeatNo)) state.dealerSeat = handObj.dealerSeatNo;
 
     if (typeof turnObj.userId === 'string' && turnObj.userId) state.turnUserId = turnObj.userId;
+    else if (turnObj.userId == null) state.turnUserId = null;
+    if (turnObj.startedAt != null) state.turnStartedAt = Number(turnObj.startedAt);
+    else if (turnObj.startedAt == null) state.turnStartedAt = null;
     if (turnObj.deadlineAt != null) state.turnDeadlineAt = Number(turnObj.deadlineAt);
+    else if (turnObj.deadlineAt == null) state.turnDeadlineAt = null;
 
     if (Number.isFinite(Number(potObj.total))) state.potTotal = Number(potObj.total);
 
@@ -704,6 +710,24 @@
     return text.length <= 8 ? text : text.slice(0, 8);
   }
 
+  function normalizeTimerMs(value){
+    var numeric = Number(value);
+    return Number.isFinite(numeric) && numeric > 0 ? Math.trunc(numeric) : null;
+  }
+
+  function getTurnClockState(){
+    var deadlineAt = normalizeTimerMs(state.turnDeadlineAt);
+    if (!deadlineAt || !state.turnUserId) return null;
+    var startedAt = normalizeTimerMs(state.turnStartedAt);
+    var totalMs = startedAt && deadlineAt > startedAt ? (deadlineAt - startedAt) : 20_000;
+    var remainingMs = Math.max(0, deadlineAt - Date.now());
+    return {
+      remainingMs: remainingMs,
+      remainingSeconds: Math.ceil(remainingMs / 1000),
+      ratio: totalMs > 0 ? Math.max(0, Math.min(1, remainingMs / totalMs)) : 0
+    };
+  }
+
   function renderSeats(){
     if (!els.seatLayer) return;
     els.seatLayer.innerHTML = '';
@@ -744,6 +768,16 @@
       var avatar = document.createElement('div');
       avatar.className = 'poker-seat-avatar';
       avatar.textContent = seat ? initials(getDisplayName(seat)) : '+';
+      if (active){
+        var turnClock = getTurnClockState();
+        if (turnClock){
+          var clock = document.createElement('div');
+          clock.className = 'poker-seat-turn-clock' + (turnClock.remainingSeconds <= 5 ? ' poker-seat-turn-clock--warning' : '');
+          clock.style.setProperty('--turn-progress', String(turnClock.ratio));
+          clock.setAttribute('aria-hidden', 'true');
+          avatar.appendChild(clock);
+        }
+      }
 
       var stack = document.createElement('div');
       stack.className = 'poker-seat-stack';
@@ -1190,6 +1224,7 @@
   }
 
   function startDemoMode(){
+    startTurnClock();
     state = cloneState(demoState);
     state.wsReady = false;
     render();
@@ -1197,6 +1232,7 @@
   }
 
   function stopLiveMode(){
+    stopTurnClock();
     state.wsReady = false;
     if (wsClient && typeof wsClient.destroy === 'function'){
       try { wsClient.destroy(); } catch (_err){}
@@ -1225,6 +1261,7 @@
       return;
     }
     stopLiveMode();
+    startTurnClock();
     state = createEmptyLiveState(tableId, getUserIdFromToken(token));
     render();
     markBootReady();
@@ -1291,6 +1328,20 @@
     if (!authWatchTimer) return;
     window.clearInterval(authWatchTimer);
     authWatchTimer = null;
+  }
+
+  function startTurnClock(){
+    if (turnClockTimer) return;
+    turnClockTimer = window.setInterval(function(){
+      if (!state.turnUserId || !state.turnDeadlineAt) return;
+      renderSeats();
+    }, 200);
+  }
+
+  function stopTurnClock(){
+    if (!turnClockTimer) return;
+    window.clearInterval(turnClockTimer);
+    turnClockTimer = null;
   }
 
   function bindAuthLifecycle(){

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -5,6 +5,11 @@ import path from 'node:path';
 import vm from 'node:vm';
 
 function makeElement(id){
+  const style = {
+    setProperty(name, value){ this[name] = String(value); },
+    getPropertyValue(name){ return this[name] || ''; },
+    removeProperty(name){ delete this[name]; }
+  };
   const element = {
     id,
     hidden: false,
@@ -13,7 +18,7 @@ function makeElement(id){
     value: '',
     className: '',
     dataset: {},
-    style: {},
+    style: style,
     children: [],
     parentNode: null,
     attributes: {},
@@ -349,6 +354,87 @@ test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat
   assert.equal(rightBottomSeat.style.left, '80%');
   assert.equal(harness.elements.pokerDealerChip.style.left, '71%');
   assert.equal(harness.elements.pokerDealerChip.style.top, '34%');
+});
+
+test('poker v2 shows a live turn clock only on the active seat avatar', async () => {
+  const nowMs = Date.now();
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 5,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-4', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'villain-1', startedAt: nowMs - 10_000, deadlineAt: nowMs + 10_000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 1, actions: [] }
+      },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const activeSeat = findSeatByLabel(harness, 'Villain 1');
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  const activeAvatar = activeSeat.children.find((node) => node.className === 'poker-seat-avatar');
+  const heroAvatar = heroSeat.children.find((node) => node.className === 'poker-seat-avatar');
+  const activeClock = activeAvatar.children.find((node) => /poker-seat-turn-clock/.test(node.className));
+  const heroClock = heroAvatar.children.find((node) => /poker-seat-turn-clock/.test(node.className));
+
+  assert.ok(activeClock, 'active seat should show a turn clock overlay');
+  assert.equal(Math.abs(Number(activeClock.style['--turn-progress']) - 0.5) < 0.02, true);
+  assert.equal(heroClock, undefined, 'inactive seats should not show the turn clock overlay');
+});
+
+test('poker v2 turns the live clock red when five seconds remain', async () => {
+  const nowMs = Date.now();
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 6,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [{ userId: 'user-1', seat: 1, displayName: 'Hero' }]
+      },
+      public: {
+        hand: { handId: 'hand-5', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'user-1', startedAt: nowMs - 15_500, deadlineAt: nowMs + 4_500 },
+        pot: { total: 4, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CHECK'] }
+      },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  const heroAvatar = heroSeat.children.find((node) => node.className === 'poker-seat-avatar');
+  const heroClock = heroAvatar.children.find((node) => /poker-seat-turn-clock/.test(node.className));
+
+  assert.ok(heroClock);
+  assert.match(heroClock.className, /poker-seat-turn-clock--warning/);
 });
 
 test('poker v2 keeps the dealer chip fixed while action moves between players', async () => {


### PR DESCRIPTION
## Summary
- add a semi-transparent circular turn timer overlay on the active player's avatar in poker v2
- drive the pie clock from live turn started/deadline timestamps and pulse it red during the last five seconds
- cover the new active-seat clock behavior with poker v2 UI tests

## Testing
- node --test tests/poker-v2-live.behavior.test.mjs
- node scripts/syntax-check.mjs