### PR TITLE
Fix poker v2 hero active ring

### DIFF
--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -62,7 +62,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat--hero{width:124px; z-index:2;}
 
-.poker-seat--hero .poker-seat-avatar{width:96px; height:96px; font-size:0.9rem; border-color:rgba(92,251,156,0.88); box-shadow:0 0 0 4px rgba(99,247,166,0.2), 0 12px 24px rgba(0,0,0,0.54);}
+.poker-seat--hero .poker-seat-avatar{width:96px; height:96px; font-size:0.9rem; box-shadow:0 12px 24px rgba(0,0,0,0.54);}
+.poker-seat--hero.poker-seat--active .poker-seat-avatar{border-color:rgba(84,245,152,0.88); box-shadow:0 0 0 4px rgba(99,247,166,0.2), 0 12px 24px rgba(0,0,0,0.54);}
 
 .poker-seat--hero .poker-seat-name{padding-right:78px;}
 

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -28,5 +28,7 @@ assert.equal(tableV2Html.indexOf('id="pokerSeatLayer"') < tableV2Html.indexOf('i
 assert.equal(tableV2Html.indexOf('id="pokerDealerChip"') < tableV2Html.indexOf('class="poker-center-layer"'), true, 'dealer chip should not live inside the center layer');
 assert.match(tableV2Css, /\.poker-menu-panel\[hidden\]\{display:none;\}/, 'poker table v2 menu should hard-hide when hidden attribute is present');
 assert.match(tableV2Css, /\.poker-action-bar\{position:fixed; right:max\(10px, env\(safe-area-inset-right\)\); bottom:max\(10px, env\(safe-area-inset-bottom\)\); width:min\(33vw, 196px\); display:grid; grid-template-columns:40px minmax\(0, 1fr\);/, 'poker table v2 action rail should dock to the bottom-right with a left-side vertical amount slider');
+assert.doesNotMatch(tableV2Css, /\.poker-seat--hero \.poker-seat-avatar\{[^}]*border-color:/, 'hero avatar should not keep an always-on active ring');
+assert.match(tableV2Css, /\.poker-seat--hero\.poker-seat--active \.poker-seat-avatar\{border-color:rgba\(84,245,152,0\.88\);/, 'hero avatar should turn green only on the active turn');
 assert.match(tableV2Html, /id="pokerBootSplash"/, 'poker table v2 should render a boot splash to avoid raw HTML flash');
 assert.match(tableV2Html, /id="pokerV2AmountValue"/, 'poker table v2 should render a compact amount value for the action slider');


### PR DESCRIPTION
## Summary
- remove the always-on green hero avatar ring in poker table v2
- keep the green ring only when the hero seat is actually active
- add a static CSS contract test so the hero ring does not regress

## Testing
- node tests/static-html.behavior.test.mjs
- node scripts/syntax-check.mjs