### PR TITLE
[codex] Add verified third-party license notices

### DIFF
--- a/about/licenses.html
+++ b/about/licenses.html
@@ -107,10 +107,31 @@
         <section class="license-section">
           <h2 data-i18n="licensesSupabaseTitle">Supabase</h2>
           <p>
-            <span data-i18n="licensesSupabaseDesc">Authentication &amp; database platform used for user accounts and XP sync.</span><br>
-            <span data-i18n="licensesSupabaseLicense">Licensed under the Apache License 2.0.</span><br>
+            <span data-i18n="licensesSupabaseDesc">Supabase JavaScript client used for authentication and data access.</span><br>
+            <span data-i18n="licensesSupabaseLicense">Licensed under the MIT License.</span><br>
             <span data-i18n="licensesSupabaseSource">Source:</span>&nbsp;
-            <a href="https://github.com/supabase/supabase" target="_blank" rel="noopener noreferrer">github.com/supabase/supabase</a>
+            <a href="https://github.com/supabase/supabase-js" target="_blank" rel="noopener noreferrer">github.com/supabase/supabase-js</a><br>
+            Local terms: <a href="../third_party/supabase-js/LICENSE">LICENSE</a> and <a href="../third_party/supabase-js/ATTRIBUTION.md">ATTRIBUTION</a>.
+          </p>
+        </section>
+
+        <section class="license-section">
+          <h2>Klaro Privacy Manager</h2>
+          <p>
+            KIProtect GmbH and contributors.<br>
+            Licensed under the BSD 3-Clause License.<br>
+            Source: <a href="https://github.com/kiprotect/klaro" target="_blank" rel="noopener noreferrer">github.com/kiprotect/klaro</a><br>
+            Local terms: <a href="../third_party/klaro/LICENSE">LICENSE</a> and <a href="../third_party/klaro/ATTRIBUTION.md">ATTRIBUTION</a>.
+          </p>
+        </section>
+
+        <section class="license-section">
+          <h2>Poppins</h2>
+          <p>
+            Poppins Project Authors; designed by Indian Type Foundry, Jonny Pinhorn and Ninad Kale.<br>
+            Licensed under the SIL Open Font License 1.1.<br>
+            Source: <a href="https://github.com/itfoundry/Poppins" target="_blank" rel="noopener noreferrer">github.com/itfoundry/Poppins</a><br>
+            Local terms: <a href="../third_party/poppins/LICENSE">LICENSE</a> and <a href="../third_party/poppins/ATTRIBUTION.md">ATTRIBUTION</a>.
           </p>
         </section>
 

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -1,0 +1,49 @@
+# Third-party licensing verification audit
+
+Audit date: 2026-06-22
+Repository revision audited: `3da23441568838d8121508228eb7d8254ea269bb`
+
+This evidence audit covers tracked games, assets, vendored libraries, manifests, lockfiles and Git history. `UNKNOWN / HIGH RISK` means the repository does not prove origin or redistribution rights; it does not assert infringement.
+
+## Executive result
+
+Licensing information is not complete in one place. `about/licenses.html` is the human-facing register, while additional evidence is scattered through `public/games/*/LICENSE`, five `games-open/*/LICENSE` files, `games-open/freedoom/LICENSE`, the Dwasm vendor directory and npm metadata.
+
+## SAFE
+
+| Component | Location | Source / author | License | Existing evidence | Attribution / redistribution |
+|---|---|---|---|---|---|
+| 2048 | `games-open/2048` | [gabrielecirulli/2048](https://github.com/gabrielecirulli/2048), Gabriele Cirulli | MIT | `public/games/2048/LICENSE`; central page | retain notice; redistribution permitted |
+| Canvas Tetris | `games-open/tetris` | [dionyziz/canvas-tetris](https://github.com/dionyziz/canvas-tetris), Dionysis Zindros | MIT | `public/games/tetris/LICENSE`; central page | retain notice; redistribution permitted |
+| Freedoom data | `games-open/freedoom/assets/freedoom2.bin` | [Freedoom contributors](https://github.com/freedoom/freedoom) | BSD-3-Clause | `games-open/freedoom/LICENSE`; central page | retain notice/conditions/disclaimer; redistribution permitted conditionally |
+| postgres | root and WS npm manifests | [porsager/postgres](https://github.com/porsager/postgres), Rasmus Porsager | Unlicense | lock/package metadata | redistribution permitted |
+| ws | WS npm manifest | [websockets/ws](https://github.com/websockets/ws), Einar Otto Stangvik and contributors | MIT | lock/package metadata | retain notice; redistribution permitted |
+
+## REVIEW REQUIRED
+
+| Component | Type / location | Proven source / license | Problem | Required fix |
+|---|---|---|---|---|
+| Klaro | vendored JS/CSS in `js/vendor/klaro` and landing duplicate | [KIProtect Klaro](https://github.com/kiprotect/klaro), BSD-3-Clause | no local license, notice, version or central entry | add upstream license/attribution; record paths; pin version separately when established |
+| Poppins | remotely loaded font in HTML | [Poppins](https://github.com/itfoundry/Poppins), OFL-1.1 | absent from notices | add font authors/source/OFL notice; ship OFL if self-hosted |
+| @supabase/supabase-js | CDN browser library | [supabase-js](https://github.com/supabase/supabase-js), MIT | central page identifies broad Supabase/Apache-2.0 instead of actual library | correct entry and retain MIT license |
+| npm dependency set | both manifests/lockfiles | package registry/upstream metadata | no committed consolidated BOM/notices | generate notices including all locked components and preserve Apache NOTICE data |
+| repository SVG/icon artwork | `img/**/*.svg`, inline SVG | Git history indicates custom repository additions | no explicit asset provenance manifest | record provenance only when maintainers can make a supported declaration; do not invent it |
+
+The locked npm set consists of Apache-2.0 (`@playwright/test`, `playwright`, `playwright-core`, `human-signals`), ISC (`isexe`, `signal-exit`, `which`, `yaml`), Unlicense (`postgres`), MIT (`ws` and the remaining named packages in `docs/third-party-notices.md`). `fsevents` and several root-lock entries omit a license field; upstream/installed package metadata must be used and kept under review.
+
+## HIGH RISK
+
+These components must not be changed merely by writing new license claims:
+
+- **Pacman** (`games-open/pacman`): local MIT claim conflicts with the cited upstream's WTFPL v2; imported revision unknown.
+- **T-Rex Runner** (`games/t-rex`): local MIT claim conflicts with the cited upstream's current BSD-3-Clause and Chromium extraction history; imported revision unknown.
+- **Twenty “Arcade Hub contributors” games**: Breakout, Flappy Bird, Minesweeper, Pong, Snake, Asteroids, Space Invaders, Frogger, Galaga, Missile Command, Simon, Connect Four, Whac-A-Mole, Memory Match, Sokoban, Brick Breaker, Tic-Tac-Toe, Hangman, Solitaire and Sudoku have no independent upstream/provenance proof. A self-issued MIT text does not prove ownership of externally copied code.
+- **Dwasm/PrBoomX binaries**: GPL text/authors exist, but exact source revision, build recipe and complete corresponding source for deployed WASM/JS are not recorded.
+- **Google libarchive/Comlink bundle in Dwasm**: embedded Apache-2.0 header exists, but exact source/version and complete applicable notice set are unproved.
+- **Poker chip atlas and 35 derivatives**: source, author and license are unknown.
+
+## Evidence locations and recommendations
+
+Existing license evidence: root `LICENSE`; `about/licenses.html`; `public/games/{2048,pacman,t-rex,tetris}/LICENSE`; `games-open/{breakout,flappy,minesweeper,pong,snake,freedoom}/LICENSE`; Dwasm `COPYING`, `AUTHORS` and `README.md`; both npm lockfiles.
+
+Maintain one `docs/third-party-notices.md` plus component license files, pin immutable upstream revisions/checksums, generate an SPDX/CycloneDX SBOM in CI, and reject new vendored files/assets without provenance. Do not rewrite upstream licenses or infer authorship from the committer.

--- a/docs/third-party-notices.md
+++ b/docs/third-party-notices.md
@@ -1,0 +1,51 @@
+# Third-party notices
+
+Generated from repository evidence and upstream license files on 2026-06-22. This document supplements, and does not replace, the complete license texts linked below. Exact package versions remain authoritative in the two lockfiles.
+
+## Games and game runtimes verified for redistribution
+
+| Component | Repository location | Source / author | License and local copy | Required notice |
+|---|---|---|---|---|
+| 2048 | `games-open/2048` | [Gabriele Cirulli](https://github.com/gabrielecirulli/2048) | MIT — `public/games/2048/LICENSE` | retain copyright and MIT text |
+| Canvas Tetris | `games-open/tetris` | [Dionysis Zindros](https://github.com/dionyziz/canvas-tetris) | MIT — `public/games/tetris/LICENSE` | retain copyright and MIT text |
+| Freedoom game data | `games-open/freedoom/assets/freedoom2.bin` | [Freedoom contributors](https://github.com/freedoom/freedoom) | BSD-3-Clause — `games-open/freedoom/LICENSE` | retain copyright, conditions and disclaimer; no endorsement |
+
+Components classified HIGH RISK in [license-audit.md](license-audit.md) are intentionally not normalized or relicensed here.
+
+## Vendored and remotely loaded browser components
+
+| Component | Location/use | Source / author | License | Local evidence / requirement |
+|---|---|---|---|---|
+| Klaro | `js/vendor/klaro/*` and landing copy | [KIProtect GmbH and contributors](https://github.com/kiprotect/klaro) | BSD-3-Clause | [license](../third_party/klaro/LICENSE), [attribution](../third_party/klaro/ATTRIBUTION.md); retain license and disclaimer |
+| Poppins | Google Fonts links in HTML; no tracked binary | [Poppins Project](https://github.com/itfoundry/Poppins); Indian Type Foundry, Jonny Pinhorn, Ninad Kale | OFL-1.1 | [license](../third_party/poppins/LICENSE), [attribution](../third_party/poppins/ATTRIBUTION.md); include OFL if font software is redistributed |
+| `@supabase/supabase-js` | jsDelivr major-v2 UMD references in HTML | [Supabase](https://github.com/supabase/supabase-js) | MIT | [license](../third_party/supabase-js/LICENSE), [attribution](../third_party/supabase-js/ATTRIBUTION.md); retain MIT notice |
+
+Klaro and Supabase CDN references do not identify exact releases in current repository evidence. These notices do not invent versions.
+
+## Direct npm runtime dependencies
+
+| Component | Location | Source / author | License | Local evidence |
+|---|---|---|---|---|
+| `postgres` | both manifests/locks | [Rasmus Porsager](https://github.com/porsager/postgres) | Unlicense | [license](../third_party/postgres/LICENSE), [attribution](../third_party/postgres/ATTRIBUTION.md) |
+| `ws` | WS server manifest/lock | [Einar Otto Stangvik and contributors](https://github.com/websockets/ws) | MIT | [license](../third_party/ws/LICENSE), [attribution](../third_party/ws/ATTRIBUTION.md) |
+
+## Complete locked npm inventory
+
+Sources are the exact npm registry tarball URLs in the lockfiles. Package author details live in upstream package manifests; they are not inferred here.
+
+| License | Locked components |
+|---|---|
+| Apache-2.0 | `@playwright/test`, `playwright`, `playwright-core`, `human-signals` |
+| ISC | `isexe`, `signal-exit`, `which`, `yaml` |
+| Unlicense | `postgres` |
+| MIT | `acorn`, `ansi-escapes`, `ansi-regex`, `ansi-styles`, `braces`, `chalk`, `cli-cursor`, `cli-truncate`, `colorette`, `commander`, `cross-spawn`, `debug`, `emoji-regex`, `environment`, `eventemitter3`, `execa`, `fill-range`, `fsevents`, `get-east-asian-width`, `get-stream`, `husky`, `is-fullwidth-code-point`, `is-number`, `is-stream`, `lilconfig`, `lint-staged`, `listr2`, `log-update`, `merge-stream`, `micromatch`, `mimic-fn`, `mimic-function`, `ms`, `npm-run-path`, `onetime`, `path-key`, `picomatch`, `pidtree`, `restore-cursor`, `rfdc`, `shebang-command`, `shebang-regex`, `slice-ansi`, `string-argv`, `string-width`, `strip-ansi`, `strip-final-newline`, `to-regex-range`, `wrap-ansi`, `ws` |
+
+Playwright distributions include an Apache-2.0 LICENSE and NOTICE. Those files remain in the installed package tarball; any deployment process that redistributes Playwright must retain them. Most packages are development-only and are not shipped by the web application, but are listed because they are third-party build/repository dependencies.
+
+## Hosted services
+
+Google Analytics and Google AdSense scripts are hosted services rather than copied repository software. Their service terms and privacy obligations require separate review and are not software license grants.
+
+## Maintenance
+
+Regenerate this file whenever either lockfile, a vendored component, a CDN URL or a font reference changes. Do not add a license for any component whose origin cannot be tied to a specific upstream artifact.

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -20,14 +20,14 @@
       en: 'Below are details for included projects.',
       pl: 'Poniżej znajdziesz szczegóły wykorzystanych projektów.'
     },
-    licensesSupabaseTitle: { en: 'Supabase', pl: 'Supabase' },
+    licensesSupabaseTitle: { en: 'Supabase JavaScript client', pl: 'Klient JavaScript Supabase' },
     licensesSupabaseDesc: {
-      en: 'Authentication & database platform used for user accounts and XP sync.',
-      pl: 'Platforma uwierzytelniania i bazy danych używana dla kont użytkowników i synchronizacji XP.'
+      en: 'JavaScript client used for authentication and data access.',
+      pl: 'Klient JavaScript używany do uwierzytelniania i dostępu do danych.'
     },
     licensesSupabaseLicense: {
-      en: 'Licensed under the Apache License 2.0.',
-      pl: 'Licencjonowane na podstawie Apache License 2.0.'
+      en: 'Licensed under the MIT License.',
+      pl: 'Licencjonowane na podstawie licencji MIT.'
     },
     licensesSupabaseSource: { en: 'Source:', pl: 'Źródło:' },
     licensesOriginalBy: { en: 'Original project by', pl: 'Oryginalny projekt:' },

--- a/third_party/klaro/ATTRIBUTION.md
+++ b/third_party/klaro/ATTRIBUTION.md
@@ -1,0 +1,10 @@
+# Klaro attribution
+
+- Component: Klaro Privacy Manager
+- Type: vendored JavaScript and CSS
+- Repository paths: `js/vendor/klaro/klaro.js`, `js/vendor/klaro/klaro.css`, and identical landing deployment copies under `landing/js/vendor/klaro/`
+- Upstream: https://github.com/kiprotect/klaro
+- Authors: KIProtect GmbH and upstream contributors
+- License: BSD-3-Clause; see [LICENSE](LICENSE)
+
+The repository does not record the exact upstream Klaro tag or commit. This attribution does not claim one. Pinning and checksumming the vendored build remains required for reproducible provenance.

--- a/third_party/klaro/LICENSE
+++ b/third_party/klaro/LICENSE
@@ -1,0 +1,31 @@
+BSD 3-Clause License
+
+Copyright (c) 2019-2020, KIProtect GmbH
+Copyright (c) various authors obtainable by running `git shortlog -nse` or
+visiting https://github.com/KIProtect/klaro/graphs/contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/npm/ATTRIBUTION.md
+++ b/third_party/npm/ATTRIBUTION.md
@@ -1,0 +1,18 @@
+# npm dependency attribution
+
+The authoritative package/version inventory is in `package-lock.json` and `ws-server/package-lock.json`. Package tarballs are sourced from `https://registry.npmjs.org/` through the exact `resolved` URLs in those files.
+
+This repository does not vendor `node_modules`. Installed packages carry their own package metadata and license/NOTICE files. The consolidated human-readable inventory is [../../docs/third-party-notices.md](../../docs/third-party-notices.md).
+
+Direct dependencies:
+
+| Package | Role | Upstream / author | License |
+|---|---|---|---|
+| `postgres` | production | https://github.com/porsager/postgres — Rasmus Porsager | Unlicense |
+| `ws` | production (WS server) | https://github.com/websockets/ws — Einar Otto Stangvik and contributors | MIT |
+| `@playwright/test` | development/test | https://github.com/microsoft/playwright — Microsoft Corporation and contributors | Apache-2.0 |
+| `acorn` | development | https://github.com/acornjs/acorn — Acorn contributors | MIT |
+| `husky` | development | https://github.com/typicode/husky — typicode and contributors | MIT |
+| `lint-staged` | development | https://github.com/lint-staged/lint-staged — lint-staged contributors | MIT |
+
+Transitive package authorship is not duplicated here because it changes with lockfile resolution. Do not infer authors from package names; use the exact package manifests and licenses in the registry tarballs when regenerating notices.

--- a/third_party/poppins/ATTRIBUTION.md
+++ b/third_party/poppins/ATTRIBUTION.md
@@ -1,0 +1,11 @@
+# Poppins attribution
+
+- Component: Poppins
+- Type: remotely loaded web font (no font binary is tracked)
+- Upstream: https://github.com/itfoundry/Poppins
+- Designers recorded by Google Fonts: Indian Type Foundry, Jonny Pinhorn, Ninad Kale
+- Copyright: Copyright 2020 The Poppins Project Authors
+- License: SIL Open Font License 1.1; see [LICENSE](LICENSE)
+- Google Fonts metadata: https://github.com/google/fonts/tree/main/ofl/poppins
+
+The OFL does not require documents rendered with the font to carry attribution. This file records the runtime dependency and the terms that apply if the font is later self-hosted or redistributed.

--- a/third_party/poppins/LICENSE
+++ b/third_party/poppins/LICENSE
@@ -1,0 +1,93 @@
+Copyright 2020 The Poppins Project Authors (https://github.com/itfoundry/Poppins)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/third_party/postgres/ATTRIBUTION.md
+++ b/third_party/postgres/ATTRIBUTION.md
@@ -1,0 +1,9 @@
+# Postgres.js attribution
+
+- Component: `postgres` / Postgres.js
+- Type: runtime npm library
+- Locations: root and `ws-server` manifests and lockfiles
+- Upstream: https://github.com/porsager/postgres
+- Author: Rasmus Porsager
+- License: Unlicense; see [LICENSE](LICENSE)
+- Locked versions at audit time: 3.4.5 (root), 3.4.8 (WS server)

--- a/third_party/postgres/LICENSE
+++ b/third_party/postgres/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>

--- a/third_party/supabase-js/ATTRIBUTION.md
+++ b/third_party/supabase-js/ATTRIBUTION.md
@@ -1,0 +1,10 @@
+# Supabase JavaScript client attribution
+
+- Component: `@supabase/supabase-js`
+- Type: browser library loaded from jsDelivr
+- Repository references: HTML `src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"`
+- Upstream: https://github.com/supabase/supabase-js
+- Author/copyright holder: Supabase
+- License: MIT; see [LICENSE](LICENSE)
+
+The current CDN reference selects major version 2 and does not prove an exact release. This notice intentionally makes no exact-version claim.

--- a/third_party/supabase-js/LICENSE
+++ b/third_party/supabase-js/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Supabase
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/ws/ATTRIBUTION.md
+++ b/third_party/ws/ATTRIBUTION.md
@@ -1,0 +1,9 @@
+# ws attribution
+
+- Component: `ws`
+- Type: runtime npm WebSocket library
+- Location: `ws-server/package.json` and lockfile
+- Upstream: https://github.com/websockets/ws
+- Original author: Einar Otto Stangvik; current upstream contributors
+- License: MIT; see [LICENSE](LICENSE)
+- Locked version at audit time: 8.19.0

--- a/third_party/ws/LICENSE
+++ b/third_party/ws/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+Copyright (c) 2013 Arnout Kazemier and contributors
+Copyright (c) 2016 Luigi Pinca and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## What changed

- Added `docs/license-audit.md` with SAFE, REVIEW REQUIRED, and HIGH RISK classifications.
- Added `docs/third-party-notices.md` as the consolidated human-readable third-party inventory.
- Added upstream license copies and `ATTRIBUTION.md` records for Klaro, Poppins, Supabase JS, Postgres.js, and ws.
- Added npm dependency attribution covering both lockfiles and the complete locked package set.
- Corrected the public Supabase entry from the broad Supabase/Apache-2.0 claim to the actually loaded `@supabase/supabase-js` client and its MIT license.
- Added public Klaro and Poppins source/license references.
- Updated English and Polish Supabase license copy consistently.

## Why

Licensing evidence was scattered and the public Supabase entry identified the wrong artifact and license. Known upstream licenses now have canonical local copies and required attribution/notice information.

## Scope and risk controls

No HIGH RISK component was changed or relicensed. This explicitly leaves Pacman, T-Rex Runner, the twenty games with unproved provenance, Dwasm/libarchive binaries, and poker chip assets untouched. Exact versions were not invented for unpinned Klaro or Supabase references.

## Validation

- Compared Klaro, Supabase JS, Postgres.js, and ws license files with current upstream copies byte-for-byte.
- Compared Poppins OFL text with upstream; only upstream trailing whitespace was normalized.
- `node scripts/syntax-check.mjs` — 178 files, passed.
- `node tests/static-html.behavior.test.mjs` — passed.
- `git diff --cached --check` — passed.
- Pre-commit lifecycle, XP badge, and game XP hook checks — passed.

## Impact

No application behavior or dependency versions change. The PR adds compliance documentation and corrects displayed third-party licensing information.