### PR TITLE
Cap poker all-in button to contestable stack

### DIFF
--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -806,6 +806,25 @@
     return Math.max(0, Math.trunc(Number(value)));
   }
 
+  function isContestableOpponentSeat(seat, currentUserId){
+    if (!seat || typeof seat.userId !== 'string' || !seat.userId) return false;
+    if (seat.userId === currentUserId) return false;
+    if (/FOLD/i.test(seat.status || '')) return false;
+    return true;
+  }
+
+  function resolveMaxContestableOpponentStackAmount(currentUserId){
+    if (!currentUserId || !Array.isArray(state.seats)) return null;
+    var max = null;
+    state.seats.forEach(function(seat){
+      if (!isContestableOpponentSeat(seat, currentUserId)) return;
+      var amount = resolveStack(seat.userId);
+      if (!Number.isFinite(amount) || amount <= 0) return;
+      max = max == null ? amount : Math.max(max, amount);
+    });
+    return max;
+  }
+
   function getAllowedActions(){
     return Array.isArray(state.legalActions) ? state.legalActions.slice() : [];
   }
@@ -1252,16 +1271,27 @@
     var stackAmount = resolveStack(state.currentUserId);
     if (!stackAmount || stackAmount < 1) return null;
     var constraints = state.actionConstraints || {};
+    var contestableOpponentStack = resolveMaxContestableOpponentStackAmount(state.currentUserId);
+    var cappedAdditional = contestableOpponentStack == null
+      ? stackAmount
+      : Math.max(0, Math.min(stackAmount, Math.trunc(contestableOpponentStack)));
     var toCall = Number.isFinite(constraints.toCall) ? Math.max(0, Math.trunc(constraints.toCall)) : null;
     if (allowed.indexOf('CALL') !== -1 && toCall != null && toCall > 0 && stackAmount <= toCall){
       return { type: 'CALL', amount: null };
     }
     if (allowed.indexOf('RAISE') !== -1 && Number.isFinite(constraints.maxRaiseTo)){
-      return { type: 'RAISE', amount: Math.max(1, Math.trunc(constraints.maxRaiseTo)) };
+      var maxRaiseTo = Math.max(1, Math.trunc(constraints.maxRaiseTo));
+      var minRaiseTo = Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
+      var currentUserBet = Math.max(0, maxRaiseTo - stackAmount);
+      var cappedRaiseTo = Math.min(maxRaiseTo, Math.max(currentUserBet + cappedAdditional, minRaiseTo));
+      if (toCall != null && toCall > 0 && cappedRaiseTo <= currentUserBet + toCall){
+        return { type: 'CALL', amount: null };
+      }
+      return { type: 'RAISE', amount: cappedRaiseTo };
     }
     if (allowed.indexOf('BET') !== -1){
       var maxBet = Number.isFinite(constraints.maxBetAmount) ? Math.max(1, Math.trunc(constraints.maxBetAmount)) : stackAmount;
-      return { type: 'BET', amount: maxBet };
+      return { type: 'BET', amount: Math.max(1, Math.min(maxBet, cappedAdditional || maxBet)) };
     }
     return null;
   }

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -813,7 +813,7 @@
     return true;
   }
 
-  function resolveMaxContestableOpponentStackAmount(currentUserId){
+  function resolveMaxContestableOpponentBehindAmount(currentUserId){
     if (!currentUserId || !Array.isArray(state.seats)) return null;
     var max = null;
     state.seats.forEach(function(seat){
@@ -1271,11 +1271,11 @@
     var stackAmount = resolveStack(state.currentUserId);
     if (!stackAmount || stackAmount < 1) return null;
     var constraints = state.actionConstraints || {};
-    var contestableOpponentStack = resolveMaxContestableOpponentStackAmount(state.currentUserId);
-    var cappedAdditional = contestableOpponentStack == null
-      ? stackAmount
-      : Math.max(0, Math.min(stackAmount, Math.trunc(contestableOpponentStack)));
     var toCall = Number.isFinite(constraints.toCall) ? Math.max(0, Math.trunc(constraints.toCall)) : null;
+    var contestableOpponentBehind = resolveMaxContestableOpponentBehindAmount(state.currentUserId);
+    var cappedTotalContribution = contestableOpponentBehind == null
+      ? stackAmount
+      : Math.max(0, Math.min(stackAmount, (toCall || 0) + Math.trunc(contestableOpponentBehind)));
     if (allowed.indexOf('CALL') !== -1 && toCall != null && toCall > 0 && stackAmount <= toCall){
       return { type: 'CALL', amount: null };
     }
@@ -1283,7 +1283,7 @@
       var maxRaiseTo = Math.max(1, Math.trunc(constraints.maxRaiseTo));
       var minRaiseTo = Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
       var currentUserBet = Math.max(0, maxRaiseTo - stackAmount);
-      var cappedRaiseTo = Math.min(maxRaiseTo, Math.max(currentUserBet + cappedAdditional, minRaiseTo));
+      var cappedRaiseTo = Math.min(maxRaiseTo, Math.max(currentUserBet + cappedTotalContribution, minRaiseTo));
       if (toCall != null && toCall > 0 && cappedRaiseTo <= currentUserBet + toCall){
         return { type: 'CALL', amount: null };
       }
@@ -1291,7 +1291,7 @@
     }
     if (allowed.indexOf('BET') !== -1){
       var maxBet = Number.isFinite(constraints.maxBetAmount) ? Math.max(1, Math.trunc(constraints.maxBetAmount)) : stackAmount;
-      return { type: 'BET', amount: Math.max(1, Math.min(maxBet, cappedAdditional || maxBet)) };
+      return { type: 'BET', amount: Math.max(1, Math.min(maxBet, cappedTotalContribution || maxBet)) };
     }
     return null;
   }

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -487,6 +487,33 @@
     return stackAmount;
   }
 
+  function isContestableOpponentSeat(seat, currentUserId){
+    if (!seat || typeof seat.userId !== 'string' || !seat.userId) return false;
+    if (seat.userId === currentUserId) return false;
+    if (typeof seat.status === 'string' && /FOLD/i.test(seat.status)) return false;
+    return true;
+  }
+
+  function resolveMaxContestableOpponentStackAmount(data, currentUserId){
+    if (!data || !currentUserId) return null;
+    var seats = Array.isArray(data.seats) ? data.seats : [];
+    var stateObj = data && data.state ? data.state : null;
+    var gameState = stateObj && stateObj.state ? stateObj.state : null;
+    var stacks = gameState && typeof gameState.stacks === 'object' && !Array.isArray(gameState.stacks) ? gameState.stacks : null;
+    if (!stacks) return null;
+    var max = null;
+    seats.forEach(function(seat){
+      if (!isContestableOpponentSeat(seat, currentUserId)) return;
+      var raw = stacks[seat.userId];
+      var amount = parseInt(raw, 10);
+      if (!isFinite(amount)) return;
+      amount = Math.trunc(amount);
+      if (amount <= 0) return;
+      max = max == null ? amount : Math.max(max, amount);
+    });
+    return max;
+  }
+
   function resolveAllInPlan(allowedInfo, data, userId){
     var info = allowedInfo || {};
     var allowed = info.allowed;
@@ -494,6 +521,10 @@
     var stackAmount = resolveCurrentUserStackAmount(data, userId);
     if (stackAmount == null || stackAmount < 1) return null;
     var constraints = normalizeActionConstraints(info.constraints);
+    var contestableOpponentStack = resolveMaxContestableOpponentStackAmount(data, userId);
+    var cappedAdditional = contestableOpponentStack == null
+      ? stackAmount
+      : Math.max(0, Math.min(stackAmount, Math.trunc(contestableOpponentStack)));
     var toCall = constraints.toCall != null ? Math.max(0, Math.trunc(constraints.toCall)) : null;
     if (allowed.has('CALL') && toCall != null && toCall > 0 && stackAmount <= toCall){
       return { type: 'CALL', amount: null };
@@ -501,13 +532,19 @@
     if (allowed.has('RAISE')){
       var raiseTo = constraints.maxRaiseTo != null ? Math.trunc(constraints.maxRaiseTo) : null;
       if (raiseTo != null && raiseTo >= 1){
-        return { type: 'RAISE', amount: raiseTo };
+        var minRaiseTo = constraints.minRaiseTo != null ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
+        var currentUserBet = Math.max(0, raiseTo - stackAmount);
+        var cappedRaiseTo = Math.min(raiseTo, Math.max(currentUserBet + cappedAdditional, minRaiseTo));
+        if (toCall != null && toCall > 0 && cappedRaiseTo <= currentUserBet + toCall){
+          return { type: 'CALL', amount: null };
+        }
+        return { type: 'RAISE', amount: cappedRaiseTo };
       }
     }
     if (allowed.has('BET')){
       var betAmount = constraints.maxBetAmount != null ? Math.trunc(constraints.maxBetAmount) : stackAmount;
       if (betAmount >= 1){
-        return { type: 'BET', amount: betAmount };
+        return { type: 'BET', amount: Math.max(1, Math.min(betAmount, cappedAdditional || betAmount)) };
       }
     }
     return null;

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -494,7 +494,7 @@
     return true;
   }
 
-  function resolveMaxContestableOpponentStackAmount(data, currentUserId){
+  function resolveMaxContestableOpponentBehindAmount(data, currentUserId){
     if (!data || !currentUserId) return null;
     var seats = Array.isArray(data.seats) ? data.seats : [];
     var stateObj = data && data.state ? data.state : null;
@@ -521,11 +521,11 @@
     var stackAmount = resolveCurrentUserStackAmount(data, userId);
     if (stackAmount == null || stackAmount < 1) return null;
     var constraints = normalizeActionConstraints(info.constraints);
-    var contestableOpponentStack = resolveMaxContestableOpponentStackAmount(data, userId);
-    var cappedAdditional = contestableOpponentStack == null
-      ? stackAmount
-      : Math.max(0, Math.min(stackAmount, Math.trunc(contestableOpponentStack)));
     var toCall = constraints.toCall != null ? Math.max(0, Math.trunc(constraints.toCall)) : null;
+    var contestableOpponentBehind = resolveMaxContestableOpponentBehindAmount(data, userId);
+    var cappedTotalContribution = contestableOpponentBehind == null
+      ? stackAmount
+      : Math.max(0, Math.min(stackAmount, (toCall || 0) + Math.trunc(contestableOpponentBehind)));
     if (allowed.has('CALL') && toCall != null && toCall > 0 && stackAmount <= toCall){
       return { type: 'CALL', amount: null };
     }
@@ -534,7 +534,7 @@
       if (raiseTo != null && raiseTo >= 1){
         var minRaiseTo = constraints.minRaiseTo != null ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
         var currentUserBet = Math.max(0, raiseTo - stackAmount);
-        var cappedRaiseTo = Math.min(raiseTo, Math.max(currentUserBet + cappedAdditional, minRaiseTo));
+        var cappedRaiseTo = Math.min(raiseTo, Math.max(currentUserBet + cappedTotalContribution, minRaiseTo));
         if (toCall != null && toCall > 0 && cappedRaiseTo <= currentUserBet + toCall){
           return { type: 'CALL', amount: null };
         }
@@ -544,7 +544,7 @@
     if (allowed.has('BET')){
       var betAmount = constraints.maxBetAmount != null ? Math.trunc(constraints.maxBetAmount) : stackAmount;
       if (betAmount >= 1){
-        return { type: 'BET', amount: Math.max(1, Math.min(betAmount, cappedAdditional || betAmount)) };
+        return { type: 'BET', amount: Math.max(1, Math.min(betAmount, cappedTotalContribution || betAmount)) };
       }
     }
     return null;

--- a/tests/poker-ui-turn-actions.test.mjs
+++ b/tests/poker-ui-turn-actions.test.mjs
@@ -135,6 +135,35 @@ const raiseAllIn = hooks.resolveAllInPlan(
 assert.equal(raiseAllIn && raiseAllIn.type, 'RAISE', 'raise spot should map ALL IN to RAISE');
 assert.equal(raiseAllIn && raiseAllIn.amount, 70, 'raise spot should map ALL IN to maxRaiseTo');
 
+const cappedRaiseAllIn = hooks.resolveAllInPlan(
+  hooks.sanitizeAllowedActions(new Set(['CALL', 'RAISE', 'FOLD']), { toCall: 10, minRaiseTo: 20, maxRaiseTo: 100 }),
+  {
+    seats: [
+      { userId: 'user-1', seatNo: 1, status: 'ACTIVE' },
+      { userId: 'user-2', seatNo: 2, status: 'ACTIVE' },
+      { userId: 'user-3', seatNo: 3, status: 'FOLDED' }
+    ],
+    state: { state: { stacks: { 'user-1': 100, 'user-2': 35, 'user-3': 250 } } }
+  },
+  'user-1'
+);
+assert.equal(cappedRaiseAllIn && cappedRaiseAllIn.type, 'RAISE', 'raise all-in should remain a raise when another active player can cover part of the shove');
+assert.equal(cappedRaiseAllIn && cappedRaiseAllIn.amount, 35, 'raise all-in should cap to the biggest active opponent stack');
+
+const coveredRaiseAllIn = hooks.resolveAllInPlan(
+  hooks.sanitizeAllowedActions(new Set(['CALL', 'RAISE', 'FOLD']), { toCall: 10, minRaiseTo: 20, maxRaiseTo: 70 }),
+  {
+    seats: [
+      { userId: 'user-1', seatNo: 1, status: 'ACTIVE' },
+      { userId: 'user-2', seatNo: 2, status: 'ACTIVE' }
+    ],
+    state: { state: { stacks: { 'user-1': 70, 'user-2': 140 } } }
+  },
+  'user-1'
+);
+assert.equal(coveredRaiseAllIn && coveredRaiseAllIn.type, 'RAISE', 'full all-in should remain unchanged when another active player covers the stack');
+assert.equal(coveredRaiseAllIn && coveredRaiseAllIn.amount, 70, 'covered all-in should still use full stack raiseTo');
+
 const noAllIn = hooks.resolveAllInPlan(
   hooks.sanitizeAllowedActions(new Set(['CHECK', 'FOLD']), { toCall: 0 }),
   { state: { state: { stacks: { 'user-1': 50 } } } },

--- a/tests/poker-ui-turn-actions.test.mjs
+++ b/tests/poker-ui-turn-actions.test.mjs
@@ -148,7 +148,7 @@ const cappedRaiseAllIn = hooks.resolveAllInPlan(
   'user-1'
 );
 assert.equal(cappedRaiseAllIn && cappedRaiseAllIn.type, 'RAISE', 'raise all-in should remain a raise when another active player can cover part of the shove');
-assert.equal(cappedRaiseAllIn && cappedRaiseAllIn.amount, 35, 'raise all-in should cap to the biggest active opponent stack');
+assert.equal(cappedRaiseAllIn && cappedRaiseAllIn.amount, 45, 'raise all-in should include toCall plus the biggest active opponent stack behind');
 
 const coveredRaiseAllIn = hooks.resolveAllInPlan(
   hooks.sanitizeAllowedActions(new Set(['CALL', 'RAISE', 'FOLD']), { toCall: 10, minRaiseTo: 20, maxRaiseTo: 70 }),

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -340,6 +340,52 @@ test('poker v2 shows compact call amount in the primary action label', async () 
   assert.equal(harness.elements.pokerV2AmountValue.textContent, '2k');
 });
 
+test('poker v2 caps all-in to the biggest active opponent stack', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 4,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' },
+          { userId: 'villain-2', seat: 3, displayName: 'Villain 2' }
+        ]
+      },
+      public: {
+        seats: [
+          { userId: 'user-1', seatNo: 1, status: 'ACTIVE' },
+          { userId: 'villain-1', seatNo: 2, status: 'ACTIVE' },
+          { userId: 'villain-2', seatNo: 3, status: 'FOLDED' }
+        ],
+        hand: { handId: 'hand-all-in', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 48, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
+        actionConstraints: { toCall: 10, minRaiseTo: 20, maxRaiseTo: 100, maxBetAmount: null },
+        stacks: { 'user-1': 100, 'villain-1': 35, 'villain-2': 250 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  harness.elements.pokerV2AllInBtn.click();
+  await harness.flush();
+
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-all-in', action: 'RAISE', amount: 35 }));
+});
+
 test('poker v2 auto-joins from query params after live auth', async () => {
   const harness = createHarness({ search: '?tableId=table-1&seatNo=4&autoJoin=1' });
   harness.fireDomContentLoaded();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -340,7 +340,7 @@ test('poker v2 shows compact call amount in the primary action label', async () 
   assert.equal(harness.elements.pokerV2AmountValue.textContent, '2k');
 });
 
-test('poker v2 caps all-in to the biggest active opponent stack', async () => {
+test('poker v2 caps raise all-in to call plus the biggest active opponent stack behind', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -383,7 +383,7 @@ test('poker v2 caps all-in to the biggest active opponent stack', async () => {
   harness.elements.pokerV2AllInBtn.click();
   await harness.flush();
 
-  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-all-in', action: 'RAISE', amount: 35 }));
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-all-in', action: 'RAISE', amount: 45 }));
 });
 
 test('poker v2 auto-joins from query params after live auth', async () => {


### PR DESCRIPTION
## Summary
- cap the UI all-in plan to the biggest active opponent stack instead of always using the full hero stack
- apply the fix consistently in classic poker UI and table v2
- add regression tests for classic resolveAllInPlan and live table v2 all-in click flow

## Notes
- backend reducer and side-pot settlement remain unchanged
- this changes only the all-in convenience button semantics in the UIs