### PR TITLE
[codex] Add minimal arcade landing game

### DIFF
--- a/landing/css/landing.css
+++ b/landing/css/landing.css
@@ -1,10 +1,15 @@
 :root {
-  --bg: #0b1220;
-  --card: #121a2b;
-  --muted: #93a0b5;
-  --text: #e9f0ff;
-  --accent: linear-gradient(135deg, #c6f, #6af);
-  --radius: 1.25rem;
+  --bg: #090e1b;
+  --panel: rgba(14, 21, 48, 0.78);
+  --panel-strong: rgba(17, 23, 53, 0.94);
+  --muted: #9fb0d0;
+  --text: #e8eeff;
+  --accent: #6ee7e7;
+  --accent-2: #a78bfa;
+  --border: rgba(110, 231, 231, 0.2);
+  --border-soft: rgba(159, 176, 208, 0.14);
+  --shadow: 0 28px 80px rgba(0, 0, 0, 0.34);
+  --radius: 18px;
 }
 
 * {
@@ -15,10 +20,26 @@ html,
 body {
   margin: 0;
   min-height: 100%;
-  background: var(--bg);
+  background:
+    radial-gradient(circle at 50% -12%, rgba(110, 231, 231, 0.2), transparent 34rem),
+    radial-gradient(circle at 85% 14%, rgba(167, 139, 250, 0.18), transparent 26rem),
+    linear-gradient(180deg, #0b1020 0%, var(--bg) 100%);
   color: var(--text);
-  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(110, 231, 231, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(110, 231, 231, 0.07) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(180deg, #000 0%, transparent 72%);
 }
 
 a {
@@ -28,22 +49,23 @@ a {
 
 a:focus-visible,
 button:focus-visible {
-  outline: 3px solid rgba(134, 225, 225, 0.65);
+  outline: 3px solid rgba(110, 231, 231, 0.7);
   outline-offset: 4px;
-  border-radius: 8px;
+  border-radius: 12px;
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  gap: 16px;
+  padding: 16px clamp(16px, 4vw, 34px);
   position: sticky;
   top: 0;
   z-index: 5;
-  background: rgba(11, 18, 32, 0.92);
-  backdrop-filter: saturate(180%) blur(10px);
-  border-bottom: 1px solid rgba(134, 225, 225, 0.1);
+  background: rgba(9, 14, 27, 0.76);
+  border-bottom: 1px solid var(--border-soft);
+  backdrop-filter: saturate(160%) blur(16px);
 }
 
 .brand {
@@ -51,58 +73,257 @@ button:focus-visible {
   gap: 12px;
   align-items: center;
   font-weight: 800;
-  font-size: 22px;
-  letter-spacing: 0.02em;
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
-  transition: opacity 0.2s ease;
-}
-
-.brand:hover {
-  opacity: 0.88;
-}
-
-.brand:active {
-  opacity: 0.75;
+  font-size: clamp(18px, 2vw, 22px);
+  color: var(--text);
 }
 
 .brand-badge {
-  width: 36px;
-  height: 36px;
+  width: 38px;
+  height: 38px;
   border-radius: 12px;
-  background: var(--accent);
-  box-shadow: 0 10px 25px rgba(102, 170, 255, 0.28);
+  background:
+    radial-gradient(circle at 30% 30%, #e8fffe 0 8%, transparent 9%),
+    linear-gradient(135deg, var(--accent), var(--accent-2));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 0 26px rgba(110, 231, 231, 0.24);
 }
 
-.nav {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-}
-
+.nav,
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .nav a {
-  font-weight: 600;
-  font-size: 15px;
   color: var(--muted);
-  transition: color 0.2s ease;
+  font-size: 14px;
+  font-weight: 700;
 }
 
-.nav a:hover,
-.nav a:focus-visible {
+.nav a:hover {
   color: var(--text);
+}
+
+.landing-main {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: clamp(20px, 4vw, 48px) 0 0;
 }
 
 .main {
   max-width: 1080px;
-  margin: 24px auto 0 auto;
+  margin: 24px auto 0;
   padding: 0 16px 40px;
+}
+
+.play-hero {
+  min-height: min(720px, calc(100vh - 110px));
+  display: grid;
+  grid-template-rows: auto minmax(260px, 1fr) auto;
+  gap: clamp(18px, 3vw, 30px);
+  align-items: center;
+  padding: clamp(22px, 4vw, 42px);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(15, 20, 48, 0.72), rgba(9, 14, 27, 0.88)),
+    radial-gradient(circle at 50% 42%, rgba(110, 231, 231, 0.16), transparent 26rem);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  position: relative;
+}
+
+.play-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 9% -95px;
+  height: 170px;
+  pointer-events: none;
+  background: radial-gradient(ellipse, rgba(110, 231, 231, 0.22), transparent 70%);
+}
+
+.hero-copy,
+.hero-actions {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(44px, 9vw, 112px);
+  line-height: 0.88;
+  letter-spacing: 0;
+}
+
+.hero-subtitle,
+.hero-actions p {
+  margin: 14px auto 0;
+  max-width: 540px;
+  color: var(--muted);
+  font-size: clamp(14px, 2vw, 17px);
+  line-height: 1.6;
+}
+
+.mini-game {
+  position: relative;
+  z-index: 1;
+  min-height: clamp(260px, 42vh, 420px);
+  border: 1px solid rgba(110, 231, 231, 0.16);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at var(--target-x, 50%) var(--target-y, 50%), rgba(110, 231, 231, 0.18), transparent 10rem),
+    linear-gradient(135deg, rgba(110, 231, 231, 0.06), rgba(167, 139, 250, 0.05));
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.mini-game::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.045) 1px, transparent 1px);
+  background-size: 24px 24px;
+  opacity: 0.55;
+}
+
+.game-hud {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  top: 16px;
+  z-index: 3;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.game-hud span {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  min-height: 34px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  color: var(--muted);
+  background: rgba(9, 14, 27, 0.72);
+  font-size: 12px;
+  font-weight: 700;
+  backdrop-filter: blur(10px);
+}
+
+.game-hud strong {
+  color: var(--text);
+  font-size: 14px;
+}
+
+.pixel-target {
+  position: absolute;
+  z-index: 4;
+  left: var(--target-left, 50%);
+  top: var(--target-top, 50%);
+  width: var(--target-size, 52px);
+  height: var(--target-size, 52px);
+  border: 0;
+  border-radius: 14px;
+  transform: translate(-50%, -50%) rotate(45deg);
+  cursor: pointer;
+  background:
+    radial-gradient(circle at 35% 35%, #ffffff 0 8%, transparent 10%),
+    linear-gradient(135deg, var(--accent), var(--accent-2));
+  box-shadow:
+    0 0 0 8px rgba(110, 231, 231, 0.08),
+    0 0 34px rgba(110, 231, 231, 0.52),
+    0 20px 42px rgba(0, 0, 0, 0.35);
+  transition:
+    left 160ms ease,
+    top 160ms ease,
+    width 160ms ease,
+    height 160ms ease,
+    transform 120ms ease;
+}
+
+.pixel-target:hover {
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.08);
+}
+
+.pixel-target:active,
+.pixel-target.is-hit {
+  transform: translate(-50%, -50%) rotate(45deg) scale(0.86);
+}
+
+.game-pulse {
+  position: absolute;
+  left: var(--target-left, 50%);
+  top: var(--target-top, 50%);
+  width: 180px;
+  height: 180px;
+  border-radius: 999px;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, rgba(110, 231, 231, 0.2), transparent 62%);
+  opacity: 0.72;
+  animation: pulse-ring 1.45s ease-out infinite;
+}
+
+.play-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 56px;
+  padding: 0 28px;
+  border-radius: 999px;
+  color: #06111c;
+  background: linear-gradient(135deg, var(--accent), #c4b5fd);
+  box-shadow: 0 18px 44px rgba(110, 231, 231, 0.28);
+  font-weight: 800;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.play-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 54px rgba(110, 231, 231, 0.36);
+}
+
+.quick-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.quick-strip div {
+  min-height: 84px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  background: var(--panel);
+}
+
+.quick-strip strong {
+  font-size: 14px;
+}
+
+.quick-strip span {
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .grid {
@@ -112,21 +333,22 @@ button:focus-visible {
 }
 
 .tile {
-  background: var(--card);
-  border-radius: var(--radius);
-  padding: 18px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.25);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  min-height: 180px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 180px;
+  padding: 18px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius);
+  background: var(--panel-strong);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.22);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .tile:hover,
 .tile:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.32);
 }
 
 .tile .title {
@@ -147,6 +369,7 @@ button:focus-visible {
 
 .about-card h1 {
   font-size: 28px;
+  line-height: 1.08;
   margin: 0 0 8px;
 }
 
@@ -161,17 +384,18 @@ button:focus-visible {
 }
 
 .about-card .eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 12px;
+  margin: 0;
   color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
 }
 
 .about-card section {
   margin-top: 4px;
 }
 
-.about-card a {
+.about-card a,
+.policy-lang-switch a {
   color: inherit;
   text-decoration: underline;
 }
@@ -180,10 +404,6 @@ button:focus-visible {
   margin: 0 0 12px;
   color: var(--muted);
   font-size: 14px;
-}
-
-.policy-lang-switch a {
-  text-decoration: underline;
 }
 
 .about-back {
@@ -196,9 +416,11 @@ button:focus-visible {
 }
 
 .ad-slot {
-  margin: 24px 0 32px;
+  min-height: 92px;
+  margin: 18px 0 28px;
   border-radius: var(--radius);
-  background: rgba(18, 26, 43, 0.7);
+  background: rgba(17, 23, 53, 0.42);
+  border: 1px solid var(--border-soft);
   padding: 12px;
   display: flex;
   justify-content: center;
@@ -206,15 +428,15 @@ button:focus-visible {
 }
 
 .footer {
-  max-width: 1080px;
-  margin: 40px auto;
-  padding: 20px 16px 60px;
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 18px 0 42px;
   color: var(--muted);
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .footer .links {
@@ -224,33 +446,65 @@ button:focus-visible {
 }
 
 .footer .links a {
-  font-weight: 500;
+  font-weight: 600;
 }
 
 .manage-cookies {
   cursor: pointer;
 }
 
-@media (max-width: 720px) {
+@keyframes pulse-ring {
+  0% {
+    transform: translate(-50%, -50%) scale(0.7);
+    opacity: 0.72;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.35);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 760px) {
   .header {
-    flex-direction: column;
-    gap: 12px;
     align-items: flex-start;
+    flex-wrap: wrap;
   }
 
   .nav {
+    order: 3;
     width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 12px;
   }
 
-  .tile {
-    min-height: 160px;
+  .play-hero {
+    min-height: auto;
+    padding: 18px;
+    border-radius: 22px;
   }
 
+  .mini-game {
+    min-height: 320px;
+  }
+
+  .quick-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .landing-main,
   .footer {
-    flex-direction: column;
-    align-items: flex-start;
+    width: min(100% - 20px, 1120px);
+  }
+
+  h1 {
+    font-size: clamp(42px, 18vw, 72px);
+  }
+
+  .quick-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .game-hud {
+    justify-content: flex-start;
   }
 }

--- a/landing/css/landing.css
+++ b/landing/css/landing.css
@@ -300,6 +300,20 @@ h1 {
   animation: pixel-burst 520ms ease-out forwards;
 }
 
+.tap-ring {
+  position: absolute;
+  z-index: 1;
+  left: var(--tap-left, 50%);
+  top: var(--tap-top, 50%);
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(110, 231, 231, 0.74);
+  border-radius: 999px;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  animation: tap-ring 620ms ease-out forwards;
+}
+
 .play-button {
   display: inline-flex;
   align-items: center;
@@ -465,6 +479,17 @@ h1 {
   100% {
     opacity: 0;
     transform: translate(-50%, -50%) scale(1.9) rotate(28deg);
+  }
+}
+
+@keyframes tap-ring {
+  0% {
+    opacity: 0.9;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(4.4);
   }
 }
 

--- a/landing/css/landing.css
+++ b/landing/css/landing.css
@@ -88,21 +88,10 @@ button:focus-visible {
   box-shadow: 0 0 26px rgba(110, 231, 231, 0.24);
 }
 
-.nav,
 .header-actions {
   display: flex;
   align-items: center;
   gap: 14px;
-}
-
-.nav a {
-  color: var(--muted);
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.nav a:hover {
-  color: var(--text);
 }
 
 .landing-main {
@@ -250,11 +239,15 @@ h1 {
     0 0 34px rgba(110, 231, 231, 0.52),
     0 20px 42px rgba(0, 0, 0, 0.35);
   transition:
-    left 160ms ease,
-    top 160ms ease,
     width 160ms ease,
     height 160ms ease,
     transform 120ms ease;
+}
+
+.pixel-target.is-clone {
+  z-index: 3;
+  opacity: 0.82;
+  filter: hue-rotate(32deg);
 }
 
 .pixel-target:hover {
@@ -264,6 +257,12 @@ h1 {
 .pixel-target:active,
 .pixel-target.is-hit {
   transform: translate(-50%, -50%) rotate(45deg) scale(0.86);
+}
+
+.pixel-target.is-small {
+  width: calc(var(--target-size, 52px) * 0.58);
+  height: calc(var(--target-size, 52px) * 0.58);
+  border-radius: 10px;
 }
 
 .game-pulse {
@@ -277,6 +276,28 @@ h1 {
   background: radial-gradient(circle, rgba(110, 231, 231, 0.2), transparent 62%);
   opacity: 0.72;
   animation: pulse-ring 1.45s ease-out infinite;
+}
+
+.pixel-burst {
+  position: absolute;
+  z-index: 2;
+  left: var(--burst-left, 50%);
+  top: var(--burst-top, 50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  background: #ffffff;
+  box-shadow:
+    0 -34px 0 var(--accent),
+    28px -20px 0 #c4b5fd,
+    34px 8px 0 var(--accent),
+    14px 34px 0 #f8fafc,
+    -24px 26px 0 #c4b5fd,
+    -36px -4px 0 var(--accent),
+    -16px -30px 0 #f8fafc;
+  animation: pixel-burst 520ms ease-out forwards;
 }
 
 .play-button {
@@ -296,34 +317,6 @@ h1 {
 .play-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 22px 54px rgba(110, 231, 231, 0.36);
-}
-
-.quick-strip {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
-  margin: 18px 0;
-}
-
-.quick-strip div {
-  min-height: 84px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  padding: 16px;
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius);
-  background: var(--panel);
-}
-
-.quick-strip strong {
-  font-size: 14px;
-}
-
-.quick-strip span {
-  color: var(--muted);
-  font-size: 13px;
 }
 
 .grid {
@@ -464,15 +457,21 @@ h1 {
   }
 }
 
+@keyframes pixel-burst {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(0.42) rotate(0deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.9) rotate(28deg);
+  }
+}
+
 @media (max-width: 760px) {
   .header {
     align-items: flex-start;
     flex-wrap: wrap;
-  }
-
-  .nav {
-    order: 3;
-    width: 100%;
   }
 
   .play-hero {
@@ -485,9 +484,6 @@ h1 {
     min-height: 320px;
   }
 
-  .quick-strip {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
 @media (max-width: 520px) {
@@ -498,10 +494,6 @@ h1 {
 
   h1 {
     font-size: clamp(42px, 18vw, 72px);
-  }
-
-  .quick-strip {
-    grid-template-columns: 1fr;
   }
 
   .game-hud {

--- a/landing/index.html
+++ b/landing/index.html
@@ -31,10 +31,6 @@
       <span class="brand-badge" aria-hidden="true"></span>
       <span>Arcade Hub</span>
     </a>
-    <nav class="nav" aria-label="Primary">
-      <a href="./about.html">About</a>
-      <a class="manage-cookies" href="#manageCookies">Manage cookies</a>
-    </nav>
     <div class="header-actions">
       <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../xp.html">
         <span class="xp-badge__label">XP</span>
@@ -64,13 +60,6 @@
         <a class="play-button" href="https://play.kcswh.pl/">Play more on Arcade Hub</a>
         <p>Fast HTML5 games, XP sync, and poker with virtual chips.</p>
       </div>
-    </section>
-
-    <section class="quick-strip" aria-label="Arcade Hub features">
-      <div><strong>Browser games</strong><span>No install</span></div>
-      <div><strong>XP sync</strong><span>Keep progress</span></div>
-      <div><strong>Poker chips</strong><span>Virtual tables</span></div>
-      <div><strong>Mobile ready</strong><span>Tap friendly</span></div>
     </section>
 
     <section class="ad-slot" aria-label="Advertisement">

--- a/landing/index.html
+++ b/landing/index.html
@@ -49,7 +49,7 @@
       <div class="mini-game" data-landing-game>
         <div class="game-hud" aria-live="polite">
           <span>Score <strong data-score>0</strong></span>
-          <span>Streak <strong data-streak>0</strong></span>
+          <span>Combo <strong data-streak>0</strong></span>
           <span>Best <strong data-best>0</strong></span>
         </div>
         <button class="pixel-target" type="button" data-target aria-label="Catch the pixel"></button>

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>KCSWH — Arcade Hub</title>
+  <title>KCSWH - Arcade Hub</title>
 
   <!-- AdSense account association tag for kcswh.pl -->
   <meta name="google-adsense-account" content="ca-pub-4054734235779751">
@@ -19,16 +19,15 @@
   <link rel="stylesheet" href="./css/landing.css">
   <link rel="stylesheet" href="../css/xp-badge.css">
 
-
-<script src="../js/adsense-init.js" defer></script>
+  <script src="../js/adsense-init.js" defer></script>
   <link rel="stylesheet" href="../js/vendor/klaro/klaro.css">
   <script src="../js/klaro-config.js" defer></script>
   <script src="../js/vendor/klaro/klaro.js" defer></script>
   <script src="../js/consent-services.js" defer></script>
 </head>
-<body>
+<body class="landing-home">
   <header class="header" role="banner">
-    <a href="../index.html" class="brand" aria-label="Arcade Hub home">
+    <a href="https://play.kcswh.pl/" class="brand" aria-label="Arcade Hub home">
       <span class="brand-badge" aria-hidden="true"></span>
       <span>Arcade Hub</span>
     </a>
@@ -38,12 +37,42 @@
     </nav>
     <div class="header-actions">
       <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../xp.html">
-        <span class="xp-badge__label">Syncing XP…</span>
+        <span class="xp-badge__label">XP</span>
       </a>
     </div>
   </header>
 
-  <main class="main">
+  <main class="landing-main">
+    <section class="play-hero" aria-labelledby="landingGameTitle">
+      <div class="hero-copy">
+        <p class="eyebrow">One tap arcade warmup</p>
+        <h1 id="landingGameTitle">Catch the Pixel</h1>
+        <p class="hero-subtitle">A tiny browser game before the real arcade opens.</p>
+      </div>
+
+      <div class="mini-game" data-landing-game>
+        <div class="game-hud" aria-live="polite">
+          <span>Score <strong data-score>0</strong></span>
+          <span>Streak <strong data-streak>0</strong></span>
+          <span>Best <strong data-best>0</strong></span>
+        </div>
+        <button class="pixel-target" type="button" data-target aria-label="Catch the pixel"></button>
+        <div class="game-pulse" aria-hidden="true"></div>
+      </div>
+
+      <div class="hero-actions">
+        <a class="play-button" href="https://play.kcswh.pl/">Play more on Arcade Hub</a>
+        <p>Fast HTML5 games, XP sync, and poker with virtual chips.</p>
+      </div>
+    </section>
+
+    <section class="quick-strip" aria-label="Arcade Hub features">
+      <div><strong>Browser games</strong><span>No install</span></div>
+      <div><strong>XP sync</strong><span>Keep progress</span></div>
+      <div><strong>Poker chips</strong><span>Virtual tables</span></div>
+      <div><strong>Mobile ready</strong><span>Tap friendly</span></div>
+    </section>
+
     <section class="ad-slot" aria-label="Advertisement">
       <ins class="adsbygoogle"
            style="display:block"
@@ -51,32 +80,6 @@
            data-ad-slot="6777117794"
            data-ad-format="auto"
            data-full-width-responsive="true"></ins>
-    </section>
-
-    <section class="tile about-card" aria-labelledby="landingIntroTitle">
-      <div class="eyebrow">Independent browser gaming project</div>
-      <h1 id="landingIntroTitle">Arcade Hub by KCSWH</h1>
-      <p>Arcade Hub is a web-based gaming project operated by KCSWH. The platform combines quick-play browser games, player profiles, cloud-synced XP, and experimental multiplayer features such as poker with virtual chips.</p>
-      <p>The goal of the site is to provide lightweight entertainment that works directly in the browser without installs. We maintain the platform, publish policy information, and handle user questions through the contact address listed below.</p>
-    </section>
-
-    <section class="grid" aria-label="Navigation">
-      <a class="tile" href="https://play.kcswh.pl/">
-        <div class="title">Play</div>
-        <div class="desc">Open the main Arcade Hub portal with browser games, accounts, XP, and poker.</div>
-      </a>
-      <a class="tile" href="./about.html">
-        <div class="title">About</div>
-        <div class="desc">Read who runs the project, what the platform offers, and how to get in touch.</div>
-      </a>
-      <a class="tile" href="mailto:contact@kcswh.pl">
-        <div class="title">Contact</div>
-        <div class="desc">Send questions, partnership ideas, support issues, or policy requests to KCSWH.</div>
-      </a>
-      <a class="tile" href="./legal/privacy.en.html">
-        <div class="title">Privacy</div>
-        <div class="desc">Review how cookies, analytics, account data, and gameplay-related information are handled.</div>
-      </a>
     </section>
   </main>
 
@@ -86,6 +89,7 @@
       <a class="manage-cookies" id="manageCookies" href="#">Manage cookies</a>
       <a href="./legal/privacy.en.html">Privacy</a>
       <a href="./about.html#terms">Arcade Terms</a>
+      <a href="mailto:contact@kcswh.pl">Contact</a>
     </div>
     <div>© <span id="year"></span> KCSWH</div>
   </footer>
@@ -93,6 +97,7 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="./js/landing-game.js" defer></script>
   <script src="../js/consent-manager.js" defer></script>
 </body>
 </html>

--- a/landing/js/landing-game.js
+++ b/landing/js/landing-game.js
@@ -1,0 +1,92 @@
+(function(){
+  var game = document.querySelector('[data-landing-game]');
+  if (!game) return;
+
+  var target = game.querySelector('[data-target]');
+  var scoreEl = game.querySelector('[data-score]');
+  var streakEl = game.querySelector('[data-streak]');
+  var bestEl = game.querySelector('[data-best]');
+  if (!target || !scoreEl || !streakEl || !bestEl) return;
+
+  var score = 0;
+  var streak = 0;
+  var best = readBest();
+  var moveTimer = 0;
+
+  bestEl.textContent = String(best);
+  placeTarget();
+  scheduleMove();
+
+  target.addEventListener('click', function(){
+    score += 1;
+    streak += 1;
+    if (score > best) {
+      best = score;
+      bestEl.textContent = String(best);
+      writeBest(best);
+    }
+
+    scoreEl.textContent = String(score);
+    streakEl.textContent = String(streak);
+    target.classList.add('is-hit');
+    window.setTimeout(function(){ target.classList.remove('is-hit'); }, 110);
+    placeTarget();
+    scheduleMove();
+  });
+
+  game.addEventListener('pointerdown', function(event){
+    if (event.target === target) return;
+    streak = 0;
+    streakEl.textContent = '0';
+  });
+
+  window.addEventListener('resize', function(){
+    placeTarget();
+  });
+
+  function scheduleMove(){
+    window.clearTimeout(moveTimer);
+    var delay = Math.max(650, 1500 - streak * 75);
+    moveTimer = window.setTimeout(function(){
+      streak = 0;
+      streakEl.textContent = '0';
+      placeTarget();
+      scheduleMove();
+    }, delay);
+  }
+
+  function placeTarget(){
+    var bounds = game.getBoundingClientRect();
+    var size = Math.max(34, 54 - Math.min(streak, 12));
+    var padding = Math.max(34, size);
+    var x = randomBetween(padding, Math.max(padding, bounds.width - padding));
+    var y = randomBetween(82, Math.max(120, bounds.height - padding));
+    var xPercent = bounds.width ? (x / bounds.width) * 100 : 50;
+    var yPercent = bounds.height ? (y / bounds.height) * 100 : 50;
+
+    game.style.setProperty('--target-left', x + 'px');
+    game.style.setProperty('--target-top', y + 'px');
+    game.style.setProperty('--target-size', size + 'px');
+    game.style.setProperty('--target-x', xPercent + '%');
+    game.style.setProperty('--target-y', yPercent + '%');
+  }
+
+  function randomBetween(min, max){
+    if (max <= min) return min;
+    return Math.round(min + Math.random() * (max - min));
+  }
+
+  function readBest(){
+    try {
+      return Number(window.localStorage.getItem('landingPixelBest')) || 0;
+    } catch (_err) {
+      return 0;
+    }
+  }
+
+  function writeBest(value){
+    try {
+      window.localStorage.setItem('landingPixelBest', String(value));
+    } catch (_err) {}
+  }
+})();

--- a/landing/js/landing-game.js
+++ b/landing/js/landing-game.js
@@ -11,15 +11,66 @@
   var score = 0;
   var streak = 0;
   var best = readBest();
-  var moveTimer = 0;
+  var speed = 42;
+  var lastFrame = 0;
+  var lastEvent = 0;
+  var nextEventDelay = randomBetween(3600, 6200);
+  var shrinkTimer = 0;
+  var clones = [];
+  var pixel = createPixelState(target, true);
 
   bestEl.textContent = String(best);
-  placeTarget();
-  scheduleMove();
+  resetPixel(pixel, true);
+  requestAnimationFrame(tick);
 
-  target.addEventListener('click', function(){
+  target.addEventListener('click', function(event){
+    event.stopPropagation();
+    hitPixel(pixel);
+  });
+
+  game.addEventListener('pointerdown', function(event){
+    if (event.target && event.target.classList && event.target.classList.contains('pixel-target')) return;
+    streak = 0;
+    streakEl.textContent = '0';
+  });
+
+  window.addEventListener('resize', function(){
+    clampPixel(pixel);
+    clones.forEach(clampPixel);
+    renderPixel(pixel);
+    clones.forEach(renderPixel);
+  });
+
+  function tick(now){
+    if (!lastFrame) lastFrame = now;
+    var dt = Math.min(0.032, (now - lastFrame) / 1000);
+    lastFrame = now;
+
+    movePixel(pixel, dt);
+    clones.forEach(function(clone){ movePixel(clone, dt); });
+    clones = clones.filter(function(clone){
+      if (now <= clone.expiresAt) return true;
+      clone.el.remove();
+      return false;
+    });
+
+    if (!lastEvent) lastEvent = now;
+    if (now - lastEvent > nextEventDelay) {
+      runRandomEvent(now);
+      lastEvent = now;
+      nextEventDelay = randomBetween(4200, 7600);
+    }
+
+    renderPixel(pixel);
+    clones.forEach(renderPixel);
+    requestAnimationFrame(tick);
+  }
+
+  function hitPixel(activePixel){
     score += 1;
     streak += 1;
+    speed = Math.min(380, speed + 18 + streak * 1.4);
+
     if (score > best) {
       best = score;
       bestEl.textContent = String(best);
@@ -28,47 +79,134 @@
 
     scoreEl.textContent = String(score);
     streakEl.textContent = String(streak);
-    target.classList.add('is-hit');
-    window.setTimeout(function(){ target.classList.remove('is-hit'); }, 110);
-    placeTarget();
-    scheduleMove();
-  });
-
-  game.addEventListener('pointerdown', function(event){
-    if (event.target === target) return;
-    streak = 0;
-    streakEl.textContent = '0';
-  });
-
-  window.addEventListener('resize', function(){
-    placeTarget();
-  });
-
-  function scheduleMove(){
-    window.clearTimeout(moveTimer);
-    var delay = Math.max(650, 1500 - streak * 75);
-    moveTimer = window.setTimeout(function(){
-      streak = 0;
-      streakEl.textContent = '0';
-      placeTarget();
-      scheduleMove();
-    }, delay);
+    burst(activePixel.x, activePixel.y);
+    activePixel.el.classList.add('is-hit');
+    window.setTimeout(function(){ activePixel.el.classList.remove('is-hit'); }, 110);
+    redirectPixel(activePixel);
   }
 
-  function placeTarget(){
-    var bounds = game.getBoundingClientRect();
-    var size = Math.max(34, 54 - Math.min(streak, 12));
-    var padding = Math.max(34, size);
-    var x = randomBetween(padding, Math.max(padding, bounds.width - padding));
-    var y = randomBetween(82, Math.max(120, bounds.height - padding));
-    var xPercent = bounds.width ? (x / bounds.width) * 100 : 50;
-    var yPercent = bounds.height ? (y / bounds.height) * 100 : 50;
+  function runRandomEvent(now){
+    if (Math.random() > 0.48) {
+      shrinkPixel();
+      return;
+    }
+    duplicatePixel(now);
+  }
 
-    game.style.setProperty('--target-left', x + 'px');
-    game.style.setProperty('--target-top', y + 'px');
-    game.style.setProperty('--target-size', size + 'px');
-    game.style.setProperty('--target-x', xPercent + '%');
-    game.style.setProperty('--target-y', yPercent + '%');
+  function shrinkPixel(){
+    window.clearTimeout(shrinkTimer);
+    target.classList.add('is-small');
+    shrinkTimer = window.setTimeout(function(){
+      target.classList.remove('is-small');
+    }, 1700);
+  }
+
+  function duplicatePixel(now){
+    var count = Math.random() > 0.55 ? 2 : 1;
+    for (var i = 0; i < count; i += 1) {
+      var cloneEl = document.createElement('button');
+      cloneEl.type = 'button';
+      cloneEl.className = 'pixel-target is-clone';
+      cloneEl.setAttribute('aria-label', 'Catch the bonus pixel');
+      game.appendChild(cloneEl);
+
+      var clone = createPixelState(cloneEl, false);
+      clone.expiresAt = now + randomBetween(1800, 2600);
+      resetPixel(clone, false);
+      cloneEl.addEventListener('click', function(event){
+        event.stopPropagation();
+        var activeClone = clones.find(function(item){ return item.el === event.currentTarget; });
+        if (!activeClone) return;
+        hitPixel(activeClone);
+        activeClone.expiresAt = 0;
+      });
+      clones.push(clone);
+    }
+  }
+
+  function createPixelState(el, primary){
+    var angle = Math.random() * Math.PI * 2;
+    return {
+      el: el,
+      primary: primary,
+      x: 0,
+      y: 0,
+      vx: Math.cos(angle),
+      vy: Math.sin(angle),
+      size: primary ? 52 : 38,
+      expiresAt: Infinity,
+    };
+  }
+
+  function resetPixel(item, centered){
+    var bounds = game.getBoundingClientRect();
+    item.size = item.primary ? 52 : 38;
+    item.x = centered ? bounds.width * 0.5 : randomBetween(54, Math.max(54, bounds.width - 54));
+    item.y = centered ? bounds.height * 0.58 : randomBetween(94, Math.max(120, bounds.height - 54));
+    redirectPixel(item);
+    clampPixel(item);
+    renderPixel(item);
+  }
+
+  function redirectPixel(item){
+    var angle = Math.random() * Math.PI * 2;
+    item.vx = Math.cos(angle);
+    item.vy = Math.sin(angle);
+  }
+
+  function movePixel(item, dt){
+    var multiplier = item.primary ? 1 : 0.82;
+    item.x += item.vx * speed * multiplier * dt;
+    item.y += item.vy * speed * multiplier * dt;
+    bouncePixel(item);
+  }
+
+  function bouncePixel(item){
+    var bounds = game.getBoundingClientRect();
+    var pad = item.size / 2 + 8;
+    var topPad = 84;
+    var maxX = Math.max(pad, bounds.width - pad);
+    var maxY = Math.max(topPad, bounds.height - pad);
+
+    if (item.x < pad || item.x > maxX) {
+      item.x = Math.min(maxX, Math.max(pad, item.x));
+      item.vx *= -1;
+    }
+    if (item.y < topPad || item.y > maxY) {
+      item.y = Math.min(maxY, Math.max(topPad, item.y));
+      item.vy *= -1;
+    }
+  }
+
+  function clampPixel(item){
+    bouncePixel(item);
+  }
+
+  function renderPixel(item){
+    var bounds = game.getBoundingClientRect();
+    var xPercent = bounds.width ? (item.x / bounds.width) * 100 : 50;
+    var yPercent = bounds.height ? (item.y / bounds.height) * 100 : 50;
+
+    item.el.style.setProperty('--target-left', item.x + 'px');
+    item.el.style.setProperty('--target-top', item.y + 'px');
+    item.el.style.setProperty('--target-size', item.size + 'px');
+
+    if (item.primary) {
+      game.style.setProperty('--target-left', item.x + 'px');
+      game.style.setProperty('--target-top', item.y + 'px');
+      game.style.setProperty('--target-size', item.size + 'px');
+      game.style.setProperty('--target-x', xPercent + '%');
+      game.style.setProperty('--target-y', yPercent + '%');
+    }
+  }
+
+  function burst(x, y){
+    var node = document.createElement('span');
+    node.className = 'pixel-burst';
+    node.style.setProperty('--burst-left', x + 'px');
+    node.style.setProperty('--burst-top', y + 'px');
+    game.appendChild(node);
+    window.setTimeout(function(){ node.remove(); }, 560);
   }
 
   function randomBetween(min, max){

--- a/landing/js/landing-game.js
+++ b/landing/js/landing-game.js
@@ -23,15 +23,22 @@
   resetPixel(pixel, true);
   requestAnimationFrame(tick);
 
-  target.addEventListener('click', function(event){
-    event.stopPropagation();
-    hitPixel(pixel);
-  });
-
   game.addEventListener('pointerdown', function(event){
-    if (event.target && event.target.classList && event.target.classList.contains('pixel-target')) return;
-    streak = 0;
-    streakEl.textContent = '0';
+    var point = getLocalPoint(event);
+    ripple(point.x, point.y);
+
+    var activePixel = findHitPixel(point.x, point.y);
+    if (activePixel) {
+      event.preventDefault();
+      hitPixel(activePixel);
+      if (!activePixel.primary) activePixel.expiresAt = 0;
+      return;
+    }
+
+    if (!isInteractiveChild(event.target)) {
+      streak = 0;
+      streakEl.textContent = '0';
+    }
   });
 
   window.addEventListener('resize', function(){
@@ -85,6 +92,22 @@
     redirectPixel(activePixel);
   }
 
+  function findHitPixel(x, y){
+    var candidates = [pixel].concat(clones);
+    for (var i = 0; i < candidates.length; i += 1) {
+      if (isInsidePixel(candidates[i], x, y)) return candidates[i];
+    }
+    return null;
+  }
+
+  function isInsidePixel(item, x, y){
+    var dx = x - item.x;
+    var dy = y - item.y;
+    var tolerance = Math.max(34, item.size * 0.8);
+    if (item.el.classList.contains('is-small')) tolerance = Math.max(28, tolerance * 0.72);
+    return Math.sqrt(dx * dx + dy * dy) <= tolerance;
+  }
+
   function runRandomEvent(now){
     if (Math.random() > 0.48) {
       shrinkPixel();
@@ -113,13 +136,6 @@
       var clone = createPixelState(cloneEl, false);
       clone.expiresAt = now + randomBetween(1800, 2600);
       resetPixel(clone, false);
-      cloneEl.addEventListener('click', function(event){
-        event.stopPropagation();
-        var activeClone = clones.find(function(item){ return item.el === event.currentTarget; });
-        if (!activeClone) return;
-        hitPixel(activeClone);
-        activeClone.expiresAt = 0;
-      });
       clones.push(clone);
     }
   }
@@ -207,6 +223,27 @@
     node.style.setProperty('--burst-top', y + 'px');
     game.appendChild(node);
     window.setTimeout(function(){ node.remove(); }, 560);
+  }
+
+  function ripple(x, y){
+    var node = document.createElement('span');
+    node.className = 'tap-ring';
+    node.style.setProperty('--tap-left', x + 'px');
+    node.style.setProperty('--tap-top', y + 'px');
+    game.appendChild(node);
+    window.setTimeout(function(){ node.remove(); }, 660);
+  }
+
+  function getLocalPoint(event){
+    var bounds = game.getBoundingClientRect();
+    return {
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+    };
+  }
+
+  function isInteractiveChild(node){
+    return !!(node && node.closest && node.closest('a, button'));
   }
 
   function randomBetween(min, max){

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -14,6 +14,8 @@ const landingConsentManagerJs = await readFile(path.join(root, 'landing', 'js', 
 const landingConsentServicesJs = await readFile(path.join(root, 'landing', 'js', 'consent-services.js'), 'utf8');
 const landingKlaroConfigJs = await readFile(path.join(root, 'landing', 'js', 'klaro-config.js'), 'utf8');
 const landingAdsenseInitJs = await readFile(path.join(root, 'landing', 'js', 'adsense-init.js'), 'utf8');
+const landingIndexHtml = await readFile(path.join(root, 'landing', 'index.html'), 'utf8');
+const landingGameJs = await readFile(path.join(root, 'landing', 'js', 'landing-game.js'), 'utf8');
 const netlifyToml = await readFile(path.join(root, 'netlify.toml'), 'utf8');
 assert.match(indexHtml, /src="\/js\/build-info\.js" defer/, 'poker index should include build-info bootstrap script');
 assert.equal(indexHtml.indexOf('/js/build-info.js') < indexHtml.indexOf('/poker/poker-ws-client.js'), true, 'poker index should load build-info before ws client');
@@ -42,5 +44,8 @@ assert.equal(landingConsentManagerJs, consentManagerJs, 'landing deploy should p
 assert.equal(landingConsentServicesJs, consentServicesJs, 'landing deploy should publish the shared consent services helper at /js/consent-services.js');
 assert.equal(landingKlaroConfigJs, klaroConfigJs, 'landing deploy should publish the shared Klaro config at /js/klaro-config.js');
 assert.equal(landingAdsenseInitJs, adsenseInitJs, 'landing deploy should publish the AdSense init helper at /js/adsense-init.js');
+assert.match(landingIndexHtml, /data-landing-game/, 'landing page should render the mini game surface');
+assert.match(landingIndexHtml, /\.\/js\/landing-game\.js/, 'landing page should load the mini game controller');
+assert.match(landingGameJs, /landingPixelBest/, 'landing mini game should persist the best score locally');
 assert.ok(netlifyToml.includes('Content-Security-Policy = "'), 'Netlify deploys should emit a CSP header');
 assert.doesNotMatch(netlifyToml, /cookiebot/i, 'Netlify CSP should not require Cookiebot hosts after the Klaro migration');


### PR DESCRIPTION
## Summary

- rebuild the landing homepage around a minimal `Catch the Pixel` mini game
- add a focused `Play more on Arcade Hub` CTA linking to `https://play.kcswh.pl/`
- keep the rest of the landing page compact with a small feature strip, ad slot, legal links, Klaro, and XP badge support
- preserve shared `landing.css` support for existing About/Privacy landing subpages
- add a static behavior check for the new landing game script and markup

## Validation

- `node --check landing/js/landing-game.js`
- `node tests/static-html.behavior.test.mjs`
- `npm run check:all`
- `node scripts/syntax-check.mjs`
- local static server returned 200 for `/landing/`, `/landing/css/landing.css`, and `/landing/js/landing-game.js`

Browser smoke with Playwright was attempted, but Chromium cannot launch in this container because required system libraries are missing.