### PR TITLE
[codex] Fix landing cookie manager assets

### DIFF
--- a/landing/js/adsense-init.js
+++ b/landing/js/adsense-init.js
@@ -1,0 +1,29 @@
+(function(){
+  function initAds(){
+    if (!Array.isArray(window.adsbygoogle)) return false;
+    var slots = document.querySelectorAll('ins.adsbygoogle:not([data-adsbygoogle-status]):not([data-ad-init="1"])');
+    if (!slots.length) return true;
+    slots.forEach(function(slot){
+      try {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+        slot.setAttribute('data-ad-init', '1');
+      } catch (_err) {
+        // Retry later after the AdSense runtime finishes bootstrapping.
+      }
+    });
+    return true;
+  }
+
+  function scheduleInit(){
+    if (initAds()) return;
+    var attempts = 0;
+    var timer = window.setInterval(function(){
+      attempts += 1;
+      if (initAds() || attempts >= 20) window.clearInterval(timer);
+    }, 500);
+  }
+
+  document.addEventListener('DOMContentLoaded', scheduleInit, { once: true });
+  window.addEventListener('CookiebotOnConsentReady', scheduleInit);
+  window.addEventListener('CookiebotOnAccept', scheduleInit);
+})();

--- a/landing/js/cookiebot-manager.js
+++ b/landing/js/cookiebot-manager.js
@@ -1,0 +1,55 @@
+(function(){
+  if (typeof document === 'undefined') return;
+
+  function matchesSelector(node, selector){
+    if (!node || !selector) return false;
+    var fn = node.matches || node.msMatchesSelector || node.webkitMatchesSelector || node.mozMatchesSelector;
+    if (!fn) return false;
+    try {
+      return fn.call(node, selector);
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function findManageLink(start){
+    var current = start;
+    while (current && current !== document){
+      if (matchesSelector(current, '#manageCookies, .manage-cookies')) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  function reopenCookiebot(){
+    if (typeof window === 'undefined') return false;
+    if (!window.Cookiebot) return false;
+    try {
+      if (typeof window.Cookiebot.renew === 'function') {
+        window.Cookiebot.renew();
+        return true;
+      }
+      if (typeof window.Cookiebot.show === 'function') {
+        window.Cookiebot.show();
+        return true;
+      }
+    } catch (err) {}
+    return false;
+  }
+
+  function notifyUnavailable(){
+    if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+      console.warn('Consent manager not loaded yet.');
+    }
+    try { alert('Consent manager not loaded yet.'); } catch (err) {}
+  }
+
+  document.addEventListener('click', function(event){
+    var link = findManageLink(event && event.target);
+    if (!link) return;
+    if (event && typeof event.preventDefault === 'function') event.preventDefault();
+    if (!reopenCookiebot()) {
+      notifyUnavailable();
+    }
+  }, { passive: false });
+})();

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -7,6 +7,9 @@ const indexHtml = await readFile(path.join(root, 'poker', 'index.html'), 'utf8')
 const tableV2Html = await readFile(path.join(root, 'poker', 'table-v2.html'), 'utf8');
 const tableV2Css = await readFile(path.join(root, 'poker', 'poker-v2.css'), 'utf8');
 const cookiebotManagerJs = await readFile(path.join(root, 'js', 'cookiebot-manager.js'), 'utf8');
+const adsenseInitJs = await readFile(path.join(root, 'js', 'adsense-init.js'), 'utf8');
+const landingCookiebotManagerJs = await readFile(path.join(root, 'landing', 'js', 'cookiebot-manager.js'), 'utf8');
+const landingAdsenseInitJs = await readFile(path.join(root, 'landing', 'js', 'adsense-init.js'), 'utf8');
 assert.match(indexHtml, /src="\/js\/build-info\.js" defer/, 'poker index should include build-info bootstrap script');
 assert.equal(indexHtml.indexOf('/js/build-info.js') < indexHtml.indexOf('/poker/poker-ws-client.js'), true, 'poker index should load build-info before ws client');
 assert.doesNotMatch(indexHtml, /pokerClassicEntry/, 'poker lobby should no longer expose the classic table entry');
@@ -26,3 +29,5 @@ assert.match(tableV2Html, /id="pokerBootSplash"/, 'poker table v2 should render 
 assert.match(tableV2Html, /id="pokerV2AmountValue"/, 'poker table v2 should render a compact amount value for the action slider');
 assert.match(cookiebotManagerJs, /#manageCookies, .manage-cookies/, 'cookie manager should delegate clicks from all manage cookies links');
 assert.equal(cookiebotManagerJs.indexOf('window.Cookiebot.renew()') < cookiebotManagerJs.indexOf('window.Cookiebot.show()'), true, 'manage cookies should reopen Cookiebot preferences before falling back to the initial banner');
+assert.equal(landingCookiebotManagerJs, cookiebotManagerJs, 'landing deploy should publish the shared Cookiebot manager at /js/cookiebot-manager.js');
+assert.equal(landingAdsenseInitJs, adsenseInitJs, 'landing deploy should publish the AdSense init helper at /js/adsense-init.js');


### PR DESCRIPTION
## Summary

Publishes the shared Cookiebot and AdSense helper scripts inside the landing site bundle so `kcswh.pl` can load them from `/js/...`.

## Root Cause

The landing site appears to be deployed with `landing/` as the publish root. Its HTML references `../js/cookiebot-manager.js` and `../js/adsense-init.js`, which resolve on `kcswh.pl` to `/js/cookiebot-manager.js` and `/js/adsense-init.js`. Those files were only present in the main portal root, not under `landing/`, so `https://kcswh.pl/js/cookiebot-manager.js` returned 404 and the "Manage cookies" links were left as inert `href="#"` anchors.

## Changes

- Add `landing/js/cookiebot-manager.js` so the landing deploy serves the manage-cookie click handler.
- Add `landing/js/adsense-init.js` so the landing deploy serves the AdSense initialization helper referenced by the landing page.
- Add static regression assertions that the landing copies match the shared helpers.

## Validation

- `node --check landing/js/cookiebot-manager.js`
- `node --check landing/js/adsense-init.js`
- `node tests/static-html.behavior.test.mjs`
- `node scripts/syntax-check.mjs`