### PR TITLE
Add poker v2 winner reveal window

### DIFF
--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -24,6 +24,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
+.poker-seat-winner-badge{position:absolute; left:50%; top:-12px; transform:translateX(-50%); padding:4px 10px; border-radius:999px; border:1px solid rgba(255,226,160,0.72); background:linear-gradient(180deg, rgba(86,57,16,0.96), rgba(24,16,8,0.94)); color:#fff4d2; font-size:0.62rem; font-weight:800; letter-spacing:0.08em; text-transform:uppercase; box-shadow:0 8px 18px rgba(0,0,0,0.34), inset 0 1px 1px rgba(255,244,208,0.24); z-index:3; pointer-events:none;}
+
 .poker-seat-avatar{position:relative; overflow:hidden; isolation:isolate; width:76px; height:76px; margin:0 auto 7px; border-radius:50%; border:2px solid rgba(255,202,127,0.6); background:radial-gradient(circle at 50% 24%, rgba(255,235,214,0.22), rgba(26,25,30,0.74) 42%, rgba(7,8,10,0.98) 78%), linear-gradient(155deg, rgba(23,26,34,0.95), rgba(8,9,13,0.99)); box-shadow:0 8px 18px rgba(0,0,0,0.48); display:flex; align-items:flex-end; justify-content:center; font-size:0.8rem; letter-spacing:0.04em; color:#ebf2ff; padding-bottom:8px;}
 
 .poker-seat-turn-clock{position:absolute; inset:-2px; border-radius:50%; pointer-events:none; z-index:1; opacity:0.88; background:conic-gradient(from -90deg, transparent 0turn, transparent calc((1 - var(--turn-progress, 0)) * 1turn), rgba(19,24,34,0.62) calc((1 - var(--turn-progress, 0)) * 1turn), rgba(19,24,34,0.62) 1turn); transform:scaleX(-1);}
@@ -53,6 +55,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat--active .poker-seat-avatar{border-color:rgba(84,245,152,0.88); box-shadow:0 0 0 3px rgba(64,225,135,0.24), 0 12px 24px rgba(0,0,0,0.54);}
 
 .poker-seat--active .poker-seat-status{color:#8df8bf; border-color:rgba(97,241,163,0.72); background:rgba(19,58,39,0.72);}
+
+.poker-seat--winner .poker-seat-avatar{border-color:rgba(255,219,133,0.88); box-shadow:0 0 0 3px rgba(255,210,99,0.15), 0 12px 22px rgba(0,0,0,0.5);}
 
 .poker-seat--folded{opacity:0.62;}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -24,7 +24,12 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
-.poker-seat-winner-badge{position:absolute; left:50%; top:-12px; transform:translateX(-50%); padding:4px 10px; border-radius:999px; border:1px solid rgba(255,226,160,0.72); background:linear-gradient(180deg, rgba(86,57,16,0.96), rgba(24,16,8,0.94)); color:#fff4d2; font-size:0.62rem; font-weight:800; letter-spacing:0.08em; text-transform:uppercase; box-shadow:0 8px 18px rgba(0,0,0,0.34), inset 0 1px 1px rgba(255,244,208,0.24); z-index:3; pointer-events:none;}
+.poker-seat-winner-badge{position:absolute; left:50%; top:-18px; transform:translateX(-50%); min-width:68px; padding:5px 8px 6px; border-radius:14px; border:1px solid rgba(255,226,160,0.72); background:linear-gradient(180deg, rgba(86,57,16,0.96), rgba(24,16,8,0.94)); color:#fff4d2; font-size:0.62rem; font-weight:800; letter-spacing:0.08em; text-transform:uppercase; box-shadow:0 8px 18px rgba(0,0,0,0.34), inset 0 1px 1px rgba(255,244,208,0.24); z-index:3; pointer-events:none; display:flex; flex-direction:column; align-items:center; gap:4px;}
+.poker-seat-winner-title{line-height:1;}
+.poker-seat-winner-label{font-size:0.5rem; font-weight:700; letter-spacing:0.04em; line-height:1.05; text-transform:uppercase; color:#ffe7b4;}
+.poker-seat-winner-cards{display:flex; flex-wrap:wrap; justify-content:center; gap:3px; max-width:74px;}
+.poker-seat-winner-card{display:flex; align-items:center; justify-content:center; min-width:20px; height:14px; padding:0 3px; border-radius:999px; background:rgba(245,248,255,0.96); color:#0f172a; font-size:0.48rem; font-weight:700; line-height:1; box-shadow:0 3px 7px rgba(0,0,0,0.24);}
+.poker-seat-winner-card--red{color:#b91c1c;}
 
 .poker-seat-avatar{position:relative; overflow:hidden; isolation:isolate; width:76px; height:76px; margin:0 auto 7px; border-radius:50%; border:2px solid rgba(255,202,127,0.6); background:radial-gradient(circle at 50% 24%, rgba(255,235,214,0.22), rgba(26,25,30,0.74) 42%, rgba(7,8,10,0.98) 78%), linear-gradient(155deg, rgba(23,26,34,0.95), rgba(8,9,13,0.99)); box-shadow:0 8px 18px rgba(0,0,0,0.48); display:flex; align-items:flex-end; justify-content:center; font-size:0.8rem; letter-spacing:0.04em; color:#ebf2ff; padding-bottom:8px;}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -43,7 +43,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat-stack{display:inline-flex; align-items:center; justify-content:center; min-width:80px; padding:6px 12px; border-radius:18px; border:1px solid rgba(255,220,177,0.25); background:linear-gradient(180deg, rgba(7,13,24,0.88), rgba(2,5,11,0.95)); box-shadow:0 6px 14px rgba(0,0,0,0.42), inset 0 1px 1px rgba(255,255,255,0.12); font-size:1.05rem; font-weight:700; color:#fef7e5;}
 
-.poker-seat-cards{margin-top:6px; display:flex; justify-content:center; gap:4px;}
+.poker-seat-cards{margin-top:6px; display:flex; justify-content:center; gap:3px;}
 
 .poker-seat-name{margin-top:4px; font-size:0.68rem; font-weight:500; color:rgba(235,241,255,0.78);}
 
@@ -80,21 +80,21 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-pot-pill{display:inline-flex; padding:8px 24px; border-radius:22px; border:1px solid rgba(255,208,128,0.38); background:linear-gradient(180deg, rgba(8,16,26,0.88), rgba(2,6,10,0.95)); font-size:2rem; font-weight:700; line-height:1; color:#f8efd6; box-shadow:0 10px 20px rgba(0,0,0,0.45), inset 0 1px 1px rgba(255,255,255,0.13);}
 
-.poker-community-cards{margin:18px auto 0; display:flex; align-items:center; justify-content:center; gap:6px;}
+.poker-community-cards{margin:18px auto 0; display:flex; align-items:center; justify-content:center; gap:5px;}
 
 .poker-dealer-chip{position:absolute; left:50%; top:50%; transform:translate(-50%, -50%); z-index:4; pointer-events:none; width:38px; height:38px; border-radius:50%; border:2px solid rgba(96,71,26,0.9); background:linear-gradient(180deg, #fee7a4, #d9ab4e); color:#2f1e09; font-size:1.25rem; font-weight:700; display:flex; align-items:center; justify-content:center; box-shadow:0 7px 16px rgba(0,0,0,0.45);}
 
-.poker-card{width:51px; height:70px; border-radius:7px; border:1px solid rgba(25,33,53,0.36); background:linear-gradient(180deg, #ffffff, #eef2fa); color:#111827; box-shadow:0 7px 14px rgba(0,0,0,0.32); display:flex; flex-direction:column; align-items:center; justify-content:center; font-size:1.75rem; font-weight:700; line-height:1;}
+.poker-card{width:46px; height:63px; border-radius:7px; border:1px solid rgba(25,33,53,0.36); background:linear-gradient(180deg, #ffffff, #eef2fa); color:#111827; box-shadow:0 7px 14px rgba(0,0,0,0.32); display:flex; flex-direction:column; align-items:center; justify-content:center; font-size:1.58rem; font-weight:700; line-height:1;}
 
-.poker-card small{margin-top:3px; font-size:0.92rem; font-weight:700;}
+.poker-card small{margin-top:3px; font-size:0.84rem; font-weight:700;}
 
 .poker-card--back{background:linear-gradient(145deg, #42567f, #1e2a47); border-color:rgba(170,188,222,0.45); position:relative; overflow:hidden;}
 
-.poker-card--back::before{content:""; position:absolute; inset:7px; border:1px solid rgba(211,222,246,0.45); border-radius:4px;}
+.poker-card--back::before{content:""; position:absolute; inset:6px; border:1px solid rgba(211,222,246,0.45); border-radius:4px;}
 
 .poker-card--red{color:#c82323;}
 
-.poker-hero-cards{position:absolute; left:50%; bottom:124px; transform:translateX(-50%); display:flex; gap:10px; z-index:3;}
+.poker-hero-cards{position:absolute; left:50%; bottom:124px; transform:translateX(-50%); display:flex; gap:9px; z-index:3;}
 
 .poker-hero-cards .poker-card:first-child{transform:rotate(-10deg);}
 
@@ -162,7 +162,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-amount-input.is-disabled input{accent-color:#6b7280;}
 
-@media (min-width:480px){.poker-scene{height:min(76vh, 860px);} .poker-seat{width:126px;} .poker-hero-cards{bottom:136px;} .poker-card{width:56px; height:76px;}}
+@media (min-width:480px){.poker-scene{height:min(76vh, 860px);} .poker-seat{width:126px;} .poker-hero-cards{bottom:136px;} .poker-card{width:50px; height:68px;}}
 
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -75,6 +75,7 @@
   var currentAccessToken = null;
   var authWatchTimer = null;
   var turnClockTimer = null;
+  var revealDismissTimer = null;
   var authUnsubscribe = null;
   var renderedSeatAnchors = {};
   var renderedSeatSlots = {};
@@ -90,6 +91,7 @@
     revealedWinnerCardsByUserId: {},
     communityCards: []
   };
+  var pendingPostRevealSnapshot = null;
   var els = {};
 
   function cloneState(source){
@@ -592,6 +594,45 @@
     return stickyWinnerReveal;
   }
 
+  function clearWinnerRevealTimer(){
+    if (!revealDismissTimer) return;
+    try { window.clearTimeout(revealDismissTimer); } catch (_err){}
+    revealDismissTimer = null;
+  }
+
+  function extractSnapshotHandId(payload){
+    if (!isObject(payload)) return null;
+    if (typeof payload.handId === 'string' && payload.handId) return payload.handId;
+    if (isObject(payload.hand) && typeof payload.hand.handId === 'string' && payload.hand.handId) return payload.hand.handId;
+    if (isObject(payload.public) && isObject(payload.public.hand) && typeof payload.public.hand.handId === 'string' && payload.public.hand.handId) return payload.public.hand.handId;
+    return null;
+  }
+
+  function scheduleRevealDismiss(){
+    var sticky = getActiveWinnerReveal();
+    clearWinnerRevealTimer();
+    if (!sticky) return;
+    var remainingMs = Math.max(0, sticky.visibleUntilMs - Date.now());
+    revealDismissTimer = window.setTimeout(function(){
+      revealDismissTimer = null;
+      stickyWinnerReveal.visibleUntilMs = 0;
+      if (pendingPostRevealSnapshot){
+        var nextPayload = pendingPostRevealSnapshot;
+        pendingPostRevealSnapshot = null;
+        mergeSnapshot(nextPayload);
+      }
+      render();
+      autoJoinSeat();
+    }, remainingMs);
+  }
+
+  function shouldDeferSnapshotUntilRevealEnds(payload){
+    var sticky = getActiveWinnerReveal();
+    if (!sticky) return false;
+    var nextHandId = extractSnapshotHandId(payload);
+    return !!(nextHandId && sticky.handId && nextHandId !== sticky.handId);
+  }
+
   function getDisplayWinnerUserIds(){
     if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.length){
       return state.showdown.winners;
@@ -676,6 +717,7 @@
     state.handSettlement = normalizeHandSettlement(handSettlementObj);
     state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
     if (state.handId && previousHandId && state.handId !== previousHandId && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
+      clearWinnerRevealTimer();
       stickyWinnerReveal.visibleUntilMs = 0;
     }
     syncStickyWinnerReveal();
@@ -1447,6 +1489,8 @@
 
   function stopLiveMode(){
     stopTurnClock();
+    clearWinnerRevealTimer();
+    pendingPostRevealSnapshot = null;
     state.wsReady = false;
     if (wsClient && typeof wsClient.destroy === 'function'){
       try { wsClient.destroy(); } catch (_err){}
@@ -1511,7 +1555,13 @@
         }
       },
       onSnapshot: function(snapshot){
-        mergeSnapshot(snapshot && snapshot.payload ? snapshot.payload : null);
+        var payload = snapshot && snapshot.payload ? snapshot.payload : null;
+        if (shouldDeferSnapshotUntilRevealEnds(payload)){
+          pendingPostRevealSnapshot = payload;
+          scheduleRevealDismiss();
+          return;
+        }
+        mergeSnapshot(payload);
         render();
         autoJoinSeat();
       },

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1030,6 +1030,8 @@
       els.dealerChip.hidden = true;
       return;
     }
+    var heroSeat = deriveCurrentSeat();
+    var heroHasDealerChip = !!(heroSeat && Number.isInteger(heroSeat.seatNo) && heroSeat.seatNo === targetSeatNo);
     var scene = els.dealerChip.parentElement || null;
     var avatarEl = renderedSeatAvatars[targetSeatNo] || null;
     if (scene && avatarEl && typeof scene.getBoundingClientRect === 'function' && typeof avatarEl.getBoundingClientRect === 'function'){
@@ -1050,9 +1052,12 @@
           var avatarRadius = Math.min(avatarRect.width, avatarRect.height) / 2;
           var chipRadius = Math.min(chipRect.width || 38, chipRect.height || 38) / 2;
           var contactDistance = avatarRadius + chipRadius - 2;
+          var chipLeftPx = avatarCenterX + (unitX * contactDistance);
+          var chipTopPx = avatarCenterY + (unitY * contactDistance);
+          if (heroHasDealerChip) chipLeftPx -= chipRadius;
           els.dealerChip.hidden = false;
-          els.dealerChip.style.left = Math.round(avatarCenterX + (unitX * contactDistance)) + 'px';
-          els.dealerChip.style.top = Math.round(avatarCenterY + (unitY * contactDistance)) + 'px';
+          els.dealerChip.style.left = Math.round(chipLeftPx) + 'px';
+          els.dealerChip.style.top = Math.round(chipTopPx) + 'px';
           return;
         }
       }
@@ -1077,7 +1082,7 @@
     if (slotIndex === 0) chipOffset = { x: 8, y: 7 };
     else if (slotIndex === 1) chipOffset = { x: -8, y: 8 };
     else if (slotIndex === 2) chipOffset = { x: -8, y: 7 };
-    else if (slotIndex === 3) chipOffset = { x: -13, y: 3 };
+    else if (slotIndex === 3) chipOffset = { x: -32, y: 3 };
     else if (slotIndex === 4) chipOffset = { x: 8, y: 7 };
     else if (slotIndex === 5) chipOffset = { x: 8, y: 8 };
     els.dealerChip.hidden = false;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -86,7 +86,8 @@
     handId: null,
     visibleUntilMs: 0,
     winners: [],
-    revealedWinnerCardsByUserId: {}
+    revealedWinnerCardsByUserId: {},
+    communityCards: []
   };
   var els = {};
 
@@ -578,7 +579,8 @@
         handId: handId,
         visibleUntilMs: Date.now() + WINNER_REVEAL_MS,
         winners: winners.slice(),
-        revealedWinnerCardsByUserId: cloneRevealedWinnerCards(state.revealedWinnerCardsByUserId)
+        revealedWinnerCardsByUserId: cloneRevealedWinnerCards(state.revealedWinnerCardsByUserId),
+        communityCards: Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []
       };
     }
   }
@@ -956,7 +958,10 @@
   function renderCommunityCards(){
     if (!els.communityCards) return;
     els.communityCards.innerHTML = '';
-    state.communityCards.forEach(function(card){
+    var cards = Array.isArray(state.communityCards) && state.communityCards.length
+      ? state.communityCards
+      : (getActiveWinnerReveal() ? stickyWinnerReveal.communityCards : []);
+    cards.forEach(function(card){
       els.communityCards.appendChild(createCard(card));
     });
   }
@@ -1000,8 +1005,8 @@
     }
     var chipOffset = { x: 0, y: -8 };
     if (slotIndex === 0) chipOffset = { x: 0, y: 8 };
-    else if (slotIndex === 1) chipOffset = { x: -9, y: 5 };
-    else if (slotIndex === 2) chipOffset = { x: -9, y: -5 };
+    else if (slotIndex === 1) chipOffset = { x: -12, y: -2 };
+    else if (slotIndex === 2) chipOffset = { x: -12, y: -12 };
     else if (slotIndex === 3) chipOffset = { x: 11, y: -7 };
     else if (slotIndex === 4) chipOffset = { x: 9, y: -5 };
     else if (slotIndex === 5) chipOffset = { x: 9, y: 5 };

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1043,13 +1043,13 @@
         slotIndex = 3;
       }
     }
-    var chipOffset = { x: 0, y: -14 };
-    if (slotIndex === 0) chipOffset = { x: 0, y: -16 };
-    else if (slotIndex === 1) chipOffset = { x: -16, y: -15 };
-    else if (slotIndex === 2) chipOffset = { x: -16, y: -18 };
-    else if (slotIndex === 3) chipOffset = { x: 14, y: -16 };
-    else if (slotIndex === 4) chipOffset = { x: 16, y: -18 };
-    else if (slotIndex === 5) chipOffset = { x: 16, y: -15 };
+    var chipOffset = { x: 0, y: 7 };
+    if (slotIndex === 0) chipOffset = { x: 8, y: 7 };
+    else if (slotIndex === 1) chipOffset = { x: -8, y: 8 };
+    else if (slotIndex === 2) chipOffset = { x: -8, y: 7 };
+    else if (slotIndex === 3) chipOffset = { x: -13, y: 3 };
+    else if (slotIndex === 4) chipOffset = { x: 8, y: 7 };
+    else if (slotIndex === 5) chipOffset = { x: 8, y: 8 };
     els.dealerChip.hidden = false;
     els.dealerChip.style.left = (anchor.x + chipOffset.x) + '%';
     els.dealerChip.style.top = (anchor.y + chipOffset.y) + '%';

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -88,7 +88,7 @@
     handId: null,
     visibleUntilMs: 0,
     winners: [],
-    revealedWinnerCardsByUserId: {},
+    revealedShowdownCardsByUserId: {},
     communityCards: []
   };
   var pendingPostRevealSnapshot = null;
@@ -124,7 +124,7 @@
       wsReady: false,
       showdown: null,
       handSettlement: null,
-      revealedWinnerCardsByUserId: {}
+      revealedShowdownCardsByUserId: {}
     };
   }
 
@@ -524,8 +524,8 @@
       reason: typeof source.reason === 'string' ? source.reason : null,
       handId: typeof source.handId === 'string' ? source.handId : null
     };
-    if (Array.isArray(source.revealedWinners)){
-      showdown.revealedWinners = source.revealedWinners
+    if (Array.isArray(source.revealedShowdownParticipants)){
+      showdown.revealedShowdownParticipants = source.revealedShowdownParticipants
         .filter(function(entry){
           return entry && typeof entry.userId === 'string';
         })
@@ -550,10 +550,10 @@
     };
   }
 
-  function mapRevealedWinnerCards(showdown){
+  function mapRevealedShowdownCards(showdown){
     var revealed = {};
-    if (!showdown || !Array.isArray(showdown.revealedWinners)) return revealed;
-    showdown.revealedWinners.forEach(function(entry){
+    if (!showdown || !Array.isArray(showdown.revealedShowdownParticipants)) return revealed;
+    showdown.revealedShowdownParticipants.forEach(function(entry){
       if (!entry || typeof entry.userId !== 'string') return;
       if (!Array.isArray(entry.holeCards) || entry.holeCards.length !== 2) return;
       revealed[entry.userId] = entry.holeCards.slice(0, 2);
@@ -582,7 +582,7 @@
         handId: handId,
         visibleUntilMs: Date.now() + WINNER_REVEAL_MS,
         winners: winners.slice(),
-        revealedWinnerCardsByUserId: cloneRevealedWinnerCards(state.revealedWinnerCardsByUserId),
+        revealedShowdownCardsByUserId: cloneRevealedWinnerCards(state.revealedShowdownCardsByUserId),
         communityCards: Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []
       };
     }
@@ -715,7 +715,7 @@
     }
     state.showdown = normalizeShowdown(showdownObj);
     state.handSettlement = normalizeHandSettlement(handSettlementObj);
-    state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
+    state.revealedShowdownCardsByUserId = mapRevealedShowdownCards(state.showdown);
     if (state.handId && previousHandId && state.handId !== previousHandId && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
       clearWinnerRevealTimer();
       stickyWinnerReveal.visibleUntilMs = 0;
@@ -894,9 +894,9 @@
 
   function getSeatRevealCards(seat){
     if (!seat || typeof seat.userId !== 'string') return null;
-    var revealed = state.revealedWinnerCardsByUserId && state.revealedWinnerCardsByUserId[seat.userId];
+    var revealed = state.revealedShowdownCardsByUserId && state.revealedShowdownCardsByUserId[seat.userId];
     if ((!Array.isArray(revealed) || revealed.length !== 2) && getActiveWinnerReveal()){
-      revealed = stickyWinnerReveal.revealedWinnerCardsByUserId[seat.userId];
+      revealed = stickyWinnerReveal.revealedShowdownCardsByUserId[seat.userId];
     }
     return Array.isArray(revealed) && revealed.length === 2 ? revealed : null;
   }

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -709,10 +709,16 @@
   }
 
   function getHeroBestHand(){
-    var mergedCards = (Array.isArray(state.heroCards) ? state.heroCards.slice(0, 2) : []).concat(Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []);
+    var mergedCards = (Array.isArray(state.heroCards) ? state.heroCards.slice(0, 2) : []).concat(getDisplayCommunityCards());
     var best = evaluateViewerBestHand(mergedCards);
     if (!best || !Array.isArray(best.cards) || best.cards.length !== 5) return null;
     return best;
+  }
+
+  function getDisplayCommunityCards(){
+    if (Array.isArray(state.communityCards) && state.communityCards.length) return state.communityCards.slice(0, 5);
+    var sticky = getActiveWinnerReveal();
+    return sticky && Array.isArray(sticky.communityCards) ? sticky.communityCards.slice(0, 5) : [];
   }
 
   function resolveStack(userId){
@@ -846,6 +852,20 @@
     return Array.isArray(revealed) && revealed.length === 2 ? revealed : null;
   }
 
+  function getWinnerHandSummary(seat){
+    if (!seat || typeof seat.userId !== 'string') return null;
+    var revealCards = getSeatRevealCards(seat);
+    if (!Array.isArray(revealCards) || revealCards.length !== 2) return null;
+    var boardCards = getDisplayCommunityCards();
+    if (!Array.isArray(boardCards) || boardCards.length < 3) return null;
+    var best = evaluateViewerBestHand(revealCards.concat(boardCards));
+    if (!best || !Array.isArray(best.cards) || best.cards.length !== 5) return null;
+    return {
+      label: formatViewerHandCategory(best.category),
+      cards: best.cards.slice(0, 5)
+    };
+  }
+
   function renderSeats(){
     if (!els.seatLayer) return;
     els.seatLayer.innerHTML = '';
@@ -928,7 +948,27 @@
       if (seat && isWinnerSeat(seat)){
         var winnerBadge = document.createElement('div');
         winnerBadge.className = 'poker-seat-winner-badge';
-        winnerBadge.textContent = 'Winner';
+        var winnerTitle = document.createElement('div');
+        winnerTitle.className = 'poker-seat-winner-title';
+        winnerTitle.textContent = 'Winner';
+        winnerBadge.appendChild(winnerTitle);
+        var winnerSummary = getWinnerHandSummary(seat);
+        if (winnerSummary){
+          var winnerLabel = document.createElement('div');
+          winnerLabel.className = 'poker-seat-winner-label';
+          winnerLabel.textContent = winnerSummary.label;
+          winnerBadge.appendChild(winnerLabel);
+          var winnerCards = document.createElement('div');
+          winnerCards.className = 'poker-seat-winner-cards';
+          winnerSummary.cards.forEach(function(card){
+            var normalizedWinnerCard = normalizeCard(card);
+            var chip = document.createElement('span');
+            chip.className = 'poker-seat-winner-card' + (normalizedWinnerCard && (normalizedWinnerCard.s === 'H' || normalizedWinnerCard.s === 'D') ? ' poker-seat-winner-card--red' : '');
+            chip.textContent = normalizedWinnerCard ? (normalizedWinnerCard.r + SUIT_SYMBOLS[normalizedWinnerCard.s]) : '?';
+            winnerCards.appendChild(chip);
+          });
+          winnerBadge.appendChild(winnerCards);
+        }
         article.appendChild(winnerBadge);
       }
       article.appendChild(stack);
@@ -958,9 +998,7 @@
   function renderCommunityCards(){
     if (!els.communityCards) return;
     els.communityCards.innerHTML = '';
-    var cards = Array.isArray(state.communityCards) && state.communityCards.length
-      ? state.communityCards
-      : (getActiveWinnerReveal() ? stickyWinnerReveal.communityCards : []);
+    var cards = getDisplayCommunityCards();
     cards.forEach(function(card){
       els.communityCards.appendChild(createCard(card));
     });
@@ -1003,13 +1041,13 @@
         slotIndex = 3;
       }
     }
-    var chipOffset = { x: 0, y: -8 };
-    if (slotIndex === 0) chipOffset = { x: 0, y: 8 };
-    else if (slotIndex === 1) chipOffset = { x: -12, y: -2 };
-    else if (slotIndex === 2) chipOffset = { x: -12, y: -12 };
-    else if (slotIndex === 3) chipOffset = { x: 11, y: -7 };
-    else if (slotIndex === 4) chipOffset = { x: 9, y: -5 };
-    else if (slotIndex === 5) chipOffset = { x: 9, y: 5 };
+    var chipOffset = { x: 0, y: -14 };
+    if (slotIndex === 0) chipOffset = { x: 0, y: -16 };
+    else if (slotIndex === 1) chipOffset = { x: -16, y: -15 };
+    else if (slotIndex === 2) chipOffset = { x: -16, y: -18 };
+    else if (slotIndex === 3) chipOffset = { x: 14, y: -16 };
+    else if (slotIndex === 4) chipOffset = { x: 16, y: -18 };
+    else if (slotIndex === 5) chipOffset = { x: 16, y: -15 };
     els.dealerChip.hidden = false;
     els.dealerChip.style.left = (anchor.x + chipOffset.x) + '%';
     els.dealerChip.style.top = (anchor.y + chipOffset.y) + '%';

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -633,6 +633,7 @@
     var nextStacks = normalizeStacks(payload);
     if (nextStacks) state.stacks = nextStacks;
 
+    var previousHandId = state.handId;
     if (typeof handObj.status === 'string' && handObj.status) state.phase = handObj.status.toUpperCase();
     if (typeof handObj.handId === 'string' && handObj.handId) state.handId = handObj.handId;
     if (Number.isInteger(payload.dealerSeat)) state.dealerSeat = payload.dealerSeat;
@@ -655,6 +656,7 @@
     else if (Array.isArray(publicObj.board)) boardSource = publicObj.board;
     else if (isObject(publicObj.board) && Array.isArray(publicObj.board.cards)) boardSource = publicObj.board.cards;
     if (boardSource) state.communityCards = normalizeCards(boardSource);
+    else if (state.handId && previousHandId && state.handId !== previousHandId) state.communityCards = [];
 
     var nextHeroCards = null;
     if (Array.isArray(payload.myHoleCards)) nextHeroCards = normalizeCards(payload.myHoleCards);
@@ -709,7 +711,7 @@
   }
 
   function getHeroBestHand(){
-    var mergedCards = (Array.isArray(state.heroCards) ? state.heroCards.slice(0, 2) : []).concat(getDisplayCommunityCards());
+    var mergedCards = (Array.isArray(state.heroCards) ? state.heroCards.slice(0, 2) : []).concat(Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []);
     var best = evaluateViewerBestHand(mergedCards);
     if (!best || !Array.isArray(best.cards) || best.cards.length !== 5) return null;
     return best;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -110,7 +110,10 @@
       youSeat: null,
       statusText: LIVE_STATUS_COPY.connecting,
       errorText: '',
-      wsReady: false
+      wsReady: false,
+      showdown: null,
+      handSettlement: null,
+      revealedWinnerCardsByUserId: {}
     };
   }
 
@@ -501,6 +504,52 @@
     };
   }
 
+  function normalizeShowdown(source){
+    if (!isObject(source)) return null;
+    var showdown = {
+      winners: Array.isArray(source.winners) ? source.winners.filter(function(userId){
+        return typeof userId === 'string' && !!userId;
+      }) : [],
+      reason: typeof source.reason === 'string' ? source.reason : null,
+      handId: typeof source.handId === 'string' ? source.handId : null
+    };
+    if (Array.isArray(source.revealedWinners)){
+      showdown.revealedWinners = source.revealedWinners
+        .filter(function(entry){
+          return entry && typeof entry.userId === 'string';
+        })
+        .map(function(entry){
+          return {
+            userId: entry.userId,
+            holeCards: normalizeCards(entry.holeCards)
+          };
+        })
+        .filter(function(entry){
+          return entry.holeCards.length === 2;
+        });
+    }
+    return showdown;
+  }
+
+  function normalizeHandSettlement(source){
+    if (!isObject(source)) return null;
+    return {
+      handId: typeof source.handId === 'string' ? source.handId : null,
+      settledAt: typeof source.settledAt === 'string' ? source.settledAt : null
+    };
+  }
+
+  function mapRevealedWinnerCards(showdown){
+    var revealed = {};
+    if (!showdown || !Array.isArray(showdown.revealedWinners)) return revealed;
+    showdown.revealedWinners.forEach(function(entry){
+      if (!entry || typeof entry.userId !== 'string') return;
+      if (!Array.isArray(entry.holeCards) || entry.holeCards.length !== 2) return;
+      revealed[entry.userId] = entry.holeCards.slice(0, 2);
+    });
+    return revealed;
+  }
+
   function mergeSnapshot(payload){
     if (!isObject(payload)) return;
     var snapshotTableId = typeof payload.tableId === 'string' && payload.tableId ? payload.tableId : null;
@@ -511,6 +560,8 @@
     var handObj = isObject(payload.hand) ? payload.hand : isObject(publicObj.hand) ? publicObj.hand : {};
     var turnObj = isObject(payload.turn) ? payload.turn : isObject(publicObj.turn) ? publicObj.turn : {};
     var potObj = isObject(payload.pot) ? payload.pot : isObject(publicObj.pot) ? publicObj.pot : {};
+    var showdownObj = isObject(payload.showdown) ? payload.showdown : isObject(publicObj.showdown) ? publicObj.showdown : null;
+    var handSettlementObj = isObject(payload.handSettlement) ? payload.handSettlement : isObject(publicObj.handSettlement) ? publicObj.handSettlement : null;
     var legalSource = payload.legalActions != null ? payload.legalActions : publicObj.legalActions;
     var constraintsPrimary = payload.actionConstraints != null ? payload.actionConstraints : publicObj.actionConstraints;
 
@@ -568,6 +619,9 @@
     if (legalActions.length || Array.isArray(legalSource) || (isObject(legalSource) && Array.isArray(legalSource.actions))){
       state.legalActions = legalActions;
     }
+    state.showdown = normalizeShowdown(showdownObj);
+    state.handSettlement = normalizeHandSettlement(handSettlementObj);
+    state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
     state.statusText = LIVE_STATUS_COPY.live;
     state.errorText = '';
@@ -728,6 +782,17 @@
     };
   }
 
+  function isWinnerSeat(seat){
+    if (!seat || typeof seat.userId !== 'string' || !state.showdown) return false;
+    return Array.isArray(state.showdown.winners) && state.showdown.winners.indexOf(seat.userId) !== -1;
+  }
+
+  function getSeatRevealCards(seat){
+    if (!seat || typeof seat.userId !== 'string') return null;
+    var revealed = state.revealedWinnerCardsByUserId && state.revealedWinnerCardsByUserId[seat.userId];
+    return Array.isArray(revealed) && revealed.length === 2 ? revealed : null;
+  }
+
   function renderSeats(){
     if (!els.seatLayer) return;
     els.seatLayer.innerHTML = '';
@@ -756,6 +821,7 @@
       article.className = 'poker-seat'
         + (active ? ' poker-seat--active' : '')
         + (folded ? ' poker-seat--folded' : '')
+        + (seat && isWinnerSeat(seat) ? ' poker-seat--winner' : '')
         + (hero ? ' poker-seat--hero' : '')
         + (!seat ? ' poker-seat--empty' : '');
       article.style.left = anchor.x + '%';
@@ -786,8 +852,15 @@
       var cards = document.createElement('div');
       cards.className = 'poker-seat-cards';
       if (!hero && seat && seat.userId){
-        cards.appendChild(createCard(null, { faceDown: true }));
-        cards.appendChild(createCard(null, { faceDown: true }));
+        var revealCards = getSeatRevealCards(seat);
+        if (revealCards){
+          revealCards.forEach(function(card){
+            cards.appendChild(createCard(card));
+          });
+        } else {
+          cards.appendChild(createCard(null, { faceDown: true }));
+          cards.appendChild(createCard(null, { faceDown: true }));
+        }
       }
 
       var name = document.createElement('div');
@@ -799,6 +872,12 @@
       status.textContent = seat ? String(seat.status || 'ACTIVE').replace(/_/g, ' ') : 'OPEN';
 
       article.appendChild(avatar);
+      if (seat && isWinnerSeat(seat)){
+        var winnerBadge = document.createElement('div');
+        winnerBadge.className = 'poker-seat-winner-badge';
+        winnerBadge.textContent = 'Winner';
+        article.appendChild(winnerBadge);
+      }
       article.appendChild(stack);
       if (cards.children.length) article.appendChild(cards);
       article.appendChild(name);

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -78,6 +78,7 @@
   var authUnsubscribe = null;
   var renderedSeatAnchors = {};
   var renderedSeatSlots = {};
+  var renderedSeatAvatars = {};
   var suggestedSeatNoParam = null;
   var shouldAutoJoin = false;
   var autoJoinAttempted = false;
@@ -873,6 +874,7 @@
     els.seatLayer.innerHTML = '';
     renderedSeatAnchors = {};
     renderedSeatSlots = {};
+    renderedSeatAvatars = {};
     var offset = getSeatNumberingOffset();
     var seatsByIndex = {};
     state.seats.forEach(function(seat){
@@ -909,6 +911,7 @@
       var avatar = document.createElement('div');
       avatar.className = 'poker-seat-avatar';
       avatar.textContent = seat ? initials(getDisplayName(seat)) : '+';
+      if (seat && Number.isInteger(seat.seatNo)) renderedSeatAvatars[seat.seatNo] = avatar;
       if (active){
         var turnClock = getTurnClockState();
         if (turnClock){
@@ -1026,6 +1029,33 @@
     if (!Number.isInteger(targetSeatNo)){
       els.dealerChip.hidden = true;
       return;
+    }
+    var scene = els.dealerChip.parentElement || null;
+    var avatarEl = renderedSeatAvatars[targetSeatNo] || null;
+    if (scene && avatarEl && typeof scene.getBoundingClientRect === 'function' && typeof avatarEl.getBoundingClientRect === 'function'){
+      var sceneRect = scene.getBoundingClientRect();
+      var avatarRect = avatarEl.getBoundingClientRect();
+      var chipRect = els.dealerChip.getBoundingClientRect();
+      if (sceneRect.width > 0 && sceneRect.height > 0 && avatarRect.width > 0 && avatarRect.height > 0){
+        var avatarCenterX = (avatarRect.left - sceneRect.left) + avatarRect.width / 2;
+        var avatarCenterY = (avatarRect.top - sceneRect.top) + avatarRect.height / 2;
+        var sceneCenterX = sceneRect.width / 2;
+        var sceneCenterY = sceneRect.height / 2;
+        var deltaX = sceneCenterX - avatarCenterX;
+        var deltaY = sceneCenterY - avatarCenterY;
+        var magnitude = Math.sqrt((deltaX * deltaX) + (deltaY * deltaY));
+        if (magnitude > 0){
+          var unitX = deltaX / magnitude;
+          var unitY = deltaY / magnitude;
+          var avatarRadius = Math.min(avatarRect.width, avatarRect.height) / 2;
+          var chipRadius = Math.min(chipRect.width || 38, chipRect.height || 38) / 2;
+          var contactDistance = avatarRadius + chipRadius - 2;
+          els.dealerChip.hidden = false;
+          els.dealerChip.style.left = Math.round(avatarCenterX + (unitX * contactDistance)) + 'px';
+          els.dealerChip.style.top = Math.round(avatarCenterY + (unitY * contactDistance)) + 'px';
+          return;
+        }
+      }
     }
     var anchor = renderedSeatAnchors[targetSeatNo] || null;
     var slotIndex = Number.isInteger(renderedSeatSlots[targetSeatNo]) ? renderedSeatSlots[targetSeatNo] : null;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -21,6 +21,7 @@
     disconnected: 'Live connection closed',
     error: 'Live table unavailable'
   };
+  var WINNER_REVEAL_MS = 4_000;
   var seatAnchors = [
     { x: 50, y: 10 },
     { x: 86, y: 28 },
@@ -81,6 +82,12 @@
   var shouldAutoJoin = false;
   var autoJoinAttempted = false;
   var bootReady = false;
+  var stickyWinnerReveal = {
+    handId: null,
+    visibleUntilMs: 0,
+    winners: [],
+    revealedWinnerCardsByUserId: {}
+  };
   var els = {};
 
   function cloneState(source){
@@ -550,6 +557,46 @@
     return revealed;
   }
 
+  function cloneRevealedWinnerCards(source){
+    var next = {};
+    if (!isObject(source)) return next;
+    Object.keys(source).forEach(function(userId){
+      if (!Array.isArray(source[userId])) return;
+      next[userId] = source[userId].slice(0, 2);
+    });
+    return next;
+  }
+
+  function syncStickyWinnerReveal(){
+    var handId = state.handId || (state.handSettlement && state.handSettlement.handId) || (state.showdown && state.showdown.handId) || null;
+    var winners = state.showdown && Array.isArray(state.showdown.winners) ? state.showdown.winners.filter(Boolean) : [];
+    if (!handId || !winners.length || state.phase !== 'SETTLED'){
+      return;
+    }
+    if (stickyWinnerReveal.handId !== handId || stickyWinnerReveal.visibleUntilMs <= Date.now()){
+      stickyWinnerReveal = {
+        handId: handId,
+        visibleUntilMs: Date.now() + WINNER_REVEAL_MS,
+        winners: winners.slice(),
+        revealedWinnerCardsByUserId: cloneRevealedWinnerCards(state.revealedWinnerCardsByUserId)
+      };
+    }
+  }
+
+  function getActiveWinnerReveal(){
+    if (!stickyWinnerReveal.handId) return null;
+    if (stickyWinnerReveal.visibleUntilMs <= Date.now()) return null;
+    return stickyWinnerReveal;
+  }
+
+  function getDisplayWinnerUserIds(){
+    if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.length){
+      return state.showdown.winners;
+    }
+    var sticky = getActiveWinnerReveal();
+    return sticky ? sticky.winners.slice() : [];
+  }
+
   function mergeSnapshot(payload){
     if (!isObject(payload)) return;
     var snapshotTableId = typeof payload.tableId === 'string' && payload.tableId ? payload.tableId : null;
@@ -622,6 +669,7 @@
     state.showdown = normalizeShowdown(showdownObj);
     state.handSettlement = normalizeHandSettlement(handSettlementObj);
     state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
+    syncStickyWinnerReveal();
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
     state.statusText = LIVE_STATUS_COPY.live;
     state.errorText = '';
@@ -783,13 +831,16 @@
   }
 
   function isWinnerSeat(seat){
-    if (!seat || typeof seat.userId !== 'string' || !state.showdown) return false;
-    return Array.isArray(state.showdown.winners) && state.showdown.winners.indexOf(seat.userId) !== -1;
+    if (!seat || typeof seat.userId !== 'string') return false;
+    return getDisplayWinnerUserIds().indexOf(seat.userId) !== -1;
   }
 
   function getSeatRevealCards(seat){
     if (!seat || typeof seat.userId !== 'string') return null;
     var revealed = state.revealedWinnerCardsByUserId && state.revealedWinnerCardsByUserId[seat.userId];
+    if ((!Array.isArray(revealed) || revealed.length !== 2) && getActiveWinnerReveal()){
+      revealed = stickyWinnerReveal.revealedWinnerCardsByUserId[seat.userId];
+    }
     return Array.isArray(revealed) && revealed.length === 2 ? revealed : null;
   }
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -561,7 +561,7 @@
     return revealed;
   }
 
-  function cloneRevealedWinnerCards(source){
+  function cloneRevealedShowdownCards(source){
     var next = {};
     if (!isObject(source)) return next;
     Object.keys(source).forEach(function(userId){
@@ -582,7 +582,7 @@
         handId: handId,
         visibleUntilMs: Date.now() + WINNER_REVEAL_MS,
         winners: winners.slice(),
-        revealedShowdownCardsByUserId: cloneRevealedWinnerCards(state.revealedShowdownCardsByUserId),
+        revealedShowdownCardsByUserId: cloneRevealedShowdownCards(state.revealedShowdownCardsByUserId),
         communityCards: Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []
       };
     }

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -22,7 +22,6 @@
     error: 'Live table unavailable'
   };
   var WINNER_REVEAL_MS = 4_000;
-  var HAND_CLEAR_MS = 500;
   var seatAnchors = [
     { x: 50, y: 10 },
     { x: 86, y: 28 },
@@ -90,10 +89,6 @@
     winners: [],
     revealedWinnerCardsByUserId: {},
     communityCards: []
-  };
-  var handClearWindow = {
-    handId: null,
-    visibleUntilMs: 0
   };
   var els = {};
 
@@ -597,20 +592,7 @@
     return stickyWinnerReveal;
   }
 
-  function activateHandClearWindow(nextHandId){
-    if (typeof nextHandId !== 'string' || !nextHandId) return;
-    handClearWindow = {
-      handId: nextHandId,
-      visibleUntilMs: Date.now() + HAND_CLEAR_MS
-    };
-  }
-
-  function isHandClearWindowActive(){
-    return !!(handClearWindow.handId && handClearWindow.handId === state.handId && handClearWindow.visibleUntilMs > Date.now());
-  }
-
   function getDisplayWinnerUserIds(){
-    if (isHandClearWindowActive()) return [];
     if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.length){
       return state.showdown.winners;
     }
@@ -694,7 +676,6 @@
     state.handSettlement = normalizeHandSettlement(handSettlementObj);
     state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
     if (state.handId && previousHandId && state.handId !== previousHandId && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
-      activateHandClearWindow(state.handId);
       stickyWinnerReveal.visibleUntilMs = 0;
     }
     syncStickyWinnerReveal();
@@ -742,7 +723,6 @@
   }
 
   function getDisplayCommunityCards(){
-    if (isHandClearWindowActive()) return [];
     if (Array.isArray(state.communityCards) && state.communityCards.length) return state.communityCards.slice(0, 5);
     var sticky = getActiveWinnerReveal();
     return sticky && Array.isArray(sticky.communityCards) ? sticky.communityCards.slice(0, 5) : [];
@@ -871,7 +851,6 @@
   }
 
   function getSeatRevealCards(seat){
-    if (isHandClearWindowActive()) return null;
     if (!seat || typeof seat.userId !== 'string') return null;
     var revealed = state.revealedWinnerCardsByUserId && state.revealedWinnerCardsByUserId[seat.userId];
     if ((!Array.isArray(revealed) || revealed.length !== 2) && getActiveWinnerReveal()){
@@ -954,7 +933,7 @@
 
       var cards = document.createElement('div');
       cards.className = 'poker-seat-cards';
-      if (!hero && seat && seat.userId && !isHandClearWindowActive()){
+      if (!hero && seat && seat.userId){
         var revealCards = getSeatRevealCards(seat);
         if (revealCards){
           revealCards.forEach(function(card){
@@ -975,7 +954,7 @@
       status.textContent = seat ? String(seat.status || 'ACTIVE').replace(/_/g, ' ') : 'OPEN';
 
       article.appendChild(avatar);
-      if (!isHandClearWindowActive() && seat && isWinnerSeat(seat)){
+      if (seat && isWinnerSeat(seat)){
         var winnerBadge = document.createElement('div');
         winnerBadge.className = 'poker-seat-winner-badge';
         var winnerTitle = document.createElement('div');
@@ -1037,7 +1016,6 @@
   function renderHeroCards(){
     if (!els.heroCards) return;
     els.heroCards.innerHTML = '';
-    if (isHandClearWindowActive()) return;
     var cards = Array.isArray(state.heroCards) ? state.heroCards : [];
     if (!cards.length){
       els.heroCards.appendChild(createCard(null, { faceDown: true }));

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -22,6 +22,7 @@
     error: 'Live table unavailable'
   };
   var WINNER_REVEAL_MS = 4_000;
+  var HAND_CLEAR_MS = 500;
   var seatAnchors = [
     { x: 50, y: 10 },
     { x: 86, y: 28 },
@@ -89,6 +90,10 @@
     winners: [],
     revealedWinnerCardsByUserId: {},
     communityCards: []
+  };
+  var handClearWindow = {
+    handId: null,
+    visibleUntilMs: 0
   };
   var els = {};
 
@@ -592,7 +597,20 @@
     return stickyWinnerReveal;
   }
 
+  function activateHandClearWindow(nextHandId){
+    if (typeof nextHandId !== 'string' || !nextHandId) return;
+    handClearWindow = {
+      handId: nextHandId,
+      visibleUntilMs: Date.now() + HAND_CLEAR_MS
+    };
+  }
+
+  function isHandClearWindowActive(){
+    return !!(handClearWindow.handId && handClearWindow.handId === state.handId && handClearWindow.visibleUntilMs > Date.now());
+  }
+
   function getDisplayWinnerUserIds(){
+    if (isHandClearWindowActive()) return [];
     if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.length){
       return state.showdown.winners;
     }
@@ -635,6 +653,7 @@
     if (nextStacks) state.stacks = nextStacks;
 
     var previousHandId = state.handId;
+    var previousPhase = state.phase;
     if (typeof handObj.status === 'string' && handObj.status) state.phase = handObj.status.toUpperCase();
     if (typeof handObj.handId === 'string' && handObj.handId) state.handId = handObj.handId;
     if (Number.isInteger(payload.dealerSeat)) state.dealerSeat = payload.dealerSeat;
@@ -674,6 +693,10 @@
     state.showdown = normalizeShowdown(showdownObj);
     state.handSettlement = normalizeHandSettlement(handSettlementObj);
     state.revealedWinnerCardsByUserId = mapRevealedWinnerCards(state.showdown);
+    if (state.handId && previousHandId && state.handId !== previousHandId && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
+      activateHandClearWindow(state.handId);
+      stickyWinnerReveal.visibleUntilMs = 0;
+    }
     syncStickyWinnerReveal();
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
     state.statusText = LIVE_STATUS_COPY.live;
@@ -719,6 +742,7 @@
   }
 
   function getDisplayCommunityCards(){
+    if (isHandClearWindowActive()) return [];
     if (Array.isArray(state.communityCards) && state.communityCards.length) return state.communityCards.slice(0, 5);
     var sticky = getActiveWinnerReveal();
     return sticky && Array.isArray(sticky.communityCards) ? sticky.communityCards.slice(0, 5) : [];
@@ -847,6 +871,7 @@
   }
 
   function getSeatRevealCards(seat){
+    if (isHandClearWindowActive()) return null;
     if (!seat || typeof seat.userId !== 'string') return null;
     var revealed = state.revealedWinnerCardsByUserId && state.revealedWinnerCardsByUserId[seat.userId];
     if ((!Array.isArray(revealed) || revealed.length !== 2) && getActiveWinnerReveal()){
@@ -929,7 +954,7 @@
 
       var cards = document.createElement('div');
       cards.className = 'poker-seat-cards';
-      if (!hero && seat && seat.userId){
+      if (!hero && seat && seat.userId && !isHandClearWindowActive()){
         var revealCards = getSeatRevealCards(seat);
         if (revealCards){
           revealCards.forEach(function(card){
@@ -950,7 +975,7 @@
       status.textContent = seat ? String(seat.status || 'ACTIVE').replace(/_/g, ' ') : 'OPEN';
 
       article.appendChild(avatar);
-      if (seat && isWinnerSeat(seat)){
+      if (!isHandClearWindowActive() && seat && isWinnerSeat(seat)){
         var winnerBadge = document.createElement('div');
         winnerBadge.className = 'poker-seat-winner-badge';
         var winnerTitle = document.createElement('div');
@@ -1012,6 +1037,7 @@
   function renderHeroCards(){
     if (!els.heroCards) return;
     els.heroCards.innerHTML = '';
+    if (isHandClearWindowActive()) return;
     var cards = Array.isArray(state.heroCards) ? state.heroCards : [];
     if (!cards.length){
       els.heroCards.appendChild(createCard(null, { faceDown: true }));

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -574,7 +574,7 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
-test('poker v2 clears the table briefly when the next hand starts after winner reveal', async () => {
+test('poker v2 clears the previous reveal immediately when the next hand starts', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -648,9 +648,13 @@ test('poker v2 clears the table briefly when the next hand starts after winner r
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
   assert.equal(findSeatChild(villainSeat, 'poker-seat-winner-badge'), undefined);
-  assert.equal(findSeatChild(villainSeat, 'poker-seat-cards'), undefined);
+  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+  assert.ok(villainCards);
+  assert.equal(villainCards.children.length, 2);
+  assert.equal(villainCards.children[0].className.includes('poker-card--back'), true);
+  assert.equal(villainCards.children[1].className.includes('poker-card--back'), true);
   assert.equal(harness.elements.pokerCommunityCards.children.length, 0);
-  assert.equal(harness.elements.pokerHeroCards.children.length, 0);
+  assert.equal(harness.elements.pokerHeroCards.children.length, 2);
 });
 
 test('poker v2 does not compute hero best hand from sticky winner reveal board after the next hand starts', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -356,8 +356,8 @@ test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat
   assert.ok(rightBottomSeat);
   assert.equal(rightTopSeat.style.left, '80%');
   assert.equal(rightBottomSeat.style.left, '80%');
-  assert.equal(harness.elements.pokerDealerChip.style.left, '71%');
-  assert.equal(harness.elements.pokerDealerChip.style.top, '34%');
+  assert.equal(harness.elements.pokerDealerChip.style.left, '68%');
+  assert.equal(harness.elements.pokerDealerChip.style.top, '27%');
 });
 
 test('poker v2 shows a live turn clock only on the active seat avatar', async () => {
@@ -592,6 +592,7 @@ test('poker v2 keeps winner badges and revealed cards visible through the local 
       public: {
         hand: { handId: 'hand-8', status: 'SETTLED', dealerSeatNo: 2 },
         turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        board: { cards: ['2H', '3H', '4H', '9C', 'KD'] },
         pot: { total: 0, sidePots: [] },
         legalActions: { seat: 1, actions: [] },
         showdown: {
@@ -649,6 +650,7 @@ test('poker v2 keeps winner badges and revealed cards visible through the local 
   assert.equal(villainCards.children.length, 2);
   assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 5);
 });
 
 test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -104,6 +104,18 @@ function createHarness(options = {}){
   };
 
   const intervalTimers = [];
+  const timeoutTimers = [];
+  let nextTimeoutId = 1;
+  let nowMs = Number.isFinite(options.nowMs) ? options.nowMs : 1_700_000_000_000;
+  const FakeDate = class extends Date {
+    constructor(...args){
+      if (args.length) super(...args);
+      else super(nowMs);
+    }
+    static now(){ return nowMs; }
+  };
+  FakeDate.parse = Date.parse;
+  FakeDate.UTC = Date.UTC;
   const sandbox = {
     window: {
       location: {
@@ -125,8 +137,15 @@ function createHarness(options = {}){
         return intervalTimers.length;
       },
       clearInterval(){},
-      clearTimeout(){},
-      setTimeout(fn){ fn(); return 1; }
+      clearTimeout(id){
+        const timer = timeoutTimers.find((entry) => entry.id === id);
+        if (timer) timer.cleared = true;
+      },
+      setTimeout(fn, delay){
+        const timer = { id: nextTimeoutId++, fn, at: nowMs + Math.max(0, Number(delay) || 0), cleared: false };
+        timeoutTimers.push(timer);
+        return timer.id;
+      }
     },
     document: {
       readyState: 'loading',
@@ -135,6 +154,7 @@ function createHarness(options = {}){
       createElement(tag){ return makeElement(tag); }
     },
     URLSearchParams,
+    Date: FakeDate,
     atob(value){ return Buffer.from(String(value), 'base64').toString('binary'); },
     Buffer,
     console
@@ -161,6 +181,17 @@ async function flush(){
     handlers.forEach((fn) => fn(event || {}));
   }
 
+  function advanceTime(ms){
+    nowMs += Math.max(0, Number(ms) || 0);
+    const due = timeoutTimers
+      .filter((timer) => !timer.cleared && timer.at <= nowMs)
+      .sort((left, right) => left.at - right.at);
+    due.forEach((timer) => {
+      timer.cleared = true;
+      timer.fn();
+    });
+  }
+
   return {
     elements,
     logs,
@@ -171,6 +202,7 @@ async function flush(){
     fireDomContentLoaded,
     fireDocumentEvent,
     flush,
+    advanceTime,
     getCreateOptions(){ return createOptions; },
     getIntervalCount(){ return intervalTimers.length; }
   };
@@ -361,8 +393,8 @@ test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat
 });
 
 test('poker v2 shows a live turn clock only on the active seat avatar', async () => {
-  const nowMs = Date.now();
-  const harness = createHarness();
+  const nowMs = 1_700_000_100_000;
+  const harness = createHarness({ nowMs });
   harness.fireDomContentLoaded();
   await harness.flush();
 
@@ -405,8 +437,8 @@ test('poker v2 shows a live turn clock only on the active seat avatar', async ()
 });
 
 test('poker v2 turns the live clock red when five seconds remain', async () => {
-  const nowMs = Date.now();
-  const harness = createHarness();
+  const nowMs = 1_700_000_200_000;
+  const harness = createHarness({ nowMs });
   harness.fireDomContentLoaded();
   await harness.flush();
 
@@ -574,7 +606,7 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
-test('poker v2 clears the previous reveal immediately when the next hand starts', async () => {
+test('poker v2 keeps the previous reveal visible for the full local window before switching to the next hand', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -647,17 +679,30 @@ test('poker v2 clears the previous reveal immediately when the next hand starts'
   await harness.flush();
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  assert.equal(findSeatChild(villainSeat, 'poker-seat-winner-badge'), undefined);
+  assert.ok(findSeatChild(villainSeat, 'poker-seat-winner-badge'));
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
   assert.ok(villainCards);
   assert.equal(villainCards.children.length, 2);
-  assert.equal(villainCards.children[0].className.includes('poker-card--back'), true);
-  assert.equal(villainCards.children[1].className.includes('poker-card--back'), true);
+  assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
+  assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 5);
+  assert.equal(harness.elements.pokerHeroCards.children.length, 2);
+
+  harness.advanceTime(4000);
+  await harness.flush();
+
+  const switchedVillainSeat = findSeatByLabel(harness, 'Villain 1');
+  assert.equal(findSeatChild(switchedVillainSeat, 'poker-seat-winner-badge'), undefined);
+  const switchedVillainCards = findSeatChild(switchedVillainSeat, 'poker-seat-cards');
+  assert.ok(switchedVillainCards);
+  assert.equal(switchedVillainCards.children.length, 2);
+  assert.equal(switchedVillainCards.children[0].className.includes('poker-card--back'), true);
+  assert.equal(switchedVillainCards.children[1].className.includes('poker-card--back'), true);
   assert.equal(harness.elements.pokerCommunityCards.children.length, 0);
   assert.equal(harness.elements.pokerHeroCards.children.length, 2);
 });
 
-test('poker v2 does not compute hero best hand from sticky winner reveal board after the next hand starts', async () => {
+test('poker v2 does not switch away from the settled reveal scene before the local window ends', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -729,11 +774,13 @@ test('poker v2 does not compute hero best hand from sticky winner reveal board a
   });
   await harness.flush();
 
-  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
-  const bestHand = findSeatChild(heroSeat, 'poker-seat-best-hand');
-
-  assert.equal(harness.elements.pokerCommunityCards.children.length, 0, 'new hand should clear the previous board immediately');
-  assert.equal(bestHand, undefined, 'hero best hand should not use sticky reveal board from the previous hand');
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 5, 'reveal board should stay visible until the local reveal window ends');
+  const villainSeat = findSeatByLabel(harness, 'Villain 1');
+  assert.ok(findSeatChild(villainSeat, 'poker-seat-winner-badge'));
+  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+  assert.ok(villainCards);
+  assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
+  assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
 test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -660,6 +660,85 @@ test('poker v2 keeps winner badges and revealed cards visible through the local 
   assert.equal(harness.elements.pokerCommunityCards.children.length, 5);
 });
 
+test('poker v2 does not compute hero best hand from sticky winner reveal board after the next hand starts', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 11,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-10', status: 'SETTLED', dealerSeatNo: 2 },
+        turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        board: { cards: ['2H', '3H', '4H', '9C', 'KD'] },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        showdown: {
+          handId: 'hand-10',
+          winners: ['villain-1'],
+          reason: 'computed',
+          revealedWinners: [
+            { userId: 'villain-1', holeCards: ['AS', 'AD'] }
+          ]
+        },
+        handSettlement: {
+          handId: 'hand-10',
+          settledAt: '2026-04-11T10:00:00.000Z'
+        }
+      },
+      private: { holeCards: [{ r: 'K', s: 'H' }, { r: 'K', s: 'D' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 12,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-11', status: 'PREFLOP', dealerSeatNo: 1 },
+        turn: { userId: 'user-1', seat: 1, startedAt: Date.now(), deadlineAt: Date.now() + 20_000 },
+        pot: { total: 3, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL'] },
+        actionConstraints: { toCall: 1 }
+      },
+      private: { holeCards: [{ r: 'Q', s: 'S' }, { r: 'J', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  const bestHand = findSeatChild(heroSeat, 'poker-seat-best-hand');
+
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 5, 'sticky reveal board should still render');
+  assert.equal(bestHand, undefined, 'hero best hand should not use sticky reveal board from the previous hand');
+});
+
 test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -574,7 +574,7 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
-test('poker v2 keeps winner badges and revealed cards visible through the local reveal window after the next hand snapshot arrives', async () => {
+test('poker v2 clears the table briefly when the next hand starts after winner reveal', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -647,17 +647,10 @@ test('poker v2 keeps winner badges and revealed cards visible through the local 
   await harness.flush();
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
-  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
-
-  assert.ok(villainBadge);
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
-  assert.ok(findSeatChild(villainBadge, 'poker-seat-winner-label'));
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-cards').children.length, 5);
-  assert.equal(villainCards.children.length, 2);
-  assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
-  assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
-  assert.equal(harness.elements.pokerCommunityCards.children.length, 5);
+  assert.equal(findSeatChild(villainSeat, 'poker-seat-winner-badge'), undefined);
+  assert.equal(findSeatChild(villainSeat, 'poker-seat-cards'), undefined);
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 0);
+  assert.equal(harness.elements.pokerHeroCards.children.length, 0);
 });
 
 test('poker v2 does not compute hero best hand from sticky winner reveal board after the next hand starts', async () => {
@@ -735,7 +728,7 @@ test('poker v2 does not compute hero best hand from sticky winner reveal board a
   const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
   const bestHand = findSeatChild(heroSeat, 'poker-seat-best-hand');
 
-  assert.equal(harness.elements.pokerCommunityCards.children.length, 5, 'sticky reveal board should still render');
+  assert.equal(harness.elements.pokerCommunityCards.children.length, 0, 'new hand should clear the previous board immediately');
   assert.equal(bestHand, undefined, 'hero best hand should not use sticky reveal board from the previous hand');
 });
 

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -259,8 +259,8 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   const bestHand = heroSeat.children.find((node) => node.className === 'poker-seat-best-hand');
   assert.ok(bestHand, 'hero seat should surface a best-hand summary');
   assert.equal(harness.elements.pokerDealerChip.hidden, false, 'dealer chip should be visible when the dealer seat is known');
-  assert.equal(harness.elements.pokerDealerChip.style.left, '25%');
-  assert.equal(harness.elements.pokerDealerChip.style.top, '62%');
+  assert.equal(harness.elements.pokerDealerChip.style.left, '32%');
+  assert.equal(harness.elements.pokerDealerChip.style.top, '49%');
 
   harness.elements.pokerV2AmountInput.value = '77';
   harness.elements.pokerV2AmountBtn.click();
@@ -356,8 +356,8 @@ test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat
   assert.ok(rightBottomSeat);
   assert.equal(rightTopSeat.style.left, '80%');
   assert.equal(rightBottomSeat.style.left, '80%');
-  assert.equal(harness.elements.pokerDealerChip.style.left, '68%');
-  assert.equal(harness.elements.pokerDealerChip.style.top, '27%');
+  assert.equal(harness.elements.pokerDealerChip.style.left, '64%');
+  assert.equal(harness.elements.pokerDealerChip.style.top, '14%');
 });
 
 test('poker v2 shows a live turn clock only on the active seat avatar', async () => {
@@ -560,10 +560,15 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
   const heroBadge = findSeatChild(heroSeat, 'poker-seat-winner-badge');
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+  const villainBadgeLabel = findSeatChild(villainBadge, 'poker-seat-winner-label');
+  const villainBadgeCards = findSeatChild(villainBadge, 'poker-seat-winner-cards');
 
   assert.ok(villainBadge);
-  assert.equal(villainBadge.textContent, 'Winner');
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
   assert.ok(heroBadge);
+  assert.ok(villainBadgeLabel);
+  assert.equal(villainBadgeLabel.textContent.length > 0, true);
+  assert.equal(villainBadgeCards.children.length, 5);
   assert.equal(villainCards.children.length, 2);
   assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
@@ -646,7 +651,9 @@ test('poker v2 keeps winner badges and revealed cards visible through the local 
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
 
   assert.ok(villainBadge);
-  assert.equal(villainBadge.textContent, 'Winner');
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
+  assert.ok(findSeatChild(villainBadge, 'poker-seat-winner-label'));
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-cards').children.length, 5);
   assert.equal(villainCards.children.length, 2);
   assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
@@ -699,6 +706,9 @@ test('poker v2 keeps winner cards hidden when the hand ends without showdown com
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
 
   assert.ok(villainBadge);
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-label'), undefined);
+  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-cards'), undefined);
   assert.equal(villainCards.children[0].className, 'poker-card poker-card--back');
   assert.equal(villainCards.children[1].className, 'poker-card poker-card--back');
 });

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -540,7 +540,7 @@ test('poker v2 keeps the dealer chip fixed while action moves between players', 
   assert.equal(harness.elements.pokerDealerChip.style.top, initialTop);
 });
 
-test('poker v2 shows winner badges and reveals showdown winner cards during settled state', async () => {
+test('poker v2 shows winner badges and reveals showdown participant cards during settled state', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -571,7 +571,7 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
           handId: 'hand-6',
           winners: ['villain-1', 'user-1'],
           reason: 'computed',
-          revealedWinners: [
+          revealedShowdownParticipants: [
             { userId: 'villain-1', holeCards: ['AS', 'AD'] },
             { userId: 'user-1', holeCards: ['KH', 'KD'] }
           ]
@@ -643,7 +643,7 @@ test('poker v2 reveals showdown cards for compared losing players without winner
           handId: 'hand-7',
           winners: ['villain-1'],
           reason: 'computed',
-          revealedWinners: [
+          revealedShowdownParticipants: [
             { userId: 'villain-1', holeCards: ['AS', 'AD'] },
             { userId: 'villain-2', holeCards: ['QS', 'QD'] }
           ]
@@ -698,7 +698,7 @@ test('poker v2 keeps the previous reveal visible for the full local window befor
           handId: 'hand-8',
           winners: ['villain-1'],
           reason: 'computed',
-          revealedWinners: [
+          revealedShowdownParticipants: [
             { userId: 'villain-1', holeCards: ['AS', 'AD'] }
           ]
         },
@@ -794,7 +794,7 @@ test('poker v2 does not switch away from the settled reveal scene before the loc
           handId: 'hand-10',
           winners: ['villain-1'],
           reason: 'computed',
-          revealedWinners: [
+          revealedShowdownParticipants: [
             { userId: 'villain-1', holeCards: ['AS', 'AD'] }
           ]
         },
@@ -845,7 +845,7 @@ test('poker v2 does not switch away from the settled reveal scene before the loc
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
-test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {
+test('poker v2 keeps showdown participant cards hidden when the hand ends without showdown comparison', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -604,6 +604,68 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   assert.equal(villainCards.children.length, 2);
   assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
+  const losingSeat = findSeatByLabel(harness, 'Villain 2');
+  const losingCards = findSeatChild(losingSeat, 'poker-seat-cards');
+  assert.ok(losingCards);
+  assert.equal(losingCards.children.length, 2);
+  assert.equal(losingCards.children[0].className.includes('poker-card--back'), true);
+  assert.equal(losingCards.children[1].className.includes('poker-card--back'), true);
+});
+
+test('poker v2 reveals showdown cards for compared losing players without winner badge', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 8,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' },
+          { userId: 'villain-2', seat: 3, displayName: 'Villain 2' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-7', status: 'SETTLED', dealerSeatNo: 2 },
+        turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        board: { cards: ['2H', '3H', '4H', '9C', 'KD'] },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        showdown: {
+          handId: 'hand-7',
+          winners: ['villain-1'],
+          reason: 'computed',
+          revealedWinners: [
+            { userId: 'villain-1', holeCards: ['AS', 'AD'] },
+            { userId: 'villain-2', holeCards: ['QS', 'QD'] }
+          ]
+        },
+        handSettlement: {
+          handId: 'hand-7',
+          settledAt: '2026-04-11T10:00:00.000Z'
+        }
+      },
+      private: { holeCards: [{ r: 'K', s: 'H' }, { r: 'K', s: 'D' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const losingSeat = findSeatByLabel(harness, 'Villain 2');
+  const losingCards = findSeatChild(losingSeat, 'poker-seat-cards');
+  assert.ok(losingCards);
+  assert.equal(losingCards.children.length, 2);
+  assert.equal(losingCards.children[0].className.includes('poker-card--back'), false);
+  assert.equal(losingCards.children[1].className.includes('poker-card--back'), false);
+  assert.equal(findSeatChild(losingSeat, 'poker-seat-winner-badge'), undefined);
 });
 
 test('poker v2 keeps the previous reveal visible for the full local window before switching to the next hand', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -259,8 +259,8 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   const bestHand = heroSeat.children.find((node) => node.className === 'poker-seat-best-hand');
   assert.ok(bestHand, 'hero seat should surface a best-hand summary');
   assert.equal(harness.elements.pokerDealerChip.hidden, false, 'dealer chip should be visible when the dealer seat is known');
-  assert.equal(harness.elements.pokerDealerChip.style.left, '32%');
-  assert.equal(harness.elements.pokerDealerChip.style.top, '49%');
+  assert.equal(harness.elements.pokerDealerChip.style.left, '24%');
+  assert.equal(harness.elements.pokerDealerChip.style.top, '74%');
 
   harness.elements.pokerV2AmountInput.value = '77';
   harness.elements.pokerV2AmountBtn.click();
@@ -356,8 +356,8 @@ test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat
   assert.ok(rightBottomSeat);
   assert.equal(rightTopSeat.style.left, '80%');
   assert.equal(rightBottomSeat.style.left, '80%');
-  assert.equal(harness.elements.pokerDealerChip.style.left, '64%');
-  assert.equal(harness.elements.pokerDealerChip.style.top, '14%');
+  assert.equal(harness.elements.pokerDealerChip.style.left, '72%');
+  assert.equal(harness.elements.pokerDealerChip.style.top, '37%');
 });
 
 test('poker v2 shows a live turn clock only on the active seat avatar', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -569,6 +569,88 @@ test('poker v2 shows winner badges and reveals showdown winner cards during sett
   assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
 });
 
+test('poker v2 keeps winner badges and revealed cards visible through the local reveal window after the next hand snapshot arrives', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 9,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-8', status: 'SETTLED', dealerSeatNo: 2 },
+        turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        showdown: {
+          handId: 'hand-8',
+          winners: ['villain-1'],
+          reason: 'computed',
+          revealedWinners: [
+            { userId: 'villain-1', holeCards: ['AS', 'AD'] }
+          ]
+        },
+        handSettlement: {
+          handId: 'hand-8',
+          settledAt: '2026-04-11T10:00:00.000Z'
+        }
+      },
+      private: { holeCards: [{ r: 'K', s: 'H' }, { r: 'K', s: 'D' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 10,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-9', status: 'PREFLOP', dealerSeatNo: 1 },
+        turn: { userId: 'user-1', seat: 1, startedAt: Date.now(), deadlineAt: Date.now() + 20_000 },
+        pot: { total: 3, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL'] },
+        actionConstraints: { toCall: 1 }
+      },
+      private: { holeCards: [{ r: 'Q', s: 'S' }, { r: 'J', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const villainSeat = findSeatByLabel(harness, 'Villain 1');
+  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
+  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+
+  assert.ok(villainBadge);
+  assert.equal(villainBadge.textContent, 'Winner');
+  assert.equal(villainCards.children.length, 2);
+  assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
+  assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
+});
+
 test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -190,6 +190,10 @@ function findSeatByLabel(harness, label){
   ).some((child) => child.className === 'poker-seat-name' && child.textContent === label));
 }
 
+function findSeatChild(seatNode, className){
+  return (seatNode.children || []).find((child) => child.className === className);
+}
+
 test('poker v2 boots live mode, preserves table links, and sends WS commands', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
@@ -502,6 +506,117 @@ test('poker v2 keeps the dealer chip fixed while action moves between players', 
 
   assert.equal(harness.elements.pokerDealerChip.style.left, initialLeft);
   assert.equal(harness.elements.pokerDealerChip.style.top, initialTop);
+});
+
+test('poker v2 shows winner badges and reveals showdown winner cards during settled state', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 7,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' },
+          { userId: 'villain-2', seat: 3, displayName: 'Villain 2' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-6', status: 'SETTLED', dealerSeatNo: 2 },
+        turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        board: { cards: ['2H', '3H', '4H', '9C', 'KD'] },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        showdown: {
+          handId: 'hand-6',
+          winners: ['villain-1', 'user-1'],
+          reason: 'computed',
+          revealedWinners: [
+            { userId: 'villain-1', holeCards: ['AS', 'AD'] },
+            { userId: 'user-1', holeCards: ['KH', 'KD'] }
+          ]
+        },
+        handSettlement: {
+          handId: 'hand-6',
+          settledAt: '2026-04-11T10:00:00.000Z'
+        }
+      },
+      private: { holeCards: [{ r: 'K', s: 'H' }, { r: 'K', s: 'D' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const villainSeat = findSeatByLabel(harness, 'Villain 1');
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
+  const heroBadge = findSeatChild(heroSeat, 'poker-seat-winner-badge');
+  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+
+  assert.ok(villainBadge);
+  assert.equal(villainBadge.textContent, 'Winner');
+  assert.ok(heroBadge);
+  assert.equal(villainCards.children.length, 2);
+  assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
+  assert.equal(villainCards.children[1].className.includes('poker-card--back'), false);
+});
+
+test('poker v2 keeps winner cards hidden when the hand ends without showdown comparison', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 8,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-7', status: 'SETTLED', dealerSeatNo: 1 },
+        turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        showdown: {
+          handId: 'hand-7',
+          winners: ['villain-1'],
+          reason: 'all_folded'
+        },
+        handSettlement: {
+          handId: 'hand-7',
+          settledAt: '2026-04-11T10:00:01.000Z'
+        }
+      },
+      private: { holeCards: [{ r: 'Q', s: 'S' }, { r: 'J', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const villainSeat = findSeatByLabel(harness, 'Villain 1');
+  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
+  const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
+
+  assert.ok(villainBadge);
+  assert.equal(villainCards.children[0].className, 'poker-card poker-card--back');
+  assert.equal(villainCards.children[1].className, 'poker-card poker-card--back');
 });
 
 test('poker v2 falls back to demo mode when tableId is missing', async () => {

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -21,7 +21,7 @@ function initialCore() {
   };
 }
 
-test("engine rollover starts next preflop hand after settled terminal action", () => {
+test("engine terminal action settles hand before explicit rollover", () => {
   let coreState = bootstrapCoreStateHand({ tableId: "table_engine_roll", coreState: initialCore(), nowMs: 1000 }).coreState;
   const oldHandId = coreState.pokerState.handId;
 
@@ -37,11 +37,11 @@ test("engine rollover starts next preflop hand after settled terminal action", (
 
   assert.equal(folded.accepted, true);
   coreState = folded.coreState;
-  assert.equal(coreState.pokerState.phase, "PREFLOP");
-  assert.notEqual(coreState.pokerState.handId, oldHandId);
+  assert.equal(coreState.pokerState.phase, "SETTLED");
+  assert.equal(coreState.pokerState.handId, oldHandId);
   assert.deepEqual(coreState.pokerState.community, []);
   assert.equal(coreState.pokerState.communityDealt, 0);
-  assert.equal(coreState.pokerState.turnUserId !== null, true);
+  assert.equal(coreState.pokerState.turnUserId, null);
 });
 
 test("fold settlement carryover preserves stack-eligible members and deterministic dealer rotation", () => {

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -390,29 +390,10 @@ export function applyCoreStateAction({ tableId, coreState, handId, userId, actio
   }
 
   const nextVersion = coreState.version + 1;
-  let rolloverCoreState = coreState;
-  let rolloverSettledState = applied.state;
-  if (applied.state?.phase === "SETTLED") {
-    const recycled = replaceBrokeBotsForNextHand({
-      coreState,
-      settledState: applied.state,
-      nextVersion
-    });
-    rolloverCoreState = recycled.coreState;
-    rolloverSettledState = recycled.settledState;
-  }
-  const rawNextPokerState = applied.state?.phase === "SETTLED"
-    ? buildNextHandStateFromSettled({
-      tableId,
-      coreState: rolloverCoreState,
-      settledState: rolloverSettledState,
-      nextVersion
-    }) || rolloverSettledState
-    : applied.state;
-  const nextPokerState = stampTurnDeadline(rawNextPokerState, nowMs);
+  const nextPokerState = stampTurnDeadline(applied.state, nowMs);
 
   const nextCoreState = {
-    ...rolloverCoreState,
+    ...coreState,
     version: nextVersion,
     pokerState: nextPokerState
   };

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -201,10 +201,49 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.equal(seated.pot.total, 0);
   assert.deepEqual(seated.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(seated.showdown.winners, ["other_user"]);
+  assert.deepEqual(seated.showdown.revealedWinners, [
+    { userId: "other_user", holeCards: ["2C", "2D"] }
+  ]);
   assert.deepEqual(seated.handSettlement.payouts, { other_user: 6 });
   assert.equal(observer.private, null);
   assert.equal(observer.showdown.potsAwarded[0].eligibleUserIds.includes("seated_user"), true);
   assert.deepEqual(seated.private, { userId: "seated_user", seat: 1, holeCards: ["AH", "AD"] });
+});
+
+test("projectRoomCoreSnapshot does not reveal winner cards when hand ends by folds", () => {
+  const snapshot = projectRoomCoreSnapshot({
+    tableId: "table_settled_folded",
+    roomId: "table_settled_folded",
+    coreState: {
+      seats: { user_a: 1, user_b: 2 },
+      pokerState: {
+        roomId: "table_settled_folded",
+        handId: "hand_settled_folded",
+        phase: "SETTLED",
+        showdown: {
+          handId: "hand_settled_folded",
+          winners: ["user_a"],
+          potsAwarded: [{ amount: 4, winners: ["user_a"] }],
+          potAwardedTotal: 4,
+          reason: "all_folded"
+        },
+        handSettlement: {
+          handId: "hand_settled_folded",
+          settledAt: "2026-03-01T00:00:00.000Z",
+          payouts: { user_a: 4 }
+        },
+        holeCardsByUserId: { user_a: ["AS", "KH"], user_b: ["2C", "2D"] }
+      }
+    },
+    members: [
+      { userId: "user_a", seat: 1 },
+      { userId: "user_b", seat: 2 }
+    ],
+    userId: "user_a",
+    youSeat: 1
+  });
+
+  assert.equal("revealedWinners" in snapshot.showdown, false);
 });
 
 test("projectRoomCoreSnapshot omits terminal fields for fresh next-hand PREFLOP state", () => {

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -201,7 +201,7 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.equal(seated.pot.total, 0);
   assert.deepEqual(seated.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(seated.showdown.winners, ["other_user"]);
-  assert.deepEqual(seated.showdown.revealedWinners, [
+  assert.deepEqual(seated.showdown.revealedShowdownParticipants, [
     { userId: "seated_user", holeCards: ["AH", "AD"] },
     { userId: "other_user", holeCards: ["2C", "2D"] }
   ]);
@@ -211,7 +211,7 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.deepEqual(seated.private, { userId: "seated_user", seat: 1, holeCards: ["AH", "AD"] });
 });
 
-test("projectRoomCoreSnapshot does not reveal winner cards when hand ends by folds", () => {
+test("projectRoomCoreSnapshot does not reveal showdown participant cards when hand ends by folds", () => {
   const snapshot = projectRoomCoreSnapshot({
     tableId: "table_settled_folded",
     roomId: "table_settled_folded",
@@ -244,7 +244,7 @@ test("projectRoomCoreSnapshot does not reveal winner cards when hand ends by fol
     youSeat: 1
   });
 
-  assert.equal("revealedWinners" in snapshot.showdown, false);
+  assert.equal("revealedShowdownParticipants" in snapshot.showdown, false);
 });
 
 test("projectRoomCoreSnapshot omits terminal fields for fresh next-hand PREFLOP state", () => {

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -202,6 +202,7 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.deepEqual(seated.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(seated.showdown.winners, ["other_user"]);
   assert.deepEqual(seated.showdown.revealedWinners, [
+    { userId: "seated_user", holeCards: ["AH", "AD"] },
     { userId: "other_user", holeCards: ["2C", "2D"] }
   ]);
   assert.deepEqual(seated.handSettlement.payouts, { other_user: 6 });

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -170,8 +170,8 @@ function normalizeShowdown(showdown) {
     reason: typeof showdown.reason === "string" ? showdown.reason : null,
     handId: typeof showdown.handId === "string" ? showdown.handId : null
   };
-  if (Array.isArray(showdown.revealedWinners)) {
-    normalized.revealedWinners = showdown.revealedWinners
+  if (Array.isArray(showdown.revealedShowdownParticipants)) {
+    normalized.revealedShowdownParticipants = showdown.revealedShowdownParticipants
       .filter((entry) => entry && typeof entry.userId === "string")
       .map((entry) => ({
         userId: entry.userId,
@@ -208,7 +208,7 @@ function resolvePrivateBranch({ state, userId, youSeat }) {
   };
 }
 
-function resolveRevealedWinners({ statePublic, state }) {
+function resolveRevealedShowdownParticipants({ statePublic, state }) {
   if (statePublic?.phase !== "SETTLED") {
     return [];
   }
@@ -337,9 +337,9 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
 
   const showdown = normalizeShowdown(statePublic.showdown);
   if (showdown) {
-    const revealedWinners = resolveRevealedWinners({ statePublic, state });
-    if (revealedWinners.length > 0) {
-      showdown.revealedWinners = revealedWinners;
+    const revealedShowdownParticipants = resolveRevealedShowdownParticipants({ statePublic, state });
+    if (revealedShowdownParticipants.length > 0) {
+      showdown.revealedShowdownParticipants = revealedShowdownParticipants;
     }
     snapshot.showdown = showdown;
   }

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -215,14 +215,32 @@ function resolveRevealedWinners({ statePublic, state }) {
   if (statePublic?.showdown?.reason !== "computed") {
     return [];
   }
-  const winners = Array.isArray(statePublic?.showdown?.winners)
-    ? statePublic.showdown.winners.filter((value) => typeof value === "string" && value)
-    : [];
-  if (winners.length === 0) {
+  const potsAwarded = Array.isArray(statePublic?.showdown?.potsAwarded) ? statePublic.showdown.potsAwarded : [];
+  const comparedUserIds = [];
+  const comparedUserIdSet = new Set();
+  potsAwarded.forEach((pot) => {
+    if (!pot || typeof pot !== "object" || !Array.isArray(pot.eligibleUserIds)) return;
+    pot.eligibleUserIds.forEach((userId) => {
+      if (typeof userId !== "string" || !userId || comparedUserIdSet.has(userId)) return;
+      comparedUserIdSet.add(userId);
+      comparedUserIds.push(userId);
+    });
+  });
+  if (comparedUserIds.length === 0) {
+    const winners = Array.isArray(statePublic?.showdown?.winners)
+      ? statePublic.showdown.winners.filter((value) => typeof value === "string" && value)
+      : [];
+    winners.forEach((userId) => {
+      if (comparedUserIdSet.has(userId)) return;
+      comparedUserIdSet.add(userId);
+      comparedUserIds.push(userId);
+    });
+  }
+  if (comparedUserIds.length === 0) {
     return [];
   }
   const holeCardsByUserId = asObject(state?.holeCardsByUserId) || {};
-  return winners
+  return comparedUserIds
     .map((userId) => ({
       userId,
       holeCards: normalizeCards(holeCardsByUserId[userId])

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -159,7 +159,7 @@ function normalizeShowdown(showdown) {
   if (!showdown || typeof showdown !== "object" || Array.isArray(showdown)) {
     return null;
   }
-  return {
+  const normalized = {
     winners: Array.isArray(showdown.winners) ? showdown.winners.filter((userId) => typeof userId === "string") : [],
     potsAwarded: Array.isArray(showdown.potsAwarded) ? showdown.potsAwarded : [],
     potAwardedTotal: Number.isFinite(showdown.potAwardedTotal)
@@ -170,6 +170,16 @@ function normalizeShowdown(showdown) {
     reason: typeof showdown.reason === "string" ? showdown.reason : null,
     handId: typeof showdown.handId === "string" ? showdown.handId : null
   };
+  if (Array.isArray(showdown.revealedWinners)) {
+    normalized.revealedWinners = showdown.revealedWinners
+      .filter((entry) => entry && typeof entry.userId === "string")
+      .map((entry) => ({
+        userId: entry.userId,
+        holeCards: normalizeCards(entry.holeCards)
+      }))
+      .filter((entry) => entry.holeCards.length === 2);
+  }
+  return normalized;
 }
 
 function normalizeHandSettlement(handSettlement) {
@@ -196,6 +206,28 @@ function resolvePrivateBranch({ state, userId, youSeat }) {
     seat: youSeat,
     holeCards
   };
+}
+
+function resolveRevealedWinners({ statePublic, state }) {
+  if (statePublic?.phase !== "SETTLED") {
+    return [];
+  }
+  if (statePublic?.showdown?.reason !== "computed") {
+    return [];
+  }
+  const winners = Array.isArray(statePublic?.showdown?.winners)
+    ? statePublic.showdown.winners.filter((value) => typeof value === "string" && value)
+    : [];
+  if (winners.length === 0) {
+    return [];
+  }
+  const holeCardsByUserId = asObject(state?.holeCardsByUserId) || {};
+  return winners
+    .map((userId) => ({
+      userId,
+      holeCards: normalizeCards(holeCardsByUserId[userId])
+    }))
+    .filter((entry) => entry.holeCards.length === 2);
 }
 
 export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, userId, youSeat }) {
@@ -287,6 +319,10 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
 
   const showdown = normalizeShowdown(statePublic.showdown);
   if (showdown) {
+    const revealedWinners = resolveRevealedWinners({ statePublic, state });
+    if (revealedWinners.length > 0) {
+      showdown.revealedWinners = revealedWinners;
+    }
     snapshot.showdown = showdown;
   }
 

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -154,7 +154,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
         potsAwarded: [{ amount: 5, winners: ["user_a"] }],
         potAwardedTotal: 5,
         reason: "computed",
-        revealedWinners: [{ userId: "user_a", holeCards: ["AS", "AD"] }]
+        revealedShowdownParticipants: [{ userId: "user_a", holeCards: ["AS", "AD"] }]
       },
       handSettlement: {
         handId: "h_terminal",
@@ -165,7 +165,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
   });
 
   assert.deepEqual(payload.public.showdown.winners, ["user_a"]);
-  assert.deepEqual(payload.public.showdown.revealedWinners, [{ userId: "user_a", holeCards: ["AS", "AD"] }]);
+  assert.deepEqual(payload.public.showdown.revealedShowdownParticipants, [{ userId: "user_a", holeCards: ["AS", "AD"] }]);
   assert.equal(payload.public.showdown.potAwardedTotal, 5);
   assert.deepEqual(payload.public.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(payload.public.actionConstraints, { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null });
@@ -173,7 +173,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
   assert.deepEqual(payload.private, { userId: "user_a", seat: 1, holeCards: ["AS", "AD"] });
 });
 
-test("buildStateSnapshotPayload omits revealed winner cards for all-folded settlements", () => {
+test("buildStateSnapshotPayload omits revealed showdown participant cards for all-folded settlements", () => {
   const payload = buildStateSnapshotPayload({
     userId: "user_a",
     tableSnapshot: {
@@ -199,7 +199,7 @@ test("buildStateSnapshotPayload omits revealed winner cards for all-folded settl
     }
   });
 
-  assert.equal("revealedWinners" in payload.public.showdown, false);
+  assert.equal("revealedShowdownParticipants" in payload.public.showdown, false);
 });
 
 test("buildStateSnapshotPayload serializes fresh next hand without stale terminal fields", () => {

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -153,7 +153,8 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
         winners: ["user_a"],
         potsAwarded: [{ amount: 5, winners: ["user_a"] }],
         potAwardedTotal: 5,
-        reason: "computed"
+        reason: "computed",
+        revealedWinners: [{ userId: "user_a", holeCards: ["AS", "AD"] }]
       },
       handSettlement: {
         handId: "h_terminal",
@@ -164,11 +165,41 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
   });
 
   assert.deepEqual(payload.public.showdown.winners, ["user_a"]);
+  assert.deepEqual(payload.public.showdown.revealedWinners, [{ userId: "user_a", holeCards: ["AS", "AD"] }]);
   assert.equal(payload.public.showdown.potAwardedTotal, 5);
   assert.deepEqual(payload.public.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(payload.public.actionConstraints, { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null });
   assert.deepEqual(payload.public.handSettlement.payouts, { user_a: 5 });
   assert.deepEqual(payload.private, { userId: "user_a", seat: 1, holeCards: ["AS", "AD"] });
+});
+
+test("buildStateSnapshotPayload omits revealed winner cards for all-folded settlements", () => {
+  const payload = buildStateSnapshotPayload({
+    userId: "user_a",
+    tableSnapshot: {
+      tableId: "table_terminal_folded",
+      roomId: "table_terminal_folded",
+      stateVersion: 11,
+      members: [{ userId: "user_a", seat: 1 }],
+      memberCount: 1,
+      youSeat: 1,
+      hand: { handId: "h_terminal_folded", status: "SETTLED", round: null, dealerSeatNo: 1 },
+      board: { cards: ["2H", "3H", "4H", "9C", "KD"] },
+      pot: { total: 0, sidePots: [] },
+      turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
+      legalActions: { seat: 1, actions: [] },
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      showdown: {
+        handId: "h_terminal_folded",
+        winners: ["user_a"],
+        potsAwarded: [{ amount: 5, winners: ["user_a"] }],
+        potAwardedTotal: 5,
+        reason: "all_folded"
+      }
+    }
+  });
+
+  assert.equal("revealedWinners" in payload.public.showdown, false);
 });
 
 test("buildStateSnapshotPayload serializes fresh next hand without stale terminal fields", () => {

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -69,8 +69,8 @@ function normalizeShowdown(showdown) {
     reason: typeof showdown.reason === "string" ? showdown.reason : null,
     handId: typeof showdown.handId === "string" ? showdown.handId : null
   };
-  if (Array.isArray(showdown.revealedWinners)) {
-    normalized.revealedWinners = showdown.revealedWinners
+  if (Array.isArray(showdown.revealedShowdownParticipants)) {
+    normalized.revealedShowdownParticipants = showdown.revealedShowdownParticipants
       .filter((entry) => entry && typeof entry.userId === "string")
       .map((entry) => ({
         userId: entry.userId,

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -58,7 +58,7 @@ function normalizeShowdown(showdown) {
   if (!showdown || typeof showdown !== "object" || Array.isArray(showdown)) {
     return null;
   }
-  return {
+  const normalized = {
     winners: Array.isArray(showdown.winners) ? showdown.winners.filter((userId) => typeof userId === "string") : [],
     potsAwarded: Array.isArray(showdown.potsAwarded) ? showdown.potsAwarded : [],
     potAwardedTotal: Number.isFinite(showdown.potAwardedTotal)
@@ -69,6 +69,16 @@ function normalizeShowdown(showdown) {
     reason: typeof showdown.reason === "string" ? showdown.reason : null,
     handId: typeof showdown.handId === "string" ? showdown.handId : null
   };
+  if (Array.isArray(showdown.revealedWinners)) {
+    normalized.revealedWinners = showdown.revealedWinners
+      .filter((entry) => entry && typeof entry.userId === "string")
+      .map((entry) => ({
+        userId: entry.userId,
+        holeCards: normalizeCards(entry.holeCards)
+      }))
+      .filter((entry) => entry.holeCards.length === 2);
+  }
+  return normalized;
 }
 
 function normalizeHandSettlement(handSettlement) {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -1330,8 +1330,8 @@ test("accepted bot autoplay handles engine poker state through river showdown wi
   assert.equal(calls.resync, 0);
   assert.ok(calls.persist > 0);
   assert.ok(coreState.version > previousVersion);
-  assert.notEqual(coreState.pokerState?.handId, previousHandId);
-  assert.equal(["PREFLOP", "FLOP", "TURN", "RIVER"].includes(coreState.pokerState?.phase), true);
+  assert.equal(coreState.pokerState?.handId, previousHandId);
+  assert.equal(coreState.pokerState?.phase, "SETTLED");
 });
 
 test("accepted bot autoplay settles showdown and allows next hand to continue", async () => {

--- a/ws-server/poker/runtime/settled-reveal-timing.behavior.test.mjs
+++ b/ws-server/poker/runtime/settled-reveal-timing.behavior.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveSettledRevealDueAt } from "./settled-reveal-timing.mjs";
+
+test("resolveSettledRevealDueAt keeps original settled timestamp instead of restarting reveal window", () => {
+  const nowMs = Date.parse("2026-04-11T12:00:00.000Z");
+  const settledAt = "2026-04-11T11:59:55.000Z";
+  const revealMs = 2_000;
+
+  const dueAt = resolveSettledRevealDueAt({ settledAt, nowMs, revealMs });
+
+  assert.equal(dueAt, Date.parse(settledAt) + revealMs);
+  assert.equal(dueAt <= nowMs, true);
+});
+
+test("resolveSettledRevealDueAt falls back to now when settledAt is missing", () => {
+  const nowMs = Date.parse("2026-04-11T12:00:00.000Z");
+  const revealMs = 2_000;
+
+  const dueAt = resolveSettledRevealDueAt({ settledAt: null, nowMs, revealMs });
+
+  assert.equal(dueAt, nowMs + revealMs);
+});

--- a/ws-server/poker/runtime/settled-reveal-timing.mjs
+++ b/ws-server/poker/runtime/settled-reveal-timing.mjs
@@ -1,0 +1,7 @@
+export function resolveSettledRevealDueAt({ settledAt, nowMs, revealMs }) {
+  const normalizedNowMs = Number.isFinite(nowMs) ? Math.trunc(nowMs) : Date.now();
+  const normalizedRevealMs = Number.isFinite(revealMs) && revealMs >= 0 ? Math.trunc(revealMs) : 0;
+  const settledAtMs = Date.parse(settledAt || "");
+  const baseMs = Number.isFinite(settledAtMs) ? settledAtMs : normalizedNowMs;
+  return baseMs + normalizedRevealMs;
+}

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -55,6 +55,75 @@ test("resolveNextDealerSeatNo skips ineligible seats based on settled continuati
 
   assert.equal(nextDealer, 3);
 });
+
+test("rolloverSettledHand delays next-hand bootstrap until explicitly invoked", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const tableId = "table_settled_rollover";
+  const wsA = fakeWs("ws-rollover-a");
+  const wsB = fakeWs("ws-rollover-b");
+
+  assert.equal(tableManager.join({ ws: wsA, userId: "user_a", tableId, requestId: "join-rollover-a", nowTs: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: wsB, userId: "user_b", tableId, requestId: "join-rollover-b", nowTs: 2 }).ok, true);
+
+  const restored = tableManager.restoreTableFromPersisted(tableId, {
+    coreState: {
+      version: 7,
+      roomId: tableId,
+      maxSeats: 6,
+      members: [
+        { userId: "user_a", seat: 1 },
+        { userId: "user_b", seat: 2 }
+      ],
+      seats: { user_a: 1, user_b: 2 },
+      publicStacks: { user_a: 102, user_b: 98 },
+      seatDetailsByUserId: {
+        user_a: { isBot: false, botProfile: null, leaveAfterHand: false },
+        user_b: { isBot: false, botProfile: null, leaveAfterHand: false }
+      },
+      pokerState: {
+        roomId: tableId,
+        handId: "hand_settled_rollover",
+        phase: "SETTLED",
+        dealerSeatNo: 1,
+        seats: [
+          { userId: "user_a", seatNo: 1, status: "ACTIVE" },
+          { userId: "user_b", seatNo: 2, status: "ACTIVE" }
+        ],
+        stacks: { user_a: 102, user_b: 98 },
+        showdown: {
+          handId: "hand_settled_rollover",
+          winners: ["user_a"],
+          potsAwarded: [{ amount: 4, winners: ["user_a"] }],
+          potAwardedTotal: 4,
+          reason: "computed"
+        },
+        handSettlement: {
+          handId: "hand_settled_rollover",
+          settledAt: "2026-04-11T10:00:00.000Z",
+          payouts: { user_a: 4 }
+        },
+        holeCardsByUserId: { user_a: ["AS", "KD"], user_b: ["2C", "2D"] }
+      }
+    },
+    presenceByUserId: new Map([
+      ["user_a", { userId: "user_a", seat: 1, connected: true, lastSeenAt: 1, expiresAt: null }],
+      ["user_b", { userId: "user_b", seat: 2, connected: true, lastSeenAt: 2, expiresAt: null }]
+    ])
+  });
+
+  assert.equal(restored.ok, true);
+  assert.equal(tableManager.persistedPokerState(tableId).phase, "SETTLED");
+
+  const rollover = tableManager.rolloverSettledHand({ tableId, nowMs: 5_000 });
+
+  assert.equal(rollover.ok, true);
+  assert.equal(rollover.changed, true);
+  const nextState = tableManager.persistedPokerState(tableId);
+  assert.equal(nextState.phase, "PREFLOP");
+  assert.equal(nextState.dealerSeatNo, 2);
+  assert.equal(nextState.turnStartedAt, 5_000);
+  assert.equal(nextState.turnDeadlineAt > nextState.turnStartedAt, true);
+});
 test("table manager exposes connected members as sorted {userId, seat} and reuses freed seats", () => {
   const tableManager = createTableManager({ maxSeats: 3, presenceTtlMs: 0 });
   const ws1 = fakeWs("ws-1");
@@ -1224,7 +1293,7 @@ test("first FLOP CHECK keeps FLOP and passes turn", () => {
   assert.equal(flopAfter.turn.userId, "user_a");
 });
 
-test("preflop fold-win auto-bootstraps next PREFLOP hand with preserved stacks", () => {
+test("preflop fold-win settles first and boots next hand only after explicit rollover", () => {
   const tableManager = createTableManager({ maxSeats: 4 });
   const wsA = fakeWs("fold-a");
   const wsB = fakeWs("fold-b");
@@ -1237,9 +1306,16 @@ test("preflop fold-win auto-bootstraps next PREFLOP hand with preserved stacks",
   const pre = tableManager.tableSnapshot(tableId, "user_b");
   const before = tableManager.tableSnapshot(tableId, "user_a");
   const close = tableManager.applyAction({ tableId, handId: pre.hand.handId, userId: pre.turn.userId, requestId: "req-fold-close", action: "FOLD", amount: 0 });
-  const after = tableManager.tableSnapshot(tableId, "user_a");
+  const settled = tableManager.tableSnapshot(tableId, "user_a");
 
   assert.equal(close.accepted, true);
+  assert.equal(settled.hand.status, "SETTLED");
+  assert.equal(settled.hand.handId, before.hand.handId);
+  assert.equal(Array.isArray(settled.showdown.winners), true);
+  assert.equal(typeof settled.handSettlement.settledAt, "string");
+  const rollover = tableManager.rolloverSettledHand({ tableId, nowMs: 3_000 });
+  const after = tableManager.tableSnapshot(tableId, "user_a");
+  assert.equal(rollover.changed, true);
   assert.equal(after.hand.status, "PREFLOP");
   assert.notEqual(after.hand.handId, before.hand.handId);
   assert.equal(after.board.cards.length, 0);
@@ -1250,7 +1326,7 @@ test("preflop fold-win auto-bootstraps next PREFLOP hand with preserved stacks",
   assert.equal(Array.isArray(after.legalActions.actions), true);
 });
 
-test("closing RIVER action auto-bootstraps next PREFLOP hand and replay is idempotent", () => {
+test("closing RIVER action settles first and replay is idempotent before rollover", () => {
   const tableManager = createTableManager({ maxSeats: 4 });
   const wsA = fakeWs("river-a");
   const wsB = fakeWs("river-b");
@@ -1274,19 +1350,11 @@ test("closing RIVER action auto-bootstraps next PREFLOP hand and replay is idemp
   assert.equal(river.hand.status, "RIVER");
   assert.equal(tableManager.applyAction({ tableId, handId: river.hand.handId, userId: "user_b", requestId: "req-river-check-1", action: "CHECK", amount: 0 }).accepted, true);
   const close = tableManager.applyAction({ tableId, handId: river.hand.handId, userId: "user_a", requestId: "req-river-check-2", action: "CHECK", amount: 0 });
-  const after = tableManager.tableSnapshot(tableId, "user_a");
+  const settled = tableManager.tableSnapshot(tableId, "user_a");
 
   assert.equal(close.accepted, true);
-  assert.equal(after.hand.status, "PREFLOP");
-  assert.notEqual(after.hand.handId, river.hand.handId);
-  assert.equal(after.board.cards.length, 0);
-  assert.equal(typeof after.turn.userId, "string");
-  assert.equal(after.pot.total, 3);
-  assert.equal("showdown" in after, false);
-  assert.equal("handSettlement" in after, false);
-  const nextHandId = after.hand.handId;
-  const nextStateVersion = after.stateVersion;
-  const nextDealerSeat = after.turn.seat;
+  assert.equal(settled.hand.status, "SETTLED");
+  assert.equal(settled.hand.handId, river.hand.handId);
 
   const replayClose = tableManager.applyAction({ tableId, handId: river.hand.handId, userId: "user_a", requestId: "req-river-check-2", action: "CHECK", amount: 0 });
   assert.equal(replayClose.accepted, true);
@@ -1295,14 +1363,23 @@ test("closing RIVER action auto-bootstraps next PREFLOP hand and replay is idemp
   assert.equal(replayClose.stateVersion, close.stateVersion);
 
   const afterReplay = tableManager.tableSnapshot(tableId, "user_a");
-  assert.equal(afterReplay.hand.handId, nextHandId);
-  assert.equal(afterReplay.stateVersion, nextStateVersion);
-  assert.equal(afterReplay.turn.seat, nextDealerSeat);
+  assert.equal(afterReplay.hand.handId, settled.hand.handId);
+  assert.equal(afterReplay.stateVersion, settled.stateVersion);
 
   const rejected = tableManager.applyAction({ tableId, handId: river.hand.handId, userId: "user_b", requestId: "req-river-check-3", action: "CHECK", amount: 0 });
   assert.equal(rejected.accepted, false);
-  assert.equal(rejected.reason, "hand_mismatch");
+  assert.equal(rejected.reason, "hand_not_live");
   assert.equal(rejected.stateVersion, close.stateVersion);
+
+  assert.equal(tableManager.rolloverSettledHand({ tableId, nowMs: 9_000 }).changed, true);
+  const after = tableManager.tableSnapshot(tableId, "user_a");
+  assert.equal(after.hand.status, "PREFLOP");
+  assert.notEqual(after.hand.handId, river.hand.handId);
+  assert.equal(after.board.cards.length, 0);
+  assert.equal(typeof after.turn.userId, "string");
+  assert.equal(after.pot.total, 3);
+  assert.equal("showdown" in after, false);
+  assert.equal("handSettlement" in after, false);
 });
 
 test("next hand rotates dealer for heads-up and three-player tables", () => {
@@ -1317,6 +1394,7 @@ test("next hand rotates dealer for heads-up and three-player tables", () => {
   const preHu = headsUpManager.tableSnapshot(headsUpTableId, "user_a");
   const dealerBeforeHu = preHu.turn.userId;
   assert.equal(headsUpManager.applyAction({ tableId: headsUpTableId, handId: preHu.hand.handId, userId: preHu.turn.userId, requestId: "hu-fold-close", action: "FOLD", amount: 0 }).accepted, true);
+  assert.equal(headsUpManager.rolloverSettledHand({ tableId: headsUpTableId, nowMs: 4_000 }).changed, true);
   const nextHu = headsUpManager.tableSnapshot(headsUpTableId, "user_a");
   assert.equal(nextHu.hand.status, "PREFLOP");
   assert.notEqual(nextHu.turn.userId, dealerBeforeHu);
@@ -1329,11 +1407,50 @@ test("next hand rotates dealer for heads-up and three-player tables", () => {
   assert.equal(ringManager.join({ ws: wsR1, userId: "user_a", tableId: ringTableId, requestId: "join-r-a" }).ok, true);
   assert.equal(ringManager.join({ ws: wsR2, userId: "user_b", tableId: ringTableId, requestId: "join-r-b" }).ok, true);
   assert.equal(ringManager.join({ ws: wsR3, userId: "user_c", tableId: ringTableId, requestId: "join-r-c" }).ok, true);
-  assert.equal(ringManager.bootstrapHand(ringTableId).ok, true);
-
-  const preRing = ringManager.tableSnapshot(ringTableId, "user_a");
-  assert.equal(preRing.turn.userId, "user_a");
-  assert.equal(ringManager.applyAction({ tableId: ringTableId, handId: preRing.hand.handId, userId: preRing.turn.userId, requestId: "ring-fold-close", action: "FOLD", amount: 0 }).accepted, true);
+  assert.equal(ringManager.restoreTableFromPersisted(ringTableId, {
+    coreState: {
+      version: 4,
+      roomId: ringTableId,
+      maxSeats: 6,
+      members: [
+        { userId: "user_a", seat: 1 },
+        { userId: "user_b", seat: 2 },
+        { userId: "user_c", seat: 3 }
+      ],
+      seats: { user_a: 1, user_b: 2, user_c: 3 },
+      publicStacks: { user_a: 100, user_b: 100, user_c: 100 },
+      seatDetailsByUserId: {
+        user_a: { isBot: false, botProfile: null, leaveAfterHand: false },
+        user_b: { isBot: false, botProfile: null, leaveAfterHand: false },
+        user_c: { isBot: false, botProfile: null, leaveAfterHand: false }
+      },
+      pokerState: {
+        roomId: ringTableId,
+        handId: "ring_settled",
+        phase: "SETTLED",
+        dealerSeatNo: 1,
+        stacks: { user_a: 100, user_b: 100, user_c: 100 },
+        showdown: {
+          handId: "ring_settled",
+          winners: ["user_b"],
+          potsAwarded: [{ amount: 9, winners: ["user_b"] }],
+          potAwardedTotal: 9,
+          reason: "computed"
+        },
+        handSettlement: {
+          handId: "ring_settled",
+          settledAt: "2026-04-11T10:00:02.000Z",
+          payouts: { user_b: 9 }
+        }
+      }
+    },
+    presenceByUserId: new Map([
+      ["user_a", { userId: "user_a", seat: 1, connected: true, lastSeenAt: 1, expiresAt: null }],
+      ["user_b", { userId: "user_b", seat: 2, connected: true, lastSeenAt: 1, expiresAt: null }],
+      ["user_c", { userId: "user_c", seat: 3, connected: true, lastSeenAt: 1, expiresAt: null }]
+    ])
+  }).ok, true);
+  assert.equal(ringManager.rolloverSettledHand({ tableId: ringTableId, nowMs: 4_000 }).changed, true);
 
   const nextRing = ringManager.tableSnapshot(ringTableId, "user_a");
   assert.equal(nextRing.hand.status, "PREFLOP");
@@ -1388,7 +1505,7 @@ test("maybeApplyTurnTimeout does nothing when deadline is unexpired", () => {
   assert.equal(after.stateVersion, before.stateVersion);
 });
 
-test("timeout progression can settle hand and auto-start next hand using supplied logical clock", () => {
+test("timeout progression can settle hand and next hand starts only after explicit rollover", () => {
   const tableManager = createTableManager({ maxSeats: 4, enableDebugCore: true, nodeEnv: "test" });
   const wsA = fakeWs("timeout-cycle-a");
   const wsB = fakeWs("timeout-cycle-b");
@@ -1403,23 +1520,31 @@ test("timeout progression can settle hand and auto-start next hand using supplie
   const previousHandId = before.hand.handId;
 
   const timeoutResult = tableManager.maybeApplyTurnTimeout({ tableId, nowMs: fixedFutureMs });
-  const after = tableManager.tableSnapshot(tableId, "user_a");
-  const livePokerState = tableManager.__debugPokerState(tableId);
+  const settled = tableManager.tableSnapshot(tableId, "user_a");
+  const settledPokerState = tableManager.__debugPokerState(tableId);
 
   assert.equal(timeoutResult.ok, true);
   assert.equal(timeoutResult.changed, true);
+  assert.equal(settled.hand.handId, previousHandId);
+  assert.equal(settled.hand.status, "SETTLED");
+  assert.equal(settledPokerState.turnStartedAt, null);
+  assert.equal(settledPokerState.turnDeadlineAt, null);
+
+  const secondSweep = tableManager.maybeApplyTurnTimeout({ tableId, nowMs: fixedFutureMs });
+  assert.equal(secondSweep.changed, false);
+
+  assert.equal(tableManager.rolloverSettledHand({ tableId, nowMs: fixedFutureMs }).changed, true);
+  const after = tableManager.tableSnapshot(tableId, "user_a");
+  const livePokerState = tableManager.__debugPokerState(tableId);
   assert.notEqual(after.hand.handId, previousHandId);
   assert.equal(after.hand.status, "PREFLOP");
   assert.equal(typeof after.turn.userId, "string");
   assert.equal(livePokerState.turnStartedAt, fixedFutureMs);
   assert.equal(livePokerState.turnDeadlineAt > fixedFutureMs, true);
-
-  const secondSweep = tableManager.maybeApplyTurnTimeout({ tableId, nowMs: fixedFutureMs });
-  assert.equal(secondSweep.changed, false);
 });
 
 
-test("applyAction resets turn deadline using supplied action clock", () => {
+test("rolloverSettledHand stamps next-turn deadline using supplied action clock", () => {
   const tableManager = createTableManager({ maxSeats: 4, enableDebugCore: true, nodeEnv: "test" });
   const wsA = fakeWs("action-clock-a");
   const wsB = fakeWs("action-clock-b");
@@ -1442,6 +1567,8 @@ test("applyAction resets turn deadline using supplied action clock", () => {
   });
 
   assert.equal(acted.accepted, true);
+  assert.equal(tableManager.__debugPokerState(tableId).turnStartedAt, null);
+  assert.equal(tableManager.rolloverSettledHand({ tableId, nowMs: actionNowMs }).changed, true);
   const livePokerState = tableManager.__debugPokerState(tableId);
   assert.equal(livePokerState.turnStartedAt, actionNowMs);
   assert.equal(livePokerState.turnDeadlineAt > actionNowMs, true);

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -10,8 +10,10 @@ import {
   buildNextHandStateFromSettled,
   isContinuationEligibleByStack,
   orderedEligibleSeatMembers,
+  replaceBrokeBotsForNextHand,
   resolveNextDealerSeatNo
 } from "../engine/poker-engine.mjs";
+import { stampTurnDeadline } from "../shared/poker-turn-timeout.mjs";
 
 const DEFAULT_PRESENCE_TTL_MS = 10_000;
 const DEFAULT_MAX_SEATS = 10;
@@ -422,6 +424,57 @@ export function createTableManager({
       action: timeoutApplied.action,
       actorUserId: timeoutApplied.actorUserId,
       stateVersion: timeoutApplied.stateVersion
+    };
+  }
+
+  function rolloverSettledHand({ tableId, nowMs = Date.now() } = {}) {
+    const table = tables.get(tableId);
+    if (!table) {
+      return { ok: false, changed: false, reason: "table_not_found", stateVersion: 0 };
+    }
+
+    const settledState = table.coreState?.pokerState;
+    if (!settledState || typeof settledState !== "object" || Array.isArray(settledState)) {
+      return { ok: true, changed: false, reason: "state_missing", stateVersion: table.coreState.version };
+    }
+    if (settledState.phase !== "SETTLED") {
+      return { ok: true, changed: false, reason: "hand_not_settled", stateVersion: table.coreState.version };
+    }
+
+    const nextVersion = Number(table.coreState.version || 0) + 1;
+    const recycled = replaceBrokeBotsForNextHand({
+      coreState: table.coreState,
+      settledState,
+      nextVersion
+    });
+    const nextHandState = buildNextHandStateFromSettled({
+      tableId,
+      coreState: recycled.coreState,
+      settledState: recycled.settledState,
+      nextVersion
+    });
+
+    if (!nextHandState) {
+      return {
+        ok: true,
+        changed: false,
+        reason: "not_enough_players",
+        stateVersion: table.coreState.version
+      };
+    }
+
+    table.coreState = {
+      ...recycled.coreState,
+      version: nextVersion,
+      pokerState: stampTurnDeadline(nextHandState, resolveNowMs({ nowMs }))
+    };
+
+    return {
+      ok: true,
+      changed: true,
+      reason: null,
+      stateVersion: table.coreState.version,
+      handId: table.coreState?.pokerState?.handId ?? null
     };
   }
 
@@ -1156,6 +1209,7 @@ export function createTableManager({
     tableSnapshot,
     bootstrapHand,
     applyAction,
+    rolloverSettledHand,
     maybeApplyTurnTimeout,
     sweepTurnTimeouts,
     listDueTurnTimeouts,

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1485,7 +1485,7 @@ test("WS table_join hydrates from persisted bootstrap fixture", async () => {
     }
   };
 
-  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret, SUPABASE_DB_URL: "", ...persistedBootstrapFixturesEnv(fixtures) } });
+  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret, WS_POKER_SETTLED_REVEAL_MS: "60000", SUPABASE_DB_URL: "", ...persistedBootstrapFixturesEnv(fixtures) } });
 
   try {
     await waitForListening(child, 5000);
@@ -2200,13 +2200,18 @@ test("timeout sweep advances seated persisted table state under observe-only run
     sendFrame(wsA, { version: "1.0", type: "table_state_sub", requestId: "snap-timeout-a", ts: "2026-02-28T00:40:03Z", payload: { tableId, view: "snapshot" } });
     const base = await nextMessageOfType(wsA, "stateSnapshot");
 
-    const timeoutUpdate = await nextStateUpdate(wsA, { baseline: base.payload, timeoutMs: 5000 });
-    assert.equal(timeoutUpdate.frame.type, "stateSnapshot");
-    assert.equal(timeoutUpdate.payload.stateVersion > base.payload.stateVersion, true);
-    assert.equal(Number.isFinite(timeoutUpdate.payload.public.turn.startedAt), true);
-    assert.equal(Number.isFinite(timeoutUpdate.payload.public.turn.deadlineAt), true);
-    assert.equal(timeoutUpdate.payload.public.turn.deadlineAt > timeoutUpdate.payload.public.turn.startedAt, true);
-    assert.equal(Object.prototype.hasOwnProperty.call(timeoutUpdate.payload.public, "holeCardsByUserId"), false);
+    const settledUpdate = await nextStateUpdate(wsA, { baseline: base.payload, timeoutMs: 5000 });
+    assert.equal(settledUpdate.frame.type, "stateSnapshot");
+    assert.equal(settledUpdate.payload.stateVersion > base.payload.stateVersion, true);
+    assert.equal(settledUpdate.payload.public.hand.status, "SETTLED");
+    assert.equal(Number.isFinite(settledUpdate.payload.public.turn.startedAt), false);
+    assert.equal(Number.isFinite(settledUpdate.payload.public.turn.deadlineAt), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(settledUpdate.payload.public, "holeCardsByUserId"), false);
+    const nextHandUpdate = await nextStateUpdate(wsA, { baseline: settledUpdate.payload, timeoutMs: 5000 });
+    assert.equal(nextHandUpdate.payload.public.hand.status, "PREFLOP");
+    assert.equal(Number.isFinite(nextHandUpdate.payload.public.turn.startedAt), true);
+    assert.equal(Number.isFinite(nextHandUpdate.payload.public.turn.deadlineAt), true);
+    assert.equal(nextHandUpdate.payload.public.turn.deadlineAt > nextHandUpdate.payload.public.turn.startedAt, true);
     assert.equal(await attemptMessage(wsA, 300), null);
 
     wsA.close();

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1347,6 +1347,102 @@ test("resume outside replay window triggers deterministic resync plus fresh snap
   }
 });
 
+test("resume fallback snapshot on settled table still schedules delayed rollover", async () => {
+  const secret = "resume-settled-secret";
+  const settledAt = new Date(Date.now()).toISOString();
+  const tableId = "table_resume_settled";
+  const fixtures = {
+    [tableId]: {
+      tableRow: { id: tableId, max_players: 6, status: "active" },
+      seatRows: [
+        { user_id: "user_resume", seat_no: 1, status: "ACTIVE", is_bot: false },
+        { user_id: "user_other", seat_no: 2, status: "ACTIVE", is_bot: false }
+      ],
+      stateRow: {
+        version: 21,
+        state: {
+          handId: "h21",
+          phase: "SETTLED",
+          dealerSeatNo: 1,
+          community: [],
+          communityDealt: 0,
+          turnUserId: null,
+          turnStartedAt: null,
+          turnDeadlineAt: null,
+          showdown: {
+            handId: "h21",
+            winners: ["user_resume"],
+            reason: "computed"
+          },
+          handSettlement: {
+            handId: "h21",
+            settledAt,
+            payouts: { user_resume: 12 }
+          },
+          stacks: {
+            user_resume: 112,
+            user_other: 88
+          }
+        }
+      }
+    }
+  };
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_STREAM_REPLAY_CAP: "1",
+      WS_POKER_SETTLED_REVEAL_MS: "1000",
+      SUPABASE_DB_URL: "",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    const helloAck = await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: "user_resume" }));
+
+    sendFrame(ws, { version: "1.0", type: "table_join", requestId: "join-settled-r1", ts: "2026-02-28T00:00:01Z", payload: { tableId } });
+    await nextMessageOfType(ws, "commandResult");
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-settled-r1", ts: "2026-02-28T00:00:02Z", payload: { tableId, view: "snapshot" } });
+    await nextMessageOfType(ws, "stateSnapshot");
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-settled-r2", ts: "2026-02-28T00:00:03Z", payload: { tableId, view: "snapshot" } });
+    await nextMessageOfType(ws, "stateSnapshot");
+    ws.close();
+
+    const ws2 = await connectClient(port);
+    await hello(ws2);
+    await auth(ws2, makeHs256Jwt({ secret, sub: "user_resume" }), "auth-settled-r2");
+    sendFrame(ws2, {
+      version: "1.0",
+      type: "resume",
+      requestId: "resume-settled-r2",
+      roomId: tableId,
+      ts: "2026-02-28T00:00:04Z",
+      payload: { tableId, sessionId: helloAck.payload.sessionId, lastSeq: 0 }
+    });
+
+    const resync = await nextMessageOfType(ws2, "resync");
+    const resumedSnapshot = await nextMessageOfType(ws2, "stateSnapshot");
+    assert.equal(resync.payload.mode, "required");
+    assert.ok(["SETTLED", "PREFLOP"].includes(resumedSnapshot.payload.public.hand.status));
+    if (resumedSnapshot.payload.public.hand.status === "SETTLED") {
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      sendFrame(ws2, { version: "1.0", type: "table_state_sub", requestId: "snap-settled-r3", ts: "2026-02-28T00:00:05Z", payload: { tableId, view: "snapshot" } });
+      const rolledSnapshot = await nextMessageOfType(ws2, "stateSnapshot");
+      assert.equal(rolledSnapshot.payload.public.hand.status, "PREFLOP");
+      assert.equal(rolledSnapshot.payload.stateVersion > resumedSnapshot.payload.stateVersion, true);
+    } else {
+      assert.equal(resumedSnapshot.payload.stateVersion > 21, true);
+    }
+    ws2.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 test("resume replay is isolated by session stream for same authenticated user", async () => {
   const secret = "same-user-session-isolation";
   const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret, WS_STREAM_REPLAY_CAP: "16" } });
@@ -3540,6 +3636,84 @@ test("WS act optimistic conflict returns deterministic rejection and restored sn
     const afterConflict = await nextMessageOfType(ws, "stateSnapshot");
     assert.equal(afterConflict.payload.stateVersion, forced.tables[tableId].stateRow.version);
 
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("optimistic conflict restore to settled state still schedules delayed rollover", async () => {
+  const secret = "persist-conflict-settled-secret";
+  const tableId = "table_ws_persist_conflict_settled";
+  const store = {
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "active" },
+        seatRows: [
+          { user_id: "seat_actor", seat_no: 1, status: "ACTIVE", is_bot: false },
+          { user_id: "seat_other", seat_no: 2, status: "ACTIVE", is_bot: false }
+        ],
+        stateRow: { version: 0, state: {} }
+      }
+    }
+  };
+  const { dir, filePath } = await writePersistedFile(store);
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_POKER_SETTLED_REVEAL_MS: "50"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: "seat_actor" }), "auth-conflict-settled");
+    sendFrame(ws, { version: "1.0", type: "table_join", requestId: "join-conflict-settled", ts: "2026-02-28T02:10:00Z", payload: { tableId } });
+    await nextMessageOfType(ws, "commandResult");
+    await nextMessageOfType(ws, "table_state");
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-conflict-settled", ts: "2026-02-28T02:10:01Z", payload: { tableId, view: "snapshot" } });
+    const baseline = await nextMessageOfType(ws, "stateSnapshot");
+    const handId = baseline.payload.public.hand.handId;
+
+    const forced = await readPersistedFile(filePath);
+    const nextVersion = baseline.payload.stateVersion + 7;
+    const settledState = {
+      ...forced.tables[tableId].stateRow.state,
+      phase: "SETTLED",
+      turnUserId: null,
+      turnStartedAt: null,
+      turnDeadlineAt: null,
+      showdown: {
+        handId,
+        winners: ["seat_actor"],
+        reason: "computed"
+      },
+      handSettlement: {
+        handId,
+        settledAt: new Date(Date.now()).toISOString(),
+        payouts: { seat_actor: 3 }
+      }
+    };
+    forced.tables[tableId].stateRow.version = nextVersion;
+    forced.tables[tableId].stateRow.state = settledState;
+    await fs.writeFile(filePath, `${JSON.stringify(forced)}\n`, "utf8");
+
+    sendFrame(ws, { version: "1.0", type: "act", requestId: "act-conflict-settled", ts: "2026-02-28T02:10:02Z", payload: { tableId, handId, action: "fold" } });
+    const rejected = await nextMessageOfType(ws, "commandResult");
+    assert.equal(rejected.payload.status, "rejected");
+    assert.equal(rejected.payload.reason, "conflict");
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-conflict-settled-after", ts: "2026-02-28T02:10:03Z", payload: { tableId, view: "snapshot" } });
+    const rolledSnapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(rolledSnapshot.payload.public.hand.status, "PREFLOP");
+    assert.equal(rolledSnapshot.payload.stateVersion > nextVersion, true);
     ws.close();
   } finally {
     child.kill("SIGTERM");

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1536,7 +1536,15 @@ test("WS table_join missing persisted table returns protocol-safe error and late
     }
   };
 
-  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret, SUPABASE_DB_URL: "", ...persistedBootstrapFixturesEnv(fixtures) } });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_POKER_SETTLED_REVEAL_MS: "60000",
+      SUPABASE_DB_URL: "",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
 
   try {
     await waitForListening(child, 5000);
@@ -2136,6 +2144,16 @@ test("duplicate act requestId is idempotent and does not emit extra advancing st
     assert.equal(firstResult.payload.status, "accepted");
     const firstUpdate = await nextStateUpdate(ws, { baseline: baseline.payload, timeoutMs: 4000 });
     assert.equal(firstUpdate.payload.stateVersion > baseline.payload.stateVersion, true);
+    let latestVersion = firstUpdate.payload.stateVersion;
+    for (;;) {
+      const maybeFrame = await attemptMessage(ws, 300);
+      if (!maybeFrame) {
+        break;
+      }
+      if (maybeFrame.type === "stateSnapshot") {
+        latestVersion = maybeFrame.payload.stateVersion;
+      }
+    }
 
     sendFrame(ws, { version: "1.0", type: "act", requestId: "act-idem", ts: "2026-02-28T01:03:03Z", payload: { tableId, handId, action: "fold" } });
     const replayResult = await nextMessageOfType(ws, "commandResult");
@@ -2144,7 +2162,7 @@ test("duplicate act requestId is idempotent and does not emit extra advancing st
 
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-idem-after", ts: "2026-02-28T01:03:04Z", payload: { tableId, view: "snapshot" } });
     const afterReplay = await nextMessageOfType(ws, "stateSnapshot");
-    assert.equal(afterReplay.payload.stateVersion, firstUpdate.payload.stateVersion);
+    assert.equal(afterReplay.payload.stateVersion, latestVersion);
 
     ws.close();
   } finally {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1524,6 +1524,76 @@ test("WS table_join hydrates from persisted bootstrap fixture", async () => {
   }
 });
 
+test("snapshot-only settled bootstrap schedules rollover without prior broadcast subscription", async () => {
+  const secret = "test-secret";
+  const token = makeHs256Jwt({ secret, sub: "user_a" });
+  const tableId = "table_settled_snapshot_rollover";
+  const fixtures = {
+    [tableId]: {
+      tableRow: { id: tableId, max_players: 6, status: "active" },
+      seatRows: [
+        { user_id: "user_a", seat_no: 1, status: "ACTIVE", is_bot: false },
+        { user_id: "user_b", seat_no: 2, status: "ACTIVE", is_bot: false }
+      ],
+      stateRow: {
+        version: 21,
+        state: {
+          handId: "h21",
+          phase: "SETTLED",
+          dealerSeatNo: 1,
+          community: [],
+          communityDealt: 0,
+          turnUserId: null,
+          handSettlement: {
+            reason: "computed",
+            settledAt: new Date(Date.now()).toISOString(),
+            winners: [{ userId: "user_a", amount: 12 }]
+          },
+          showdown: {
+            reason: "computed",
+            winners: [{ userId: "user_a", amount: 12 }]
+          },
+          stacks: { user_a: 112, user_b: 88 }
+        }
+      }
+    }
+  };
+
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_POKER_SETTLED_REVEAL_MS: "50",
+      SUPABASE_DB_URL: "",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    const authOk = await auth(ws, token);
+    assert.equal(authOk.type, "authOk");
+
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "req-snap-1", ts: "2026-02-28T00:00:03Z", payload: { tableId, view: "snapshot" } });
+    const initialSnapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(initialSnapshot.payload.public.hand.status, "SETTLED");
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "req-snap-2", ts: "2026-02-28T00:00:04Z", payload: { tableId, view: "snapshot" } });
+    const rolledSnapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(rolledSnapshot.payload.public.hand.status, "PREFLOP");
+    assert.equal(rolledSnapshot.payload.stateVersion > initialSnapshot.payload.stateVersion, true);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 test("WS table_join missing persisted table returns protocol-safe error and later valid join works", async () => {
   const secret = "test-secret";
   const token = makeHs256Jwt({ secret, sub: "user_a" });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -27,6 +27,7 @@ import { handleBotStepCommand } from "./poker/handlers/bot-autoplay.mjs";
 import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
+import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -831,9 +832,11 @@ function maybeScheduleSettledRollover(tableId) {
   }
 
   const nowMs = Date.now();
-  const settledAtMs = Date.parse(pokerState?.handSettlement?.settledAt || "");
-  const effectiveSettledAtMs = Number.isFinite(settledAtMs) ? Math.max(settledAtMs, nowMs) : nowMs;
-  const dueAt = effectiveSettledAtMs + settledRevealMs;
+  const dueAt = resolveSettledRevealDueAt({
+    settledAt: pokerState?.handSettlement?.settledAt || null,
+    nowMs,
+    revealMs: settledRevealMs
+  });
   const existing = settledRolloverTimerByTableId.get(tableId);
   if (existing && existing.dueAt === dueAt) {
     return;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -830,17 +830,17 @@ function maybeScheduleSettledRollover(tableId) {
     return;
   }
 
+  const nowMs = Date.now();
   const settledAtMs = Date.parse(pokerState?.handSettlement?.settledAt || "");
-  const dueAt = Number.isFinite(settledAtMs)
-    ? settledAtMs + settledRevealMs
-    : Date.now() + settledRevealMs;
+  const effectiveSettledAtMs = Number.isFinite(settledAtMs) ? Math.max(settledAtMs, nowMs) : nowMs;
+  const dueAt = effectiveSettledAtMs + settledRevealMs;
   const existing = settledRolloverTimerByTableId.get(tableId);
   if (existing && existing.dueAt === dueAt) {
     return;
   }
 
   clearSettledRolloverTimer(tableId);
-  const delayMs = Math.max(0, dueAt - Date.now());
+  const delayMs = Math.max(0, dueAt - nowMs);
   const timer = setTimeout(() => {
     settledRolloverTimerByTableId.delete(tableId);
     void enqueueTableCommand({

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -101,7 +101,7 @@ function resolveObserveOnlyJoin(rawValue) {
 function resolveSettledRevealMs(rawValue) {
   const parsed = Number(rawValue);
   if (!Number.isFinite(parsed) || parsed < 0) {
-    return 2_000;
+    return 4_000;
   }
   return Math.trunc(parsed);
 }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -26,6 +26,7 @@ import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import { handleBotStepCommand } from "./poker/handlers/bot-autoplay.mjs";
 import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
+import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -94,6 +95,14 @@ function resolveObserveOnlyJoin(rawValue) {
   }
   const normalized = String(rawValue).trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function resolveSettledRevealMs(rawValue) {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 2_000;
+  }
+  return Math.trunc(parsed);
 }
 
 function resolveAuthoritativeJoinEnabled(rawValue, { hasSupabaseDbUrl = false, observeOnlyJoinEnabled = false } = {}) {
@@ -175,10 +184,12 @@ let inactiveCleanupExecutorPromise = null;
 let acceptedBotAutoplayExecutorPromise = null;
 let beginSqlWsLoaderPromise = null;
 const timeoutFailureTrackerByTableId = new Map();
+const settledRolloverTimerByTableId = new Map();
 const TURN_TIMEOUT_FATAL_PREFIXES = ["showdown_"];
 const TURN_TIMEOUT_FATAL_REASONS = new Set(["timeout_apply_failed"]);
 const DEFAULT_INACTIVE_CLEANUP_ADAPTER_URL = new URL("./poker/persistence/inactive-cleanup-adapter.mjs", import.meta.url).href;
 const DEFAULT_ACCEPTED_BOT_AUTOPLAY_ADAPTER_URL = new URL("./poker/runtime/accepted-bot-autoplay-adapter.mjs", import.meta.url).href;
+const settledRevealMs = resolveSettledRevealMs(process.env.WS_POKER_SETTLED_REVEAL_MS);
 
 async function loadAuthoritativeLeaveExecutor() {
   if (!authoritativeLeaveExecutorPromise) {
@@ -798,7 +809,99 @@ function broadcastResyncRequired(tableId, reason) {
   }
 }
 
+function clearSettledRolloverTimer(tableId) {
+  const existing = settledRolloverTimerByTableId.get(tableId);
+  if (!existing) {
+    return;
+  }
+  clearTimeout(existing.timer);
+  settledRolloverTimerByTableId.delete(tableId);
+}
+
+function maybeScheduleSettledRollover(tableId) {
+  if (settledRevealMs <= 0) {
+    clearSettledRolloverTimer(tableId);
+    return;
+  }
+
+  const pokerState = tableManager.persistedPokerState(tableId);
+  if (!pokerState || pokerState.phase !== "SETTLED") {
+    clearSettledRolloverTimer(tableId);
+    return;
+  }
+
+  const settledAtMs = Date.parse(pokerState?.handSettlement?.settledAt || "");
+  const dueAt = Number.isFinite(settledAtMs)
+    ? settledAtMs + settledRevealMs
+    : Date.now() + settledRevealMs;
+  const existing = settledRolloverTimerByTableId.get(tableId);
+  if (existing && existing.dueAt === dueAt) {
+    return;
+  }
+
+  clearSettledRolloverTimer(tableId);
+  const delayMs = Math.max(0, dueAt - Date.now());
+  const timer = setTimeout(() => {
+    settledRolloverTimerByTableId.delete(tableId);
+    void enqueueTableCommand({
+      tableId,
+      commandName: "settled_rollover",
+      dedupeKey: "settled_rollover",
+      run: async () => {
+        const rollover = tableManager.rolloverSettledHand({ tableId, nowMs: Date.now() });
+        if (!rollover?.ok) {
+          return rollover;
+        }
+        if (!rollover.changed) {
+          return rollover;
+        }
+
+        const persisted = await persistMutatedState({
+          tableId,
+          expectedVersion: Number(rollover.stateVersion) - 1,
+          mutationKind: "settled_rollover"
+        });
+        if (!persisted?.ok) {
+          await recoverFromPersistConflict({
+            tableId,
+            restoreTableFromPersisted,
+            broadcastStateSnapshots,
+            broadcastResyncRequired
+          });
+          return {
+            ok: false,
+            changed: false,
+            reason: persisted?.reason || "persist_failed",
+            stateVersion: rollover.stateVersion
+          };
+        }
+
+        broadcastStateSnapshots(tableId);
+        try {
+          scheduleBotStep({
+            tableId,
+            trigger: "settled_rollover",
+            requestId: null,
+            frameTs: null
+          });
+        } catch (error) {
+          klogSafe("ws_settled_rollover_bot_autoplay_failed", {
+            tableId,
+            message: error?.message || "unknown"
+          });
+        }
+        return rollover;
+      }
+    });
+  }, delayMs);
+  if (typeof timer?.unref === "function") {
+    timer.unref();
+  }
+  settledRolloverTimerByTableId.set(tableId, { timer, dueAt });
+}
+
 function broadcastStateSnapshots(tableId) {
+  maybeScheduleSettledRollover(tableId);
   const recipients = tableManager.orderedConnectionsForTable(tableId, (socket) => socket.__connState?.sessionId ?? "");
   for (const recipient of recipients) {
     const recipientConnState = recipient.__connState;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -590,6 +590,7 @@ function sendTableState(ws, connState, { requestId = null, tableState, tableSnap
 }
 
 function sendStateSnapshot(ws, connState, { requestId = null, tableSnapshot, reason = null }) {
+  maybeScheduleSettledRollover(tableSnapshot.tableId);
   const payload = buildStateSnapshotPayload({
     tableSnapshot,
     userId: connState.session.userId

--- a/ws-tests/ws-poker-protocol-compliance.test.mjs
+++ b/ws-tests/ws-poker-protocol-compliance.test.mjs
@@ -925,7 +925,16 @@ test("duplicate act requestId does not emit additional advancing state frame", a
       stateRow: { version: 0, state: {} }
     }
   };
-  const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: secret, ...observeOnlyJoinEnv(), SUPABASE_DB_URL: "", WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures) } });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_POKER_SETTLED_REVEAL_MS: "60000",
+      ...observeOnlyJoinEnv(),
+      SUPABASE_DB_URL: "",
+      WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+    }
+  });
 
   try {
     await waitForListening(child, 5000);
@@ -945,6 +954,16 @@ test("duplicate act requestId does not emit additional advancing state frame", a
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-idem-2", ts: "2026-02-28T00:06:02Z", payload: { tableId, view: "snapshot" } });
     const afterFirst = await nextMessageOfType(ws, "stateSnapshot", 5000, "afterFirstAct", ["commandResult"]);
     assert.equal(afterFirst.type, "stateSnapshot");
+    let latestVersion = afterFirst.payload.stateVersion;
+    for (;;) {
+      const frame = await attemptMessage(ws, 300);
+      if (!frame) {
+        break;
+      }
+      if (frame.type === "stateSnapshot") {
+        latestVersion = frame.payload.stateVersion;
+      }
+    }
 
     sendFrame(ws, { version: "1.0", type: "act", requestId: "act-idem", ts: "2026-02-28T00:06:03Z", payload: { tableId, handId: base.payload.public.hand.handId, action: "fold" } });
     let replay = null;
@@ -964,7 +983,7 @@ test("duplicate act requestId does not emit additional advancing state frame", a
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-idem-3", ts: "2026-02-28T00:06:04Z", payload: { tableId, view: "snapshot" } });
     const afterReplay = await nextMessageOfType(ws, "stateSnapshot", 5000, "afterReplayAct", ["commandResult"]);
     assert.equal(afterReplay.type, "stateSnapshot");
-    assert.equal(afterReplay.payload.stateVersion, afterFirst.payload.stateVersion);
+    assert.equal(afterReplay.payload.stateVersion, latestVersion);
 
     ws.close();
   } finally {


### PR DESCRIPTION
## Summary
- change poker hand lifecycle from implicit auto-rollover to `SETTLED -> delayed/server-driven rollover`
- keep poker hands in `SETTLED` for a short reveal window before the WS server explicitly rolls to the next hand
- expose showdown winner reveal data only for real showdown comparisons, not fold wins
- render luxury `Winner` badges and temporary winner card reveals in `table-v2`
- keep winner badges and revealed winner cards visible in the UI for a guaranteed local reveal window even if the next-hand snapshot arrives early

## Testing
- `node --test ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs`
- `node --test ws-server/poker/read-model/state-snapshot.behavior.test.mjs`
- `node --test ws-server/poker/table/table-manager.behavior.test.mjs`
- `node --test --test-name-pattern "resume fallback snapshot on settled table still schedules delayed rollover|optimistic conflict restore to settled state still schedules delayed rollover" ws-server/server.behavior.test.mjs`
- `node --test tests/poker-v2-live.behavior.test.mjs`
- `node scripts/syntax-check.mjs`
