### PR TITLE
[codex] Fix Cookiebot manage button

### DIFF
--- a/account.html
+++ b/account.html
@@ -232,5 +232,6 @@
       <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
     </div>
   </footer>
+  <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/admin.html
+++ b/admin.html
@@ -522,5 +522,6 @@
       <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
     </div>
   </footer>
+  <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>

--- a/js/cookiebot-manager.js
+++ b/js/cookiebot-manager.js
@@ -25,12 +25,12 @@
     if (typeof window === 'undefined') return false;
     if (!window.Cookiebot) return false;
     try {
-      if (typeof window.Cookiebot.show === 'function') {
-        window.Cookiebot.show();
-        return true;
-      }
       if (typeof window.Cookiebot.renew === 'function') {
         window.Cookiebot.renew();
+        return true;
+      }
+      if (typeof window.Cookiebot.show === 'function') {
+        window.Cookiebot.show();
         return true;
       }
     } catch (err) {}

--- a/play.html
+++ b/play.html
@@ -339,6 +339,6 @@
       <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
     </div>
   </footer>
+  <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>
-

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -6,6 +6,7 @@ const root = process.cwd();
 const indexHtml = await readFile(path.join(root, 'poker', 'index.html'), 'utf8');
 const tableV2Html = await readFile(path.join(root, 'poker', 'table-v2.html'), 'utf8');
 const tableV2Css = await readFile(path.join(root, 'poker', 'poker-v2.css'), 'utf8');
+const cookiebotManagerJs = await readFile(path.join(root, 'js', 'cookiebot-manager.js'), 'utf8');
 assert.match(indexHtml, /src="\/js\/build-info\.js" defer/, 'poker index should include build-info bootstrap script');
 assert.equal(indexHtml.indexOf('/js/build-info.js') < indexHtml.indexOf('/poker/poker-ws-client.js'), true, 'poker index should load build-info before ws client');
 assert.doesNotMatch(indexHtml, /pokerClassicEntry/, 'poker lobby should no longer expose the classic table entry');
@@ -23,3 +24,5 @@ assert.doesNotMatch(tableV2Css, /\.poker-seat--hero \.poker-seat-avatar\{[^}]*bo
 assert.match(tableV2Css, /\.poker-seat--hero\.poker-seat--active \.poker-seat-avatar\{border-color:rgba\(84,245,152,0\.88\);/, 'hero avatar should turn green only on the active turn');
 assert.match(tableV2Html, /id="pokerBootSplash"/, 'poker table v2 should render a boot splash to avoid raw HTML flash');
 assert.match(tableV2Html, /id="pokerV2AmountValue"/, 'poker table v2 should render a compact amount value for the action slider');
+assert.match(cookiebotManagerJs, /#manageCookies, .manage-cookies/, 'cookie manager should delegate clicks from all manage cookies links');
+assert.equal(cookiebotManagerJs.indexOf('window.Cookiebot.renew()') < cookiebotManagerJs.indexOf('window.Cookiebot.show()'), true, 'manage cookies should reopen Cookiebot preferences before falling back to the initial banner');

--- a/xp.html
+++ b/xp.html
@@ -185,5 +185,6 @@
       <button type="button" class="lang-btn" data-lang="en" aria-pressed="false">EN</button>
     </div>
   </footer>
+  <script src="js/cookiebot-manager.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the shared Cookiebot manage button handler so it opens the consent preferences panel after a user has already saved choices.

## Root Cause

The central `js/cookiebot-manager.js` handler called `Cookiebot.show()` before `Cookiebot.renew()`. After consent had already been stored, `show()` can no-op or only target the initial banner flow, which made the "Manage cookies" link appear broken on the landing page and other pages.

## Changes

- Prefer `Cookiebot.renew()` for manage-cookie clicks, with `show()` kept as a fallback.
- Add a static regression assertion so the manager keeps delegating manage-cookie links and keeps `renew()` before `show()`.

## Validation

- `node scripts/syntax-check.mjs`
- `node tests/static-html.behavior.test.mjs`