### PR TITLE
Stabilize post-merge WS behavior harness

### DIFF
--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -245,36 +245,48 @@ async function writeTestModule(source, filename = "ws-test-module.mjs") {
 }
 
 async function nextMessageOfType(ws, type, timeoutMs = 10000) {
-  const started = Date.now();
-  while (true) {
-    const elapsed = Date.now() - started;
-    const remainingMs = timeoutMs - elapsed;
-    if (remainingMs <= 0) {
-      break;
-    }
-
-    const frame = await nextMessage(ws, remainingMs);
-    if (frame?.type === type) {
-      return frame;
-    }
-  }
-  throw new Error(`Timed out waiting for message type: ${type}`);
+  return nextMessageMatching(
+    ws,
+    (frame) => frame?.type === type,
+    timeoutMs
+  );
 }
 
 async function nextMessageMatching(ws, predicate, timeoutMs = 10000) {
-  const started = Date.now();
-  while (true) {
-    const elapsed = Date.now() - started;
-    const remainingMs = timeoutMs - elapsed;
-    if (remainingMs <= 0) {
-      break;
-    }
-    const frame = await nextMessage(ws, remainingMs);
-    if (predicate(frame)) {
-      return frame;
-    }
-  }
-  throw new Error("Timed out waiting for matching websocket message");
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+
+    const onMessage = (data) => {
+      const frame = JSON.parse(String(data));
+      if (!predicate(frame)) return;
+      cleanup();
+      resolve(frame);
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before matching message: ${code}`));
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for matching websocket message"));
+    }, timeoutMs);
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
 }
 
 function nextCommandResultForRequest(ws, requestId, timeoutMs = 10000) {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -245,11 +245,18 @@ async function writeTestModule(source, filename = "ws-test-module.mjs") {
 }
 
 async function nextMessageOfType(ws, type, timeoutMs = 10000) {
-  return nextMessageMatching(
-    ws,
-    (frame) => frame?.type === type,
-    timeoutMs
-  );
+  try {
+    return await nextMessageMatching(
+      ws,
+      (frame) => frame?.type === type,
+      timeoutMs
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "Timed out waiting for matching websocket message") {
+      throw new Error(`Timed out waiting for message type: ${type}`);
+    }
+    throw error;
+  }
 }
 
 async function nextMessageMatching(ws, predicate, timeoutMs = 10000) {


### PR DESCRIPTION
## Summary
- make websocket test matchers listen continuously instead of reattaching between frames
- prevent back-to-back frames like commandResult + table_state from being dropped in ws behavior tests
- stabilize the post-merge WS deploy harness on main

## Testing
- node --test --test-name-pattern "server startup/auth works with persisted bootstrap disabled|same-socket frame ordering is preserved when bootstrap load is slow|human act against queued bots returns next actionable human snapshot" ws-server/server.behavior.test.mjs
- node scripts/syntax-check.mjs