### PR TITLE
fix(ws-preview): close stale disconnected poker tables

### DIFF
--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -226,6 +226,39 @@ test("inactive cleanup preserves fresh live hand without mutating disconnected a
   assert.deepEqual(harness.tableState.stateRow.state.stacks, { human_1: 250, human_2: 300, bot_1: 170 });
 });
 
+test("inactive cleanup preserves fresh bots-only live hand for disconnected human when activity is recent", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 250 },
+      { user_id: "bot_1", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 170 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-fresh-bots-only-disconnect",
+      turnUserId: "bot_1",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "bot_1", seatNo: 2, status: "ACTIVE" }
+      ],
+      stacks: { human_1: 250, bot_1: 170 }
+    },
+    lastActivityAt: "2026-03-01T00:01:55.000Z"
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, false);
+  assert.equal(result.closed, false);
+  assert.equal(result.deferred, true);
+  assert.equal(result.status, "cleaned_live_hand_preserved");
+  assert.equal(harness.cashouts.length, 0);
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_1")?.status, "ACTIVE");
+  assert.equal(harness.tableState.tableStatus, "OPEN");
+  assert.equal(harness.tableState.stateRow.state.turnUserId, "bot_1");
+});
+
 test("inactive cleanup closes stale live hand for disconnected human after activity timeout", async () => {
   const harness = createCleanupHarness({
     seatRows: [
@@ -258,6 +291,43 @@ test("inactive cleanup closes stale live hand for disconnected human after activ
   assert.equal(harness.tableState.stateRow.state.phase, "HAND_DONE");
   assert.equal(harness.tableState.stateRow.state.turnUserId, null);
   assert.deepEqual(harness.tableState.stateRow.state.stacks, { bot_1: 170 });
+});
+
+test("inactive cleanup does not close stale live hand when another active human remains", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 250 },
+      { user_id: "human_2", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 300 },
+      { user_id: "bot_1", seat_no: 3, status: "ACTIVE", is_bot: true, stack: 170 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-stale-active-human-remains",
+      turnUserId: "human_2",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "human_2", seatNo: 2, status: "ACTIVE" },
+        { userId: "bot_1", seatNo: 3, status: "ACTIVE" }
+      ],
+      stacks: { human_1: 250, human_2: 300, bot_1: 170 }
+    },
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastActivityAt: "2026-03-01T00:00:10.000Z",
+    nowMs: Date.parse("2026-03-01T00:02:00.000Z")
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(result.closed, false);
+  assert.equal(result.status, "cleaned");
+  assert.equal(harness.tableState.tableStatus, "OPEN");
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_1")?.status, "INACTIVE");
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_2")?.status, "ACTIVE");
+  assert.equal(harness.tableState.stateRow.state.turnUserId, "human_2");
+  assert.deepEqual(harness.tableState.stateRow.state.stacks, { human_2: 300, bot_1: 170 });
 });
 
 test("inactive cleanup system sweep keeps bots-only live table open until hand completion", async () => {

--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -172,7 +172,8 @@ test("inactive cleanup preserves replacement bot turn holder when seat rows stil
         { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE" }
       ],
       stacks: { human_1: 250, bot_auto_2_38: 100, bot_keep_3: 170 }
-    }
+    },
+    lastActivityAt: "2026-03-01T00:01:55.000Z"
   });
 
   const result = await harness.run();
@@ -223,6 +224,40 @@ test("inactive cleanup preserves fresh live hand without mutating disconnected a
   assert.equal(harness.seatState.find((row) => row.user_id === "human_1")?.status, "ACTIVE");
   assert.equal(harness.tableState.stateRow.state.turnUserId, "human_2");
   assert.deepEqual(harness.tableState.stateRow.state.stacks, { human_1: 250, human_2: 300, bot_1: 170 });
+});
+
+test("inactive cleanup closes stale live hand for disconnected human after activity timeout", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 250 },
+      { user_id: "bot_1", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 170 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-stale-disconnect",
+      turnUserId: "human_1",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "bot_1", seatNo: 2, status: "ACTIVE" }
+      ],
+      stacks: { human_1: 250, bot_1: 170 }
+    },
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastActivityAt: "2026-03-01T00:00:10.000Z",
+    nowMs: Date.parse("2026-03-01T00:02:00.000Z")
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.closed, true);
+  assert.equal(result.status, "cleaned_closed");
+  assert.equal(harness.tableState.tableStatus, "CLOSED");
+  assert.equal(harness.seatState.every((row) => row.status === "INACTIVE"), true);
+  assert.equal(harness.tableState.stateRow.state.phase, "HAND_DONE");
+  assert.equal(harness.tableState.stateRow.state.turnUserId, null);
+  assert.deepEqual(harness.tableState.stateRow.state.stacks, { bot_1: 170 });
 });
 
 test("inactive cleanup system sweep keeps bots-only live table open until hand completion", async () => {

--- a/shared/poker-domain/inactive-cleanup.mjs
+++ b/shared/poker-domain/inactive-cleanup.mjs
@@ -226,8 +226,7 @@ export async function executeInactiveCleanup({
       const liveHandIsFresh =
         !logicalStaleReason
         && (
-          normalizedUserId !== null
-          || tableLastActivityAtMs == null
+          tableLastActivityAtMs == null
           || nowMs - tableLastActivityAtMs < liveHandStaleMs
         );
       if (liveHandIsFresh) {

--- a/tests/poker-inactive-cleanup.behavior.test.mjs
+++ b/tests/poker-inactive-cleanup.behavior.test.mjs
@@ -127,6 +127,51 @@ test('fresh live hand disconnect preserves active seat and state without cashout
   assert.equal(ctx.updates.length, 0);
 });
 
+test('stale live hand disconnect closes bots-only table after activity timeout even without a turn deadline', async () => {
+  const nowMs = Date.parse('2026-03-01T00:02:00.000Z');
+  const ctx = makeTx({
+    seat: { table_id: 'table-stale-live-preserve', user_id: 'user-1', seat_no: 1, status: 'ACTIVE', is_bot: false, stack: 25 },
+    state: {
+      phase: 'PREFLOP',
+      handId: 'hand-stale-live-preserve',
+      turnUserId: 'user-1',
+      turnDeadlineAt: null,
+      stacks: { 'user-1': 40, 'bot-1': 50 }
+    },
+    allSeats: [
+      { user_id: 'user-1', status: 'INACTIVE', is_bot: false, stack: 0 },
+      { user_id: 'bot-1', status: 'ACTIVE', is_bot: true, stack: 50 }
+    ],
+    createdAt: '2026-03-01T00:00:00.000Z',
+    lastActivityAt: '2026-03-01T00:00:10.000Z'
+  });
+  const originalDateNow = Date.now;
+  Date.now = () => nowMs;
+  try {
+    const result = await executeInactiveCleanup({
+      tableId: 'table-stale-live-preserve',
+      userId: 'user-1',
+      requestId: 'req-stale-live-preserve',
+      env: {},
+      beginSql: async (fn) => fn(ctx.tx),
+      postTransaction: async (payload) => ctx.ledgerCalls.push(payload),
+      isHoleCardsTableMissing: () => false
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.closed, true);
+    assert.equal(result.status, 'cleaned_closed');
+    const stateUpdate = ctx.updates.filter((u) => u.kind === 'state').at(-1)?.value;
+    assert.equal(stateUpdate.phase, 'HAND_DONE');
+    assert.equal(stateUpdate.turnUserId, null);
+    assert.deepEqual(stateUpdate.stacks, { 'bot-1': 50 });
+    const closedUpdate = ctx.updates.find((u) => String(u.query).includes("set status = 'CLOSED'"));
+    assert.ok(closedUpdate);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test('singleton human disconnect closes table, ignores bots keep-alive, and close cashout uses state-first', async () => {
   const ctx = makeTx({
     seat: { table_id: 'table-3', user_id: 'user-3', seat_no: 3, status: 'ACTIVE', is_bot: false, stack: 5 },

--- a/tests/poker-inactive-cleanup.behavior.test.mjs
+++ b/tests/poker-inactive-cleanup.behavior.test.mjs
@@ -127,6 +127,40 @@ test('fresh live hand disconnect preserves active seat and state without cashout
   assert.equal(ctx.updates.length, 0);
 });
 
+test('fresh bots-only live hand with recent activity stays open for disconnected human when deadline is missing', async () => {
+  const ctx = makeTx({
+    seat: { table_id: 'table-fresh-bots-only', user_id: 'user-1', seat_no: 1, status: 'ACTIVE', is_bot: false, stack: 25 },
+    state: {
+      phase: 'PREFLOP',
+      handId: 'hand-fresh-bots-only',
+      turnUserId: 'bot-1',
+      turnDeadlineAt: null,
+      stacks: { 'user-1': 40, 'bot-1': 50 }
+    },
+    allSeats: [
+      { user_id: 'user-1', status: 'ACTIVE', is_bot: false, stack: 25 },
+      { user_id: 'bot-1', status: 'ACTIVE', is_bot: true, stack: 50 }
+    ],
+    lastActivityAt: new Date(Date.now()).toISOString()
+  });
+
+  const result = await executeInactiveCleanup({
+    tableId: 'table-fresh-bots-only',
+    userId: 'user-1',
+    requestId: 'req-fresh-bots-only',
+    env: {},
+    beginSql: async (fn) => fn(ctx.tx),
+    postTransaction: async (payload) => ctx.ledgerCalls.push(payload),
+    isHoleCardsTableMissing: () => false
+  });
+
+  assert.equal(result.status, 'cleaned_live_hand_preserved');
+  assert.equal(result.closed, false);
+  assert.equal(result.changed, false);
+  assert.equal(ctx.ledgerCalls.length, 0);
+  assert.equal(ctx.updates.length, 0);
+});
+
 test('stale live hand disconnect closes bots-only table after activity timeout even without a turn deadline', async () => {
   const nowMs = Date.parse('2026-03-01T00:02:00.000Z');
   const ctx = makeTx({
@@ -167,6 +201,51 @@ test('stale live hand disconnect closes bots-only table after activity timeout e
     assert.deepEqual(stateUpdate.stacks, { 'bot-1': 50 });
     const closedUpdate = ctx.updates.find((u) => String(u.query).includes("set status = 'CLOSED'"));
     assert.ok(closedUpdate);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
+test('stale live hand disconnect does not close table when another active human remains', async () => {
+  const nowMs = Date.parse('2026-03-01T00:02:00.000Z');
+  const ctx = makeTx({
+    seat: { table_id: 'table-stale-other-human', user_id: 'user-1', seat_no: 1, status: 'ACTIVE', is_bot: false, stack: 25 },
+    state: {
+      phase: 'PREFLOP',
+      handId: 'hand-stale-other-human',
+      turnUserId: 'user-2',
+      turnDeadlineAt: null,
+      stacks: { 'user-1': 40, 'user-2': 90, 'bot-1': 50 }
+    },
+    allSeats: [
+      { user_id: 'user-1', status: 'INACTIVE', is_bot: false, stack: 0 },
+      { user_id: 'user-2', status: 'ACTIVE', is_bot: false, stack: 90 },
+      { user_id: 'bot-1', status: 'ACTIVE', is_bot: true, stack: 50 }
+    ],
+    createdAt: '2026-03-01T00:00:00.000Z',
+    lastActivityAt: '2026-03-01T00:00:10.000Z'
+  });
+  const originalDateNow = Date.now;
+  Date.now = () => nowMs;
+  try {
+    const result = await executeInactiveCleanup({
+      tableId: 'table-stale-other-human',
+      userId: 'user-1',
+      requestId: 'req-stale-other-human',
+      env: {},
+      beginSql: async (fn) => fn(ctx.tx),
+      postTransaction: async (payload) => ctx.ledgerCalls.push(payload),
+      isHoleCardsTableMissing: () => false
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.closed, false);
+    assert.equal(result.status, 'cleaned');
+    const stateUpdate = ctx.updates.filter((u) => u.kind === 'state').at(-1)?.value;
+    assert.equal(stateUpdate.turnUserId, 'user-2');
+    assert.deepEqual(stateUpdate.stacks, { 'user-2': 90, 'bot-1': 50 });
+    const closedUpdate = ctx.updates.find((u) => String(u.query).includes("set status = 'CLOSED'"));
+    assert.equal(closedUpdate, undefined);
   } finally {
     Date.now = originalDateNow;
   }

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -64,3 +64,44 @@ test("persisted state writer strips runtime private cards before file persistenc
     await fs.rm(dir, { recursive: true, force: true });
   }
 });
+
+test("persisted state writer bumps table last_activity_at on successful db mutation", async () => {
+  const queries = [];
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (fn) => fn({
+      unsafe: async (query, params = []) => {
+        queries.push({ query: String(query), params });
+        if (String(query).startsWith("update public.poker_state set version = version + 1")) {
+          return [{ version: 5 }];
+        }
+        return [];
+      }
+    }),
+    klog: () => {}
+  });
+
+  const result = await writer.writeMutation({
+    tableId: "t_db",
+    expectedVersion: 4,
+    nextState: {
+      tableId: "t_db",
+      handId: "hand_db",
+      handSeed: "seed_db",
+      phase: "TURN",
+      community: ["AS", "KS", "QS", "JD"],
+      communityDealt: 4,
+      seats: [{ userId: "u1", seatNo: 1, status: "ACTIVE" }],
+      stacks: { u1: 100 }
+    }
+  });
+
+  assert.deepEqual(result, { ok: true, newVersion: 5 });
+  assert.equal(
+    queries.some((entry) => (
+      entry.query === "update public.poker_tables set last_activity_at = now() where id = $1;"
+      && entry.params[0] === "t_db"
+    )),
+    true
+  );
+});


### PR DESCRIPTION
The inactive cleanup path treated user-scoped live hands as fresh regardless of table inactivity, which let disconnect cleanup defer forever and left stale tables full. Tighten the freshness check to respect table activity for disconnect cleanup too, and add regressions for stale live hands without a turn deadline.