### PR TITLE
Improve site content for AdSense review readiness

### DIFF
--- a/about.en.html
+++ b/about.en.html
@@ -118,8 +118,9 @@
     <button id="debugDumpButton" class="debug-dump-button" type="button" hidden>Dump diagnostics</button>
     <div id="debugToast" class="debug-toast" role="status" aria-live="polite"></div>
     <h1>About</h1>
-    <p>This is a simple arcade portal (MVP). More games and features are coming soon.</p>
-    <p>Contact: <a href="#" class="ft-link">email</a></p>
+    <p>Arcade Hub is a browser gaming portal focused on fast-loading HTML5 arcade games, lightweight player accounts, and a shared XP system across supported titles.</p>
+    <p>We build and maintain the project as an independent web platform under KCSWH, with an emphasis on simple controls, mobile-friendly layouts, and clear account and privacy settings.</p>
+    <p>Contact: <a href="mailto:contact@kcswh.pl" class="ft-link">contact@kcswh.pl</a></p>
     <p><a href="#" class="ft-link manage-cookies" data-i18n="manageCookies">Manage cookies</a></p>
     <p><a id="backLink" href="index.html?lang=en" class="ft-link">Back to portal</a></p>
 

--- a/about.pl.html
+++ b/about.pl.html
@@ -118,8 +118,9 @@
     <button id="debugDumpButton" class="debug-dump-button" type="button" hidden>Dump diagnostics</button>
     <div id="debugToast" class="debug-toast" role="status" aria-live="polite"></div>
     <h1>O serwisie</h1>
-    <p>To prosty portal arcade (MVP). Więcej gier i funkcji już wkrótce.</p>
-    <p>Kontakt: <a href="#" class="ft-link">email</a></p>
+    <p>Arcade Hub to przeglądarkowy portal z grami skupiony na szybkich grach HTML5, lekkich kontach graczy oraz wspólnym systemie XP dla obsługiwanych tytułów.</p>
+    <p>Projekt rozwijamy niezależnie pod marką KCSWH, z naciskiem na proste sterowanie, układy przyjazne dla urządzeń mobilnych oraz czytelne informacje o kontach, cookies i prywatności.</p>
+    <p>Kontakt: <a href="mailto:contact@kcswh.pl" class="ft-link">contact@kcswh.pl</a></p>
     <p><a href="#" class="ft-link manage-cookies" data-i18n="manageCookies">Zarządzaj cookies</a></p>
     <p><a id="backLink" href="index.html?lang=pl" class="ft-link">Wróć do portalu</a></p>
 

--- a/landing/about.html
+++ b/landing/about.html
@@ -47,17 +47,28 @@
   <main class="main">
     <article class="tile about-card">
       <h1>About Arcade Hub</h1>
-      <p>Arcade Hub is a lightweight portal that curates a handful of bite-sized web games. We keep the experience fast, focused, and friendly on every device.</p>
-      <p>New releases are added regularly—check back often to discover fresh challenges and community favourites.</p>
+      <p>Arcade Hub is an independent browser gaming project operated by KCSWH. We publish quick-play HTML5 games, maintain player-facing portal pages, and support account features such as XP sync and optional sign-in.</p>
+      <p>The platform is designed to work directly in the browser on desktop and mobile devices. We focus on short sessions, accessible controls, and clear information about privacy, cookies, and account management.</p>
+
+      <section>
+        <h2>What you can do on the site</h2>
+        <p>Visitors can browse and play arcade titles in the main portal, use optional accounts for cloud-synced progress, and access social gameplay features that are being developed around virtual-chip poker and community play.</p>
+      </section>
 
       <section>
         <h2>Contact</h2>
         <p>Questions, feedback, or partnership ideas? Drop us a line at <a href="mailto:contact@kcswh.pl">contact@kcswh.pl</a>.</p>
       </section>
 
+      <section id="terms">
+        <h2>Arcade terms</h2>
+        <p>Arcade Hub is intended for entertainment use in the browser. Users are expected to use the site lawfully, avoid abuse or cheating, protect their own credentials, and respect any gameplay or account restrictions published on the platform.</p>
+        <p>We may update site features, moderate abusive activity, or suspend access when required to protect the service, player accounts, or platform integrity.</p>
+      </section>
+
       <section>
         <h2>Policies</h2>
-        <p>Read the latest <a href="./legal/privacy.en.html">Privacy Policy</a> and <a href="https://play.kcswh.pl/legal/terms.en.html">Arcade Terms of Use</a>. These documents explain how we process data and the rules for using the arcade.</p>
+        <p>Read the latest <a href="./legal/privacy.en.html">Privacy Policy</a> and the <a href="#terms">Arcade terms</a> above. These explain how we process data, manage cookies, and set the basic rules for using the project.</p>
         <p><a class="manage-cookies" href="#">Manage cookies</a> at any time to review your consent choices.</p>
       </section>
 
@@ -69,7 +80,7 @@
       <div class="links">
         <a href="./index.html">Home</a>
         <a href="./legal/privacy.en.html">Privacy</a>
-        <a href="https://play.kcswh.pl/legal/terms.en.html">Arcade Terms</a>
+        <a href="#terms">Arcade Terms</a>
       </div>
       <div>© <span id="year"></span> KCSWH</div>
   </footer>

--- a/landing/index.html
+++ b/landing/index.html
@@ -67,18 +67,29 @@
            data-full-width-responsive="true"></ins>
     </section>
 
+    <section class="tile about-card" aria-labelledby="landingIntroTitle">
+      <div class="eyebrow">Independent browser gaming project</div>
+      <h1 id="landingIntroTitle">Arcade Hub by KCSWH</h1>
+      <p>Arcade Hub is a web-based gaming project operated by KCSWH. The platform combines quick-play browser games, player profiles, cloud-synced XP, and experimental multiplayer features such as poker with virtual chips.</p>
+      <p>The goal of the site is to provide lightweight entertainment that works directly in the browser without installs. We maintain the platform, publish policy information, and handle user questions through the contact address listed below.</p>
+    </section>
+
     <section class="grid" aria-label="Navigation">
       <a class="tile" href="https://play.kcswh.pl/">
         <div class="title">Play</div>
-        <div class="desc">Jump into the games hub</div>
+        <div class="desc">Open the main Arcade Hub portal with browser games, accounts, XP, and poker.</div>
       </a>
       <a class="tile" href="./about.html">
         <div class="title">About</div>
-        <div class="desc">Learn more about the project</div>
+        <div class="desc">Read who runs the project, what the platform offers, and how to get in touch.</div>
       </a>
       <a class="tile" href="mailto:contact@kcswh.pl">
         <div class="title">Contact</div>
-        <div class="desc">Get in touch</div>
+        <div class="desc">Send questions, partnership ideas, support issues, or policy requests to KCSWH.</div>
+      </a>
+      <a class="tile" href="./legal/privacy.en.html">
+        <div class="title">Privacy</div>
+        <div class="desc">Review how cookies, analytics, account data, and gameplay-related information are handled.</div>
       </a>
     </section>
   </main>
@@ -88,7 +99,7 @@
       <a href="./about.html">About</a>
       <a class="manage-cookies" id="manageCookies" href="#">Manage cookies</a>
       <a href="./legal/privacy.en.html">Privacy</a>
-      <a href="https://play.kcswh.pl/legal/terms.en.html">Arcade Terms</a>
+      <a href="./about.html#terms">Arcade Terms</a>
     </div>
     <div>© <span id="year"></span> KCSWH</div>
   </footer>

--- a/poker/index.html
+++ b/poker/index.html
@@ -79,6 +79,11 @@
            data-ad-format="auto"
            data-full-width-responsive="true"></ins>
     </section>
+    <section class="poker-panel poker-intro-panel" aria-labelledby="pokerIntroTitle">
+      <h2 id="pokerIntroTitle">Arcade Poker with virtual chips</h2>
+      <p>Arcade Poker is the multiplayer card room inside Arcade Hub. It is designed for browser-based play using virtual chips, player accounts, and social tables inside the wider arcade platform.</p>
+      <p>No cash-out is offered on this page. Sign in to access the lobby, join tables, and manage your in-platform poker activity.</p>
+    </section>
     <div id="pokerAuthMsg" class="poker-auth-msg" hidden>
       <div class="poker-auth-text" data-i18n="pokerAuthLobby">Please log in to access the poker lobby.</div>
       <div class="poker-auth-actions">

--- a/poker/poker.css
+++ b/poker/poker.css
@@ -62,6 +62,22 @@
 
 .poker-panel h3{margin:0 0 12px; font:600 15px Poppins, sans-serif; color:#cdd6ff;}
 
+.poker-intro-panel h2{
+  margin:0 0 10px;
+  font:700 20px Poppins, sans-serif;
+  color:#e8eeff;
+}
+
+.poker-intro-panel p{
+  margin:0 0 10px;
+  font:500 14px/1.6 Poppins, sans-serif;
+  color:var(--muted);
+}
+
+.poker-intro-panel p:last-child{
+  margin-bottom:0;
+}
+
 .poker-showdown-panel{background:rgba(12,18,34,.55);}
 
 .poker-showdown-section{display:flex; flex-direction:column; gap:6px; margin-bottom:10px;}


### PR DESCRIPTION
## Summary
- replace unfinished/MVP wording on the public about pages with fuller publisher-facing descriptions
- expand `kcswh.pl` landing content to better explain ownership, purpose, and contact details
- add a public poker intro clarifying virtual-chip play before the sign-in gate

## Why
These changes target common AdSense review risks around thin content, incomplete messaging, and gated pages with too little public context.