### PR TITLE
Fix stale closed poker tables in WS lobby

### DIFF
--- a/shared/poker-domain/leave.behavior.test.mjs
+++ b/shared/poker-domain/leave.behavior.test.mjs
@@ -544,6 +544,7 @@ for (const settledPhase of ["SETTLED", "HAND_DONE"]) {
   assert.equal(first.ok, true);
   assert.deepEqual(second, first);
   assert.equal(first.cashedOut, 44);
+  assert.equal(first.tableStatus, "CLOSED");
   assert.equal(ctx.calls.cashouts, 1);
   assert.equal(ctx.calls.deleteSeat, 1);
   assert.equal(ctx.calls.closeTable, 1);
@@ -625,6 +626,7 @@ for (const settledPhase of ["SETTLED", "HAND_DONE"]) {
   });
   assert.equal(result.ok, true);
   assert.equal(result.cashedOut, 45);
+  assert.equal(result.tableStatus, "OPEN");
   assert.equal(ctx.calls.cashouts, 1);
   assert.equal(ctx.calls.deleteSeat, 1);
   assert.equal(ctx.calls.closeTable, 0);

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -47,6 +47,12 @@ const sanitizePersistedState = (stateInput) => {
   return sanitizePerHandArtifacts(rest);
 };
 
+const normalizeTableStatus = (value) => {
+  if (typeof value !== "string") return "OPEN";
+  const normalized = value.trim().toUpperCase();
+  return normalized || "OPEN";
+};
+
 const normalizeCardCodeForValidation = (cardCode) => {
   if (typeof cardCode !== "string") return null;
   const code = cardCode.trim().toUpperCase();
@@ -430,13 +436,14 @@ const executePostLeaveBotAutoplayLoop = async ({
   };
 };
 
-const buildAlreadyLeftResultPayload = ({ tableId, seatNo, includeState, state, userId }) => {
+const buildAlreadyLeftResultPayload = ({ tableId, seatNo, includeState, state, userId, tableStatus = "OPEN" }) => {
   const viewState = withoutPrivateState(sanitizeNoopResponseState(state, userId));
   return {
     ok: true,
     tableId,
     cashedOut: 0,
     seatNo: Number.isInteger(seatNo) ? seatNo : null,
+    tableStatus: normalizeTableStatus(tableStatus),
     status: "already_left",
     ...(includeState
       ? {
@@ -486,6 +493,7 @@ export async function executePokerLeave({
         if (!table) {
           throw makeError(404, "table_not_found");
         }
+        let finalTableStatus = normalizeTableStatus(table.status);
 
         const stateRows = await tx.unsafe(
           "select version, state from public.poker_state where table_id = $1 for update;",
@@ -531,6 +539,7 @@ export async function executePokerLeave({
             includeState,
             state: currentState,
             userId: userId,
+            tableStatus: finalTableStatus,
           });
           if (requestId) {
             await storePokerRequestResult(tx, {
@@ -584,6 +593,7 @@ export async function executePokerLeave({
               includeState,
               state: currentState,
               userId: userId,
+              tableStatus: finalTableStatus,
             });
             if (requestId) {
               await storePokerRequestResult(tx, {
@@ -941,6 +951,7 @@ export async function executePokerLeave({
             "update public.poker_seats set status = 'INACTIVE', stack = 0 where table_id = $1;",
             [tableId]
           );
+          finalTableStatus = "CLOSED";
           if (table.status !== "CLOSED") {
             await tx.unsafe(
               "update public.poker_tables set status = 'CLOSED', updated_at = now(), last_activity_at = now() where id = $1;",
@@ -976,6 +987,7 @@ export async function executePokerLeave({
           tableId,
           cashedOut: shouldDetachSeatAndStack ? detachedCashOutAmount : 0,
           seatNo: seatNo ?? null,
+          tableStatus: finalTableStatus,
           ...(includeState
             ? {
                 state: {

--- a/ws-server/poker/handlers/leave.behavior.test.mjs
+++ b/ws-server/poker/handlers/leave.behavior.test.mjs
@@ -34,7 +34,7 @@ function createCtx() {
       },
       loadAuthoritativeLeaveExecutor: async () => async (args) => {
         calls.executorArgs = args;
-        return { ok: true, state: { version: 3, state: { handId: "h1" } } };
+        return { ok: true, tableStatus: "CLOSED", state: { version: 3, state: { handId: "h1" } } };
       },
       sendCommandResult: (_ws, _connState, payload) => {
         calls.command.push(payload);
@@ -58,6 +58,7 @@ test("handleLeaveCommand accepts and broadcasts when authoritative leave changes
 
   assert.equal(calls.executorArgs.tableId, "t1");
   assert.equal(calls.buildArgs.tableId, "t1");
+  assert.equal(calls.buildArgs.tableStatus, "CLOSED");
   assert.equal(calls.restoreArgs[0].tableId, "t1");
   assert.equal(calls.leaveArgs[0].tableId, "t1");
   assert.equal(calls.command.length, 1);

--- a/ws-server/poker/handlers/leave.mjs
+++ b/ws-server/poker/handlers/leave.mjs
@@ -44,7 +44,8 @@ export async function handleLeaveCommand({
           tableId,
           userId: connState.session.userId,
           stateVersion: left?.state?.version ?? null,
-          pokerState: left?.state?.state ?? null
+          pokerState: left?.state?.state ?? null,
+          tableStatus: left?.tableStatus ?? null
         })
       : { ok: false, code: "authoritative_state_invalid" };
     if (!restored?.ok || !restored?.restoredTable) {

--- a/ws-server/poker/table/table-manager.leave-restore.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.leave-restore.behavior.test.mjs
@@ -224,3 +224,59 @@ test("buildAuthoritativeLeaveRestore rehydrates deterministic runtime hand state
   assert.equal(manager.persistedPokerState("t3").phase, "RIVER");
   assert.equal(manager.persistedPokerState("t3").community.length, 5);
 });
+
+test("buildAuthoritativeLeaveRestore applies authoritative closed table status", () => {
+  const manager = createTableManager();
+  manager.restoreTableFromPersisted("t4", {
+    tableId: "t4",
+    tableStatus: "OPEN",
+    coreState: {
+      roomId: "t4",
+      maxSeats: 6,
+      version: 4,
+      members: [
+        { userId: "u1", seat: 1 },
+        { userId: "bot-1", seat: 2 }
+      ],
+      seats: { u1: 1, "bot-1": 2 },
+      seatDetailsByUserId: {
+        u1: { isBot: false, botProfile: null, leaveAfterHand: false },
+        "bot-1": { isBot: true, botProfile: "TRIVIAL", leaveAfterHand: false }
+      },
+      publicStacks: { u1: 50, "bot-1": 50 },
+      pokerState: {
+        tableId: "t4",
+        phase: "HAND_DONE",
+        seats: [
+          { userId: "u1", seatNo: 1 },
+          { userId: "bot-1", seatNo: 2, isBot: true }
+        ],
+        stacks: { u1: 50, "bot-1": 50 },
+        leftTableByUserId: {}
+      }
+    },
+    presenceByUserId: new Map()
+  });
+
+  const restored = manager.buildAuthoritativeLeaveRestore({
+    tableId: "t4",
+    userId: "u1",
+    stateVersion: 5,
+    tableStatus: "CLOSED",
+    pokerState: {
+      tableId: "t4",
+      phase: "HAND_DONE",
+      seats: [
+        { userId: "u1", seatNo: 1 },
+        { userId: "bot-1", seatNo: 2, isBot: true }
+      ],
+      stacks: { "bot-1": 50 },
+      leftTableByUserId: { u1: true }
+    }
+  });
+
+  assert.equal(restored.ok, true);
+  assert.equal(restored.restoredTable.tableStatus, "CLOSED");
+  manager.restoreTableFromPersisted("t4", restored.restoredTable);
+  assert.equal(manager.isTableClosed("t4"), true);
+});

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -967,7 +967,7 @@ export function createTableManager({
     };
   }
 
-  function buildAuthoritativeLeaveRestore({ tableId, userId, stateVersion = null, pokerState = null }) {
+  function buildAuthoritativeLeaveRestore({ tableId, userId, stateVersion = null, pokerState = null, tableStatus = null }) {
     const table = ensureTable(tableId);
     const normalizedState = pokerState && typeof pokerState === "object" && !Array.isArray(pokerState) ? pokerState : null;
     const stateTableId = typeof normalizedState?.tableId === "string" ? normalizedState.tableId : "";
@@ -1060,7 +1060,9 @@ export function createTableManager({
       ok: true,
       restoredTable: {
         tableId,
-        tableStatus: table.tableStatus,
+        tableStatus: typeof tableStatus === "string" && tableStatus.trim()
+          ? normalizeTableStatus(tableStatus)
+          : table.tableStatus,
         coreState: {
           ...table.coreState,
           version: Number.isInteger(stateVersion) && stateVersion >= 0 ? stateVersion : table.coreState.version,

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2468,6 +2468,181 @@ export function createInactiveCleanupExecutor({ env }) {
   }
 });
 
+test("table_leave authoritative close removes closed bots-only table from lobby immediately", async () => {
+  const secret = "leave-closed-lobby-sync-secret";
+  const humanUserId = "leave_closed_human";
+  const tableId = "table_leave_closed_lobby_sync";
+  const botSeat2 = makeBotUserId(tableId, 2);
+  const botSeat3 = makeBotUserId(tableId, 3);
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+          { user_id: botSeat2, seat_no: 2, status: "ACTIVE", is_bot: true, stack: 100 },
+          { user_id: botSeat3, seat_no: 3, status: "ACTIVE", is_bot: true, stack: 100 }
+        ],
+        stateRow: {
+          version: 7,
+          state: {
+            tableId,
+            roomId: tableId,
+            phase: "HAND_DONE",
+            handId: "",
+            seats: [
+              { userId: humanUserId, seatNo: 1, status: "ACTIVE" },
+              { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true },
+              { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true }
+            ],
+            stacks: {
+              [humanUserId]: 100,
+              [botSeat2]: 100,
+              [botSeat3]: 100
+            },
+            leftTableByUserId: {}
+          }
+        }
+      }
+    }
+  });
+  const leaveModule = await writeTestModule(`
+import fs from "node:fs/promises";
+
+export async function executePokerLeave({ tableId, userId, includeState = false }) {
+  const raw = await fs.readFile(process.env.WS_PERSISTED_STATE_FILE, "utf8");
+  const doc = JSON.parse(raw || "{}");
+  const table = doc?.tables?.[tableId];
+  if (!table) {
+    return { ok: false, code: "table_not_found" };
+  }
+
+  const seatRows = Array.isArray(table.seatRows) ? table.seatRows : [];
+  const seatRow = seatRows.find((row) => row?.user_id === userId) || null;
+  const seatNo = Number.isInteger(Number(seatRow?.seat_no)) ? Number(seatRow.seat_no) : null;
+  const currentVersion = Number(table?.stateRow?.version || 0);
+  const state = table?.stateRow?.state && typeof table.stateRow.state === "object" && !Array.isArray(table.stateRow.state)
+    ? table.stateRow.state
+    : {};
+
+  table.tableRow = { ...(table.tableRow || {}), status: "CLOSED" };
+  table.seatRows = seatRows.map((row) => (
+    row?.user_id === userId
+      ? { ...row, status: "INACTIVE", stack: 0 }
+      : row
+  ));
+
+  const publicState = {
+    ...state,
+    phase: "HAND_DONE",
+    handId: "",
+    turnUserId: null,
+    seats: [
+      { userId, seatNo: 1, status: "ACTIVE" },
+      { userId: "${botSeat2}", seatNo: 2, status: "ACTIVE", isBot: true },
+      { userId: "${botSeat3}", seatNo: 3, status: "ACTIVE", isBot: true }
+    ],
+    stacks: {
+      "${botSeat2}": 100,
+      "${botSeat3}": 100
+    },
+    leftTableByUserId: {
+      ...(state.leftTableByUserId || {}),
+      [userId]: true
+    }
+  };
+
+  table.stateRow = {
+    version: currentVersion + 1,
+    state: publicState
+  };
+
+  await fs.writeFile(process.env.WS_PERSISTED_STATE_FILE, JSON.stringify(doc) + "\\n", "utf8");
+
+  return {
+    ok: true,
+    tableId,
+    seatNo,
+    cashedOut: 100,
+    tableStatus: "CLOSED",
+    ...(includeState
+      ? {
+          state: {
+            version: currentVersion + 1,
+            state: publicState
+          },
+          viewState: publicState
+        }
+      : {})
+  };
+}
+`, "leave-closed-lobby-sync.mjs");
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_AUTHORITATIVE_LEAVE_MODULE_PATH: leaveModule.filePath
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+
+    const humanWs = await connectClient(port);
+    await hello(humanWs);
+    await auth(humanWs, makeHs256Jwt({ secret, sub: humanUserId }), "auth-leave-closed-human");
+    sendFrame(humanWs, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "sub-leave-closed-human",
+      ts: "2026-02-28T00:10:01Z",
+      payload: { tableId, view: "snapshot" }
+    });
+    await nextMessageOfType(humanWs, "stateSnapshot");
+
+    const lobbyWs = await connectClient(port);
+    await hello(lobbyWs);
+    await auth(lobbyWs, makeHs256Jwt({ secret, sub: "leave_closed_lobby_user" }), "auth-leave-closed-lobby");
+    sendFrame(lobbyWs, {
+      version: "1.0",
+      type: "lobby_subscribe",
+      requestId: "lobby-leave-closed",
+      ts: "2026-02-28T00:10:02Z",
+      payload: {}
+    });
+    const initialLobbySnapshot = await nextMessageOfType(lobbyWs, "lobby_snapshot");
+    assert.equal(initialLobbySnapshot.payload.tables.some((table) => table?.tableId === tableId), true);
+
+    sendFrame(humanWs, {
+      version: "1.0",
+      type: "table_leave",
+      requestId: "leave-closed-human",
+      ts: "2026-02-28T00:10:03Z",
+      payload: { tableId }
+    });
+    const leaveAck = await nextCommandResultForRequest(humanWs, "leave-closed-human");
+    assert.equal(leaveAck.payload.status, "accepted");
+
+    const removedSnapshot = await nextMessageMatching(
+      lobbyWs,
+      (frame) => frame?.type === "lobby_snapshot"
+        && Array.isArray(frame?.payload?.tables)
+        && !frame.payload.tables.some((table) => table?.tableId === tableId),
+      5000
+    );
+    assert.deepEqual(removedSnapshot.payload.tables.some((table) => table?.tableId === tableId), false);
+
+    const persisted = await readPersistedFile(filePath);
+    assert.equal(persisted.tables[tableId].tableRow.status, "CLOSED");
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(leaveModule.dir, { recursive: true, force: true });
+  }
+});
+
 test("WS table_join hydrates from persisted bootstrap fixture", async () => {
   const secret = "test-secret";
   const token = makeHs256Jwt({ secret, sub: "user_a" });


### PR DESCRIPTION
Propagate authoritative leave table status through WS restore so closed bot-only tables stay closed in runtime and disappear from the lobby. Add coverage for the leave response, restore path, and lobby regression.