### PR TITLE
Broadcast snapshots after each bot step

### DIFF
--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -23,6 +23,28 @@ test("handleBotStepCommand broadcasts when autoplay changes state", async () => 
   assert.equal(calls.snapshots, 1);
 });
 
+test("handleBotStepCommand skips duplicate final broadcast when steps already emitted snapshots", async () => {
+  const calls = { snapshots: 0 };
+  const result = await handleBotStepCommand({
+    tableId: "t1",
+    trigger: "act",
+    requestId: "r1b",
+    runBotStep: async () => ({
+      ok: true,
+      changed: true,
+      actionCount: 3,
+      reason: "non_action_phase",
+      broadcastedStepCount: 3
+    }),
+    broadcastStateSnapshots: () => {
+      calls.snapshots += 1;
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.snapshots, 0);
+});
+
 test("handleBotStepCommand broadcasts when autoplay fails", async () => {
   const calls = { snapshots: 0 };
   const result = await handleBotStepCommand({

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -34,7 +34,9 @@ test("handleBotStepCommand skips duplicate final broadcast when steps already em
       changed: true,
       actionCount: 3,
       reason: "non_action_phase",
-      broadcastedStepCount: 3
+      broadcastedStepCount: 3,
+      lastBroadcastStateVersion: 18,
+      finalStateVersion: 18
     }),
     broadcastStateSnapshots: () => {
       calls.snapshots += 1;
@@ -43,6 +45,30 @@ test("handleBotStepCommand skips duplicate final broadcast when steps already em
 
   assert.equal(result.ok, true);
   assert.equal(calls.snapshots, 0);
+});
+
+test("handleBotStepCommand falls back to final broadcast when last step snapshot did not reach final version", async () => {
+  const calls = { snapshots: 0 };
+  const result = await handleBotStepCommand({
+    tableId: "t1",
+    trigger: "act",
+    requestId: "r1c",
+    runBotStep: async () => ({
+      ok: true,
+      changed: true,
+      actionCount: 3,
+      reason: "non_action_phase",
+      broadcastedStepCount: 2,
+      lastBroadcastStateVersion: 17,
+      finalStateVersion: 18
+    }),
+    broadcastStateSnapshots: () => {
+      calls.snapshots += 1;
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.snapshots, 1);
 });
 
 test("handleBotStepCommand broadcasts when autoplay fails", async () => {

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -30,8 +30,13 @@ export async function handleBotStepCommand({
     });
   }
 
-  const stepSnapshotsAlreadyBroadcast = Number(botStepResult?.broadcastedStepCount || 0) > 0;
-  if (botStepResult?.ok === false || (botStepResult?.changed === true && !stepSnapshotsAlreadyBroadcast)) {
+  const lastBroadcastStateVersion = Number(botStepResult?.lastBroadcastStateVersion);
+  const finalStateVersion = Number(botStepResult?.finalStateVersion);
+  const finalStateAlreadyBroadcast =
+    Number.isFinite(lastBroadcastStateVersion)
+    && Number.isFinite(finalStateVersion)
+    && lastBroadcastStateVersion === finalStateVersion;
+  if (botStepResult?.ok === false || (botStepResult?.changed === true && !finalStateAlreadyBroadcast)) {
     broadcastStateSnapshots(tableId);
   }
   return botStepResult;

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -30,7 +30,8 @@ export async function handleBotStepCommand({
     });
   }
 
-  if (botStepResult?.ok === false || botStepResult?.changed === true) {
+  const stepSnapshotsAlreadyBroadcast = Number(botStepResult?.broadcastedStepCount || 0) > 0;
+  if (botStepResult?.ok === false || (botStepResult?.changed === true && !stepSnapshotsAlreadyBroadcast)) {
     broadcastStateSnapshots(tableId);
   }
   return botStepResult;

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -203,6 +203,7 @@ test("accepted bot autoplay waits before each bot action in bots-only hands", as
   let persistedState = { ...initHandState({ tableId: "t-delay-bots-only", seats, stacks }).state, handId: "h-delay-bots-only-1" };
   let persistedVersion = 20;
   const observedSleepMs = [];
+  let broadcastedStepCount = 0;
   const seatOrder = seats.slice().sort((a, b) => a.seatNo - b.seatNo).map((seat) => seat.userId);
   const maybeMaterialize = (privateState) => {
     const eligible = seatOrder.filter((userId) => !privateState.foldedByUserId?.[userId] && !privateState.leftTableByUserId?.[userId] && !privateState.sitOutByUserId?.[userId]);
@@ -238,6 +239,9 @@ test("accepted bot autoplay waits before each bot action in bots-only hands", as
     sleep: async (ms) => {
       observedSleepMs.push(ms);
     },
+    onBotStepPersisted: async () => {
+      broadcastedStepCount += 1;
+    },
     persistMutatedState: async () => ({ ok: true }),
     restoreTableFromPersisted: async () => ({ ok: true }),
     broadcastResyncRequired: () => {},
@@ -249,7 +253,9 @@ test("accepted bot autoplay waits before each bot action in bots-only hands", as
   assert.equal(result.reason, "non_action_phase");
   assert.equal(persistedState.phase, "SETTLED");
   assert.ok(result.actionCount > 1);
+  assert.equal(result.broadcastedStepCount, result.actionCount);
   assert.equal(result.actionCount, observedSleepMs.length);
+  assert.equal(broadcastedStepCount, result.actionCount);
   assert.deepEqual(observedSleepMs, Array(result.actionCount).fill(2000));
 });
 

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -307,6 +307,66 @@ test("accepted bot autoplay aborts during a later delayed bot step when turn sto
   assert.equal(sleepCallCount, 2);
 });
 
+test("accepted bot autoplay exposes final state version when a later step broadcast fails", async () => {
+  const seats = [{ userId: "bot_1", seatNo: 1, isBot: true }, { userId: "bot_2", seatNo: 2, isBot: true }];
+  const stacks = { bot_1: 100, bot_2: 100 };
+  let persistedState = { ...initHandState({ tableId: "t-delay-broadcast-fail", seats, stacks }).state, handId: "h-delay-broadcast-fail-1" };
+  let persistedVersion = 40;
+  let stepBroadcastCalls = 0;
+  const seatOrder = seats.slice().sort((a, b) => a.seatNo - b.seatNo).map((seat) => seat.userId);
+  const maybeMaterialize = (privateState) => {
+    const eligible = seatOrder.filter((userId) => !privateState.foldedByUserId?.[userId] && !privateState.leftTableByUserId?.[userId] && !privateState.sitOutByUserId?.[userId]);
+    const handId = typeof privateState.handId === "string" ? privateState.handId : "";
+    const showdownHandId = typeof privateState.showdown?.handId === "string" ? privateState.showdown.handId : "";
+    const alreadyMaterialized = !!handId && !!showdownHandId && handId === showdownHandId;
+    if (alreadyMaterialized || (eligible.length > 1 && privateState.phase !== "SHOWDOWN")) return privateState;
+    return materializeShowdownAndPayout({
+      state: privateState,
+      seatUserIdsInOrder: seatOrder,
+      holeCardsByUserId: privateState.holeCardsByUserId,
+      computeShowdown,
+      awardPotsAtShowdown,
+      klog: () => {}
+    }).nextState;
+  };
+  const tableManager = {
+    persistedPokerState: () => persistedState,
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: () => ({ seats }),
+    applyAction: ({ userId, action, amount }) => {
+      const applied = applyRuntimeAction(persistedState, { type: action, userId, amount });
+      const advanced = runAdvanceLoop(applied.state, [], [], advanceIfNeeded);
+      persistedState = maybeMaterialize(advanced.nextState);
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    env: { WS_BOT_REACTION_MIN_MS: "0", WS_BOT_REACTION_MAX_MS: "0" },
+    onBotStepPersisted: async () => {
+      stepBroadcastCalls += 1;
+      if (stepBroadcastCalls >= 2) {
+        throw new Error("snapshot_push_failed");
+      }
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-delay-broadcast-fail", trigger: "act", requestId: "r-delay-broadcast-fail" });
+  assert.equal(result.ok, true);
+  assert.ok(result.actionCount > 1);
+  assert.ok(result.broadcastedStepCount >= 1);
+  assert.ok(result.broadcastedStepCount < result.actionCount);
+  assert.ok(Number.isFinite(result.lastBroadcastStateVersion));
+  assert.equal(result.finalStateVersion, persistedVersion);
+  assert.ok(result.finalStateVersion > result.lastBroadcastStateVersion);
+});
+
 test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
   const tableManager = {
     persistedPokerState: () => ({

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -616,6 +616,7 @@ export function createAcceptedBotStepExecutor({
     });
     try {
       let broadcastedStepCount = 0;
+      let lastBroadcastStateVersion = null;
       const botLoop = await runBotAutoplayLoop({
         tableId,
         requestId: `${trigger || "ws"}:${requestId || "no-request-id"}`,
@@ -855,6 +856,7 @@ export function createAcceptedBotStepExecutor({
               latestState
             });
             broadcastedStepCount += 1;
+            lastBroadcastStateVersion = Number(applied.stateVersion);
           } catch (error) {
             klog("ws_bot_autoplay_step_broadcast_failed", {
               ...baseLog,
@@ -891,6 +893,7 @@ export function createAcceptedBotStepExecutor({
         ? tableManager.tableSnapshot(tableId, finalTurnUserId)
         : tableManager.tableSnapshot(tableId, state.turnUserId || "");
       const finalSeatBotMap = buildSeatBotMap(finalTurnSnapshot?.seats);
+      const finalStateVersion = Number(tableManager.persistedStateVersion(tableId) || 0);
       const pendingBotTurn = !!finalPublicState
         && isActionPhase(finalPublicState.phase)
         && isBotTurnAuthoritatively(tableManager, tableId, finalTurnUserId, finalSeatBotMap);
@@ -901,6 +904,8 @@ export function createAcceptedBotStepExecutor({
         actionCount: botLoop?.botActionCount || 0,
         reason: botLoop?.botStopReason || "not_attempted",
         broadcastedStepCount,
+        lastBroadcastStateVersion,
+        finalStateVersion,
         pendingBotTurn,
         phase: typeof finalPublicState?.phase === "string" ? finalPublicState.phase : null,
         turnUserId: finalTurnUserId,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -530,6 +530,7 @@ export function createAcceptedBotStepExecutor({
   persistMutatedState,
   restoreTableFromPersisted,
   broadcastResyncRequired,
+  onBotStepPersisted = () => {},
   env = process.env,
   random = Math.random,
   now = Date.now,
@@ -614,6 +615,7 @@ export function createAcceptedBotStepExecutor({
       maxActions: 1
     });
     try {
+      let broadcastedStepCount = 0;
       const botLoop = await runBotAutoplayLoop({
         tableId,
         requestId: `${trigger || "ws"}:${requestId || "no-request-id"}`,
@@ -844,6 +846,25 @@ export function createAcceptedBotStepExecutor({
             legalActionSummary: lastKnown.legalActionSummary,
             stateVersion: Number(applied.stateVersion)
           });
+          try {
+            await onBotStepPersisted({
+              tableId,
+              botTurnUserId,
+              botAction,
+              stateVersion: Number(applied.stateVersion),
+              latestState
+            });
+            broadcastedStepCount += 1;
+          } catch (error) {
+            klog("ws_bot_autoplay_step_broadcast_failed", {
+              ...baseLog,
+              botTurnUserId: botTurnUserId || null,
+              actionType: botAction?.type || null,
+              amount: botAction?.amount ?? null,
+              stateVersion: Number(applied.stateVersion),
+              message: error?.message || "unknown"
+            });
+          }
           return {
             ok: true,
             loopVersion: Number(applied.stateVersion),
@@ -879,6 +900,7 @@ export function createAcceptedBotStepExecutor({
         changed: (botLoop?.botActionCount || 0) > 0,
         actionCount: botLoop?.botActionCount || 0,
         reason: botLoop?.botStopReason || "not_attempted",
+        broadcastedStepCount,
         pendingBotTurn,
         phase: typeof finalPublicState?.phase === "string" ? finalPublicState.phase : null,
         turnUserId: finalTurnUserId,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -231,6 +231,9 @@ async function loadAcceptedBotAutoplayExecutor() {
           persistMutatedState,
           restoreTableFromPersisted,
           broadcastResyncRequired,
+          onBotStepPersisted: ({ tableId }) => {
+            broadcastStateSnapshots(tableId);
+          },
           env: process.env,
           klog: klogSafe
         });


### PR DESCRIPTION
## Summary
- broadcast WS state snapshots after every persisted bot action during autoplay
- avoid duplicate final bot autoplay broadcast when step snapshots already went out
- cover per-step snapshot emission in bot autoplay runtime and handler tests

## Testing
- node --test ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
- node --test ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
- node --test --test-name-pattern "human act against queued bots returns next actionable human snapshot" ws-server/server.behavior.test.mjs
- node scripts/syntax-check.mjs