### PR TITLE
[codex] Guest poker PR2

### DIFF
--- a/docs/poker-guest-mode-pr2-implementation-plan.md
+++ b/docs/poker-guest-mode-pr2-implementation-plan.md
@@ -1,0 +1,29 @@
+# Poker Guest Mode PR2 Implementation Plan
+
+## Goal
+Make guest poker feel explicit and bounded: guests can play, but they clearly see that the session is temporary and isolated from Arcade economy features.
+
+## Scope for PR2
+- Show a persistent guest limitations panel on the poker table.
+- Hide the XP badge while guest mode is active.
+- Keep the guest badge visible so the session state is obvious.
+- Preserve authenticated poker flow unchanged.
+- Add focused tests for the guest UI state and guest session flow.
+
+## Implementation Steps
+1. Add guest restrictions markup to `poker/table-v2.html`.
+2. Style the guest panel in `poker/poker-v2.css`.
+3. Toggle guest-specific UI state in `poker/poker-v2.js`.
+4. Extend the poker v2 behavior harness to cover guest mode.
+5. Add a static HTML/CSS contract check for the new panel.
+
+## Validation
+- Guest mode still auto-joins the token-bound guest table.
+- XP badge is hidden in guest mode.
+- Guest restrictions panel is visible in guest mode.
+- Authenticated poker behavior remains unchanged.
+
+## Notes
+- This PR does not change the backend guest-session contract.
+- This PR does not introduce a new economy path for guest chips.
+- Breaking impact expected: none.

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -164,6 +164,22 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-live-btn--accent{background:linear-gradient(180deg, #2f79df, #1c4497);}
 
+.poker-guest-panel{margin-top:12px; padding:14px 14px 12px; border-radius:18px; border:1px solid rgba(255,223,180,0.2); background:rgba(8,13,22,0.72);}
+
+.poker-guest-panel[hidden]{display:none;}
+
+.poker-guest-panel__title{font-size:0.9rem; font-weight:700; letter-spacing:0.01em; color:#f8efd6;}
+
+.poker-guest-panel__list{margin:10px 0 0; padding:0; list-style:none; display:grid; gap:6px;}
+
+.poker-guest-panel__item{display:flex; gap:8px; align-items:flex-start; font-size:0.86rem; line-height:1.35; color:#d6e1f5;}
+
+.poker-guest-panel__item::before{flex:0 0 auto; font-weight:800;}
+
+.poker-guest-panel__item--allowed::before{content:"✓"; color:#8df8bf;}
+
+.poker-guest-panel__item--blocked::before{content:"✕"; color:#ffb5b5;}
+
 .poker-live-input{display:flex; flex-direction:column; gap:5px; font-size:0.72rem; font-weight:600; letter-spacing:0.03em; text-transform:uppercase; color:#b9c6dc;}
 
 .poker-live-input input{width:102px; min-height:42px; padding:0 12px; border-radius:14px; border:1px solid rgba(255,223,180,0.22); background:rgba(6,10,18,0.88); color:#f7f9fe; font-size:0.98rem; font-weight:700;}

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1954,6 +1954,8 @@
         els.turnText.textContent = 'Waiting for action';
       }
     }
+    if (els.xpBadge) els.xpBadge.hidden = !!isGuestMode;
+    if (els.guestPanel) els.guestPanel.hidden = !isGuestMode;
   }
 
   function resolvePrimaryAction(allowed){
@@ -2544,6 +2546,7 @@
     els.screen = document.getElementById('pokerTableScreen');
     if (typeof document.querySelector === 'function') els.scene = document.querySelector('.poker-scene');
     if (!els.scene) els.scene = els.screen;
+    els.xpBadge = document.getElementById('xpBadge');
     els.bootSplash = document.getElementById('pokerBootSplash');
     els.menuToggle = document.getElementById('pokerMenuToggle');
     els.menuPanel = document.getElementById('pokerMenuPanel');
@@ -2561,6 +2564,7 @@
     els.turnText = document.getElementById('pokerV2TurnText');
     els.stackText = document.getElementById('pokerV2StackText');
     els.errorText = document.getElementById('pokerV2ErrorText');
+    els.guestPanel = document.getElementById('pokerV2GuestPanel');
     els.signInBtn = document.getElementById('pokerV2SignInBtn');
     els.guestBadge = document.getElementById('pokerV2GuestBadge');
     els.joinBtn = document.getElementById('pokerV2JoinBtn');

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -56,6 +56,18 @@
         <input type="hidden" id="pokerV2SeatNo" value="1">
         <input type="hidden" id="pokerV2BuyIn" value="100">
       </div>
+      <section class="poker-guest-panel" id="pokerV2GuestPanel" hidden aria-labelledby="pokerV2GuestPanelTitle">
+        <div class="poker-guest-panel__title" id="pokerV2GuestPanelTitle">Guest account</div>
+        <ul class="poker-guest-panel__list">
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Play Poker</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Learn the game</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No saved chips</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No XP</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No achievements</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No rankings</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">Multiplayer requires account</li>
+        </ul>
+      </section>
       <div class="poker-live-error" id="pokerV2ErrorText" hidden></div>
     </section>
 

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -103,10 +103,11 @@ function createHarness(options = {}){
   const source = fs.readFileSync(path.join(process.cwd(), 'poker', 'poker-v2.js'), 'utf8');
   const elements = {};
   [
+    'xpBadge',
     'pokerMenuToggle', 'pokerMenuPanel', 'pokerLobbyLink',
     'pokerSeatLayer', 'pokerSeatChipLayer', 'pokerChipFxLayer', 'pokerPotPill', 'pokerPotChipStack', 'pokerCommunityCards', 'pokerDealerChip',
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
-    'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2SignInBtn', 'pokerV2SeatNo',
+    'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
@@ -120,6 +121,7 @@ function createHarness(options = {}){
     elements[id] = makeElement(id);
   });
   elements.pokerLobbyLink.href = '/poker/';
+  elements.xpBadge.href = '/xp.html';
   elements.pokerV2SeatNo.value = '1';
   elements.pokerV2BuyIn.value = '100';
   elements.pokerV2AmountInput.value = '20';
@@ -175,6 +177,7 @@ function createHarness(options = {}){
 
   const intervalTimers = [];
   const timeoutTimers = [];
+  const sessionStorageEntries = new Map();
   let nextTimeoutId = 1;
   let nowMs = Number.isFinite(options.nowMs) ? options.nowMs : 1_700_000_000_000;
   const FakeDate = class extends Date {
@@ -217,6 +220,12 @@ function createHarness(options = {}){
         return timer.id;
       }
     },
+    sessionStorage: {
+      getItem(key){ return sessionStorageEntries.has(String(key)) ? sessionStorageEntries.get(String(key)) : null; },
+      setItem(key, value){ sessionStorageEntries.set(String(key), String(value)); },
+      removeItem(key){ sessionStorageEntries.delete(String(key)); },
+      clear(){ sessionStorageEntries.clear(); }
+    },
     document: {
       readyState: 'loading',
       addEventListener(type, fn){ documentEvents[type] = documentEvents[type] || []; documentEvents[type].push(fn); },
@@ -231,6 +240,11 @@ function createHarness(options = {}){
     console
   };
   sandbox.window.document = sandbox.document;
+  sandbox.window.sessionStorage = sandbox.sessionStorage;
+
+  if (options.guestSession) {
+    sandbox.sessionStorage.setItem('poker:guestSession', JSON.stringify(options.guestSession));
+  }
 
   vm.createContext(sandbox);
   vm.runInContext(source, sandbox, { filename: 'poker/poker-v2.js' });
@@ -388,6 +402,33 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   assert.equal(harness.leavePayloads.length, 1);
   assert.equal(JSON.stringify(harness.leavePayloads[0]), JSON.stringify({ tableId: 'table-1' }));
   assert.equal(harness.windowLocation.href, '/poker/');
+});
+
+test('poker v2 guest mode shows restrictions panel, hides XP badge, and still auto-joins', async () => {
+  const guestPayload = Buffer.from(JSON.stringify({ sub: 'guest_user_1' })).toString('base64url');
+  const guestToken = `aaa.${guestPayload}.zzz`;
+  const harness = createHarness({
+    search: '?tableId=guest_table_1&guest=1&autoJoin=1',
+    guestSession: {
+      token: guestToken,
+      tableId: 'guest_table_1',
+      guestId: 'guest_user_1',
+      nickname: 'Guest1234',
+      expiresAt: Date.now() + 3_600_000
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  assert.ok(ws, 'guest mode should still bootstrap a WS client');
+  assert.equal(ws.guestToken, guestToken);
+  assert.equal(harness.elements.xpBadge.hidden, true, 'guest mode should hide the XP badge');
+  assert.equal(harness.elements.pokerV2GuestBadge.hidden, false, 'guest mode should show the guest badge');
+  assert.equal(harness.elements.pokerV2GuestPanel.hidden, false, 'guest mode should show the restrictions panel');
+
+  await waitFor(() => harness.joinPayloads.length === 1);
+  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'guest_table_1', buyIn: 100, autoSeat: true, preferredSeatNo: 1 }));
 });
 
 test('poker v2 shows a closed-table countdown, cancels on recovery, and redirects after five seconds', async () => {

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -31,6 +31,7 @@ assert.doesNotMatch(indexHtml, /pokerClassicEntry/, 'poker lobby should no longe
 assert.match(tableV2Html, /id="pokerV2JoinBtn"/, 'poker table v2 should include live join control');
 assert.match(tableV2Html, /id="pokerLobbyLink"/, 'poker table v2 should include a back-to-lobby link in the hamburger menu');
 assert.match(tableV2Html, /id="pokerV2ClosedTableModal"/, 'poker table v2 should render the closed-table redirect notice');
+assert.match(tableV2Html, /id="pokerV2GuestPanel"/, 'poker table v2 should render the guest restrictions panel');
 assert.doesNotMatch(tableV2Html, /pokerClassicLink/, 'poker table v2 should not expose the classic table link');
 assert.doesNotMatch(tableV2Html, /pokerV2Link/, 'poker table v2 should not expose a self-link in the hamburger menu');
 assert.doesNotMatch(tableV2Html, /pokerV2DemoPill/, 'poker table v2 should not render the legacy demo pill');
@@ -39,6 +40,8 @@ assert.equal(tableV2Html.indexOf('id="pokerSeatLayer"') < tableV2Html.indexOf('i
 assert.equal(tableV2Html.indexOf('id="pokerDealerChip"') < tableV2Html.indexOf('class="poker-center-layer"'), true, 'dealer chip should not live inside the center layer');
 assert.match(tableV2Css, /\.poker-menu-panel\[hidden\]\{display:none;\}/, 'poker table v2 menu should hard-hide when hidden attribute is present');
 assert.match(tableV2Css, /\.poker-closed-table-modal\{z-index:65;\}/, 'poker table v2 should style the closed-table redirect notice');
+assert.match(tableV2Css, /\.poker-guest-panel\{margin-top:12px; padding:14px 14px 12px; border-radius:18px; border:1px solid rgba\(255,223,180,0\.2\); background:rgba\(8,13,22,0\.72\);\}/, 'poker table v2 should style the guest restrictions panel');
+assert.match(tableV2Css, /\.poker-guest-panel__item--blocked::before\{content:"✕"; color:#ffb5b5;\}/, 'guest restrictions panel should visibly mark blocked items');
 assert.match(tableV2Css, /\.poker-action-bar\{position:fixed; right:max\(10px, env\(safe-area-inset-right\)\); bottom:max\(10px, env\(safe-area-inset-bottom\)\); width:min\(33vw, 196px\); display:grid; grid-template-columns:40px minmax\(0, 1fr\);/, 'poker table v2 action rail should dock to the bottom-right with a left-side vertical amount slider');
 assert.doesNotMatch(tableV2Css, /\.poker-seat--hero \.poker-seat-avatar\{[^}]*border-color:/, 'hero avatar should not keep an always-on active ring');
 assert.match(tableV2Css, /\.poker-seat--hero\.poker-seat--active \.poker-seat-avatar\{border-color:rgba\(84,245,152,0\.88\);/, 'hero avatar should turn green only on the active turn');


### PR DESCRIPTION
PR2 closes the guest-mode UX gap on the poker table.

What changed:
- Added a persistent guest restrictions panel in the live poker table UI.
- Hid the XP badge while guest mode is active.
- Kept the guest badge visible so the session state is obvious.
- Left authenticated poker flow unchanged.
- Added focused behavior and static-contract tests for the guest UI state.

Validation:
- `node --test tests/poker-v2-live.behavior.test.mjs tests/static-html.behavior.test.mjs tests/poker-guest-session.behavior.test.mjs ws-server/server.guest-mode.behavior.test.mjs`

Impact:
- Guest sessions remain isolated from XP / rankings / achievements in the poker surface.
- No breaking impact expected.