### PR TITLE
[codex] Fix stable asset cache headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -148,16 +148,17 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
 
-# Cache static assets
+# CSS and JS use stable filenames in this repo, so browsers must revalidate them
+# after deploys. Long immutable caching is only safe for fingerprinted filenames.
 [[headers]]
   for = "/css/*"
   [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 [[headers]]
   for = "/js/*"
   [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 [[headers]]
   for = "/assets/*"

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -90,3 +90,9 @@ assert.match(netlifyToml, /for = "\/games-open\/freedoom\/\*"/, 'Netlify should 
 assert.doesNotMatch(netlifyToml, /dwasm\.m-h\.org\.uk/, 'Netlify Freedoom CSP should not rely on a remote WAD mirror');
 assert.ok(netlifyToml.includes('Content-Security-Policy = "'), 'Netlify deploys should emit a CSP header');
 assert.doesNotMatch(netlifyToml, /cookiebot/i, 'Netlify CSP should not require Cookiebot hosts after the Klaro migration');
+assert.match(netlifyToml, /for = "\/css\/\*"[\s\S]*?Cache-Control = "public, max-age=0, must-revalidate"/, 'CSS files use stable names and should revalidate after deploys');
+assert.match(netlifyToml, /for = "\/js\/\*"[\s\S]*?Cache-Control = "public, max-age=0, must-revalidate"/, 'JS files use stable names and should revalidate after deploys');
+const cssHeaderBlock = netlifyToml.match(/\[\[headers\]\]\s+for = "\/css\/\*"[\s\S]*?(?=\n\[\[headers\]\]|$)/)?.[0] || '';
+const jsHeaderBlock = netlifyToml.match(/\[\[headers\]\]\s+for = "\/js\/\*"[\s\S]*?(?=\n\[\[headers\]\]|$)/)?.[0] || '';
+assert.doesNotMatch(cssHeaderBlock, /immutable/, 'Stable CSS paths must not be cached as immutable');
+assert.doesNotMatch(jsHeaderBlock, /immutable/, 'Stable JS paths must not be cached as immutable');


### PR DESCRIPTION
Summary

- make stable `/css/*` and `/js/*` paths revalidate after deploys instead of caching as immutable for a year
- keep long immutable caching for `/assets/*`
- add static deploy-contract checks so CSS/JS stable paths cannot regress to immutable caching

Root cause

Landing HTML was revalidated, but CSS and JS assets used stable filenames while Netlify sent `Cache-Control: public, max-age=31536000, immutable`. Normal browser profiles could therefore keep old `landing.css` or `landing-game.js` after deploys, producing broken UI until cache refresh. Incognito worked because it started with an empty cache.

Validation

- `node tests/static-html.behavior.test.mjs`
- `node scripts/syntax-check.mjs`
- `npm run check:all`
- `npm test`