### PR TITLE
Add human-like poker bot reaction delay

### DIFF
--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -149,6 +149,54 @@ test("accepted bot autoplay clamps reaction delay to the remaining turn window",
   assert.deepEqual(observed, [750]);
 });
 
+test("accepted bot autoplay aborts cleanly when turn changes during reaction delay", async () => {
+  const nowMs = Date.now();
+  let currentState = {
+    version: 2,
+    tableId: "t1",
+    handId: "h1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    turnDeadlineAt: nowMs + 20_000,
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...currentState }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: (_tableId, turnUserId) => ({
+      seats: [
+        { userId: "human_1", seatNo: 1, isBot: false },
+        { userId: "bot_2", seatNo: 2, isBot: turnUserId === "bot_2" }
+      ]
+    }),
+    applyAction: () => {
+      throw new Error("unexpected_apply");
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "2000", WS_BOT_REACTION_MAX_MS: "2000" },
+    now: () => nowMs,
+    sleep: async () => {
+      currentState = {
+        ...currentState,
+        turnUserId: "human_1"
+      };
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t1", trigger: "act", requestId: "r-delay-turn-change" });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, false);
+  assert.equal(result.reason, "turn_changed_during_delay");
+});
+
 test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
   const tableManager = {
     persistedPokerState: () => ({

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import { createAcceptedBotAutoplayExecutor } from "./accepted-bot-autoplay-adapter.mjs";
+import { createAcceptedBotAutoplayExecutor as createAcceptedBotAutoplayExecutorBase } from "./accepted-bot-autoplay-adapter.mjs";
 import { initHandState, applyAction as applyRuntimeAction, advanceIfNeeded } from "../snapshot-runtime/poker-reducer.mjs";
 import { buildBootstrappedPokerState, applyCoreStateAction } from "../engine/poker-engine.mjs";
 import { computeSharedLegalActions } from "../shared/poker-primitives.mjs";
@@ -9,6 +9,20 @@ import { runAdvanceLoop } from "../../shared/poker-domain/poker-autoplay.mjs";
 import { materializeShowdownAndPayout } from "../snapshot-runtime/poker-materialize-showdown.mjs";
 import { computeShowdown } from "../snapshot-runtime/poker-showdown.mjs";
 import { awardPotsAtShowdown } from "../snapshot-runtime/poker-payout.mjs";
+
+function createAcceptedBotAutoplayExecutor(options = {}) {
+  const mergedEnv = {
+    WS_BOT_REACTION_MIN_MS: "0",
+    WS_BOT_REACTION_MAX_MS: "0",
+    ...(options.env || {})
+  };
+  return createAcceptedBotAutoplayExecutorBase({
+    sleep: async () => {},
+    random: () => 0,
+    ...options,
+    env: mergedEnv
+  });
+}
 
 test("autoplay adapter resolves shared autoplay from neutral shared module path", () => {
   const source = fs.readFileSync(new URL("./accepted-bot-autoplay-adapter.mjs", import.meta.url), "utf8");
@@ -51,6 +65,88 @@ test("accepted bot autoplay executes and persists when bot is on turn", async ()
   const result = await run({ tableId: "t1", trigger: "act", requestId: "r1" });
   assert.equal(result.ok, true);
   assert.equal(calls.persist > 0, true);
+});
+
+test("accepted bot autoplay waits a human-like reaction delay before acting", async () => {
+  const observed = { sleepMs: [], persist: 0 };
+  const nowMs = Date.now();
+  const state = {
+    version: 2,
+    tableId: "t1",
+    handId: "h1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    turnDeadlineAt: nowMs + 20_000,
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 3 })
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "2000", WS_BOT_REACTION_MAX_MS: "4000" },
+    now: () => nowMs,
+    random: () => 0.5,
+    sleep: async (ms) => {
+      observed.sleepMs.push(ms);
+    },
+    persistMutatedState: async () => {
+      observed.persist += 1;
+      return { ok: true };
+    },
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t1", trigger: "act", requestId: "r-delay" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(observed.sleepMs, [3000]);
+  assert.equal(observed.persist, 1);
+});
+
+test("accepted bot autoplay clamps reaction delay to the remaining turn window", async () => {
+  const observed = [];
+  const nowMs = Date.now();
+  const state = {
+    version: 2,
+    tableId: "t1",
+    handId: "h1",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    turnDeadlineAt: nowMs + 900,
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }] }),
+    applyAction: () => ({ accepted: true, changed: true, replayed: false, stateVersion: 3 })
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "2000", WS_BOT_REACTION_MAX_MS: "4000" },
+    now: () => nowMs,
+    random: () => 0.99,
+    sleep: async (ms) => {
+      observed.push(ms);
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t1", trigger: "act", requestId: "r-delay-clamp" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(observed, [750]);
 });
 
 test("accepted bot autoplay no-ops when next turn is not a bot", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -555,7 +555,7 @@ export function createAcceptedBotStepExecutor({
       actionAmount: null,
       legalActionSummary: null
     };
-    const privateState = tableManager.persistedPokerState(tableId);
+    let privateState = tableManager.persistedPokerState(tableId);
     if (!privateState || typeof privateState !== "object") {
       return { ok: true, changed: false, actionCount: 0, reason: "missing_state" };
     }
@@ -581,7 +581,7 @@ export function createAcceptedBotStepExecutor({
           return { state: applied.state, events: [] };
         }
       : (loopPrivateState, botAction) => applyLegacyRuntimeAction(loopPrivateState, botAction);
-    const state = withoutPrivateState(privateState);
+    let state = withoutPrivateState(privateState);
     lastKnown.state = state;
     if (!isActionPhase(state?.phase) || !state?.turnUserId) {
       return { ok: true, changed: false, actionCount: 0, reason: "not_action_phase" };
@@ -602,9 +602,9 @@ export function createAcceptedBotStepExecutor({
       return { ok: true, changed: false, actionCount: 0, reason: "autoplay_unavailable", noop: true };
     }
 
-    const turnSnapshot = tableManager.tableSnapshot(tableId, state.turnUserId);
-    const seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
-    const seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
+    let turnSnapshot = tableManager.tableSnapshot(tableId, state.turnUserId);
+    let seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
+    let seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
     const cfg = getBotAutoplayConfig(env);
     if (isBotTurnAuthoritatively(tableManager, tableId, state.turnUserId, seatBotMap)) {
       const reactionDelayMs = resolveBotReactionDelayMs({
@@ -616,6 +616,21 @@ export function createAcceptedBotStepExecutor({
       });
       if (reactionDelayMs > 0) {
         await sleep(reactionDelayMs);
+        privateState = tableManager.persistedPokerState(tableId);
+        if (!privateState || typeof privateState !== "object") {
+          return { ok: true, changed: false, actionCount: 0, reason: "missing_state_after_delay" };
+        }
+        state = withoutPrivateState(privateState);
+        lastKnown.state = state;
+        if (!isActionPhase(state?.phase) || !state?.turnUserId) {
+          return { ok: true, changed: false, actionCount: 0, reason: "turn_changed_during_delay" };
+        }
+        turnSnapshot = tableManager.tableSnapshot(tableId, state.turnUserId);
+        seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
+        seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
+        if (!isBotTurnAuthoritatively(tableManager, tableId, state.turnUserId, seatBotMap)) {
+          return { ok: true, changed: false, actionCount: 0, reason: "turn_changed_during_delay" };
+        }
       }
     }
     logVerbose("ws_bot_autoplay_loop_start", {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -16,6 +16,8 @@ import { computeLegalActions as computeLegacyLegalActions } from "../snapshot-ru
 
 const DEFAULT_SHARED_AUTOPLAY_MODULE_URL = new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url).href;
 const sharedAutoplayModulePromiseByUrl = new Map();
+const DEFAULT_BOT_REACTION_MIN_MS = 2_000;
+const DEFAULT_BOT_REACTION_MAX_MS = 4_000;
 
 const isActionPhase = (phase) => phase === "PREFLOP" || phase === "FLOP" || phase === "TURN" || phase === "RIVER";
 const noopAdvanceIfNeeded = (state) => ({ state, events: [] });
@@ -134,7 +136,38 @@ function buildSeatUserIdsInOrder(state) {
 function getBotAutoplayConfig(env = process.env) {
   const hardCapRaw = Number(env?.POKER_BOTS_BOTS_ONLY_HAND_HARD_CAP);
   const botsOnlyHandCompletionHardCap = Number.isInteger(hardCapRaw) && hardCapRaw > 0 ? hardCapRaw : 80;
-  return { botsOnlyHandCompletionHardCap, policyVersion: "WS_SHARED_AUTOPLAY" };
+  const configuredMinRaw = Number(env?.WS_BOT_REACTION_MIN_MS);
+  const configuredMaxRaw = Number(env?.WS_BOT_REACTION_MAX_MS);
+  const minReactionMs = Number.isFinite(configuredMinRaw) && configuredMinRaw >= 0
+    ? Math.trunc(configuredMinRaw)
+    : DEFAULT_BOT_REACTION_MIN_MS;
+  const maxReactionMs = Number.isFinite(configuredMaxRaw) && configuredMaxRaw >= 0
+    ? Math.trunc(configuredMaxRaw)
+    : DEFAULT_BOT_REACTION_MAX_MS;
+  return {
+    botsOnlyHandCompletionHardCap,
+    minReactionMs,
+    maxReactionMs,
+    policyVersion: "WS_SHARED_AUTOPLAY"
+  };
+}
+
+function resolveBotReactionDelayMs({ state, minReactionMs, maxReactionMs, random = Math.random, now = Date.now }) {
+  const minMs = Number.isFinite(minReactionMs) ? Math.max(0, Math.trunc(minReactionMs)) : DEFAULT_BOT_REACTION_MIN_MS;
+  const maxMs = Number.isFinite(maxReactionMs) ? Math.max(minMs, Math.trunc(maxReactionMs)) : Math.max(minMs, DEFAULT_BOT_REACTION_MAX_MS);
+  if (maxMs <= 0) return 0;
+  const rand = typeof random === "function" ? Number(random()) : 0;
+  const normalizedRandom = Number.isFinite(rand) ? Math.max(0, Math.min(0.999999, rand)) : 0;
+  const sampledDelayMs = minMs + Math.floor((maxMs - minMs + 1) * normalizedRandom);
+  const deadlineAt = Number(state?.turnDeadlineAt);
+  if (!Number.isFinite(deadlineAt)) return sampledDelayMs;
+  const nowMs = typeof now === "function" ? Number(now()) : Date.now();
+  const safeRemainingMs = Math.max(0, Math.trunc(deadlineAt - nowMs - 150));
+  return Math.min(sampledDelayMs, safeRemainingMs);
+}
+
+function sleepMs(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function buildPersistedFromPrivateState(privateStateInput, actorUserId, actionRequestId, withoutPrivateStateImpl = withoutLegacyPrivateState) {
@@ -498,6 +531,9 @@ export function createAcceptedBotStepExecutor({
   restoreTableFromPersisted,
   broadcastResyncRequired,
   env = process.env,
+  random = Math.random,
+  now = Date.now,
+  sleep = sleepMs,
   klog = () => {}
 } = {}) {
   const verboseAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
@@ -570,6 +606,18 @@ export function createAcceptedBotStepExecutor({
     const seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
     const seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
     const cfg = getBotAutoplayConfig(env);
+    if (isBotTurnAuthoritatively(tableManager, tableId, state.turnUserId, seatBotMap)) {
+      const reactionDelayMs = resolveBotReactionDelayMs({
+        state,
+        minReactionMs: cfg.minReactionMs,
+        maxReactionMs: cfg.maxReactionMs,
+        random,
+        now
+      });
+      if (reactionDelayMs > 0) {
+        await sleep(reactionDelayMs);
+      }
+    }
     logVerbose("ws_bot_autoplay_loop_start", {
       ...baseLog,
       runtimeFlavor,

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -88,7 +88,13 @@ function waitForExit(proc) {
 function createServer({ env = {} } = {}) {
   return getFreePort().then((port) => {
     const child = spawn(process.execPath, ["ws-server/server.mjs"], {
-      env: { ...process.env, PORT: String(port), ...env },
+      env: {
+        ...process.env,
+        PORT: String(port),
+        WS_BOT_REACTION_MIN_MS: "0",
+        WS_BOT_REACTION_MAX_MS: "0",
+        ...env
+      },
       stdio: ["ignore", "pipe", "pipe"]
     });
     return { port, child };


### PR DESCRIPTION
## Summary
- add a configurable bot reaction delay in the WS autoplay runtime to make bot turns feel human
- default bot reaction timing to 2-4 seconds and clamp it to the remaining turn deadline window
- cover reaction delay sampling and clamping with adapter behavior tests

## Testing
- node --test ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
- node scripts/syntax-check.mjs