### PR TITLE
[codex] Add profiled poker bot autoplay

### DIFF
--- a/netlify/functions/_shared/poker-bots.mjs
+++ b/netlify/functions/_shared/poker-bots.mjs
@@ -196,7 +196,10 @@ function pickLegalAction(legalActions, preferredTypes) {
     if (!action) continue;
     const amount = readAmount(action);
     if (type === "BET" || type === "RAISE") {
-      return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+      if (amount == null) continue;
+      const normalizedAmount = Math.trunc(amount);
+      if (normalizedAmount <= 0) continue;
+      return { type, amount: normalizedAmount };
     }
     return { type };
   }

--- a/netlify/functions/_shared/poker-bots.mjs
+++ b/netlify/functions/_shared/poker-bots.mjs
@@ -20,7 +20,9 @@ const parseIntClamped = (value, fallback, min, max) => {
   return parsed;
 };
 
-const parseProfile = (value, fallback = "TRIVIAL") => {
+const BOT_PROFILES = ["TIGHT", "NORMAL", "LOOSE"];
+
+const parseProfile = (value, fallback = "RANDOM") => {
   const normalized = normalizeString(value).toUpperCase();
   return normalized || fallback;
 };
@@ -63,8 +65,9 @@ function getBotConfig(env = process.env) {
   const source = env || {};
   return {
     enabled: parseBool(source.POKER_BOTS_ENABLED, false),
-    maxPerTable: parseIntClamped(source.POKER_BOTS_MAX_PER_TABLE, 2, 0, 9),
-    defaultProfile: parseProfile(source.POKER_BOT_PROFILE_DEFAULT, "TRIVIAL"),
+    minPerTable: parseIntClamped(source.POKER_BOTS_MIN_PER_TABLE, 2, 0, 9),
+    maxPerTable: parseIntClamped(source.POKER_BOTS_MAX_PER_TABLE, 5, 0, 9),
+    defaultProfile: parseProfile(source.POKER_BOT_PROFILE_DEFAULT, "RANDOM"),
     buyInBB: parseIntClamped(source.POKER_BOT_BUYIN_BB, 100, 1, 1000),
     bankrollSystemKey: normalizeString(source.POKER_BOT_BANKROLL_SYSTEM_KEY) || "TREASURY",
     maxActionsPerPoll: parseIntClamped(source.POKER_BOTS_MAX_ACTIONS_PER_POLL, 2, 0, 10),
@@ -79,22 +82,155 @@ function makeBotSystemKey(tableId, seatNo) {
   return `POKER_BOT:${tableId}:${seatNo}`;
 }
 
-function computeTargetBotCount({ maxPlayers, humanCount, maxBots } = {}) {
+function clampRandom(random = Math.random) {
+  const sampled = typeof random === "function" ? Number(random()) : Number(random);
+  if (!Number.isFinite(sampled)) return 0;
+  return Math.max(0, Math.min(0.999999, sampled));
+}
+
+function randomIntInclusive(min, max, random = Math.random) {
+  const low = Math.ceil(Number(min));
+  const high = Math.floor(Number(max));
+  if (!Number.isInteger(low) || !Number.isInteger(high) || high < low) return low;
+  return low + Math.floor((high - low + 1) * clampRandom(random));
+}
+
+function normalizeBotProfile(value, random = Math.random) {
+  const normalized = normalizeString(value).toUpperCase();
+  if (BOT_PROFILES.includes(normalized)) return normalized;
+  if (normalized === "TRIVIAL" || normalized === "DEFAULT") return "NORMAL";
+  const index = randomIntInclusive(0, BOT_PROFILES.length - 1, random);
+  return BOT_PROFILES[index] || "NORMAL";
+}
+
+function computeTargetBotCount({ maxPlayers, humanCount, maxBots, minBots = 2, random = Math.random } = {}) {
   const totalSeats = Number.isFinite(Number(maxPlayers)) ? Math.trunc(Number(maxPlayers)) : 0;
   const humans = Number.isFinite(Number(humanCount)) ? Math.trunc(Number(humanCount)) : 0;
   const limit = Number.isFinite(Number(maxBots)) ? Math.trunc(Number(maxBots)) : 0;
+  const minimum = Number.isFinite(Number(minBots)) ? Math.trunc(Number(minBots)) : 0;
   const totalSeatsSafe = Math.max(0, totalSeats);
   const humansSafe = Math.max(0, humans);
   const limitSafe = Math.max(0, limit);
+  const minimumSafe = Math.max(0, minimum);
 
   if (humansSafe <= 0) return 0;
   if (humansSafe >= totalSeatsSafe) return 0;
 
-  const maxBotsAllowedByCapacity = Math.max(0, (totalSeatsSafe - humansSafe) - 1);
-  return Math.max(0, Math.min(limitSafe, maxBotsAllowedByCapacity));
+  const maxBotsAllowedByCapacity = Math.max(0, totalSeatsSafe - humansSafe);
+  const upper = Math.max(0, Math.min(limitSafe, maxBotsAllowedByCapacity));
+  if (upper <= 0) return 0;
+  const lower = Math.min(upper, Math.max(1, minimumSafe));
+  return randomIntInclusive(lower, upper, random);
 }
 
-function chooseBotActionTrivial(legalActions) {
+function cardRank(card) {
+  const raw = typeof card === "string" ? card.trim().slice(0, -1).toUpperCase() : card?.r;
+  if (typeof raw === "number" && Number.isInteger(raw)) return raw;
+  if (raw === "A") return 14;
+  if (raw === "K") return 13;
+  if (raw === "Q") return 12;
+  if (raw === "J") return 11;
+  if (raw === "T" || raw === "10") return 10;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 2 && parsed <= 14 ? parsed : 0;
+}
+
+function cardSuit(card) {
+  return typeof card === "string" ? card.trim().slice(-1).toUpperCase() : normalizeString(card?.s).toUpperCase();
+}
+
+function botCardsFromContext(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const privateCards = context?.privateState?.holeCardsByUserId?.[userId];
+  const publicCards = context?.state?.holeCardsByUserId?.[userId];
+  return Array.isArray(privateCards) ? privateCards : Array.isArray(publicCards) ? publicCards : [];
+}
+
+function scorePreflop(cards) {
+  if (!Array.isArray(cards) || cards.length < 2) return 0.45;
+  const ranks = cards.map(cardRank).sort((a, b) => b - a);
+  const suited = cardSuit(cards[0]) && cardSuit(cards[0]) === cardSuit(cards[1]);
+  const pair = ranks[0] === ranks[1];
+  const high = ranks[0] || 0;
+  const low = ranks[1] || 0;
+  if (pair) return high >= 11 ? 0.95 : high >= 8 ? 0.78 : 0.62;
+  let score = (high + low) / 28;
+  if (suited) score += 0.1;
+  if (high >= 14 && low >= 10) score += 0.2;
+  else if (high >= 13 && low >= 10) score += 0.12;
+  if (Math.abs(high - low) <= 2) score += 0.05;
+  return Math.max(0.05, Math.min(0.98, score));
+}
+
+function scorePostflop(cards, community) {
+  const allCards = [...(Array.isArray(cards) ? cards : []), ...(Array.isArray(community) ? community : [])];
+  if (allCards.length < 3) return scorePreflop(cards);
+  const rankCounts = new Map();
+  const suitCounts = new Map();
+  for (const card of allCards) {
+    const rank = cardRank(card);
+    const suit = cardSuit(card);
+    if (rank) rankCounts.set(rank, (rankCounts.get(rank) || 0) + 1);
+    if (suit) suitCounts.set(suit, (suitCounts.get(suit) || 0) + 1);
+  }
+  const counts = [...rankCounts.values()].sort((a, b) => b - a);
+  const maxSuit = Math.max(0, ...suitCounts.values());
+  if (counts[0] >= 4) return 0.98;
+  if (counts[0] >= 3 && counts[1] >= 2) return 0.94;
+  if (maxSuit >= 5) return 0.9;
+  if (counts[0] >= 3) return 0.82;
+  if (counts[0] >= 2 && counts[1] >= 2) return 0.72;
+  if (counts[0] >= 2) return 0.58;
+  return Math.max(0.1, Math.min(0.55, scorePreflop(cards) - 0.12 + (maxSuit === 4 ? 0.12 : 0)));
+}
+
+function strengthThresholds(profile) {
+  if (profile === "TIGHT") return { bet: 0.78, call: 0.55, bluff: 0.06, aggression: 0.28 };
+  if (profile === "LOOSE") return { bet: 0.62, call: 0.32, bluff: 0.18, aggression: 0.55 };
+  return { bet: 0.7, call: 0.43, bluff: 0.11, aggression: 0.38 };
+}
+
+function pickLegalAction(legalActions, preferredTypes) {
+  for (const type of preferredTypes) {
+    const action = findAction(legalActions, type);
+    if (!action) continue;
+    const amount = readAmount(action);
+    if (type === "BET" || type === "RAISE") {
+      return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+    }
+    return { type };
+  }
+  return null;
+}
+
+function chooseBotActionProfiled(legalActions, context = {}) {
+  const seatProfile = Array.isArray(context?.state?.seats)
+    ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile
+    : null;
+  const profile = normalizeBotProfile(context?.profile ?? context?.botProfile ?? seatProfile, context?.random);
+  const cards = botCardsFromContext(context);
+  const phase = normalizeString(context?.state?.phase).toUpperCase();
+  const strength = phase === "PREFLOP" ? scorePreflop(cards) : scorePostflop(cards, context?.state?.community);
+  const thresholds = strengthThresholds(profile);
+  const roll = clampRandom(context?.random);
+  const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
+
+  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) {
+    return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+  }
+  if (toCall <= 0 && strength >= thresholds.call - 0.15) {
+    return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);
+  }
+  if (strength >= thresholds.call || roll < thresholds.call * 0.35) {
+    return pickLegalAction(legalActions, ["CALL", "CHECK", "FOLD"]);
+  }
+  return pickLegalAction(legalActions, ["CHECK", "FOLD", "CALL"]);
+}
+
+function chooseBotActionTrivial(legalActions, context = {}) {
+  const profiled = chooseBotActionProfiled(legalActions, context);
+  if (profiled) return profiled;
+
   const check = findAction(legalActions, "CHECK");
   if (check) return { type: "CHECK" };
 
@@ -104,18 +240,6 @@ function chooseBotActionTrivial(legalActions) {
   const fold = findAction(legalActions, "FOLD");
   if (fold) return { type: "FOLD" };
 
-  const bet = findAction(legalActions, "BET");
-  if (bet) {
-    const amount = readAmount(bet);
-    return { type: "BET", amount: amount == null ? 0 : amount };
-  }
-
-  const raise = findAction(legalActions, "RAISE");
-  if (raise) {
-    const amount = readAmount(raise);
-    return { type: "RAISE", amount: amount == null ? 0 : amount };
-  }
-
   return null;
 }
 
@@ -124,7 +248,7 @@ function getBotAutoplayConfig(env = process.env) {
   return {
     maxActionsPerRequest: parseIntClamped(source.POKER_BOTS_MAX_ACTIONS_PER_REQUEST, 5, 1, 20),
     botsOnlyHandCompletionHardCap: parseIntClamped(source.POKER_BOTS_BOTS_ONLY_HAND_HARD_CAP, 80, 10, 250),
-    policyVersion: normalizeString(source.POKER_BOT_POLICY_VERSION) || "TRIVIAL_V1",
+    policyVersion: normalizeString(source.POKER_BOT_POLICY_VERSION) || "PROFILED_RANDOM_V1",
   };
 }
 
@@ -147,6 +271,7 @@ function isBotTurn(turnUserId, seatBotMap) {
 
 export {
   buildSeatBotMap,
+  chooseBotActionProfiled,
   chooseBotActionTrivial,
   computeTargetBotCount,
   getBotAutoplayConfig,

--- a/netlify/functions/_shared/poker-bots.mjs
+++ b/netlify/functions/_shared/poker-bots.mjs
@@ -206,6 +206,12 @@ function pickLegalAction(legalActions, preferredTypes) {
   return null;
 }
 
+function hasAggressedThisRound(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const lastAction = normalizeString(context?.state?.lastBettingRoundActionByUserId?.[userId]).toUpperCase();
+  return lastAction === "BET" || lastAction === "RAISE";
+}
+
 function chooseBotActionProfiled(legalActions, context = {}) {
   const seatProfile = Array.isArray(context?.state?.seats)
     ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile
@@ -217,9 +223,10 @@ function chooseBotActionProfiled(legalActions, context = {}) {
   const thresholds = strengthThresholds(profile);
   const roll = clampRandom(context?.random);
   const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
+  const aggressiveTypes = hasAggressedThisRound(context) ? ["BET", "CALL", "CHECK", "FOLD"] : ["BET", "RAISE", "CALL", "CHECK", "FOLD"];
 
   if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) {
-    return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+    return pickLegalAction(legalActions, aggressiveTypes);
   }
   if (toCall <= 0 && strength >= thresholds.call - 0.15) {
     return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -380,7 +380,12 @@ function pickLegalAction(legalActions, preferredTypes) {
     const action = findAction(legalActions, type);
     if (!action) continue;
     const amount = readAmount(action);
-    if (type === "BET" || type === "RAISE") return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+    if (type === "BET" || type === "RAISE") {
+      if (amount == null) continue;
+      const normalizedAmount = Math.trunc(amount);
+      if (normalizedAmount <= 0) continue;
+      return { type, amount: normalizedAmount };
+    }
     return { type };
   }
   return null;

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -391,6 +391,12 @@ function pickLegalAction(legalActions, preferredTypes) {
   return null;
 }
 
+function hasAggressedThisRound(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const lastAction = normalizeString(context?.state?.lastBettingRoundActionByUserId?.[userId]).toUpperCase();
+  return lastAction === "BET" || lastAction === "RAISE";
+}
+
 function chooseBotActionProfiled(legalActions, context = {}) {
   const seatProfile = Array.isArray(context?.state?.seats) ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile : null;
   const profile = normalizeBotProfile(context?.profile ?? context?.botProfile ?? seatProfile, context?.random);
@@ -400,7 +406,8 @@ function chooseBotActionProfiled(legalActions, context = {}) {
   const thresholds = strengthThresholds(profile);
   const roll = clampRandom(context?.random);
   const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
-  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+  const aggressiveTypes = hasAggressedThisRound(context) ? ["BET", "CALL", "CHECK", "FOLD"] : ["BET", "RAISE", "CALL", "CHECK", "FOLD"];
+  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, aggressiveTypes);
   if (toCall <= 0 && strength >= thresholds.call - 0.15) return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);
   if (strength >= thresholds.call || roll < thresholds.call * 0.35) return pickLegalAction(legalActions, ["CALL", "CHECK", "FOLD"]);
   return pickLegalAction(legalActions, ["CHECK", "FOLD", "CALL"]);

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -23,7 +23,9 @@ function parseIntClamped(value, fallback, min, max) {
   return parsed;
 }
 
-function parseProfile(value, fallback = "TRIVIAL") {
+const BOT_PROFILES = ["TIGHT", "NORMAL", "LOOSE"];
+
+function parseProfile(value, fallback = "RANDOM") {
   const normalized = normalizeString(value).toUpperCase();
   return normalized || fallback;
 }
@@ -82,8 +84,9 @@ function parseStakes(raw) {
 function getBotConfig(env = process.env) {
   return {
     enabled: parseBool(env?.POKER_BOTS_ENABLED, false),
-    maxPerTable: parseIntClamped(env?.POKER_BOTS_MAX_PER_TABLE, 2, 0, 9),
-    defaultProfile: parseProfile(env?.POKER_BOT_PROFILE_DEFAULT, "TRIVIAL"),
+    minPerTable: parseIntClamped(env?.POKER_BOTS_MIN_PER_TABLE, 2, 0, 9),
+    maxPerTable: parseIntClamped(env?.POKER_BOTS_MAX_PER_TABLE, 5, 0, 9),
+    defaultProfile: parseProfile(env?.POKER_BOT_PROFILE_DEFAULT, "RANDOM"),
     buyInBB: parseIntClamped(env?.POKER_BOT_BUYIN_BB, 100, 1, 1000),
     bankrollSystemKey: normalizeString(env?.POKER_BOT_BANKROLL_SYSTEM_KEY) || "TREASURY"
   };
@@ -97,12 +100,37 @@ function makeBotSystemKey(tableId, seatNo) {
   return `POKER_BOT:${tableId}:${seatNo}`;
 }
 
-export function computeTargetBotCount({ maxPlayers, humanCount, maxBots } = {}) {
+function clampRandom(random = Math.random) {
+  const sampled = typeof random === "function" ? Number(random()) : Number(random);
+  if (!Number.isFinite(sampled)) return 0;
+  return Math.max(0, Math.min(0.999999, sampled));
+}
+
+function randomIntInclusive(min, max, random = Math.random) {
+  const low = Math.ceil(Number(min));
+  const high = Math.floor(Number(max));
+  if (!Number.isInteger(low) || !Number.isInteger(high) || high < low) return low;
+  return low + Math.floor((high - low + 1) * clampRandom(random));
+}
+
+function normalizeBotProfile(value, random = Math.random) {
+  const normalized = normalizeString(value).toUpperCase();
+  if (BOT_PROFILES.includes(normalized)) return normalized;
+  if (normalized === "TRIVIAL" || normalized === "DEFAULT") return "NORMAL";
+  const index = randomIntInclusive(0, BOT_PROFILES.length - 1, random);
+  return BOT_PROFILES[index] || "NORMAL";
+}
+
+export function computeTargetBotCount({ maxPlayers, humanCount, maxBots, minBots = 2, random = Math.random } = {}) {
   const totalSeats = Number.isFinite(Number(maxPlayers)) ? Math.trunc(Number(maxPlayers)) : 0;
   const humans = Number.isFinite(Number(humanCount)) ? Math.trunc(Number(humanCount)) : 0;
   const limit = Number.isFinite(Number(maxBots)) ? Math.trunc(Number(maxBots)) : 0;
+  const minimum = Number.isFinite(Number(minBots)) ? Math.trunc(Number(minBots)) : 0;
   if (humans <= 0 || humans >= totalSeats) return 0;
-  return Math.max(0, Math.min(Math.max(0, limit), Math.max(0, (totalSeats - humans) - 1)));
+  const upper = Math.max(0, Math.min(Math.max(0, limit), Math.max(0, totalSeats - humans)));
+  if (upper <= 0) return 0;
+  const lower = Math.min(upper, Math.max(1, Math.max(0, minimum)));
+  return randomIntInclusive(lower, upper, random);
 }
 
 export function shouldSeedBotsOnJoin({ humanCount } = {}) {
@@ -177,7 +205,7 @@ async function loadSeatRows(tx, tableId) {
   return Array.isArray(rows) ? rows : [];
 }
 
-async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, humanUserId, postTransaction, klog = () => {} }) {
+async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, humanUserId, postTransaction, klog = () => {}, random = Math.random }) {
   if (!cfg?.enabled || typeof postTransaction !== "function") return [];
   const stakesParsed = parseStakes(tableStakes);
   if (!stakesParsed.ok) {
@@ -190,7 +218,7 @@ async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, huma
   const humanCount = activeSeats.filter((row) => !row?.is_bot).length;
   if (!shouldSeedBotsOnJoin({ humanCount })) return [];
 
-  const targetBots = computeTargetBotCount({ maxPlayers, humanCount, maxBots: cfg.maxPerTable });
+  const targetBots = computeTargetBotCount({ maxPlayers, humanCount, minBots: cfg.minPerTable, maxBots: cfg.maxPerTable, random });
   if (!Number.isInteger(targetBots) || targetBots <= 0) return [];
 
   const existingBotCount = activeSeats.filter((row) => row?.is_bot).length;
@@ -206,6 +234,7 @@ async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, huma
     if (occupied.has(seatNo)) continue;
     const botUserId = makeBotUserId(tableId, seatNo);
     const botSystemKey = makeBotSystemKey(tableId, seatNo);
+    const botProfile = normalizeBotProfile(cfg.defaultProfile, random);
     const insertRows = await tx.unsafe(
       `
 insert into public.poker_seats (table_id, user_id, seat_no, status, is_bot, bot_profile, leave_after_hand, stack, last_seen_at, joined_at)
@@ -213,7 +242,7 @@ values ($1, $2, $3, 'ACTIVE', true, $4, false, $5, now(), now())
 on conflict do nothing
 returning seat_no;
       `,
-      [tableId, botUserId, seatNo, cfg.defaultProfile, buyInChips]
+      [tableId, botUserId, seatNo, botProfile, buyInChips]
     );
     if (!insertRows?.length) continue;
 
@@ -228,7 +257,7 @@ returning seat_no;
           botSystemKey,
           tableId,
           seatNo,
-          botProfile: cfg.defaultProfile,
+          botProfile: botProfile,
           reason: "BOT_SEED_BUY_IN"
         },
         entries: [
@@ -243,7 +272,7 @@ returning seat_no;
         seatNo,
         status: "ACTIVE",
         isBot: true,
-        botProfile: cfg.defaultProfile,
+        botProfile: botProfile,
         leaveAfterHand: false,
         stack: buyInChips
       });
@@ -260,8 +289,121 @@ returning seat_no;
   return seededBots;
 }
 
+function readAmount(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  for (const key of ["min", "minimum", "minAmount", "amountMin", "amount"]) {
+    const value = Number(entry[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function findAction(legalActions, actionType) {
+  const target = normalizeString(actionType).toUpperCase();
+  for (const entry of Array.isArray(legalActions) ? legalActions : []) {
+    if (typeof entry === "string" && entry.toUpperCase() === target) return { type: target };
+    const entryType = normalizeString(entry?.type || entry?.action).toUpperCase();
+    if (entryType === target) return entry;
+  }
+  return null;
+}
+
+function cardRank(card) {
+  const raw = typeof card === "string" ? card.trim().slice(0, -1).toUpperCase() : card?.r;
+  if (typeof raw === "number" && Number.isInteger(raw)) return raw;
+  if (raw === "A") return 14;
+  if (raw === "K") return 13;
+  if (raw === "Q") return 12;
+  if (raw === "J") return 11;
+  if (raw === "T" || raw === "10") return 10;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 2 && parsed <= 14 ? parsed : 0;
+}
+
+function cardSuit(card) {
+  return typeof card === "string" ? card.trim().slice(-1).toUpperCase() : normalizeString(card?.s).toUpperCase();
+}
+
+function botCardsFromContext(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const privateCards = context?.privateState?.holeCardsByUserId?.[userId];
+  const publicCards = context?.state?.holeCardsByUserId?.[userId];
+  return Array.isArray(privateCards) ? privateCards : Array.isArray(publicCards) ? publicCards : [];
+}
+
+function scorePreflop(cards) {
+  if (!Array.isArray(cards) || cards.length < 2) return 0.45;
+  const ranks = cards.map(cardRank).sort((a, b) => b - a);
+  const suited = cardSuit(cards[0]) && cardSuit(cards[0]) === cardSuit(cards[1]);
+  const pair = ranks[0] === ranks[1];
+  const high = ranks[0] || 0;
+  const low = ranks[1] || 0;
+  if (pair) return high >= 11 ? 0.95 : high >= 8 ? 0.78 : 0.62;
+  let score = (high + low) / 28;
+  if (suited) score += 0.1;
+  if (high >= 14 && low >= 10) score += 0.2;
+  else if (high >= 13 && low >= 10) score += 0.12;
+  if (Math.abs(high - low) <= 2) score += 0.05;
+  return Math.max(0.05, Math.min(0.98, score));
+}
+
+function scorePostflop(cards, community) {
+  const allCards = [...(Array.isArray(cards) ? cards : []), ...(Array.isArray(community) ? community : [])];
+  if (allCards.length < 3) return scorePreflop(cards);
+  const rankCounts = new Map();
+  const suitCounts = new Map();
+  for (const card of allCards) {
+    const rank = cardRank(card);
+    const suit = cardSuit(card);
+    if (rank) rankCounts.set(rank, (rankCounts.get(rank) || 0) + 1);
+    if (suit) suitCounts.set(suit, (suitCounts.get(suit) || 0) + 1);
+  }
+  const counts = [...rankCounts.values()].sort((a, b) => b - a);
+  const maxSuit = Math.max(0, ...suitCounts.values());
+  if (counts[0] >= 4) return 0.98;
+  if (counts[0] >= 3 && counts[1] >= 2) return 0.94;
+  if (maxSuit >= 5) return 0.9;
+  if (counts[0] >= 3) return 0.82;
+  if (counts[0] >= 2 && counts[1] >= 2) return 0.72;
+  if (counts[0] >= 2) return 0.58;
+  return Math.max(0.1, Math.min(0.55, scorePreflop(cards) - 0.12 + (maxSuit === 4 ? 0.12 : 0)));
+}
+
+function strengthThresholds(profile) {
+  if (profile === "TIGHT") return { bet: 0.78, call: 0.55, bluff: 0.06, aggression: 0.28 };
+  if (profile === "LOOSE") return { bet: 0.62, call: 0.32, bluff: 0.18, aggression: 0.55 };
+  return { bet: 0.7, call: 0.43, bluff: 0.11, aggression: 0.38 };
+}
+
+function pickLegalAction(legalActions, preferredTypes) {
+  for (const type of preferredTypes) {
+    const action = findAction(legalActions, type);
+    if (!action) continue;
+    const amount = readAmount(action);
+    if (type === "BET" || type === "RAISE") return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+    return { type };
+  }
+  return null;
+}
+
+function chooseBotActionProfiled(legalActions, context = {}) {
+  const seatProfile = Array.isArray(context?.state?.seats) ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile : null;
+  const profile = normalizeBotProfile(context?.profile ?? context?.botProfile ?? seatProfile, context?.random);
+  const cards = botCardsFromContext(context);
+  const phase = normalizeString(context?.state?.phase).toUpperCase();
+  const strength = phase === "PREFLOP" ? scorePreflop(cards) : scorePostflop(cards, context?.state?.community);
+  const thresholds = strengthThresholds(profile);
+  const roll = clampRandom(context?.random);
+  const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
+  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+  if (toCall <= 0 && strength >= thresholds.call - 0.15) return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);
+  if (strength >= thresholds.call || roll < thresholds.call * 0.35) return pickLegalAction(legalActions, ["CALL", "CHECK", "FOLD"]);
+  return pickLegalAction(legalActions, ["CHECK", "FOLD", "CALL"]);
+}
+
 export {
   applySeatsAndStacksToState,
+  chooseBotActionProfiled,
   asSeatSnapshot,
   getBotConfig,
   loadSeatRows,

--- a/shared/poker-domain/join.behavior.test.mjs
+++ b/shared/poker-domain/join.behavior.test.mjs
@@ -17,7 +17,7 @@ function withBotEnv(fn) {
   process.env.POKER_BOTS_ENABLED = "1";
   process.env.POKER_BOTS_MAX_PER_TABLE = "2";
   process.env.POKER_BOT_BUYIN_BB = "100";
-  process.env.POKER_BOT_PROFILE_DEFAULT = "TRIVIAL";
+  process.env.POKER_BOT_PROFILE_DEFAULT = "NORMAL";
   return Promise.resolve()
     .then(fn)
     .finally(() => {
@@ -994,8 +994,8 @@ test("first human authoritative join seeds exactly two bots and persists bot sea
   assert.equal(result.snapshot.seats.length, 3);
   assert.deepEqual(result.snapshot.seats.map((seat) => seat.seatNo), [1, 2, 3]);
   assert.deepEqual(result.snapshot.seats.filter((seat) => seat.isBot).map((seat) => ({ seatNo: seat.seatNo, botProfile: seat.botProfile, leaveAfterHand: seat.leaveAfterHand === true })), [
-    { seatNo: 2, botProfile: "TRIVIAL", leaveAfterHand: false },
-    { seatNo: 3, botProfile: "TRIVIAL", leaveAfterHand: false }
+    { seatNo: 2, botProfile: "NORMAL", leaveAfterHand: false },
+    { seatNo: 3, botProfile: "NORMAL", leaveAfterHand: false }
   ]);
   assert.equal(result.snapshot.stacks.human_1, 150);
   assert.equal(Object.values(result.snapshot.stacks).filter((stack) => stack === 200).length, 2);

--- a/shared/poker-domain/poker-autoplay.mjs
+++ b/shared/poker-domain/poker-autoplay.mjs
@@ -59,7 +59,8 @@ export const runBotAutoplayLoop = async ({
   chooseBotActionTrivial,
   isBotTurn,
   applyAction,
-  beforeBotActionStep
+  beforeBotActionStep,
+  botActionRandom = Math.random
 }) => {
   let responseFinalState = initialState;
   let loopPrivateState = initialPrivateState;
@@ -135,7 +136,12 @@ export const runBotAutoplayLoop = async ({
     }
 
     const botLegalInfo = computeLegalActions({ statePublic: withoutPrivateState(responseFinalState), userId: botTurnUserId });
-    const botChoice = chooseBotActionTrivial(botLegalInfo.actions);
+    const botChoice = chooseBotActionTrivial(botLegalInfo.actions, {
+      state: responseFinalState,
+      privateState: loopPrivateState,
+      userId: botTurnUserId,
+      random: botActionRandom
+    });
     if (!botChoice || !botChoice.type) { botStopReason = "no_legal_action"; break; }
 
     const botRequestId = buildBotRequestId(responseFinalState, botTurnUserId, botActionCount + 1);

--- a/skills.md
+++ b/skills.md
@@ -166,9 +166,15 @@ Agents MUST use this to locate logic quickly.
 
 ### Logs
 - `journalctl`
+- Production WS logs:
+  - `journalctl -u ws-server.service`
+- Preview WS logs:
+  - `journalctl -u ws-server-preview.service`
+- For live debugging, add `-f`; for recent bounded output, add `--no-pager -n 200`.
 
 ### Rule
 - No Docker assumptions unless explicitly present
+- When investigating WS preview or production behavior, check the relevant journald service before inferring from code alone.
 
 ---
 

--- a/tests/poker-bots.unit.test.mjs
+++ b/tests/poker-bots.unit.test.mjs
@@ -82,6 +82,20 @@ import {
     chooseBotActionTrivial([{ type: "RAISE", min: 20 }, "CALL", "FOLD"], { ...strongPreflop, state: { phase: "PREFLOP", toCallByUserId: { bot_1: 2 } } }),
     { type: "RAISE", amount: 20 }
   );
+  assert.deepEqual(
+    chooseBotActionTrivial(
+      [{ type: "RAISE", min: 22 }, "CALL", "FOLD"],
+      {
+        ...strongPreflop,
+        state: {
+          phase: "PREFLOP",
+          toCallByUserId: { bot_1: 4 },
+          lastBettingRoundActionByUserId: { bot_1: "RAISE" }
+        }
+      }
+    ),
+    { type: "CALL" }
+  );
 
   const weakTightFacingCall = {
     userId: "bot_2",

--- a/tests/poker-bots.unit.test.mjs
+++ b/tests/poker-bots.unit.test.mjs
@@ -10,8 +10,9 @@ import {
 {
   const cfg = getBotConfig({});
   assert.equal(cfg.enabled, false);
-  assert.equal(cfg.maxPerTable, 2);
-  assert.equal(cfg.defaultProfile, "TRIVIAL");
+  assert.equal(cfg.minPerTable, 2);
+  assert.equal(cfg.maxPerTable, 5);
+  assert.equal(cfg.defaultProfile, "RANDOM");
   assert.equal(cfg.buyInBB, 100);
   assert.equal(cfg.bankrollSystemKey, "TREASURY");
   assert.equal(cfg.maxActionsPerPoll, 2);
@@ -22,6 +23,7 @@ import {
   assert.equal(getBotConfig({ POKER_BOTS_ENABLED: "true" }).enabled, true);
   assert.equal(getBotConfig({ POKER_BOTS_ENABLED: "0" }).enabled, false);
   assert.equal(getBotConfig({ POKER_BOTS_ENABLED: "false" }).enabled, false);
+  assert.equal(getBotConfig({ POKER_BOTS_MIN_PER_TABLE: "1" }).minPerTable, 1);
   assert.equal(getBotConfig({ POKER_BOTS_MAX_PER_TABLE: "99" }).maxPerTable, 9);
   assert.equal(getBotConfig({ POKER_BOT_BUYIN_BB: "0" }).buyInBB, 1);
   assert.equal(getBotConfig({ POKER_BOT_PROFILE_DEFAULT: " tight " }).defaultProfile, "TIGHT");
@@ -44,20 +46,43 @@ import {
 }
 
 {
-  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 1, maxBots: 2 }), 2);
-  assert.equal(computeTargetBotCount({ maxPlayers: 2, humanCount: 1, maxBots: 2 }), 0);
-  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 5, maxBots: 2 }), 0);
-  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 0, maxBots: 2 }), 0);
-  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 6, maxBots: 2 }), 0);
+  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 1, minBots: 2, maxBots: 5, random: () => 0 }), 2);
+  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 1, minBots: 2, maxBots: 5, random: () => 0.999 }), 5);
+  assert.equal(computeTargetBotCount({ maxPlayers: 2, humanCount: 1, minBots: 2, maxBots: 5 }), 1);
+  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 5, minBots: 2, maxBots: 5 }), 1);
+  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 0, maxBots: 5 }), 0);
+  assert.equal(computeTargetBotCount({ maxPlayers: 6, humanCount: 6, maxBots: 5 }), 0);
 }
 
 {
-  assert.deepEqual(chooseBotActionTrivial(["CHECK", "CALL"]), { type: "CHECK" });
-  assert.deepEqual(chooseBotActionTrivial(["CALL", "FOLD"]), { type: "CALL" });
-  assert.deepEqual(chooseBotActionTrivial(["FOLD"]), { type: "FOLD" });
+  const strongPreflop = {
+    userId: "bot_1",
+    botProfile: "NORMAL",
+    random: () => 0.2,
+    state: { phase: "PREFLOP", toCallByUserId: { bot_1: 0 } },
+    privateState: { holeCardsByUserId: { bot_1: ["AS", "AD"] } }
+  };
   assert.deepEqual(
-    chooseBotActionTrivial([{ type: "BET", min: 15 }, { type: "RAISE", min: 22 }]),
-    { type: "BET", amount: 15 },
+    chooseBotActionTrivial([{ type: "BET", min: 15 }, "CHECK", "FOLD"], strongPreflop),
+    { type: "BET", amount: 15 }
   );
-  assert.equal(chooseBotActionTrivial([]), null);
+
+  const weakTightFacingCall = {
+    userId: "bot_2",
+    botProfile: "TIGHT",
+    random: () => 0.9,
+    state: { phase: "PREFLOP", toCallByUserId: { bot_2: 8 } },
+    privateState: { holeCardsByUserId: { bot_2: ["2C", "7D"] } }
+  };
+  assert.deepEqual(chooseBotActionTrivial(["CALL", "FOLD"], weakTightFacingCall), { type: "FOLD" });
+
+  const freeCheck = {
+    userId: "bot_3",
+    botProfile: "LOOSE",
+    random: () => 0.9,
+    state: { phase: "FLOP", community: ["2S", "9D", "KC"], toCallByUserId: { bot_3: 0 } },
+    privateState: { holeCardsByUserId: { bot_3: ["3C", "8D"] } }
+  };
+  assert.deepEqual(chooseBotActionTrivial(["CHECK", "FOLD"], freeCheck), { type: "CHECK" });
+  assert.equal(chooseBotActionTrivial([], strongPreflop), null);
 }

--- a/tests/poker-bots.unit.test.mjs
+++ b/tests/poker-bots.unit.test.mjs
@@ -66,6 +66,18 @@ import {
     chooseBotActionTrivial([{ type: "BET", min: 15 }, "CHECK", "FOLD"], strongPreflop),
     { type: "BET", amount: 15 }
   );
+  assert.deepEqual(
+    chooseBotActionTrivial(["BET", "CHECK", "FOLD"], strongPreflop),
+    { type: "CHECK" }
+  );
+  assert.deepEqual(
+    chooseBotActionTrivial([{ type: "BET", amount: 0 }, "CHECK", "FOLD"], strongPreflop),
+    { type: "CHECK" }
+  );
+  assert.deepEqual(
+    chooseBotActionTrivial(["RAISE", "CALL", "FOLD"], { ...strongPreflop, state: { phase: "PREFLOP", toCallByUserId: { bot_1: 2 } } }),
+    { type: "CALL" }
+  );
 
   const weakTightFacingCall = {
     userId: "bot_2",

--- a/tests/poker-bots.unit.test.mjs
+++ b/tests/poker-bots.unit.test.mjs
@@ -78,6 +78,10 @@ import {
     chooseBotActionTrivial(["RAISE", "CALL", "FOLD"], { ...strongPreflop, state: { phase: "PREFLOP", toCallByUserId: { bot_1: 2 } } }),
     { type: "CALL" }
   );
+  assert.deepEqual(
+    chooseBotActionTrivial([{ type: "RAISE", min: 20 }, "CALL", "FOLD"], { ...strongPreflop, state: { phase: "PREFLOP", toCallByUserId: { bot_1: 2 } } }),
+    { type: "RAISE", amount: 20 }
+  );
 
   const weakTightFacingCall = {
     userId: "bot_2",

--- a/ws-server/poker/handlers/join.behavior.test.mjs
+++ b/ws-server/poker/handlers/join.behavior.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { handleJoinCommand } from './join.mjs';
 
 function baseCtx(payload = {}){
-  const calls = { command: [], table: 0, snapshots: 0, joinArgs: null, authoritativeArgs: null, sendError: 0, sentErrors: [], actorTableState: 0, resync: 0, logs: [] };
+  const calls = { command: [], table: 0, snapshots: 0, joinArgs: null, authoritativeArgs: null, sendError: 0, sentErrors: [], actorTableState: 0, resync: 0, autoplay: [], logs: [] };
   const tableManager = {
     ensureTableLoaded: async () => ({ ok: true }),
     join: (args) => { calls.joinArgs = args; return { ok: true, changed: true, tableState: { tableId: 't1', members: [] } }; },
@@ -47,6 +47,7 @@ function baseCtx(payload = {}){
       observeOnlyJoinEnabled: false,
       persistedBootstrapEnabled: false,
       loadAuthoritativeJoinExecutor: async () => async (args) => { calls.authoritativeArgs = args; return { ok: true, seatNo: 2, stack: 100 }; },
+      scheduleBotStep: (payload) => { calls.autoplay.push(payload); },
       klog: (event, payload) => { calls.logs.push({ event, payload }); }
     }
   };
@@ -69,6 +70,24 @@ test('handleJoinCommand forwards autoSeat + preferredSeatNo intent', async () =>
   assert.equal(calls.joinArgs.autoSeat, true);
   assert.equal(calls.joinArgs.preferredSeatNo, 2);
   assert.equal(calls.joinArgs.buyIn, 150);
+});
+
+test('handleJoinCommand schedules bot autoplay after join bootstraps first hand', async () => {
+  const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 100 });
+  ctx.frame.ts = '2026-02-28T00:00:01Z';
+  ctx.tableManager.bootstrapHand = () => ({ ok: true, changed: true, bootstrap: 'started' });
+
+  await handleJoinCommand(ctx);
+
+  assert.equal(calls.command[0].status, 'accepted');
+  assert.equal(calls.snapshots, 1);
+  assert.equal(calls.autoplay.length, 1);
+  assert.deepEqual(calls.autoplay[0], {
+    tableId: 't1',
+    trigger: 'join_bootstrap',
+    requestId: 'r1',
+    frameTs: '2026-02-28T00:00:01Z'
+  });
 });
 
 test('handleJoinCommand forwards join intent to authoritative executor when enabled', async () => {

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -71,7 +71,7 @@ function restoredAuthoritativeStateLooksComplete({ restoredTable, userId, seatNo
 
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
 
-export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, klog = () => {} }) {
+export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {} }) {
   const tableId = frame.__resolvedTableId;
   const authoritativeJoinRequired = authoritativeJoinEnabled && !observeOnlyJoinEnabled;
   const parsedJoinIntent = parseJoinIntent(frame.payload);
@@ -294,5 +294,19 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
   }
   if (bootstrapped?.changed) {
     broadcastStateSnapshots(tableId);
+    try {
+      scheduleBotStep({
+        tableId,
+        trigger: "join_bootstrap",
+        requestId: frame.requestId ?? null,
+        frameTs: frame.ts
+      });
+    } catch (error) {
+      klog("ws_join_bootstrap_bot_autoplay_failed", {
+        tableId,
+        requestId: frame.requestId ?? null,
+        message: error?.message || "unknown"
+      });
+    }
   }
 }

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -67,6 +67,46 @@ test("accepted bot autoplay executes and persists when bot is on turn", async ()
   assert.equal(calls.persist > 0, true);
 });
 
+test("accepted bot autoplay does not emit zero-amount bet when legal bet has no amount", async () => {
+  const observed = { action: null };
+  const state = {
+    version: 2,
+    tableId: "t-zero-bet",
+    handId: "h-zero-bet",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 },
+    holeCardsByUserId: { bot_2: ["AS", "AD"] },
+    toCallByUserId: { bot_2: 0 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true, botProfile: "NORMAL" }] }),
+    applyAction: ({ action, amount }) => {
+      observed.action = { action, amount };
+      assert.notDeepEqual({ action, amount }, { action: "BET", amount: 0 });
+      assert.notDeepEqual({ action, amount }, { action: "RAISE", amount: 0 });
+      return { accepted: true, changed: true, replayed: false, stateVersion: 3 };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    random: () => 0,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-zero-bet", trigger: "act", requestId: "r-zero-bet" });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(observed.action?.action, "CHECK");
+});
+
 test("accepted bot autoplay waits a human-like reaction delay before acting", async () => {
   const observed = { sleepMs: [], persist: 0 };
   const nowMs = Date.now();

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -152,6 +152,50 @@ test("accepted bot autoplay enriches legal raise with a positive amount", async 
   assert.equal(observed.action?.amount, 4);
 });
 
+test("accepted bot autoplay does not repeatedly min-reraise after the bot already raised this round", async () => {
+  const observed = { action: null };
+  const state = {
+    version: 2,
+    tableId: "t-no-reraise-loop",
+    handId: "h-no-reraise-loop",
+    phase: "TURN",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 },
+    community: ["AS", "AD", "AC", "2H"],
+    holeCardsByUserId: { bot_2: ["AH", "KD"] },
+    currentBet: 4,
+    lastRaiseSize: 2,
+    betThisRoundByUserId: { human_1: 4, bot_2: 2 },
+    toCallByUserId: { bot_2: 2 },
+    lastBettingRoundActionByUserId: { bot_2: "RAISE" }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true, botProfile: "LOOSE" }] }),
+    applyAction: ({ action, amount }) => {
+      observed.action = { action, amount };
+      return { accepted: true, changed: true, replayed: false, stateVersion: 3 };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    random: () => 0,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-no-reraise-loop", trigger: "act", requestId: "r-no-reraise-loop" });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(observed.action?.action, "CALL");
+  assert.equal(observed.action?.amount, undefined);
+});
+
 test("accepted bot autoplay waits a human-like reaction delay before acting", async () => {
   const observed = { sleepMs: [], persist: 0 };
   const nowMs = Date.now();

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -18,7 +18,7 @@ function createAcceptedBotAutoplayExecutor(options = {}) {
   };
   return createAcceptedBotAutoplayExecutorBase({
     sleep: async () => {},
-    random: () => 0,
+    random: () => 0.5,
     ...options,
     env: mergedEnv
   });

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -67,7 +67,7 @@ test("accepted bot autoplay executes and persists when bot is on turn", async ()
   assert.equal(calls.persist > 0, true);
 });
 
-test("accepted bot autoplay does not emit zero-amount bet when legal bet has no amount", async () => {
+test("accepted bot autoplay enriches legal bet with a positive amount", async () => {
   const observed = { action: null };
   const state = {
     version: 2,
@@ -104,7 +104,52 @@ test("accepted bot autoplay does not emit zero-amount bet when legal bet has no 
   const result = await run({ tableId: "t-zero-bet", trigger: "act", requestId: "r-zero-bet" });
   assert.equal(result.ok, true);
   assert.equal(result.changed, true);
-  assert.equal(observed.action?.action, "CHECK");
+  assert.equal(observed.action?.action, "BET");
+  assert.equal(Number.isInteger(observed.action?.amount), true);
+  assert.equal(observed.action.amount > 0, true);
+});
+
+test("accepted bot autoplay enriches legal raise with a positive amount", async () => {
+  const observed = { action: null };
+  const state = {
+    version: 2,
+    tableId: "t-raise-amount",
+    handId: "h-raise-amount",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 },
+    holeCardsByUserId: { bot_2: ["AS", "AD"] },
+    currentBet: 2,
+    lastRaiseSize: 2,
+    betThisRoundByUserId: { human_1: 2, bot_2: 0 },
+    toCallByUserId: { bot_2: 2 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true, botProfile: "LOOSE" }] }),
+    applyAction: ({ action, amount }) => {
+      observed.action = { action, amount };
+      assert.notDeepEqual({ action, amount }, { action: "RAISE", amount: 0 });
+      return { accepted: true, changed: true, replayed: false, stateVersion: 3 };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    random: () => 0,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-raise-amount", trigger: "act", requestId: "r-raise-amount" });
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(observed.action?.action, "RAISE");
+  assert.equal(observed.action?.amount, 4);
 });
 
 test("accepted bot autoplay waits a human-like reaction delay before acting", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs
@@ -1,0 +1,10 @@
+import { createAcceptedBotAutoplayExecutor as createRealAcceptedBotAutoplayExecutor } from "./accepted-bot-autoplay-adapter.mjs";
+
+export function createAcceptedBotAutoplayExecutor(options = {}) {
+  return createRealAcceptedBotAutoplayExecutor({
+    ...options,
+    random: () => 0.5
+  });
+}
+
+export const createAcceptedBotStepExecutor = createAcceptedBotAutoplayExecutor;

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -119,6 +119,49 @@ function strengthThresholds(profile) {
   return { bet: 0.7, call: 0.43, bluff: 0.11, aggression: 0.38 };
 }
 
+function bucketStrength(strength) {
+  if (strength >= 0.8) return "very_strong";
+  if (strength >= 0.65) return "strong";
+  if (strength >= 0.45) return "medium";
+  if (strength >= 0.25) return "weak";
+  return "very_weak";
+}
+
+function bucketRoll(roll) {
+  if (roll < 0.2) return "low";
+  if (roll < 0.5) return "medium";
+  if (roll < 0.8) return "high";
+  return "very_high";
+}
+
+function describeAggressiveActionSkip(legalActions, actionType) {
+  const action = findAction(legalActions, actionType);
+  if (!action) return null;
+  const amount = readAmount(action);
+  if (amount == null) return "missing_amount";
+  if (Math.trunc(amount) <= 0) return "invalid_amount";
+  return null;
+}
+
+function buildBotDecisionDiagnostics({ legalActions, context, profile, roll, action }) {
+  const cards = botCardsFromContext(context);
+  const phase = normalizeString(context?.state?.phase).toUpperCase();
+  const strength = phase === "PREFLOP" ? scorePreflop(cards) : scorePostflop(cards, context?.state?.community);
+  return {
+    botUserId: typeof context?.userId === "string" ? context.userId : null,
+    botProfile: profile,
+    phase: phase || null,
+    handStrengthBucket: bucketStrength(strength),
+    randomRollBucket: bucketRoll(roll),
+    selectedAction: action?.type || null,
+    selectedAmount: action?.amount ?? null,
+    aggressiveActionSkips: {
+      bet: describeAggressiveActionSkip(legalActions, "BET"),
+      raise: describeAggressiveActionSkip(legalActions, "RAISE")
+    }
+  };
+}
+
 function pickLegalAction(legalActions, preferredTypes) {
   for (const type of preferredTypes) {
     const action = findAction(legalActions, type);
@@ -867,19 +910,36 @@ export function createAcceptedBotStepExecutor({
         },
         withoutPrivateState,
         chooseBotActionTrivial: (legalActions, context = {}) => {
-          let action = chooseBotActionTrivial(legalActions, {
+          const botUserId = context?.userId || lastKnown?.state?.turnUserId || "";
+          const botSeat = tableManager.tableSnapshot?.(tableId, botUserId)?.seats?.find((seat) => seat?.userId === botUserId);
+          const botProfile = normalizeString(context?.profile ?? context?.botProfile ?? botSeat?.botProfile).toUpperCase() || "NORMAL";
+          const decisionRoll = clampRandom(context?.random);
+          const decisionContext = {
             ...context,
-            profile: tableManager.tableSnapshot?.(tableId, context?.userId || lastKnown?.state?.turnUserId || "")?.seats?.find((seat) => seat?.userId === (context?.userId || lastKnown?.state?.turnUserId))?.botProfile
-          });
+            profile: botProfile,
+            random: () => decisionRoll
+          };
+          let action = chooseBotActionTrivial(legalActions, decisionContext);
           if ((!action || !action.type) && Array.isArray(legalActions) && legalActions.length > 0) {
             action = chooseBotActionFallback(legalActions);
             klog(action?.type ? "ws_bot_autoplay_fallback_action" : "ws_bot_autoplay_no_fallback_action", {
               ...baseLog,
-              botTurnUserId: context?.userId || (typeof lastKnown?.state?.turnUserId === "string" ? lastKnown.state.turnUserId : null),
+              botTurnUserId: botUserId || null,
               legalActionSummary: summarizeLegalActions(legalActions),
               actionType: action?.type || null
             });
           }
+          klog("ws_bot_autoplay_decision", {
+            ...baseLog,
+            ...buildBotDecisionDiagnostics({
+              legalActions,
+              context: decisionContext,
+              profile: botProfile,
+              roll: decisionRoll,
+              action
+            }),
+            legalActionSummary: summarizeLegalActions(legalActions)
+          });
           lastKnown = { ...lastKnown, stage: "action_chosen", actionType: action?.type || null, actionAmount: action?.amount ?? null };
           logVerbose("ws_bot_autoplay_action_chosen", {
             ...baseLog,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -214,6 +214,12 @@ function pickLegalAction(legalActions, preferredTypes) {
   return null;
 }
 
+function hasAggressedThisRound(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const lastAction = normalizeString(context?.state?.lastBettingRoundActionByUserId?.[userId]).toUpperCase();
+  return lastAction === "BET" || lastAction === "RAISE";
+}
+
 function chooseBotActionProfiled(legalActions, context = {}) {
   const seatProfile = Array.isArray(context?.state?.seats) ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile : null;
   const profile = normalizeString(context?.profile ?? context?.botProfile ?? seatProfile).toUpperCase() || "NORMAL";
@@ -223,7 +229,8 @@ function chooseBotActionProfiled(legalActions, context = {}) {
   const thresholds = strengthThresholds(profile);
   const roll = clampRandom(context?.random);
   const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
-  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+  const aggressiveTypes = hasAggressedThisRound(context) ? ["BET", "CALL", "CHECK", "FOLD"] : ["BET", "RAISE", "CALL", "CHECK", "FOLD"];
+  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, aggressiveTypes);
   if (toCall <= 0 && strength >= thresholds.call - 0.15) return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);
   if (strength >= thresholds.call || roll < thresholds.call * 0.35) return pickLegalAction(legalActions, ["CALL", "CHECK", "FOLD"]);
   return pickLegalAction(legalActions, ["CHECK", "FOLD", "CALL"]);

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -1,5 +1,4 @@
 import { recoverFromPersistConflict } from "./persist-conflict-recovery.mjs";
-import { chooseBotActionProfiled as chooseSharedBotActionProfiled } from "../../shared/poker-domain/bots.mjs";
 
 import { TURN_MS } from "../shared/poker-turn-timeout.mjs";
 import { applyAction as applySharedAction } from "../shared/poker-action-reducer.mjs";
@@ -23,6 +22,129 @@ const DEFAULT_BOT_REACTION_MAX_MS = 4_000;
 const isActionPhase = (phase) => phase === "PREFLOP" || phase === "FLOP" || phase === "TURN" || phase === "RIVER";
 const isCurrentHandPhase = (phase) => isActionPhase(phase) || phase === "SHOWDOWN" || phase === "HAND_DONE";
 const noopAdvanceIfNeeded = (state) => ({ state, events: [] });
+
+function normalizeString(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function clampRandom(random = Math.random) {
+  const sampled = typeof random === "function" ? Number(random()) : Number(random);
+  if (!Number.isFinite(sampled)) return 0;
+  return Math.max(0, Math.min(0.999999, sampled));
+}
+
+function readAmount(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  for (const key of ["min", "minimum", "minAmount", "amountMin", "amount"]) {
+    const value = Number(entry[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function findAction(legalActions, actionType) {
+  const target = normalizeString(actionType).toUpperCase();
+  for (const entry of Array.isArray(legalActions) ? legalActions : []) {
+    if (typeof entry === "string" && entry.toUpperCase() === target) return { type: target };
+    const entryType = normalizeString(entry?.type || entry?.action).toUpperCase();
+    if (entryType === target) return entry;
+  }
+  return null;
+}
+
+function botCardsFromContext(context = {}) {
+  const userId = typeof context?.userId === "string" ? context.userId : "";
+  const privateCards = context?.privateState?.holeCardsByUserId?.[userId];
+  const publicCards = context?.state?.holeCardsByUserId?.[userId];
+  return Array.isArray(privateCards) ? privateCards : Array.isArray(publicCards) ? publicCards : [];
+}
+
+function cardRank(card) {
+  const raw = typeof card === "string" ? card.trim().slice(0, -1).toUpperCase() : card?.r;
+  if (typeof raw === "number" && Number.isInteger(raw)) return raw;
+  if (raw === "A") return 14;
+  if (raw === "K") return 13;
+  if (raw === "Q") return 12;
+  if (raw === "J") return 11;
+  if (raw === "T" || raw === "10") return 10;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 2 && parsed <= 14 ? parsed : 0;
+}
+
+function cardSuit(card) {
+  return typeof card === "string" ? card.trim().slice(-1).toUpperCase() : normalizeString(card?.s).toUpperCase();
+}
+
+function scorePreflop(cards) {
+  if (!Array.isArray(cards) || cards.length < 2) return 0.45;
+  const ranks = cards.map(cardRank).sort((a, b) => b - a);
+  const suited = cardSuit(cards[0]) && cardSuit(cards[0]) === cardSuit(cards[1]);
+  const pair = ranks[0] === ranks[1];
+  const high = ranks[0] || 0;
+  const low = ranks[1] || 0;
+  if (pair) return high >= 11 ? 0.95 : high >= 8 ? 0.78 : 0.62;
+  let score = (high + low) / 28;
+  if (suited) score += 0.1;
+  if (high >= 14 && low >= 10) score += 0.2;
+  else if (high >= 13 && low >= 10) score += 0.12;
+  if (Math.abs(high - low) <= 2) score += 0.05;
+  return Math.max(0.05, Math.min(0.98, score));
+}
+
+function scorePostflop(cards, community) {
+  const allCards = [...(Array.isArray(cards) ? cards : []), ...(Array.isArray(community) ? community : [])];
+  if (allCards.length < 3) return scorePreflop(cards);
+  const rankCounts = new Map();
+  const suitCounts = new Map();
+  for (const card of allCards) {
+    const rank = cardRank(card);
+    const suit = cardSuit(card);
+    if (rank) rankCounts.set(rank, (rankCounts.get(rank) || 0) + 1);
+    if (suit) suitCounts.set(suit, (suitCounts.get(suit) || 0) + 1);
+  }
+  const counts = [...rankCounts.values()].sort((a, b) => b - a);
+  const maxSuit = Math.max(0, ...suitCounts.values());
+  if (counts[0] >= 4) return 0.98;
+  if (counts[0] >= 3 && counts[1] >= 2) return 0.94;
+  if (maxSuit >= 5) return 0.9;
+  if (counts[0] >= 3) return 0.82;
+  if (counts[0] >= 2 && counts[1] >= 2) return 0.72;
+  if (counts[0] >= 2) return 0.58;
+  return Math.max(0.1, Math.min(0.55, scorePreflop(cards) - 0.12 + (maxSuit === 4 ? 0.12 : 0)));
+}
+
+function strengthThresholds(profile) {
+  if (profile === "TIGHT") return { bet: 0.78, call: 0.55, bluff: 0.06, aggression: 0.28 };
+  if (profile === "LOOSE") return { bet: 0.62, call: 0.32, bluff: 0.18, aggression: 0.55 };
+  return { bet: 0.7, call: 0.43, bluff: 0.11, aggression: 0.38 };
+}
+
+function pickLegalAction(legalActions, preferredTypes) {
+  for (const type of preferredTypes) {
+    const action = findAction(legalActions, type);
+    if (!action) continue;
+    const amount = readAmount(action);
+    if (type === "BET" || type === "RAISE") return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+    return { type };
+  }
+  return null;
+}
+
+function chooseBotActionProfiled(legalActions, context = {}) {
+  const seatProfile = Array.isArray(context?.state?.seats) ? context.state.seats.find((seat) => seat?.userId === context?.userId)?.botProfile : null;
+  const profile = normalizeString(context?.profile ?? context?.botProfile ?? seatProfile).toUpperCase() || "NORMAL";
+  const cards = botCardsFromContext(context);
+  const phase = normalizeString(context?.state?.phase).toUpperCase();
+  const strength = phase === "PREFLOP" ? scorePreflop(cards) : scorePostflop(cards, context?.state?.community);
+  const thresholds = strengthThresholds(profile);
+  const roll = clampRandom(context?.random);
+  const toCall = Number(context?.state?.toCallByUserId?.[context?.userId] ?? 0);
+  if ((strength >= thresholds.bet && roll < thresholds.aggression) || roll < thresholds.bluff) return pickLegalAction(legalActions, ["BET", "RAISE", "CALL", "CHECK", "FOLD"]);
+  if (toCall <= 0 && strength >= thresholds.call - 0.15) return pickLegalAction(legalActions, ["CHECK", "BET", "CALL", "FOLD"]);
+  if (strength >= thresholds.call || roll < thresholds.call * 0.35) return pickLegalAction(legalActions, ["CALL", "CHECK", "FOLD"]);
+  return pickLegalAction(legalActions, ["CHECK", "FOLD", "CALL"]);
+}
+
 
 function isPlainObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -105,7 +227,7 @@ function isBotTurnAuthoritatively(tableManager, tableId, turnUserId, seatBotMap)
 }
 
 function chooseBotActionTrivial(legalActions, context = {}) {
-  return chooseSharedBotActionProfiled(legalActions, context);
+  return chooseBotActionProfiled(legalActions, context);
 }
 
 function buildSeatBotMap(seats) {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -124,7 +124,12 @@ function pickLegalAction(legalActions, preferredTypes) {
     const action = findAction(legalActions, type);
     if (!action) continue;
     const amount = readAmount(action);
-    if (type === "BET" || type === "RAISE") return { type, amount: amount == null ? 0 : Math.max(0, Math.trunc(amount)) };
+    if (type === "BET" || type === "RAISE") {
+      if (amount == null) continue;
+      const normalizedAmount = Math.trunc(amount);
+      if (normalizedAmount <= 0) continue;
+      return { type, amount: normalizedAmount };
+    }
     return { type };
   }
   return null;

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -750,7 +750,7 @@ export function createAcceptedBotStepExecutor({
         maxActions: 1,
         botsOnlyHandCompletionHardCap: cfg.botsOnlyHandCompletionHardCap,
         policyVersion: cfg.policyVersion,
-        botActionRandom: () => 0.5,
+        botActionRandom: random,
         klog,
         isActionPhase,
         advanceIfNeeded,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -143,6 +143,42 @@ function describeAggressiveActionSkip(legalActions, actionType) {
   return null;
 }
 
+function enrichBotLegalActions(legalInfo = {}) {
+  const actions = Array.isArray(legalInfo?.actions) ? legalInfo.actions : [];
+  const minRaiseTo = Number(legalInfo?.minRaiseTo);
+  const maxRaiseTo = Number(legalInfo?.maxRaiseTo);
+  const maxBetAmount = Number(legalInfo?.maxBetAmount);
+  const normalizedMinRaiseTo = Number.isFinite(minRaiseTo) ? Math.trunc(minRaiseTo) : null;
+  const normalizedMaxRaiseTo = Number.isFinite(maxRaiseTo) ? Math.trunc(maxRaiseTo) : null;
+  const normalizedMaxBetAmount = Number.isFinite(maxBetAmount) ? Math.trunc(maxBetAmount) : null;
+  return actions.map((action) => {
+    const type = typeof action === "string"
+      ? action.toUpperCase()
+      : normalizeString(action?.type || action?.action).toUpperCase();
+    if (type === "BET" && normalizedMaxBetAmount > 0) {
+      return {
+        type: "BET",
+        min: 1,
+        minAmount: 1,
+        amount: 1,
+        max: normalizedMaxBetAmount,
+        maxAmount: normalizedMaxBetAmount
+      };
+    }
+    if (type === "RAISE" && normalizedMinRaiseTo > 0) {
+      return {
+        type: "RAISE",
+        min: normalizedMinRaiseTo,
+        minAmount: normalizedMinRaiseTo,
+        amount: normalizedMinRaiseTo,
+        max: normalizedMaxRaiseTo,
+        maxAmount: normalizedMaxRaiseTo
+      };
+    }
+    return action;
+  });
+}
+
 function buildBotDecisionDiagnostics({ legalActions, context, profile, roll, action }) {
   const cards = botCardsFromContext(context);
   const phase = normalizeString(context?.state?.phase).toUpperCase();
@@ -686,16 +722,26 @@ function buildDiagnosticSnapshot(state) {
 function summarizeLegalActions(legalActions) {
   const actions = Array.isArray(legalActions) ? legalActions : [];
   const types = [];
+  const aggressiveAmounts = {};
   for (const item of actions) {
     if (typeof item === "string") {
       types.push(item);
     } else if (item && typeof item === "object" && typeof item.type === "string") {
       types.push(item.type);
+      const type = item.type.toUpperCase();
+      if (type === "BET" || type === "RAISE") {
+        aggressiveAmounts[type.toLowerCase()] = {
+          amount: Number.isFinite(Number(item.amount)) ? Number(item.amount) : null,
+          min: Number.isFinite(Number(item.min ?? item.minAmount)) ? Number(item.min ?? item.minAmount) : null,
+          max: Number.isFinite(Number(item.max ?? item.maxAmount)) ? Number(item.max ?? item.maxAmount) : null
+        };
+      }
     }
   }
   return {
     count: actions.length,
-    types: [...new Set(types)].slice(0, 8)
+    types: [...new Set(types)].slice(0, 8),
+    aggressiveAmounts
   };
 }
 
@@ -842,7 +888,11 @@ export function createAcceptedBotStepExecutor({
         },
         computeLegalActions: ({ statePublic, userId }) => {
           const legal = computeLegalActions({ statePublic, userId });
-          const legalSummary = summarizeLegalActions(legal?.actions);
+          const botLegal = {
+            ...legal,
+            actions: enrichBotLegalActions(legal)
+          };
+          const legalSummary = summarizeLegalActions(botLegal?.actions);
           lastKnown = { ...lastKnown, stage: "turn_snapshot", state: statePublic, legalActionSummary: legalSummary };
           logVerbose("ws_bot_autoplay_turn_snapshot", {
             ...baseLog,
@@ -851,7 +901,7 @@ export function createAcceptedBotStepExecutor({
             ...buildDiagnosticSnapshot(statePublic),
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
           });
-          return legal;
+          return botLegal;
         },
         beforeBotActionStep: async ({
           responseFinalState,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -230,6 +230,10 @@ function chooseBotActionTrivial(legalActions, context = {}) {
   return chooseBotActionProfiled(legalActions, context);
 }
 
+function chooseBotActionFallback(legalActions) {
+  return pickLegalAction(legalActions, ["CHECK", "CALL", "FOLD"]);
+}
+
 function buildSeatBotMap(seats) {
   const rows = Array.isArray(seats) ? seats : [];
   const map = new Map();
@@ -858,10 +862,19 @@ export function createAcceptedBotStepExecutor({
         },
         withoutPrivateState,
         chooseBotActionTrivial: (legalActions, context = {}) => {
-          const action = chooseBotActionTrivial(legalActions, {
+          let action = chooseBotActionTrivial(legalActions, {
             ...context,
             profile: tableManager.tableSnapshot?.(tableId, context?.userId || lastKnown?.state?.turnUserId || "")?.seats?.find((seat) => seat?.userId === (context?.userId || lastKnown?.state?.turnUserId))?.botProfile
           });
+          if ((!action || !action.type) && Array.isArray(legalActions) && legalActions.length > 0) {
+            action = chooseBotActionFallback(legalActions);
+            klog(action?.type ? "ws_bot_autoplay_fallback_action" : "ws_bot_autoplay_no_fallback_action", {
+              ...baseLog,
+              botTurnUserId: context?.userId || (typeof lastKnown?.state?.turnUserId === "string" ? lastKnown.state.turnUserId : null),
+              legalActionSummary: summarizeLegalActions(legalActions),
+              actionType: action?.type || null
+            });
+          }
           lastKnown = { ...lastKnown, stage: "action_chosen", actionType: action?.type || null, actionAmount: action?.amount ?? null };
           logVerbose("ws_bot_autoplay_action_chosen", {
             ...baseLog,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -1,4 +1,5 @@
 import { recoverFromPersistConflict } from "./persist-conflict-recovery.mjs";
+import { chooseBotActionProfiled as chooseSharedBotActionProfiled } from "../../shared/poker-domain/bots.mjs";
 
 import { TURN_MS } from "../shared/poker-turn-timeout.mjs";
 import { applyAction as applySharedAction } from "../shared/poker-action-reducer.mjs";
@@ -103,16 +104,8 @@ function isBotTurnAuthoritatively(tableManager, tableId, turnUserId, seatBotMap)
   return isBotTurn(turnUserId, seatBotMap);
 }
 
-function chooseBotActionTrivial(legalActions) {
-  const actions = Array.isArray(legalActions) ? legalActions : [];
-  if (actions.includes("CHECK")) return { type: "CHECK" };
-  if (actions.includes("CALL")) return { type: "CALL" };
-  if (actions.includes("FOLD")) return { type: "FOLD" };
-  const bet = actions.find((entry) => entry && typeof entry === "object" && entry.type === "BET");
-  if (bet) return { type: "BET", amount: Number.isFinite(Number(bet.min)) ? Number(bet.min) : 0 };
-  const raise = actions.find((entry) => entry && typeof entry === "object" && entry.type === "RAISE");
-  if (raise) return { type: "RAISE", amount: Number.isFinite(Number(raise.min)) ? Number(raise.min) : 0 };
-  return null;
+function chooseBotActionTrivial(legalActions, context = {}) {
+  return chooseSharedBotActionProfiled(legalActions, context);
 }
 
 function buildSeatBotMap(seats) {
@@ -635,6 +628,7 @@ export function createAcceptedBotStepExecutor({
         maxActions: 1,
         botsOnlyHandCompletionHardCap: cfg.botsOnlyHandCompletionHardCap,
         policyVersion: cfg.policyVersion,
+        botActionRandom: () => 0.5,
         klog,
         isActionPhase,
         advanceIfNeeded,
@@ -741,8 +735,11 @@ export function createAcceptedBotStepExecutor({
           };
         },
         withoutPrivateState,
-        chooseBotActionTrivial: (legalActions) => {
-          const action = chooseBotActionTrivial(legalActions);
+        chooseBotActionTrivial: (legalActions, context = {}) => {
+          const action = chooseBotActionTrivial(legalActions, {
+            ...context,
+            profile: tableManager.tableSnapshot?.(tableId, context?.userId || lastKnown?.state?.turnUserId || "")?.seats?.find((seat) => seat?.userId === (context?.userId || lastKnown?.state?.turnUserId))?.botProfile
+          });
           lastKnown = { ...lastKnown, stage: "action_chosen", actionType: action?.type || null, actionAmount: action?.amount ?? null };
           logVerbose("ws_bot_autoplay_action_chosen", {
             ...baseLog,

--- a/ws-server/poker/runtime/table-command-queue.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-command-queue.behavior.test.mjs
@@ -101,3 +101,46 @@ test("table command queue coalesces deduped commands while one is queued or runn
   await first;
   assert.equal(runCount, 1);
 });
+
+test("table command queue runs non-deduped bot-step cascade commands even while a prior step is active", async () => {
+  const queue = createTableCommandQueue();
+  const order = [];
+  let releaseFirst = null;
+  const waitForRelease = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  const first = queue.enqueue({
+    tableId: "bot-cascade-table",
+    run: async () => {
+      order.push("bot_step:first:start");
+      await waitForRelease;
+      order.push("bot_step:first:end");
+      return { ok: true, shouldContinue: true };
+    }
+  });
+
+  const second = queue.enqueue({
+    tableId: "bot-cascade-table",
+    run: async () => {
+      order.push("bot_step:second:start");
+      order.push("bot_step:second:end");
+      return { ok: true, shouldContinue: false };
+    }
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(order, ["bot_step:first:start"]);
+  releaseFirst();
+
+  assert.deepEqual(await Promise.all([first, second]), [
+    { ok: true, shouldContinue: true },
+    { ok: true, shouldContinue: false }
+  ]);
+  assert.deepEqual(order, [
+    "bot_step:first:start",
+    "bot_step:first:end",
+    "bot_step:second:start",
+    "bot_step:second:end"
+  ]);
+});

--- a/ws-server/poker/runtime/table-janitor.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-janitor.behavior.test.mjs
@@ -69,6 +69,39 @@ test("evaluateTableHealth classifies stale human seats from last_seen_at", () =>
   assert.equal(result.reasonCode, "stale_human_last_seen_expired");
 });
 
+test("evaluateTableHealth does not stale-clean a connected human with an old persisted heartbeat", () => {
+  const result = evaluateTableHealth({
+    tableId: "t_connected_old_seen",
+    nowMs: NOW_MS,
+    activeSeatFreshMs: 120_000,
+    seatedReconnectGraceMs: 90_000,
+    persistedTable: {
+      status: "OPEN",
+      created_at: iso(-600_000),
+      last_activity_at: iso(-240_000)
+    },
+    persistedSeats: [
+      { user_id: "u1", status: "ACTIVE", is_bot: false, last_seen_at: iso(-240_000) }
+    ],
+    persistedState: {
+      phase: "PREFLOP",
+      turnUserId: "bot_1",
+      turnDeadlineAt: NOW_MS + 30_000
+    },
+    runtime: {
+      loaded: true,
+      tableStatus: "OPEN",
+      hasConnectedHumanPresence: true,
+      connectedUserIds: ["u1"]
+    }
+  });
+
+  assert.equal(result.healthy, true);
+  assert.equal(result.classification, "healthy");
+  assert.equal(result.action, "noop");
+  assert.equal(result.reasonCode, "healthy_live_hand_active");
+});
+
 test("evaluateTableHealth classifies abandoned live hands", () => {
   const result = evaluateTableHealth({
     tableId: "t_abandoned_live_hand",

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -1922,6 +1922,72 @@ test("maybeApplyTurnTimeout applies deterministic action once for expired turn",
   assert.equal(afterReplay.stateVersion, after.stateVersion);
 });
 
+test("listDueTurnTimeouts marks expired bot turns for autoplay safety", () => {
+  const tableManager = createTableManager({ maxSeats: 4, enableDebugCore: true, nodeEnv: "test" });
+  const tableId = "table_due_bot_timeout";
+  const nowMs = 10_000;
+  const restored = tableManager.restoreTableFromPersisted(tableId, {
+    coreState: {
+      version: 4,
+      roomId: tableId,
+      maxSeats: 4,
+      members: [
+        { userId: "human_a", seat: 1 },
+        { userId: "bot_b", seat: 2 }
+      ],
+      seats: { human_a: 1, bot_b: 2 },
+      publicStacks: { human_a: 99, bot_b: 99 },
+      seatDetailsByUserId: {
+        human_a: { isBot: false, botProfile: null, leaveAfterHand: false },
+        bot_b: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false }
+      },
+      pokerState: {
+        roomId: tableId,
+        handId: "hand_due_bot_timeout",
+        phase: "FLOP",
+        dealerSeatNo: 1,
+        turnUserId: "bot_b",
+        turnStartedAt: 1,
+        turnDeadlineAt: 2,
+        seats: [
+          { userId: "human_a", seatNo: 1, status: "ACTIVE", isBot: false },
+          { userId: "bot_b", seatNo: 2, status: "ACTIVE", isBot: true }
+        ],
+        handSeats: [
+          { userId: "human_a", seatNo: 1, status: "ACTIVE", isBot: false },
+          { userId: "bot_b", seatNo: 2, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { human_a: 99, bot_b: 99 },
+        committedByUserId: { human_a: 0, bot_b: 0 },
+        contributionsByUserId: { human_a: 1, bot_b: 1 },
+        foldedByUserId: {},
+        leftTableByUserId: {},
+        sitOutByUserId: {},
+        pendingAutoSitOutByUserId: {},
+        community: ["2S", "7D", "9C"],
+        deck: ["AS", "KD"],
+        holeCardsByUserId: { human_a: ["AH", "AD"], bot_b: ["3C", "4C"] },
+        pot: 2,
+        potTotal: 2,
+        currentBet: 0,
+        minRaise: 2
+      }
+    },
+    presenceByUserId: new Map([
+      ["human_a", { userId: "human_a", seat: 1, connected: true, lastSeenAt: 1, expiresAt: null }],
+      ["bot_b", { userId: "bot_b", seat: 2, connected: false, lastSeenAt: 1, expiresAt: null }]
+    ])
+  });
+
+  assert.equal(restored.ok, true);
+  const due = tableManager.listDueTurnTimeouts({ nowMs });
+
+  assert.equal(due.length, 1);
+  assert.equal(due[0].tableId, tableId);
+  assert.equal(due[0].turnUserId, "bot_b");
+  assert.equal(due[0].isBotTurn, true);
+});
+
 test("maybeApplyTurnTimeout does nothing when deadline is unexpired", () => {
   const tableManager = createTableManager({ maxSeats: 4 });
   const wsA = fakeWs("timeout-noop-a");

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -733,7 +733,15 @@ export function createTableManager({
       }
       const timeoutDecision = decideCoreStateTurnTimeout({ coreState: table?.coreState, nowMs });
       if (timeoutDecision?.due === true) {
-        due.push({ tableId, stateVersion: timeoutDecision.stateVersion });
+        const turnUserId = typeof timeoutDecision?.decision?.actorUserId === "string"
+          ? timeoutDecision.decision.actorUserId
+          : (typeof timeoutDecision?.liveState?.turnUserId === "string" ? timeoutDecision.liveState.turnUserId : null);
+        due.push({
+          tableId,
+          stateVersion: timeoutDecision.stateVersion,
+          turnUserId,
+          isBotTurn: isCoreStateBotUser(table?.coreState, turnUserId)
+        });
       }
     }
     return due;

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -11,6 +11,7 @@ import WebSocket from "ws";
 import { makeBotUserId } from "../shared/poker-domain/bots.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "./poker/shared/poker-primitives.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
+import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 
 const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
@@ -4138,6 +4139,106 @@ test("human act against queued bots returns next actionable human snapshot", asy
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);
+  }
+});
+
+test("table_state_sub schedules autoplay for restored live bot turn before timeout sweep", async () => {
+  const secret = "restored-bot-turn-sub-secret";
+  const tableId = "table_restored_bot_turn_sub_autoplay";
+  const humanUserId = "restored_sub_human";
+  const botSeat2 = makeBotUserId(tableId, 2);
+  const botSeat3 = makeBotUserId(tableId, 3);
+  const baseCoreState = {
+    roomId: tableId,
+    version: 8,
+    maxSeats: 6,
+    members: [
+      { userId: humanUserId, seat: 1 },
+      { userId: botSeat2, seat: 2 },
+      { userId: botSeat3, seat: 3 }
+    ],
+    seats: [
+      { userId: humanUserId, seatNo: 1, status: "ACTIVE" },
+      { userId: botSeat2, seatNo: 2, status: "ACTIVE" },
+      { userId: botSeat3, seatNo: 3, status: "ACTIVE" }
+    ],
+    seatDetailsByUserId: {
+      [humanUserId]: { isBot: false, stack: 100 },
+      [botSeat2]: { isBot: true, botProfile: "NORMAL", stack: 100 },
+      [botSeat3]: { isBot: true, botProfile: "NORMAL", stack: 100 }
+    },
+    publicStacks: {
+      [humanUserId]: 100,
+      [botSeat2]: 100,
+      [botSeat3]: 100
+    }
+  };
+  const liveState = {
+    ...buildBootstrappedPokerState({
+      tableId,
+      coreState: baseCoreState,
+      dealerSeatNo: 2,
+      startingStacks: baseCoreState.publicStacks,
+      handVersion: baseCoreState.version
+    }),
+    turnStartedAt: Date.now(),
+    turnDeadlineAt: Date.now() + 60_000
+  };
+  assert.equal(liveState.turnUserId, botSeat2);
+
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+          { user_id: botSeat2, seat_no: 2, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" },
+          { user_id: botSeat3, seat_no: 3, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" }
+        ],
+        stateRow: { version: baseCoreState.version, state: liveState }
+      }
+    }
+  });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_TIMEOUT_SWEEP_MS: "60000",
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: humanUserId }), "auth-restored-bot-turn-sub");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "sub-restored-bot-turn",
+      ts: "2026-02-28T01:45:01Z",
+      payload: { tableId }
+    });
+    const initial = await nextMessageOfType(ws, "table_state");
+    assert.equal(initial.payload.tableId, tableId);
+
+    const autoplayUpdate = await nextMessageMatching(
+      ws,
+      (frame) => frame?.type === "stateSnapshot" && Number(frame?.payload?.stateVersion || 0) > baseCoreState.version,
+      5000
+    );
+    assert.notEqual(autoplayUpdate.payload.public.turn.userId, botSeat2);
+
+    const persisted = await readPersistedFile(filePath);
+    assert.equal(persisted.tables[tableId].stateRow.version > baseCoreState.version, true);
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
   }
 });
 

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -12,6 +12,11 @@ import { makeBotUserId } from "../shared/poker-domain/bots.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "./poker/shared/poker-primitives.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
 
+const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
+  "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
+  import.meta.url
+).href;
+
 function getFreePort() {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();
@@ -94,6 +99,7 @@ function createServer({ env = {} } = {}) {
         PORT: String(port),
         WS_BOT_REACTION_MIN_MS: "0",
         WS_BOT_REACTION_MAX_MS: "0",
+        WS_ACCEPTED_BOT_AUTOPLAY_ADAPTER_MODULE_PATH: FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL,
         ...env
       },
       stdio: ["ignore", "pipe", "pipe"]

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -4242,6 +4242,106 @@ test("table_state_sub schedules autoplay for restored live bot turn before timeo
   }
 });
 
+test("resync schedules autoplay for restored live bot turn before timeout sweep", async () => {
+  const secret = "restored-bot-turn-resync-secret";
+  const tableId = "table_restored_bot_turn_resync_autoplay";
+  const humanUserId = "restored_resync_human";
+  const botSeat2 = makeBotUserId(tableId, 2);
+  const botSeat3 = makeBotUserId(tableId, 3);
+  const baseCoreState = {
+    roomId: tableId,
+    version: 8,
+    maxSeats: 6,
+    members: [
+      { userId: humanUserId, seat: 1 },
+      { userId: botSeat2, seat: 2 },
+      { userId: botSeat3, seat: 3 }
+    ],
+    seats: [
+      { userId: humanUserId, seatNo: 1, status: "ACTIVE" },
+      { userId: botSeat2, seatNo: 2, status: "ACTIVE" },
+      { userId: botSeat3, seatNo: 3, status: "ACTIVE" }
+    ],
+    seatDetailsByUserId: {
+      [humanUserId]: { isBot: false, stack: 100 },
+      [botSeat2]: { isBot: true, botProfile: "NORMAL", stack: 100 },
+      [botSeat3]: { isBot: true, botProfile: "NORMAL", stack: 100 }
+    },
+    publicStacks: {
+      [humanUserId]: 100,
+      [botSeat2]: 100,
+      [botSeat3]: 100
+    }
+  };
+  const liveState = {
+    ...buildBootstrappedPokerState({
+      tableId,
+      coreState: baseCoreState,
+      dealerSeatNo: 2,
+      startingStacks: baseCoreState.publicStacks,
+      handVersion: baseCoreState.version
+    }),
+    turnStartedAt: Date.now(),
+    turnDeadlineAt: Date.now() + 60_000
+  };
+  assert.equal(liveState.turnUserId, botSeat2);
+
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+          { user_id: botSeat2, seat_no: 2, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" },
+          { user_id: botSeat3, seat_no: 3, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" }
+        ],
+        stateRow: { version: baseCoreState.version, state: liveState }
+      }
+    }
+  });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_TIMEOUT_SWEEP_MS: "60000",
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: humanUserId }), "auth-restored-bot-turn-resync");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "resync",
+      requestId: "resync-restored-bot-turn",
+      ts: "2026-02-28T01:46:01Z",
+      payload: { tableId }
+    });
+    const resynced = await nextMessageOfType(ws, "table_state");
+    assert.equal(resynced.payload.tableId, tableId);
+
+    const autoplayUpdate = await nextMessageMatching(
+      ws,
+      (frame) => frame?.type === "stateSnapshot" && Number(frame?.payload?.stateVersion || 0) > baseCoreState.version,
+      5000
+    );
+    assert.notEqual(autoplayUpdate.payload.public.turn.userId, botSeat2);
+
+    const persisted = await readPersistedFile(filePath);
+    assert.equal(persisted.tables[tableId].stateRow.version > baseCoreState.version, true);
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("observer snapshot stays public-state consistent with seated snapshot after queued bot progression", async () => {
   const secret = "observer-public-consistency-secret";
   const humanUserId = "observer_public_human";

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -5613,7 +5613,7 @@ test("authoritative WS table_join seeds two bots once and returns authoritative 
       POKER_BOTS_ENABLED: "1",
       POKER_BOTS_MAX_PER_TABLE: "2",
       POKER_BOT_BUYIN_BB: "100",
-      POKER_BOT_PROFILE_DEFAULT: "TRIVIAL"
+      POKER_BOT_PROFILE_DEFAULT: "NORMAL"
     }
   });
 
@@ -5651,8 +5651,8 @@ test("authoritative WS table_join seeds two bots once and returns authoritative 
     assert.equal(firstState.payload.members.some((entry) => entry.userId === botSeat2), false);
     assert.deepEqual(firstState.payload.seats, [
       { userId: "bot_seed_human", seatNo: 1, status: "ACTIVE" },
-      { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
-      { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" }
+      { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "NORMAL" },
+      { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "NORMAL" }
     ]);
     assert.equal(typeof firstState.payload.stacks.bot_seed_human, "number");
     assert.equal(typeof firstState.payload.stacks[botSeat2], "number");

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1948,9 +1948,25 @@ async function sweepTurnTimeoutsAndBroadcast() {
   });
   await Promise.allSettled(timeoutUpdates.map((update) => enqueueTableCommand({
     tableId: update.tableId,
-    commandName: "turn_timeout",
-    dedupeKey: "turn_timeout",
+    commandName: update.isBotTurn === true ? "bot_timeout_safety" : "turn_timeout",
+    dedupeKey: update.isBotTurn === true ? null : "turn_timeout",
     run: async () => {
+      if (update.isBotTurn === true) {
+        klogSafe("ws_bot_timeout_safety_autoplay", {
+          tableId: update.tableId,
+          turnUserId: update.turnUserId || null,
+          stateVersion: Number.isFinite(Number(update.stateVersion)) ? Number(update.stateVersion) : null
+        });
+        return handleBotStepCommand({
+          tableId: update.tableId,
+          trigger: "bot_timeout_safety",
+          requestId: `bot-timeout-safety:${update.tableId}:${nowMs}`,
+          frameTs: null,
+          runBotStep,
+          broadcastStateSnapshots,
+          klog: klogSafe
+        });
+      }
       const result = await handleTurnTimeoutCommand({
         tableId: update.tableId,
         nowMs,
@@ -2315,6 +2331,7 @@ wss.on("connection", (ws) => {
           observeOnlyJoinEnabled,
           persistedBootstrapEnabled,
           loadAuthoritativeJoinExecutor,
+          scheduleBotStep,
           klog: klogSafe
         })
       });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1828,21 +1828,34 @@ async function loadPersistedTableHealthSnapshot(tableId) {
 
 function buildTableJanitorRuntimeContext(tableId, persistedSeats = []) {
   const loaded = tableManager.listTableIds().includes(tableId);
-  const connectedUserIds = [];
+  const connectedUserIds = new Set();
+  if (loaded && typeof tableManager.orderedConnectionsForTable === "function") {
+    const sockets = tableManager.orderedConnectionsForTable(tableId, (socket) => {
+      const userId = socket?.__connState?.session?.userId;
+      return typeof userId === "string" ? userId : "";
+    });
+    for (const socket of sockets) {
+      if (socket?.__connState?.sessionInvalidated === true) continue;
+      const userId = socket?.__connState?.session?.userId;
+      if (typeof userId === "string" && userId.trim()) {
+        connectedUserIds.add(userId.trim());
+      }
+    }
+  }
   for (const seat of persistedSeats || []) {
     if (seat?.is_bot === true) continue;
     const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
     if (!userId) continue;
     const activeSockets = sessionStore.connectionsForUser(userId) || [];
     if (activeSockets.some((socket) => tableSocketMatches(socket, tableId))) {
-      connectedUserIds.push(userId);
+      connectedUserIds.add(userId);
     }
   }
   return {
     loaded,
     tableStatus: loaded ? (tableManager.isTableClosed(tableId) ? "CLOSED" : "OPEN") : null,
     hasConnectedHumanPresence: tableManager.hasConnectedHumanPresence(tableId),
-    connectedUserIds
+    connectedUserIds: [...connectedUserIds]
   };
 }
 
@@ -2675,6 +2688,7 @@ wss.on("connection", (ws) => {
         return;
       }
       sendGameplaySnapshot(ws, connState, { requestId: frame.requestId ?? null, tableId, snapshot: loaded.snapshot });
+      maybeTouchPersistedSeatLastSeen(connState);
       return;
     }
 
@@ -2708,6 +2722,7 @@ wss.on("connection", (ws) => {
           klog: klogSafe
         })
       });
+      maybeTouchPersistedSeatLastSeen(connState);
       return;
     }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -477,7 +477,6 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
   const enqueueStep = () => enqueueTableCommand({
     tableId,
     commandName: "bot_step",
-    dedupeKey: "bot_step",
     run: async () => handleBotStepCommand({
       tableId,
       trigger,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2419,6 +2419,12 @@ wss.on("connection", (ws) => {
         const resyncedSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
         sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: resynced.tableState, tableSnapshot: resyncedSnapshot });
         maybeTouchPersistedSeatLastSeen(connState);
+        scheduleObservedBotTurn({
+          tableId,
+          trigger: "resync",
+          requestId: frame.requestId ?? null,
+          frameTs: frame.ts
+        });
         return;
       }
 
@@ -2508,11 +2514,23 @@ wss.on("connection", (ws) => {
         const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
         await nextEventLoopTurn();
         sendStateSnapshot(ws, connState, { tableSnapshot, reason: replay.reason });
+        scheduleObservedBotTurn({
+          tableId,
+          trigger: "resume_resync",
+          requestId: frame.requestId ?? null,
+          frameTs: frame.ts
+        });
         return;
       }
 
       if (replay.frames.length === 0) {
         sendResumeAck(ws, connState, { requestId: frame.requestId ?? null, tableId });
+        scheduleObservedBotTurn({
+          tableId,
+          trigger: "resume_ack",
+          requestId: frame.requestId ?? null,
+          frameTs: frame.ts
+        });
         return;
       }
 
@@ -2520,6 +2538,12 @@ wss.on("connection", (ws) => {
         connState.session.latestDeliveredSeqByTableId.set(tableId, replayFrame.seq);
         sendFrame(ws, replayFrame);
       }
+      scheduleObservedBotTurn({
+        tableId,
+        trigger: "resume_replay",
+        requestId: frame.requestId ?? null,
+        frameTs: frame.ts
+      });
       return;
     }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -459,6 +459,18 @@ function buildAutoplayStartSnapshot(tableId) {
   };
 }
 
+function buildBotTurnScheduleKey(tableId) {
+  const state = tableManager.persistedPokerState(tableId);
+  if (!state || typeof state !== "object") return null;
+  if (!isLiveHandPhase(state.phase) || state.phase === "SHOWDOWN") return null;
+  const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId.trim() : "";
+  if (!turnUserId || tableManager.isBotUser(tableId, turnUserId) !== true) return null;
+  const stateVersion = Number(tableManager.persistedStateVersion(tableId) || state.version || 0);
+  const handId = typeof state.handId === "string" && state.handId.trim() ? state.handId.trim() : "unknown_hand";
+  const phase = typeof state.phase === "string" && state.phase.trim() ? state.phase.trim() : "unknown_phase";
+  return `${tableId}:${stateVersion}:${handId}:${phase}:${turnUserId}`;
+}
+
 async function runBotStep({ tableId, trigger, requestId, frameTs }) {
   const acceptedBotAutoplayExecutor = await loadAcceptedBotAutoplayExecutor();
   const startSnapshot = buildAutoplayStartSnapshot(tableId);
@@ -472,6 +484,8 @@ async function runBotStep({ tableId, trigger, requestId, frameTs }) {
   });
   return acceptedBotAutoplayExecutor({ tableId, trigger, requestId, frameTs });
 }
+
+const scheduledObservedBotTurnKeys = new Map();
 
 function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
   const enqueueStep = () => enqueueTableCommand({
@@ -502,6 +516,34 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
     return queued;
   };
   return runCascade();
+}
+
+function scheduleObservedBotTurn({ tableId, trigger, requestId = null, frameTs = null }) {
+  const scheduleKey = buildBotTurnScheduleKey(tableId);
+  if (!scheduleKey) {
+    scheduledObservedBotTurnKeys.delete(tableId);
+    return false;
+  }
+  if (scheduledObservedBotTurnKeys.get(tableId) === scheduleKey) return false;
+  scheduledObservedBotTurnKeys.set(tableId, scheduleKey);
+  try {
+    scheduleBotStep({ tableId, trigger, requestId, frameTs });
+    klogSafe("ws_observed_bot_turn_autoplay_scheduled", {
+      tableId,
+      trigger: trigger || null,
+      scheduleKey
+    });
+    return true;
+  } catch (error) {
+    scheduledObservedBotTurnKeys.delete(tableId);
+    klogSafe("ws_observed_bot_turn_autoplay_failed", {
+      tableId,
+      trigger: trigger || null,
+      scheduleKey,
+      message: error?.message || "unknown"
+    });
+    return false;
+  }
 }
 
 function enqueueTableCommand({ tableId, commandName, dedupeKey = null, run }) {
@@ -2578,6 +2620,12 @@ wss.on("connection", (ws) => {
       const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
       sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: subscribed.tableState, tableSnapshot });
       maybeTouchPersistedSeatLastSeen(connState);
+      scheduleObservedBotTurn({
+        tableId,
+        trigger: "table_state_sub",
+        requestId: frame.requestId ?? null,
+        frameTs: frame.ts
+      });
       return;
     }
 

--- a/ws-server/shared/poker-domain/bots.mjs
+++ b/ws-server/shared/poker-domain/bots.mjs
@@ -1,1 +1,1 @@
-export { chooseBotActionProfiled, makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";
+export { makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";

--- a/ws-server/shared/poker-domain/bots.mjs
+++ b/ws-server/shared/poker-domain/bots.mjs
@@ -1,1 +1,1 @@
-export { makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";
+export { chooseBotActionProfiled, makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -255,6 +255,22 @@ async function nextStateUpdate(ws, { baseline = null, timeoutMs = 10000 } = {}) 
   }
 }
 
+async function nextAdvancedStateUpdate(ws, { baseline, timeoutMs = 10000 } = {}) {
+  const started = Date.now();
+  let current = baseline;
+  while (true) {
+    const remainingMs = timeoutMs - (Date.now() - started);
+    if (remainingMs <= 0) {
+      throw new Error("Timed out waiting for advanced state update frame");
+    }
+    const next = await nextStateUpdate(ws, { baseline: current, timeoutMs: remainingMs });
+    current = next.payload;
+    if (Number(current?.stateVersion) > Number(baseline?.stateVersion ?? -1)) {
+      return next;
+    }
+  }
+}
+
 async function waitForHumanTurn(ws, { userId, baseline, timeoutMs = 5000 }) {
   let current = baseline;
   if (current?.public?.turn?.userId === userId) {
@@ -518,14 +534,14 @@ test("authoritative WS table_join can progress through human act and bot timeout
     const actAck = await nextCommandResultForRequest(ws, "act-runtime-human");
     assert.equal(actAck.payload.status, "accepted");
 
-    const afterHumanAction = await nextStateUpdate(ws, {
+    const afterHumanAction = await nextAdvancedStateUpdate(ws, {
       baseline: humanTurnSnapshot,
       timeoutMs: 4000
     });
     assert.equal(afterHumanAction.payload.stateVersion > humanTurnSnapshot.stateVersion, true);
     assert.equal(afterHumanAction.payload.public.hand.handId, humanTurnSnapshot.public.hand.handId);
 
-    const afterBotAutoplay = await nextStateUpdate(ws, {
+    const afterBotAutoplay = await nextAdvancedStateUpdate(ws, {
       baseline: afterHumanAction.payload,
       timeoutMs: 5000
     });

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -271,6 +271,20 @@ async function nextAdvancedStateUpdate(ws, { baseline, timeoutMs = 10000 } = {})
   }
 }
 
+async function nextStateSnapshotAtLeast(ws, { stateVersion, timeoutMs = 10000 } = {}) {
+  const started = Date.now();
+  while (true) {
+    const remainingMs = timeoutMs - (Date.now() - started);
+    if (remainingMs <= 0) {
+      throw new Error(`Timed out waiting for stateSnapshot at version ${stateVersion}`);
+    }
+    const frame = await nextMessage(ws, remainingMs);
+    if (frame?.type === "stateSnapshot" && Number(frame?.payload?.stateVersion) >= Number(stateVersion)) {
+      return frame;
+    }
+  }
+}
+
 async function waitForHumanTurn(ws, { userId, baseline, timeoutMs = 5000 }) {
   let current = baseline;
   if (current?.public?.turn?.userId === userId) {
@@ -553,7 +567,10 @@ test("authoritative WS table_join can progress through human act and bot timeout
       ts: "2026-02-28T06:20:03Z",
       payload: { tableId, view: "snapshot" }
     });
-    const postAutoplaySnapshot = await nextMessageOfType(ws, "stateSnapshot");
+    const postAutoplaySnapshot = await nextStateSnapshotAtLeast(ws, {
+      stateVersion: afterBotAutoplay.payload.stateVersion,
+      timeoutMs: 5000
+    });
     assert.equal(postAutoplaySnapshot.payload.stateVersion >= afterBotAutoplay.payload.stateVersion, true);
     assert.equal(typeof postAutoplaySnapshot.payload.public.hand.handId, "string");
     const postAutoplayHumanTurn = await waitForHumanTurn(ws, {

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -196,8 +196,8 @@ function isStableReplayJoinState(frame, { tableId, userId, botSeat2, botSeat3 })
   ];
   const expectedSeats = [
     { userId, seatNo: 1, status: "ACTIVE" },
-    { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
-    { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" }
+    { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "NORMAL" },
+    { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "NORMAL" }
   ];
   try {
     assert.deepEqual(members, expectedMembers);
@@ -331,7 +331,7 @@ function runtimeJoinEnv({ secret, filePath }) {
     POKER_BOTS_ENABLED: "1",
     POKER_BOTS_MAX_PER_TABLE: "2",
     POKER_BOT_BUYIN_BB: "100",
-    POKER_BOT_PROFILE_DEFAULT: "TRIVIAL",
+    POKER_BOT_PROFILE_DEFAULT: "NORMAL",
     WS_BOT_REACTION_MIN_MS: "0",
     WS_BOT_REACTION_MAX_MS: "0",
     WS_POKER_TURN_MS: "250",
@@ -395,8 +395,8 @@ test("authoritative WS table_join returns a fully seated stacked snapshot and ke
     assert.equal(typeof joinedState.payload.hand.handId, "string");
     assert.deepEqual(joinedState.payload.seats, [
       { userId: "runtime_human", seatNo: 1, status: "ACTIVE" },
-      { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
-      { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" }
+      { userId: botSeat2, seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "NORMAL" },
+      { userId: botSeat3, seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "NORMAL" }
     ]);
     assert.equal(joinedState.payload.seats.filter((seat) => seat?.status === "ACTIVE").length >= 3, true);
     assert.equal(typeof joinedState.payload.stacks.runtime_human, "number");


### PR DESCRIPTION
## Summary
- replace trivial poker bot decisions with simple tight/normal/loose profiled strategy
- randomize solo bot fill to a configurable 2-5 bot range within table capacity
- keep autoplay actions routed through legal-action and reducer validation

## Validation
- node --check netlify/functions/_shared/poker-bots.mjs
- node --check shared/poker-domain/bots.mjs
- node --check ws-server/shared/poker-domain/bots.mjs
- node --check shared/poker-domain/poker-autoplay.mjs
- node --check ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
- node tests/poker-bots.unit.test.mjs
- node shared/poker-domain/join.behavior.test.mjs
- node ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs