### PR TITLE
[codex] Fix landing XP badge link

### DIFF
--- a/landing/about.html
+++ b/landing/about.html
@@ -28,8 +28,8 @@
       <a class="manage-cookies" href="#">Manage cookies</a>
     </nav>
     <div class="header-actions">
-      <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../xp.html">
-        <span class="xp-badge__label">Syncing XP…</span>
+      <a id="xpBadge" class="xp-badge" aria-label="Open XP panel on Arcade Hub" href="https://play.kcswh.pl/xp.html">
+        <span class="xp-badge__label">XP</span>
       </a>
     </div>
   </header>

--- a/landing/index.html
+++ b/landing/index.html
@@ -32,7 +32,7 @@
       <span>Arcade Hub</span>
     </a>
     <div class="header-actions">
-      <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../xp.html">
+      <a id="xpBadge" class="xp-badge" aria-label="Open XP panel on Arcade Hub" href="https://play.kcswh.pl/xp.html">
         <span class="xp-badge__label">XP</span>
       </a>
     </div>

--- a/landing/legal/privacy.en.html
+++ b/landing/legal/privacy.en.html
@@ -28,8 +28,8 @@
       <a class="manage-cookies" href="#manageCookies">Manage cookies</a>
     </nav>
     <div class="header-actions">
-      <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../../xp.html">
-        <span class="xp-badge__label">Syncing XP…</span>
+      <a id="xpBadge" class="xp-badge" aria-label="Open XP panel on Arcade Hub" href="https://play.kcswh.pl/xp.html">
+        <span class="xp-badge__label">XP</span>
       </a>
     </div>
   </header>

--- a/landing/legal/privacy.pl.html
+++ b/landing/legal/privacy.pl.html
@@ -28,8 +28,8 @@
       <a class="manage-cookies" href="#manageCookies">Zarządzaj cookies</a>
     </nav>
     <div class="header-actions">
-      <a id="xpBadge" class="xp-badge xp-badge--loading" aria-live="polite" aria-busy="true" href="../../xp.html">
-        <span class="xp-badge__label">Synchronizuję XP…</span>
+      <a id="xpBadge" class="xp-badge" aria-label="Otworz panel XP w Arcade Hub" href="https://play.kcswh.pl/xp.html">
+        <span class="xp-badge__label">XP</span>
       </a>
     </div>
   </header>

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -15,6 +15,9 @@ const landingConsentServicesJs = await readFile(path.join(root, 'landing', 'js',
 const landingKlaroConfigJs = await readFile(path.join(root, 'landing', 'js', 'klaro-config.js'), 'utf8');
 const landingAdsenseInitJs = await readFile(path.join(root, 'landing', 'js', 'adsense-init.js'), 'utf8');
 const landingIndexHtml = await readFile(path.join(root, 'landing', 'index.html'), 'utf8');
+const landingAboutHtml = await readFile(path.join(root, 'landing', 'about.html'), 'utf8');
+const landingPrivacyEnHtml = await readFile(path.join(root, 'landing', 'legal', 'privacy.en.html'), 'utf8');
+const landingPrivacyPlHtml = await readFile(path.join(root, 'landing', 'legal', 'privacy.pl.html'), 'utf8');
 const landingGameJs = await readFile(path.join(root, 'landing', 'js', 'landing-game.js'), 'utf8');
 const netlifyToml = await readFile(path.join(root, 'netlify.toml'), 'utf8');
 assert.match(indexHtml, /src="\/js\/build-info\.js" defer/, 'poker index should include build-info bootstrap script');
@@ -47,5 +50,7 @@ assert.equal(landingAdsenseInitJs, adsenseInitJs, 'landing deploy should publish
 assert.match(landingIndexHtml, /data-landing-game/, 'landing page should render the mini game surface');
 assert.match(landingIndexHtml, /\.\/js\/landing-game\.js/, 'landing page should load the mini game controller');
 assert.match(landingGameJs, /landingPixelBest/, 'landing mini game should persist the best score locally');
+assert.equal([landingIndexHtml, landingAboutHtml, landingPrivacyEnHtml, landingPrivacyPlHtml].every((html) => html.includes('href="https://play.kcswh.pl/xp.html"')), true, 'landing XP badges should link to the play subdomain XP panel');
+assert.equal([landingIndexHtml, landingAboutHtml, landingPrivacyEnHtml, landingPrivacyPlHtml].some((html) => /href="\.\.?\/.*xp\.html"|xp-badge--loading/.test(html)), false, 'landing XP badges should not point to missing local XP pages or show a permanent loading state');
 assert.ok(netlifyToml.includes('Content-Security-Policy = "'), 'Netlify deploys should emit a CSP header');
 assert.doesNotMatch(netlifyToml, /cookiebot/i, 'Netlify CSP should not require Cookiebot hosts after the Klaro migration');


### PR DESCRIPTION
## Summary

- point landing XP badges to `https://play.kcswh.pl/xp.html` instead of missing local `xp.html` paths
- remove the permanent loading state from landing XP badges because the landing deploy does not run the full XP runtime
- cover the landing XP link behavior in the static HTML behavior test

## Rationale

The landing deploy is separate from the play subdomain and does not include the full `xp.html` route. The reliable place to show authenticated total XP is the play subdomain, where the XP page and auth/runtime scripts already exist. For visitors who are not signed in, the click still lands on the same XP panel on `play.kcswh.pl`, where the portal can handle the guest/sign-in state.

## Validation

- `node tests/static-html.behavior.test.mjs`
- `npm run check:all`
- `node scripts/syntax-check.mjs`