### PR TITLE
Add per-action bot reaction delay

### DIFF
--- a/shared/poker-domain/poker-autoplay.mjs
+++ b/shared/poker-domain/poker-autoplay.mjs
@@ -58,16 +58,19 @@ export const runBotAutoplayLoop = async ({
   withoutPrivateState,
   chooseBotActionTrivial,
   isBotTurn,
-  applyAction
+  applyAction,
+  beforeBotActionStep
 }) => {
   let responseFinalState = initialState;
   let loopPrivateState = initialPrivateState;
   let loopVersion = initialVersion;
+  let loopSeatBotMap = seatBotMap;
+  let loopSeatUserIdsInOrder = Array.isArray(seatUserIdsInOrder) ? seatUserIdsInOrder.slice() : [];
   let botActionCount = 0;
   let botStopReason = "not_attempted";
   let lastBotActionSummary = null;
   let responseEvents = [];
-  const botsOnlyAtStart = !hasParticipatingHumanInHand(responseFinalState, seatBotMap);
+  const botsOnlyAtStart = !hasParticipatingHumanInHand(responseFinalState, loopSeatBotMap);
   const effectiveMaxBotActions = botsOnlyAtStart
     ? Math.max(maxActions, botsOnlyHandCompletionHardCap)
     : maxActions;
@@ -87,8 +90,49 @@ export const runBotAutoplayLoop = async ({
 
   while (botActionCount < effectiveMaxBotActions) {
     if (!isActionPhase(responseFinalState.phase)) { botStopReason = "non_action_phase"; break; }
-    const botTurnUserId = responseFinalState.turnUserId;
-    if (!isBotTurn(botTurnUserId, seatBotMap)) { botStopReason = "turn_not_bot"; break; }
+    let botTurnUserId = responseFinalState.turnUserId;
+    if (!isBotTurn(botTurnUserId, loopSeatBotMap)) { botStopReason = "turn_not_bot"; break; }
+
+    if (typeof beforeBotActionStep === "function") {
+      const delayedStep = await beforeBotActionStep({
+        responseFinalState,
+        loopPrivateState,
+        loopVersion,
+        seatBotMap: loopSeatBotMap,
+        seatUserIdsInOrder: loopSeatUserIdsInOrder,
+        botActionCount,
+        effectiveMaxBotActions,
+        botTurnUserId
+      });
+      if (!delayedStep?.ok) {
+        botStopReason = delayedStep?.reason || "before_step_failed";
+        break;
+      }
+      if (delayedStep.responseFinalState && typeof delayedStep.responseFinalState === "object") {
+        responseFinalState = delayedStep.responseFinalState;
+      }
+      if (delayedStep.loopPrivateState && typeof delayedStep.loopPrivateState === "object") {
+        loopPrivateState = delayedStep.loopPrivateState;
+      }
+      if (Number.isFinite(Number(delayedStep.loopVersion))) {
+        loopVersion = Number(delayedStep.loopVersion);
+      }
+      if (delayedStep.seatBotMap instanceof Map || delayedStep.seatBotMap) {
+        loopSeatBotMap = delayedStep.seatBotMap;
+      }
+      if (Array.isArray(delayedStep.seatUserIdsInOrder)) {
+        loopSeatUserIdsInOrder = delayedStep.seatUserIdsInOrder.slice();
+      }
+      if (!isActionPhase(responseFinalState.phase)) {
+        botStopReason = "non_action_phase";
+        break;
+      }
+      if (!isBotTurn(responseFinalState.turnUserId, loopSeatBotMap)) {
+        botStopReason = delayedStep?.reason || "turn_not_bot";
+        break;
+      }
+      botTurnUserId = responseFinalState.turnUserId;
+    }
 
     const botLegalInfo = computeLegalActions({ statePublic: withoutPrivateState(responseFinalState), userId: botTurnUserId });
     const botChoice = chooseBotActionTrivial(botLegalInfo.actions);
@@ -121,7 +165,7 @@ export const runBotAutoplayLoop = async ({
     const botAdvanced = runAdvanceLoop(botNextState, botEvents, botAdvanceEvents, advanceIfNeeded);
     botNextState = botAdvanced.nextState;
 
-    const botEligibleUserIds = seatUserIdsInOrder.filter((userId) =>
+    const botEligibleUserIds = loopSeatUserIdsInOrder.filter((userId) =>
       typeof userId === "string"
       && !botNextState.foldedByUserId?.[userId]
       && !botNextState.leftTableByUserId?.[userId]
@@ -138,7 +182,7 @@ export const runBotAutoplayLoop = async ({
     if ((botNeedsSingleWinnerResolution || botNeedsFullShowdownResolution) && typeof materializeShowdownState === "function") {
       botNextState = materializeShowdownState(
         botNextState,
-        seatUserIdsInOrder,
+        loopSeatUserIdsInOrder,
         loopPrivateState?.holeCardsByUserId,
         { requiresShowdownComparison: botNeedsFullShowdownResolution }
       );

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -197,6 +197,110 @@ test("accepted bot autoplay aborts cleanly when turn changes during reaction del
   assert.equal(result.reason, "turn_changed_during_delay");
 });
 
+test("accepted bot autoplay waits before each bot action in bots-only hands", async () => {
+  const seats = [{ userId: "bot_1", seatNo: 1, isBot: true }, { userId: "bot_2", seatNo: 2, isBot: true }];
+  const stacks = { bot_1: 100, bot_2: 100 };
+  let persistedState = { ...initHandState({ tableId: "t-delay-bots-only", seats, stacks }).state, handId: "h-delay-bots-only-1" };
+  let persistedVersion = 20;
+  const observedSleepMs = [];
+  const seatOrder = seats.slice().sort((a, b) => a.seatNo - b.seatNo).map((seat) => seat.userId);
+  const maybeMaterialize = (privateState) => {
+    const eligible = seatOrder.filter((userId) => !privateState.foldedByUserId?.[userId] && !privateState.leftTableByUserId?.[userId] && !privateState.sitOutByUserId?.[userId]);
+    const handId = typeof privateState.handId === "string" ? privateState.handId : "";
+    const showdownHandId = typeof privateState.showdown?.handId === "string" ? privateState.showdown.handId : "";
+    const alreadyMaterialized = !!handId && !!showdownHandId && handId === showdownHandId;
+    if (alreadyMaterialized || (eligible.length > 1 && privateState.phase !== "SHOWDOWN")) return privateState;
+    return materializeShowdownAndPayout({
+      state: privateState,
+      seatUserIdsInOrder: seatOrder,
+      holeCardsByUserId: privateState.holeCardsByUserId,
+      computeShowdown,
+      awardPotsAtShowdown,
+      klog: () => {}
+    }).nextState;
+  };
+  const tableManager = {
+    persistedPokerState: () => persistedState,
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: () => ({ seats }),
+    applyAction: ({ userId, action, amount }) => {
+      const applied = applyRuntimeAction(persistedState, { type: action, userId, amount });
+      const advanced = runAdvanceLoop(applied.state, [], [], advanceIfNeeded);
+      persistedState = maybeMaterialize(advanced.nextState);
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "2000", WS_BOT_REACTION_MAX_MS: "2000" },
+    sleep: async (ms) => {
+      observedSleepMs.push(ms);
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-delay-bots-only", trigger: "act", requestId: "r-delay-bots-only" });
+  assert.equal(result.ok, true);
+  assert.equal(result.reason, "non_action_phase");
+  assert.equal(persistedState.phase, "SETTLED");
+  assert.ok(result.actionCount > 1);
+  assert.equal(result.actionCount, observedSleepMs.length);
+  assert.deepEqual(observedSleepMs, Array(result.actionCount).fill(2000));
+});
+
+test("accepted bot autoplay aborts during a later delayed bot step when turn stops being authoritative bot turn", async () => {
+  const seats = [{ userId: "bot_1", seatNo: 1, isBot: true }, { userId: "bot_2", seatNo: 2, isBot: true }];
+  const stacks = { bot_1: 100, bot_2: 100 };
+  let persistedState = initHandState({ tableId: "t-delay-bots-race", seats, stacks }).state;
+  let persistedVersion = 30;
+  let sleepCallCount = 0;
+  let authoritativeBotTurnLost = false;
+  const tableManager = {
+    persistedPokerState: () => persistedState,
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: (_tableId, turnUserId) => ({
+      seats: seats.map((seat) => ({
+        ...seat,
+        isBot: authoritativeBotTurnLost && seat.userId === turnUserId ? false : true
+      }))
+    }),
+    applyAction: ({ userId, action, amount }) => {
+      const applied = applyRuntimeAction(persistedState, { type: action, userId, amount });
+      const advanced = runAdvanceLoop(applied.state, [], [], advanceIfNeeded);
+      persistedState = advanced.nextState;
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "2000", WS_BOT_REACTION_MAX_MS: "2000" },
+    sleep: async () => {
+      sleepCallCount += 1;
+      if (sleepCallCount === 2) {
+        authoritativeBotTurnLost = true;
+      }
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-delay-bots-race", trigger: "act", requestId: "r-delay-bots-race" });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(result.actionCount, 1);
+  assert.equal(result.reason, "turn_changed_during_delay");
+  assert.equal(sleepCallCount, 2);
+});
+
 test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
   const tableManager = {
     persistedPokerState: () => ({

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -606,33 +606,6 @@ export function createAcceptedBotStepExecutor({
     let seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
     let seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
     const cfg = getBotAutoplayConfig(env);
-    if (isBotTurnAuthoritatively(tableManager, tableId, state.turnUserId, seatBotMap)) {
-      const reactionDelayMs = resolveBotReactionDelayMs({
-        state,
-        minReactionMs: cfg.minReactionMs,
-        maxReactionMs: cfg.maxReactionMs,
-        random,
-        now
-      });
-      if (reactionDelayMs > 0) {
-        await sleep(reactionDelayMs);
-        privateState = tableManager.persistedPokerState(tableId);
-        if (!privateState || typeof privateState !== "object") {
-          return { ok: true, changed: false, actionCount: 0, reason: "missing_state_after_delay" };
-        }
-        state = withoutPrivateState(privateState);
-        lastKnown.state = state;
-        if (!isActionPhase(state?.phase) || !state?.turnUserId) {
-          return { ok: true, changed: false, actionCount: 0, reason: "turn_changed_during_delay" };
-        }
-        turnSnapshot = tableManager.tableSnapshot(tableId, state.turnUserId);
-        seatBotMap = buildSeatBotMap(turnSnapshot?.seats);
-        seatUserIdsInOrder = buildSeatUserIdsInOrder(privateState);
-        if (!isBotTurnAuthoritatively(tableManager, tableId, state.turnUserId, seatBotMap)) {
-          return { ok: true, changed: false, actionCount: 0, reason: "turn_changed_during_delay" };
-        }
-      }
-    }
     logVerbose("ws_bot_autoplay_loop_start", {
       ...baseLog,
       runtimeFlavor,
@@ -701,6 +674,61 @@ export function createAcceptedBotStepExecutor({
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
           });
           return legal;
+        },
+        beforeBotActionStep: async ({
+          responseFinalState,
+          loopPrivateState,
+          loopVersion,
+          seatBotMap: loopSeatBotMap,
+          seatUserIdsInOrder: loopSeatOrder,
+          botActionCount,
+          botTurnUserId
+        }) => {
+          if (!isBotTurnAuthoritatively(tableManager, tableId, botTurnUserId, loopSeatBotMap)) {
+            return { ok: false, reason: "turn_not_bot" };
+          }
+          const reactionDelayMs = resolveBotReactionDelayMs({
+            state: responseFinalState,
+            minReactionMs: cfg.minReactionMs,
+            maxReactionMs: cfg.maxReactionMs,
+            random,
+            now
+          });
+          if (reactionDelayMs > 0) {
+            logVerbose("ws_bot_autoplay_reaction_delay", {
+              ...baseLog,
+              botTurnUserId: botTurnUserId || null,
+              botActionCount,
+              delayMs: reactionDelayMs,
+              ...buildDiagnosticSnapshot(responseFinalState),
+              stateVersion: Number(loopVersion || tableManager.persistedStateVersion(tableId) || 0)
+            });
+            await sleep(reactionDelayMs);
+          }
+
+          const refreshedPrivateState = tableManager.persistedPokerState(tableId);
+          if (!refreshedPrivateState || typeof refreshedPrivateState !== "object") {
+            return { ok: false, reason: "missing_state_after_delay" };
+          }
+          const refreshedState = withoutPrivateState(refreshedPrivateState);
+          lastKnown.state = refreshedState;
+          if (!isActionPhase(refreshedState?.phase) || !refreshedState?.turnUserId) {
+            return { ok: false, reason: "turn_changed_during_delay" };
+          }
+          const refreshedTurnSnapshot = tableManager.tableSnapshot(tableId, refreshedState.turnUserId);
+          const refreshedSeatBotMap = buildSeatBotMap(refreshedTurnSnapshot?.seats);
+          const refreshedSeatUserIdsInOrder = buildSeatUserIdsInOrder(refreshedPrivateState);
+          if (!isBotTurnAuthoritatively(tableManager, tableId, refreshedState.turnUserId, refreshedSeatBotMap)) {
+            return { ok: false, reason: "turn_changed_during_delay" };
+          }
+          return {
+            ok: true,
+            responseFinalState: refreshedState,
+            loopPrivateState: refreshedPrivateState,
+            loopVersion: Number(tableManager.persistedStateVersion(tableId) || loopVersion || 0),
+            seatBotMap: refreshedSeatBotMap,
+            seatUserIdsInOrder: refreshedSeatUserIdsInOrder.length > 0 ? refreshedSeatUserIdsInOrder : loopSeatOrder
+          };
         },
         withoutPrivateState,
         chooseBotActionTrivial: (legalActions) => {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -245,36 +245,48 @@ async function writeTestModule(source, filename = "ws-test-module.mjs") {
 }
 
 async function nextMessageOfType(ws, type, timeoutMs = 10000) {
-  const started = Date.now();
-  while (true) {
-    const elapsed = Date.now() - started;
-    const remainingMs = timeoutMs - elapsed;
-    if (remainingMs <= 0) {
-      break;
-    }
-
-    const frame = await nextMessage(ws, remainingMs);
-    if (frame?.type === type) {
-      return frame;
-    }
-  }
-  throw new Error(`Timed out waiting for message type: ${type}`);
+  return nextMessageMatching(
+    ws,
+    (frame) => frame?.type === type,
+    timeoutMs
+  );
 }
 
 async function nextMessageMatching(ws, predicate, timeoutMs = 10000) {
-  const started = Date.now();
-  while (true) {
-    const elapsed = Date.now() - started;
-    const remainingMs = timeoutMs - elapsed;
-    if (remainingMs <= 0) {
-      break;
-    }
-    const frame = await nextMessage(ws, remainingMs);
-    if (predicate(frame)) {
-      return frame;
-    }
-  }
-  throw new Error("Timed out waiting for matching websocket message");
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+
+    const onMessage = (data) => {
+      const frame = JSON.parse(String(data));
+      if (!predicate(frame)) return;
+      cleanup();
+      resolve(frame);
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before matching message: ${code}`));
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for matching websocket message"));
+    }, timeoutMs);
+
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
 }
 
 function nextCommandResultForRequest(ws, requestId, timeoutMs = 10000) {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -245,11 +245,18 @@ async function writeTestModule(source, filename = "ws-test-module.mjs") {
 }
 
 async function nextMessageOfType(ws, type, timeoutMs = 10000) {
-  return nextMessageMatching(
-    ws,
-    (frame) => frame?.type === type,
-    timeoutMs
-  );
+  try {
+    return await nextMessageMatching(
+      ws,
+      (frame) => frame?.type === type,
+      timeoutMs
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "Timed out waiting for matching websocket message") {
+      throw new Error(`Timed out waiting for message type: ${type}`);
+    }
+    throw error;
+  }
 }
 
 async function nextMessageMatching(ws, predicate, timeoutMs = 10000) {


### PR DESCRIPTION
## Summary
- move bot reaction delay from one pre-loop pause to a per-action hook inside shared autoplay
- re-read persisted state after each delay and abort cleanly if the turn changes during the wait
- add coverage for multi-step bot delays and mid-loop turn-change races while keeping WS env=0 deterministic

## Testing
- node --test ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
- node --test --test-name-pattern "human act against queued bots returns next actionable human snapshot" ws-server/server.behavior.test.mjs
- node scripts/syntax-check.mjs