### PR TITLE
[codex] Implement poker guest mode foundation

### DIFF
--- a/netlify/functions/poker-guest-session.mjs
+++ b/netlify/functions/poker-guest-session.mjs
@@ -1,0 +1,130 @@
+import { createHmac, randomInt, randomUUID } from "node:crypto";
+
+function klog(kind, data) {
+  const payload = data && typeof data === "object" ? ` ${JSON.stringify(data)}` : "";
+  process.stdout.write(`[klog] ${kind}${payload}\n`);
+}
+
+function baseHeaders() {
+  return {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  };
+}
+
+function corsAllowList(env = process.env) {
+  const fromEnv = (env.XP_CORS_ALLOW ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const siteUrl = env.URL;
+  if (siteUrl && !fromEnv.includes(siteUrl)) {
+    fromEnv.push(siteUrl);
+  }
+  return fromEnv;
+}
+
+function corsHeaders(origin, env = process.env) {
+  const headers = baseHeaders();
+  if (!origin) return headers;
+
+  const allow = corsAllowList(env);
+  const isNetlifyDomain = /^https:\/\/[a-z0-9-]+\.netlify\.app$/i.test(origin);
+  if (!isNetlifyDomain && !allow.includes(origin)) return null;
+
+  return {
+    ...headers,
+    "access-control-allow-origin": origin,
+    "access-control-allow-credentials": "true",
+    "access-control-allow-headers": "authorization, content-type",
+    "access-control-allow-methods": "POST, OPTIONS",
+  };
+}
+
+function getHeader(headers, key) {
+  if (!headers || typeof headers !== "object") return undefined;
+  return headers[key] ?? headers[key.toLowerCase()] ?? headers[key.toUpperCase()];
+}
+
+function toBase64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function resolveMintSecret(env) {
+  if (typeof env.WS_AUTH_HS256_SECRET === "string" && env.WS_AUTH_HS256_SECRET.length > 0) {
+    return env.WS_AUTH_HS256_SECRET;
+  }
+  if (typeof env.WS_AUTH_TEST_SECRET === "string" && env.WS_AUTH_TEST_SECRET.length > 0) {
+    return env.WS_AUTH_TEST_SECRET;
+  }
+  return null;
+}
+
+function resolveTtlSec(env) {
+  const parsed = Number(env.WS_GUEST_MINT_TTL_SEC || env.WS_MINT_TTL_SEC || "1800");
+  if (!Number.isFinite(parsed) || parsed <= 0) return 1800;
+  return Math.min(3600, Math.floor(parsed));
+}
+
+function signGuestToken({ sub, nickname, tableId, secret, ttlSec }) {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub,
+    mode: "guest",
+    nickname,
+    tableId,
+    iat: nowSec,
+    exp: nowSec + ttlSec,
+  };
+  const encodedHeader = toBase64UrlJson(header);
+  const encodedPayload = toBase64UrlJson(payload);
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = createHmac("sha256", secret).update(data).digest("base64url");
+  return `${data}.${signature}`;
+}
+
+function randomGuestNickname() {
+  const suffix = String(randomInt(1000, 10000));
+  return `Guest${suffix}`;
+}
+
+export async function handler(event) {
+  const origin = getHeader(event.headers, "origin");
+  const originCors = corsHeaders(origin);
+  const optionsHeaders = originCors || baseHeaders();
+
+  if (event.httpMethod === "OPTIONS") {
+    if (origin && !originCors) {
+      return { statusCode: 403, headers: baseHeaders(), body: JSON.stringify({ error: "forbidden_origin" }) };
+    }
+    return { statusCode: 204, headers: optionsHeaders, body: "" };
+  }
+
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, headers: optionsHeaders, body: JSON.stringify({ error: "method_not_allowed" }) };
+  }
+
+  if (!origin || !originCors) {
+    return { statusCode: 403, headers: baseHeaders(), body: JSON.stringify({ error: "forbidden_origin" }) };
+  }
+
+  const mintSecret = resolveMintSecret(process.env);
+  if (!mintSecret) {
+    klog("poker_guest_session_unconfigured", { hasAuthSecret: false });
+    return { statusCode: 500, headers: originCors, body: JSON.stringify({ error: "server_error" }) };
+  }
+
+  const guestId = `guest_${randomUUID()}`;
+  const tableId = `guest_table_${randomUUID()}`;
+  const nickname = randomGuestNickname();
+  const expiresInSec = resolveTtlSec(process.env);
+  const token = signGuestToken({ sub: guestId, nickname, tableId, secret: mintSecret, ttlSec: expiresInSec });
+
+  klog("poker_guest_session_created", { tableId, guestIdPrefix: guestId.slice(0, 12), expiresInSec });
+  return {
+    statusCode: 200,
+    headers: originCors,
+    body: JSON.stringify({ ok: true, token, userId: guestId, guestId, nickname, tableId, mode: "guest", expiresInSec }),
+  };
+}

--- a/poker/index.html
+++ b/poker/index.html
@@ -86,6 +86,7 @@
     <div id="pokerAuthMsg" class="poker-auth-msg" hidden>
       <div class="poker-auth-text" data-i18n="pokerAuthLobby">Please log in to access the poker lobby.</div>
       <div class="poker-auth-actions">
+        <button id="pokerGuestPlay" class="poker-btn poker-btn--primary">Play as Guest</button>
         <button id="pokerSignIn" class="poker-btn poker-btn--primary" data-i18n="signIn">Sign In</button>
       </div>
     </div>

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -103,6 +103,8 @@
   var tableId = readTableId();
   var wsClient = null;
   var currentAccessToken = null;
+  var currentGuestSession = null;
+  var isGuestMode = false;
   var authWatchTimer = null;
   var turnClockTimer = null;
   var revealDismissTimer = null;
@@ -283,6 +285,30 @@
       return searchParams.get('tableId');
     } catch (_err){
       searchParams = null;
+      return null;
+    }
+  }
+
+
+  function readGuestMode(){
+    try {
+      if (!searchParams) searchParams = new URLSearchParams(window.location.search || "");
+      return searchParams.get("guest") === "1";
+    } catch (_err){
+      return false;
+    }
+  }
+
+  function readGuestSession(){
+    try {
+      var raw = window.sessionStorage ? window.sessionStorage.getItem("poker:guestSession") : null;
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || !parsed.token || !parsed.tableId) return null;
+      if (tableId && parsed.tableId !== tableId) return null;
+      if (Number(parsed.expiresAt) && Number(parsed.expiresAt) <= Date.now()) return null;
+      return parsed;
+    } catch (_err){
       return null;
     }
   }
@@ -2116,6 +2142,7 @@
     }
 
     if (els.signInBtn) els.signInBtn.hidden = signedIn;
+    if (els.guestBadge) els.guestBadge.hidden = !isGuestMode;
     if (els.joinBtn) els.joinBtn.hidden = false;
     if (els.joinBtn) els.joinBtn.disabled = joinDisabled;
     if (els.joinBtn) {
@@ -2535,6 +2562,7 @@
     els.stackText = document.getElementById('pokerV2StackText');
     els.errorText = document.getElementById('pokerV2ErrorText');
     els.signInBtn = document.getElementById('pokerV2SignInBtn');
+    els.guestBadge = document.getElementById('pokerV2GuestBadge');
     els.joinBtn = document.getElementById('pokerV2JoinBtn');
     els.joinSeat = document.getElementById('pokerV2SeatNo');
     els.joinBuyIn = document.getElementById('pokerV2BuyIn');
@@ -2616,6 +2644,7 @@
     markBootReady();
     wsClient = window.PokerWsClient.create({
       tableId: tableId,
+      guestToken: isGuestMode && currentGuestSession ? currentGuestSession.token : null,
       getAccessToken: function(){ return Promise.resolve(currentAccessToken); },
       klog: klog,
       onStatus: function(status, info){
@@ -2742,11 +2771,23 @@
     shouldAutoJoin = readAutoJoinParam();
     bindMenu();
     bindControls();
-    bindAuthLifecycle();
+    isGuestMode = readGuestMode();
+    currentGuestSession = isGuestMode ? readGuestSession() : null;
     if (!tableId){
       startDemoMode();
       return;
     }
+    if (isGuestMode){
+      if (!currentGuestSession || !currentGuestSession.token){
+        applySignedOutState();
+        setError('Guest session expired. Start again from the lobby.');
+        return;
+      }
+      currentAccessToken = null;
+      startLiveMode(currentGuestSession.token);
+      return;
+    }
+    bindAuthLifecycle();
     getAccessToken().then(function(token){
       currentAccessToken = token;
       if (!token){

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -83,6 +83,7 @@
     var mode = options.mode === 'lobby' ? 'lobby' : 'table';
     var tableId = typeof options.tableId === 'string' ? options.tableId.trim() : '';
     var getAccessToken = typeof options.getAccessToken === 'function' ? options.getAccessToken : null;
+    var guestToken = typeof options.guestToken === 'string' && options.guestToken ? options.guestToken : null;
     var onStatus = typeof options.onStatus === 'function' ? options.onStatus : function(){};
     var onSnapshot = typeof options.onSnapshot === 'function' ? options.onSnapshot : function(){};
     var onLobbySnapshot = typeof options.onLobbySnapshot === 'function' ? options.onLobbySnapshot : function(){};
@@ -208,6 +209,11 @@
     }
 
     async function mintAndAuth(){
+      if (guestToken){
+        emitStatus('authenticating', { mode: 'guest' });
+        send('auth', { token: guestToken });
+        return;
+      }
       if (!getAccessToken) throw new Error('missing_access_token_provider');
       var accessToken = await getAccessToken();
       if (!accessToken) throw new Error('missing_access_token');

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -3,6 +3,7 @@
 
   var CREATE_URL = '/.netlify/functions/poker-create-table';
   var QUICK_SEAT_URL = '/.netlify/functions/poker-quick-seat';
+  var GUEST_SESSION_URL = '/.netlify/functions/poker-guest-session';
   var WS_JOIN_ENDPOINT = 'ws:join';
   var WS_LEAVE_ENDPOINT = 'ws:leave';
   var WS_START_HAND_ENDPOINT = 'ws:start_hand';
@@ -629,6 +630,9 @@
     }
     if (opts.autoStart === true){
       query.push('autoStart=1');
+    }
+    if (opts.guest === true){
+      query.push('guest=1');
     }
     return path + (query.length ? ('?' + query.join('&')) : '');
   }
@@ -1474,6 +1478,7 @@
     var bbInput = document.getElementById('pokerBb');
     var maxPlayersInput = document.getElementById('pokerMaxPlayers');
     var signInBtn = document.getElementById('pokerSignIn');
+    var guestPlayBtn = document.getElementById('pokerGuestPlay');
 
     var LOBBY_RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000];
     var authTimer = null;
@@ -1746,6 +1751,43 @@
     }
 
 
+
+    function storeGuestSession(data){
+      if (!data || !data.token || !data.tableId) return false;
+      try {
+        window.sessionStorage.setItem("poker:guestSession", JSON.stringify({
+          token: data.token,
+          tableId: data.tableId,
+          guestId: data.guestId || data.userId || null,
+          nickname: data.nickname || null,
+          expiresAt: Date.now() + Math.max(1, Number(data.expiresInSec || 1800)) * 1000
+        }));
+        return true;
+      } catch (_err){
+        return false;
+      }
+    }
+
+    async function playAsGuest(){
+      setError(errorEl, null);
+      if (guestPlayBtn) setLoading(guestPlayBtn, true);
+      try {
+        var res = await fetch(GUEST_SESSION_URL, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+        var data = {};
+        try { data = await res.json(); } catch (_err){}
+        if (!res.ok || !data || data.ok !== true || !data.token || !data.tableId){
+          throw new Error(data && data.error ? data.error : "guest_session_failed");
+        }
+        storeGuestSession(data);
+        navigateToPokerTable(data.tableId, { autoJoin: true, guest: true });
+      } catch (err){
+        klog("poker_guest_session_error", { error: err && (err.message || err.code) ? (err.message || err.code) : "unknown" });
+        setError(errorEl, "Guest mode is temporarily unavailable");
+      } finally {
+        if (guestPlayBtn) setLoading(guestPlayBtn, false);
+      }
+    }
+
     async function quickSeat(){
       setError(errorEl, null);
       var sb = parseInt(sbInput ? sbInput.value : 1, 10);
@@ -1831,6 +1873,9 @@
       refreshBtn.addEventListener('click', function(){
         refreshLobby('manual_refresh');
       });
+    }
+    if (guestPlayBtn){
+      guestPlayBtn.addEventListener('click', playAsGuest);
     }
     if (quickSeatBtn){
       quickSeatBtn.addEventListener('click', quickSeat);

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -49,6 +49,7 @@
         <div class="poker-live-turn" id="pokerV2TurnText">Waiting for action</div>
       </div>
       <div class="poker-live-actions">
+        <div class="poker-live-pill" id="pokerV2GuestBadge" hidden>Guest account</div>
         <button type="button" class="poker-live-btn" id="pokerV2SignInBtn">Sign in</button>
         <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2JoinBtn">Join</button>
         <button type="button" class="poker-live-btn" id="pokerV2LeaveBtn" hidden>Leave</button>

--- a/tests/poker-guest-session.behavior.test.mjs
+++ b/tests/poker-guest-session.behavior.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHmac } from "node:crypto";
+
+import { withEnv } from "./helpers/xp-test-helpers.mjs";
+import { handler as pokerGuestSessionHandler } from "../netlify/functions/poker-guest-session.mjs";
+import { verifyToken } from "../ws-server/poker/auth/verify-token.mjs";
+
+function base64urlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function makeGuestJwt({ secret, sub, tableId, nickname = "Guest1234", expOffsetSec = 3600 }) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub,
+    mode: "guest",
+    nickname,
+    tableId,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + expOffsetSec,
+  };
+  const encodedHeader = base64urlJson(header);
+  const encodedPayload = base64urlJson(payload);
+  const signature = createHmac("sha256", secret).update(`${encodedHeader}.${encodedPayload}`).digest("base64url");
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+function guestSessionEvent(method) {
+  return {
+    httpMethod: method,
+    headers: { origin: "https://arcade.test" },
+  };
+}
+
+test("guest session endpoint mints an expiring guest token that verifies", async () => {
+  await withEnv({
+    URL: "https://arcade.test",
+    WS_AUTH_TEST_SECRET: "guest-secret",
+  }, async () => {
+    const response = await pokerGuestSessionHandler(guestSessionEvent("POST"));
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.mode, "guest");
+    assert.equal(typeof body.token, "string");
+    assert.equal(typeof body.tableId, "string");
+    assert.ok(body.tableId.startsWith("guest_table_"));
+    assert.ok(body.nickname.startsWith("Guest"));
+
+    const verified = verifyToken({ token: body.token, env: { WS_AUTH_TEST_SECRET: "guest-secret" } });
+    assert.equal(verified.ok, true);
+    assert.equal(verified.identityMode, "guest");
+    assert.equal(verified.tableId, body.tableId);
+    assert.equal(verified.nickname, body.nickname);
+  });
+});
+
+test("expired guest token is rejected", () => {
+  const token = makeGuestJwt({
+    secret: "guest-secret",
+    sub: "guest_expired",
+    tableId: "guest_table_expired",
+    expOffsetSec: -60,
+  });
+
+  const result = verifyToken({ token, env: { WS_AUTH_TEST_SECRET: "guest-secret" } });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "auth_expired");
+});

--- a/ws-server/poker/auth/verify-token.mjs
+++ b/ws-server/poker/auth/verify-token.mjs
@@ -10,6 +10,10 @@ function base64UrlDecode(input) {
   return base64UrlToBuffer(input).toString("utf8");
 }
 
+function normalizeIdentityMode(value) {
+  return value === "guest" ? "guest" : "user";
+}
+
 function verifyHs256({ token, secret }) {
   const parts = token.split(".");
   if (parts.length !== 3) {
@@ -44,7 +48,18 @@ function verifyHs256({ token, secret }) {
     return { ok: false, code: "auth_invalid", message: "Token subject is required" };
   }
 
-  return { ok: true, userId: payload.sub };
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (payload.exp != null && Number.isFinite(Number(payload.exp)) && Number(payload.exp) <= nowSec) {
+    return { ok: false, code: "auth_expired", message: "Token is expired" };
+  }
+
+  return {
+    ok: true,
+    userId: payload.sub.trim(),
+    identityMode: normalizeIdentityMode(payload.mode),
+    nickname: typeof payload.nickname === "string" && payload.nickname.trim() ? payload.nickname.trim().slice(0, 40) : null,
+    tableId: typeof payload.tableId === "string" && payload.tableId.trim() ? payload.tableId.trim() : null
+  };
 }
 
 export function verifyToken({ token, env = process.env }) {

--- a/ws-server/poker/handlers/auth.mjs
+++ b/ws-server/poker/handlers/auth.mjs
@@ -16,6 +16,8 @@ export function handleAuth({ frame, connState, nowTs, verifyToken }) {
   const bound = bindSessionUser({
     session: connState.session,
     userId: verification.userId,
+    identityMode: verification.identityMode || "user",
+    nickname: verification.nickname || null,
     nowTs
   });
 
@@ -24,6 +26,9 @@ export function handleAuth({ frame, connState, nowTs, verifyToken }) {
   }
 
   connState.userId = connState.session.userId;
+  connState.identityMode = connState.session.identityMode || "user";
+  connState.nickname = connState.session.nickname || null;
+  connState.guestTableId = verification.tableId || null;
 
   const response = {
     version: PROTOCOL_VERSION,
@@ -32,7 +37,9 @@ export function handleAuth({ frame, connState, nowTs, verifyToken }) {
     sessionId: connState.sessionId,
     payload: {
       sessionId: connState.sessionId,
-      userId: connState.session.userId
+      userId: connState.session.userId,
+      mode: connState.identityMode,
+      nickname: connState.nickname
     }
   };
 

--- a/ws-server/poker/reconnect/resync.behavior.test.mjs
+++ b/ws-server/poker/reconnect/resync.behavior.test.mjs
@@ -1381,7 +1381,7 @@ test("recoverable persistence conflict does not force resync and explicit resync
     await fs.writeFile(filePath, `${JSON.stringify(forcedRaw)}\n`, "utf8");
 
     sendFrame(ws, { version: "1.0", type: "act", requestId: "act-conflict-resync", ts: "2026-02-28T03:00:02Z", payload: { tableId, handId, action: "fold" } });
-    const rejected = await nextMessageForRequest(ws, "commandResult", "act-conflict-resync", { skipTypes: ["stateSnapshot", "statePatch"] });
+    const rejected = await nextMessageForRequest(ws, "commandResult", "act-conflict-resync", { skipTypes: ["stateSnapshot", "statePatch"], timeoutMs: 10000 });
     assert.equal(rejected.payload.status, "rejected");
     const maybeImmediateRecovery = await attemptMessage(ws, 400);
     assert.notEqual(maybeImmediateRecovery?.type, "resync");

--- a/ws-server/poker/runtime/session.mjs
+++ b/ws-server/poker/runtime/session.mjs
@@ -11,11 +11,17 @@ function ensureTableReplay(session, tableId) {
   return session.replayByTableId.get(tableId);
 }
 
+function normalizeIdentityMode(value) {
+  return value === "guest" ? "guest" : "user";
+}
+
 export function createSession({ sessionId, nowTs, replayWindowSize = DEFAULT_REPLAY_WINDOW_SIZE }) {
   const ts = nowIso(nowTs);
   return {
     sessionId,
     userId: null,
+    identityMode: null,
+    nickname: null,
     authedAt: null,
     lastSeenAt: ts,
     latestDeliveredSeq: 0,
@@ -31,17 +37,21 @@ export function touchSession(session, nowTs) {
   return session;
 }
 
-export function bindSessionUser({ session, userId, nowTs }) {
+export function bindSessionUser({ session, userId, identityMode = "user", nickname = null, nowTs }) {
   const ts = nowIso(nowTs);
+  const nextIdentityMode = normalizeIdentityMode(identityMode);
+  const nextNickname = typeof nickname === "string" && nickname.trim() ? nickname.trim().slice(0, 40) : null;
 
   if (session.userId === null) {
     session.userId = userId;
+    session.identityMode = nextIdentityMode;
+    session.nickname = nextNickname;
     session.authedAt = ts;
     session.lastSeenAt = ts;
     return { ok: true, changed: true };
   }
 
-  if (session.userId !== userId) {
+  if (session.userId !== userId || normalizeIdentityMode(session.identityMode) !== nextIdentityMode) {
     return {
       ok: false,
       code: "auth_session_locked",
@@ -49,6 +59,7 @@ export function bindSessionUser({ session, userId, nowTs }) {
     };
   }
 
+  session.nickname = nextNickname || session.nickname || null;
   session.lastSeenAt = ts;
   return { ok: true, changed: false };
 }
@@ -97,7 +108,6 @@ export function resolveReplay({ session, tableId, lastSeq }) {
     frames
   };
 }
-
 
 export function ackSessionSeq({ session, tableId, seq }) {
   const latestDelivered = session.latestDeliveredSeqByTableId.get(tableId) ?? 0;

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -397,6 +397,61 @@ export function createTableManager({
     return { ok: true, existed, table };
   }
 
+
+  function materializeGuestTable({ tableId, guestUserId, nickname = null, maxPlayers = 6, botCount = 3, stack = 100, nowMs = Date.now() } = {}) {
+    const normalizedTableId = typeof tableId === "string" ? tableId.trim() : "";
+    const normalizedGuestUserId = typeof guestUserId === "string" ? guestUserId.trim() : "";
+    if (!normalizedTableId || !normalizedGuestUserId) {
+      return { ok: false, code: "invalid_guest_table" };
+    }
+    const resolvedMaxPlayers = Number.isInteger(maxPlayers) && maxPlayers >= 2 && maxPlayers <= maxSeats ? maxPlayers : Math.min(6, maxSeats);
+    const resolvedBotCount = Math.max(1, Math.min(resolvedMaxPlayers - 1, Number.isInteger(botCount) ? botCount : 3));
+    const resolvedStack = Number.isFinite(Number(stack)) && Number(stack) > 0 ? Math.trunc(Number(stack)) : 100;
+    const existed = tables.has(normalizedTableId);
+    const table = ensureTable(normalizedTableId);
+    if (existed && Array.isArray(table.coreState?.members) && table.coreState.members.some((member) => member?.userId === normalizedGuestUserId)) {
+      touchTableActivity(table, nowMs);
+      return { ok: true, existed: true, table };
+    }
+    const members = [{ userId: normalizedGuestUserId, seat: 1 }];
+    const seats = { [normalizedGuestUserId]: 1 };
+    const seatDetailsByUserId = {
+      [normalizedGuestUserId]: { isBot: false, botProfile: null, leaveAfterHand: false, nickname }
+    };
+    const publicStacks = { [normalizedGuestUserId]: resolvedStack };
+    for (let idx = 0; idx < resolvedBotCount; idx += 1) {
+      const seatNo = idx + 2;
+      const botUserId = `bot_guest_${seatNo}_${normalizedTableId}`.slice(0, 120);
+      members.push({ userId: botUserId, seat: seatNo });
+      seats[botUserId] = seatNo;
+      seatDetailsByUserId[botUserId] = {
+        isBot: true,
+        botProfile: idx % 3 === 0 ? "NORMAL" : idx % 3 === 1 ? "TIGHT" : "LOOSE",
+        leaveAfterHand: false
+      };
+      publicStacks[botUserId] = resolvedStack;
+    }
+    table.tableStatus = "OPEN";
+    table.tableMeta = normalizeTableMeta({ maxPlayers: resolvedMaxPlayers, stakes: { sb: 1, bb: 2 }, createdAtMs: nowMs, lastActivityAtMs: nowMs }, resolvedMaxPlayers, {
+      defaultCreatedAtMs: nowMs,
+      defaultLastActivityAtMs: nowMs
+    });
+    table.coreState = {
+      ...table.coreState,
+      roomId: normalizedTableId,
+      maxSeats: resolvedMaxPlayers,
+      version: existed ? Number(table.coreState.version || 0) : 0,
+      members,
+      seats,
+      seatDetailsByUserId,
+      publicStacks,
+      pokerState: buildEmptyLobbyPokerState(normalizedTableId)
+    };
+    table.pendingPersistedBootstrap = false;
+    touchTableActivity(table, nowMs);
+    return { ok: true, existed, table };
+  }
+
   async function ensureTableLoaded(tableId, { allowCreate = false } = {}) {
     const existingTable = tables.get(tableId);
     if (existingTable && !needsPersistedBootstrap(existingTable)) {
@@ -1691,6 +1746,7 @@ export function createTableManager({
     listTableIds,
     tableMeta,
     materializeLobbyTable,
+    materializeGuestTable,
     resolveImplicitLeaveTableId,
     sweepExpiredPresence,
     persistedPokerState,

--- a/ws-server/server.guest-mode.behavior.test.mjs
+++ b/ws-server/server.guest-mode.behavior.test.mjs
@@ -1,0 +1,598 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+import WebSocket from "ws";
+
+const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
+  "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
+  import.meta.url
+).href;
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const address = srv.address();
+      const port = address && typeof address === "object" ? address.port : null;
+      srv.close((err) => {
+        if (err) return reject(err);
+        if (!port) return reject(new Error("Port allocation failed"));
+        resolve(port);
+      });
+    });
+    srv.on("error", reject);
+  });
+}
+
+function waitForListening(proc, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    const cleanup = () => {
+      clearTimeout(timer);
+      proc.stdout.off("data", onStdout);
+      proc.stderr.off("data", onStderr);
+      proc.off("exit", onExit);
+    };
+    const onStdout = (buf) => {
+      const text = String(buf);
+      stdoutChunks.push(text);
+      if (text.includes("WS listening on")) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onStderr = (buf) => {
+      stderrChunks.push(String(buf));
+    };
+    const summarize = (chunks) => {
+      const joined = chunks.join("");
+      return joined ? joined.slice(-4000) : "<empty>";
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Server did not start in time. stdout: ${summarize(stdoutChunks)} stderr: ${summarize(stderrChunks)}`));
+    }, timeoutMs);
+    const onExit = (code, signal) => {
+      cleanup();
+      reject(new Error(`Server exited before ready: code=${code} signal=${signal || "none"}. stdout: ${summarize(stdoutChunks)} stderr: ${summarize(stderrChunks)}`));
+    };
+    proc.stdout.on("data", onStdout);
+    proc.stderr.on("data", onStderr);
+    proc.once("exit", onExit);
+  });
+}
+
+function waitForExit(proc) {
+  if (proc.exitCode !== null) return Promise.resolve();
+  return new Promise((resolve) => proc.once("exit", resolve));
+}
+
+function createServer({ env = {} } = {}) {
+  return getFreePort().then((port) => {
+    const child = spawn(process.execPath, ["ws-server/server.mjs"], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        WS_BOT_REACTION_MIN_MS: "0",
+        WS_BOT_REACTION_MAX_MS: "0",
+        WS_ACCEPTED_BOT_AUTOPLAY_ADAPTER_MODULE_PATH: FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { port, child };
+  });
+}
+
+function connectClient(port) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextMessage(ws, timeoutMs = 10000) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    const onMessage = (data) => {
+      cleanup();
+      resolve(JSON.parse(String(data)));
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before message: ${code}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for websocket message"));
+    }, timeoutMs);
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
+}
+
+function nextMessageMatching(ws, predicate, timeoutMs = 10000) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    const onMessage = (data) => {
+      const frame = JSON.parse(String(data));
+      if (!predicate(frame)) return;
+      cleanup();
+      resolve(frame);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before matching message: ${code}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for matching websocket message"));
+    }, timeoutMs);
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
+}
+
+function nextMessageOfType(ws, type, timeoutMs = 10000) {
+  return nextMessageMatching(ws, (frame) => frame?.type === type, timeoutMs);
+}
+
+function nextCommandResultForRequest(ws, requestId, timeoutMs = 10000) {
+  return nextMessageMatching(
+    ws,
+    (frame) => frame?.type === "commandResult" && frame?.payload?.requestId === requestId,
+    timeoutMs
+  );
+}
+
+function sendFrame(ws, frame) {
+  ws.send(JSON.stringify(frame));
+}
+
+function base64urlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function makeJwt({ secret, sub, expOffsetSec = 3600, mode = "user", nickname = null, tableId = null }) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + expOffsetSec,
+  };
+  if (mode) payload.mode = mode;
+  if (nickname) payload.nickname = nickname;
+  if (tableId) payload.tableId = tableId;
+  const encodedHeader = base64urlJson(header);
+  const encodedPayload = base64urlJson(payload);
+  const signature = createHmac("sha256", secret).update(`${encodedHeader}.${encodedPayload}`).digest("base64url");
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+function makeGuestJwt({ secret, sub, tableId, nickname, expOffsetSec = 3600 }) {
+  return makeJwt({
+    secret,
+    sub,
+    mode: "guest",
+    nickname,
+    tableId,
+    expOffsetSec,
+  });
+}
+
+async function writePersistedFile(fixture) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ws-persist-"));
+  const filePath = path.join(dir, "persisted-state.json");
+  await fs.writeFile(filePath, `${JSON.stringify(fixture)}\n`, "utf8");
+  return { dir, filePath };
+}
+
+async function readPersistedFile(filePath) {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function hello(ws) {
+  sendFrame(ws, {
+    version: "1.0",
+    type: "hello",
+    requestId: "req-hello",
+    ts: "2026-02-28T00:00:00Z",
+    payload: { supportedVersions: ["1.0"] },
+  });
+  return nextMessage(ws);
+}
+
+async function auth(ws, token, requestId = "req-auth") {
+  sendFrame(ws, {
+    version: "1.0",
+    type: "auth",
+    requestId,
+    ts: "2026-02-28T00:00:01Z",
+    payload: { token },
+  });
+  return nextMessage(ws);
+}
+
+function tableJoinFrame(tableId, requestId) {
+  return {
+    version: "1.0",
+    type: "table_join",
+    requestId,
+    ts: "2026-02-28T00:00:02Z",
+    payload: { tableId },
+  };
+}
+
+async function joinTable(ws, tableId, requestId) {
+  sendFrame(ws, tableJoinFrame(tableId, requestId));
+  const ack = await nextCommandResultForRequest(ws, requestId);
+  const tableState = await nextMessageOfType(ws, "table_state");
+  return { ack, tableState };
+}
+
+test("guest can auth and join only its token-bound guest_table_*", async () => {
+  const secret = "guest-bound-secret";
+  const guestUserId = "guest_user_1";
+  const boundTableId = "guest_table_bound_1";
+  const otherTableId = "guest_table_other_1";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    const authOk = await auth(
+      ws,
+      makeGuestJwt({ secret, sub: guestUserId, tableId: boundTableId, nickname: "Guest2468" }),
+      "auth-guest-bound"
+    );
+    assert.equal(authOk.type, "authOk");
+    assert.equal(authOk.payload.mode, "guest");
+    assert.equal(authOk.payload.nickname, "Guest2468");
+
+    const accepted = await joinTable(ws, boundTableId, "join-guest-bound");
+    assert.equal(accepted.ack.payload.status, "accepted");
+    assert.equal(accepted.tableState.roomId, boundTableId);
+
+    sendFrame(ws, tableJoinFrame(otherTableId, "join-guest-other"));
+    const rejected = await nextCommandResultForRequest(ws, "join-guest-other");
+    assert.equal(rejected.payload.status, "rejected");
+    assert.equal(rejected.payload.reason, "guest_multiplayer_requires_account");
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("guest cannot join normal table", async () => {
+  const secret = "guest-normal-table-secret";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(
+      ws,
+      makeGuestJwt({ secret, sub: "guest_user_2", tableId: "guest_table_normal_gate", nickname: "Guest9021" }),
+      "auth-guest-normal"
+    );
+
+    sendFrame(ws, tableJoinFrame("table_normal_gate", "join-normal-gate"));
+    const rejected = await nextCommandResultForRequest(ws, "join-normal-gate");
+    assert.equal(rejected.payload.status, "rejected");
+    assert.equal(rejected.payload.reason, "guest_multiplayer_requires_account");
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("normal user cannot join guest_table_*", async () => {
+  const secret = "normal-guest-table-secret";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeJwt({ secret, sub: "user_1" }), "auth-normal-user");
+
+    sendFrame(ws, tableJoinFrame("guest_table_reserved", "join-guest-table-as-user"));
+    const rejected = await nextCommandResultForRequest(ws, "join-guest-table-as-user");
+    assert.equal(rejected.payload.status, "rejected");
+    assert.equal(rejected.payload.reason, "guest_table_requires_guest_session");
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("guest table is not included in lobby snapshot", async () => {
+  const secret = "guest-lobby-secret";
+  const guestTableId = "guest_table_lobby_hidden";
+  const normalTableId = "table_lobby_visible";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+
+  try {
+    await waitForListening(child, 5000);
+
+    const normalWs = await connectClient(port);
+    await hello(normalWs);
+    await auth(normalWs, makeJwt({ secret, sub: "normal_lobby_user" }), "auth-normal-lobby");
+    const normalJoin = await joinTable(normalWs, normalTableId, "join-normal-visible");
+    assert.equal(normalJoin.ack.payload.status, "accepted");
+
+    const guestWs = await connectClient(port);
+    await hello(guestWs);
+    await auth(
+      guestWs,
+      makeGuestJwt({ secret, sub: "guest_lobby_user", tableId: guestTableId, nickname: "Guest7777" }),
+      "auth-guest-lobby"
+    );
+    const guestJoin = await joinTable(guestWs, guestTableId, "join-guest-hidden");
+    assert.equal(guestJoin.ack.payload.status, "accepted");
+
+    const lobbyWs = await connectClient(port);
+    await hello(lobbyWs);
+    await auth(lobbyWs, makeJwt({ secret, sub: "lobby_viewer" }), "auth-lobby-viewer");
+    sendFrame(lobbyWs, {
+      version: "1.0",
+      type: "lobby_subscribe",
+      requestId: "lobby-snapshot",
+      ts: "2026-02-28T00:00:03Z",
+      payload: {},
+    });
+    const snapshot = await nextMessageOfType(lobbyWs, "lobby_snapshot");
+    assert.equal(snapshot.payload.tables.some((table) => table.tableId === normalTableId), true);
+    assert.equal(snapshot.payload.tables.some((table) => table.tableId === guestTableId), false);
+
+    normalWs.close();
+    guestWs.close();
+    lobbyWs.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("guest table mutations skip persistence and ledger", async () => {
+  const secret = "guest-persistence-secret";
+  const guestTableId = "guest_table_no_persist";
+  const guestUserId = "guest_user_ledger";
+  const { dir, filePath } = await writePersistedFile({});
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+    },
+  });
+  const serverLogs = [];
+
+  try {
+    await waitForListening(child, 5000);
+    child.stdout.on("data", (buf) => {
+      serverLogs.push(String(buf));
+    });
+
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(
+      ws,
+      makeGuestJwt({ secret, sub: guestUserId, tableId: guestTableId, nickname: "Guest4501" }),
+      "auth-guest-persist"
+    );
+    const joined = await joinTable(ws, guestTableId, "join-guest-persist");
+    assert.equal(joined.ack.payload.status, "accepted");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "guest-persist-snapshot",
+      ts: "2026-02-28T00:00:04Z",
+      payload: { tableId: guestTableId, view: "snapshot" },
+    });
+    const snapshot = await nextMessageOfType(ws, "stateSnapshot");
+    const legalActions = Array.isArray(snapshot.payload?.public?.legalActions?.actions)
+      ? snapshot.payload.public.legalActions.actions
+      : [];
+    const handId = snapshot.payload?.public?.hand?.handId;
+    const action = legalActions.includes("CALL") ? "CALL" : legalActions.includes("CHECK") ? "CHECK" : legalActions[0] || "FOLD";
+
+    serverLogs.length = 0;
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "act",
+      requestId: "guest-act",
+      ts: "2026-02-28T00:00:05Z",
+      payload: { tableId: guestTableId, handId, action },
+    });
+    const actAck = await nextCommandResultForRequest(ws, "guest-act");
+    assert.equal(actAck.payload.status, "accepted");
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const persisted = await readPersistedFile(filePath);
+    assert.deepEqual(persisted, {});
+    assert.equal(serverLogs.some((line) => line.includes("ws_state_persist_start")), false);
+    assert.equal(serverLogs.some((line) => line.includes("poker_ledger")), false);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("guest can play at least one action and bot autoplay continues", async () => {
+  const secret = "guest-autoplay-secret";
+  const guestTableId = "guest_table_autoplay";
+  const guestUserId = "guest_user_autoplay";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+  const serverLogs = [];
+
+  try {
+    await waitForListening(child, 5000);
+    child.stdout.on("data", (buf) => {
+      const text = String(buf);
+      if (text.includes("ws_bot_autoplay")) {
+        serverLogs.push(text.trim());
+      }
+    });
+
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(
+      ws,
+      makeGuestJwt({ secret, sub: guestUserId, tableId: guestTableId, nickname: "Guest6123" }),
+      "auth-guest-autoplay"
+    );
+    const joined = await joinTable(ws, guestTableId, "join-guest-autoplay");
+    assert.equal(joined.ack.payload.status, "accepted");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "guest-autoplay-snapshot",
+      ts: "2026-02-28T00:00:06Z",
+      payload: { tableId: guestTableId, view: "snapshot" },
+    });
+    const snapshot = await nextMessageOfType(ws, "stateSnapshot");
+    const legalActions = Array.isArray(snapshot.payload?.public?.legalActions?.actions)
+      ? snapshot.payload.public.legalActions.actions
+      : [];
+    const handId = snapshot.payload?.public?.hand?.handId;
+    const action = legalActions.includes("CALL") ? "CALL" : legalActions.includes("CHECK") ? "CHECK" : legalActions[0] || "FOLD";
+
+    serverLogs.length = 0;
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "act",
+      requestId: "guest-autoplay-act",
+      ts: "2026-02-28T00:00:07Z",
+      payload: { tableId: guestTableId, handId, action },
+    });
+    const actAck = await nextCommandResultForRequest(ws, "guest-autoplay-act");
+    assert.equal(actAck.payload.status, "accepted");
+
+    const nextState = await nextMessageMatching(
+      ws,
+      (frame) =>
+        (frame?.type === "stateSnapshot" || frame?.type === "statePatch") &&
+        frame?.payload?.public?.turn?.userId != null &&
+        frame.payload.public.turn.userId !== guestUserId,
+      15000
+    );
+    assert.equal(nextState.payload.public.turn.userId !== guestUserId, true);
+    assert.equal(serverLogs.some((line) => line.includes("ws_bot_autoplay")), true);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("authenticated poker flow still works", async () => {
+  const secret = "auth-flow-secret";
+  const normalTableId = "table_auth_flow";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    const authOk = await auth(ws, makeJwt({ secret, sub: "user_auth_flow" }), "auth-flow");
+    assert.equal(authOk.type, "authOk");
+    assert.equal(authOk.payload.userId, "user_auth_flow");
+
+    const joined = await joinTable(ws, normalTableId, "join-auth-flow");
+    assert.equal(joined.ack.payload.status, "accepted");
+    assert.equal(joined.tableState.roomId, normalTableId);
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "auth-flow-snapshot",
+      ts: "2026-02-28T00:00:08Z",
+      payload: { tableId: normalTableId, view: "snapshot" },
+    });
+    const snapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(snapshot.type, "stateSnapshot");
+    assert.equal(snapshot.payload?.public != null, true);
+    assert.equal(snapshot.payload?.public?.turn != null, true);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -408,6 +408,7 @@ function tableSocketMatches(socket, tableId) {
 }
 
 async function touchPersistedSeatLastSeen({ tableId, userId }) {
+  if (isGuestTableId(tableId)) return false;
   if (!persistedBootstrapEnabled) return false;
   if (typeof tableId !== "string" || !tableId || typeof userId !== "string" || !userId) return false;
   const key = staleSeatCandidateKey(tableId, userId);
@@ -692,6 +693,14 @@ function normalizeTableId(value) {
   return tableId;
 }
 
+function isGuestTableId(tableId) {
+  return typeof tableId === "string" && tableId.startsWith("guest_table_");
+}
+
+function isGuestSession(connState) {
+  return connState?.session?.identityMode === "guest" || connState?.identityMode === "guest";
+}
+
 function resolveRoomId(frame, { allowMissing = false } = {}) {
   const envelopeRoomIdProvided = frame.roomId !== undefined;
   const payloadTableIdProvided = frame.payload.tableId !== undefined;
@@ -795,6 +804,7 @@ function isLobbyTableJoinable({ seats, maxPlayers, lastActivityAtMs }) {
 }
 
 function buildLobbyTableEntry(tableId) {
+  if (isGuestTableId(tableId)) return null;
   if (tableManager.isTableClosed(tableId) === true) {
     return null;
   }
@@ -1112,6 +1122,9 @@ function broadcastTableState(tableId, { excludeWs = null } = {}) {
 
 
 async function persistMutatedState({ tableId, expectedVersion, mutationKind, acceptedActionAudit = null }) {
+  if (isGuestTableId(tableId)) {
+    return { ok: true, skipped: true, guest: true };
+  }
   if (!persistedStateWriter) {
     return { ok: true, skipped: true };
   }
@@ -2454,6 +2467,83 @@ wss.on("connection", (ws) => {
         return;
       }
       frame.__resolvedTableId = resolvedRoomId.roomId;
+
+      if (isGuestSession(connState)) {
+        if (!isGuestTableId(frame.__resolvedTableId) || (connState.guestTableId && connState.guestTableId !== frame.__resolvedTableId)) {
+          sendCommandResult(ws, connState, {
+            requestId: frame.requestId ?? null,
+            tableId: frame.__resolvedTableId,
+            status: "rejected",
+            reason: "guest_multiplayer_requires_account"
+          });
+          return;
+        }
+        const materializedGuest = tableManager.materializeGuestTable({
+          tableId: frame.__resolvedTableId,
+          guestUserId: connState.session.userId,
+          nickname: connState.session.nickname || connState.nickname || null,
+          nowMs: Date.now()
+        });
+        if (!materializedGuest?.ok) {
+          sendCommandResult(ws, connState, {
+            requestId: frame.requestId ?? null,
+            tableId: frame.__resolvedTableId,
+            status: "rejected",
+            reason: materializedGuest?.code || "guest_table_failed"
+          });
+          return;
+        }
+        sessionStore.trackConnection({ ws, userId: connState.session.userId, sessionId: connState.session.sessionId });
+        const joined = tableManager.join({
+          ws,
+          userId: connState.session.userId,
+          tableId: frame.__resolvedTableId,
+          requestId: frame.requestId,
+          nowTs: Date.now(),
+          authoritativeSeatNo: 1,
+          buyIn: 100
+        });
+        if (!joined.ok) {
+          sendCommandResult(ws, connState, {
+            requestId: frame.requestId ?? null,
+            tableId: frame.__resolvedTableId,
+            status: "rejected",
+            reason: joined.code || "join_failed"
+          });
+          return;
+        }
+        const bootstrapped = tableManager.bootstrapHand(frame.__resolvedTableId, { nowMs: Date.now() });
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId: frame.__resolvedTableId,
+          status: "accepted",
+          reason: joined.changed ? null : "already_joined"
+        });
+        const tableSnapshot = tableManager.tableSnapshot(frame.__resolvedTableId, connState.session.userId);
+        sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: joined.tableState, tableSnapshot });
+        if (joined.changed || bootstrapped?.changed) {
+          broadcastStateSnapshots(frame.__resolvedTableId);
+          broadcastTableState(frame.__resolvedTableId, { excludeWs: ws });
+          scheduleBotStep({
+            tableId: frame.__resolvedTableId,
+            trigger: "guest_join_bootstrap",
+            requestId: frame.requestId ?? null,
+            frameTs: frame.ts
+          });
+        }
+        return;
+      }
+
+      if (isGuestTableId(frame.__resolvedTableId)) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId: frame.__resolvedTableId,
+          status: "rejected",
+          reason: "guest_table_requires_guest_session"
+        });
+        return;
+      }
+
       await enqueueTableCommand({
         tableId: frame.__resolvedTableId,
         commandName: "join",
@@ -2706,6 +2796,23 @@ wss.on("connection", (ws) => {
         return;
       }
       const tableId = resolvedRoomId.roomId;
+
+      if (isGuestSession(connState)) {
+        if (!isGuestTableId(tableId) || (connState.guestTableId && connState.guestTableId !== tableId)) {
+          sendError(ws, connState, {
+            code: "INVALID_COMMAND",
+            message: "guest_multiplayer_requires_account",
+            requestId: frame.requestId ?? null
+          });
+          return;
+        }
+        tableManager.materializeGuestTable({
+          tableId,
+          guestUserId: connState.session.userId,
+          nickname: connState.session.nickname || connState.nickname || null,
+          nowMs: Date.now()
+        });
+      }
 
       const wantsSnapshot = frame.payload?.view === "snapshot" || frame.payload?.mode === "snapshot";
       if (wantsSnapshot) {


### PR DESCRIPTION
## Summary

Implements PR1 for Poker Guest Mode foundation:

- adds a `poker-guest-session` Netlify function that mints short-lived anonymous Guest tokens with `Guest####` nicknames and dedicated `guest_table_*` table IDs
- extends WS auth/session metadata with `mode`, nickname, and token-bound Guest table handling
- materializes in-memory Guest poker tables with bots, blocks Guest access to multiplayer tables, hides Guest tables from the lobby, and skips persistence for Guest table state
- adds signed-out lobby UI for `Play as Guest` and a table-side Guest badge while preserving the existing authenticated flow

## Validation

- `rtk node --check netlify/functions/poker-guest-session.mjs`
- `rtk node --check ws-server/poker/auth/verify-token.mjs`
- `rtk node --check ws-server/poker/handlers/auth.mjs`
- `rtk node --check ws-server/poker/runtime/session.mjs`
- `rtk node --check ws-server/poker/table/table-manager.mjs`
- `rtk node --check ws-server/server.mjs`
- `rtk node --check poker/poker-ws-client.js`
- `rtk node --check poker/poker.js`
- `rtk node --check poker/poker-v2.js`
- `rtk node ws-server/poker/auth/verify-token.behavior.test.mjs`

## Breaking impact

None expected. Authenticated Poker mint/auth/join paths remain in place; Guest behavior is gated by Guest token metadata and `guest_table_` table IDs.