### PR TITLE
[codex] Implement guest poker registration incentives

### DIFF
--- a/account.html
+++ b/account.html
@@ -40,6 +40,14 @@
     .account-panel__btn--primary{ background:linear-gradient(90deg, #6ee7e7, #a78bfa); color:#0b1020; }
 
     .account-panel__btn--ghost{ background:rgba(255, 255, 255, 0.08); color:#e2e8f0; }
+
+    .account-bonus{ display:grid; gap:10px; margin-top:16px; padding:14px; border-radius:14px; border:1px solid rgba(110, 231, 231, 0.18); background:rgba(255, 255, 255, 0.03); }
+
+    .account-bonus__title{ font-size:15px; font-weight:700; color:#f8fafc; }
+
+    .account-bonus__btn{ justify-self:start; padding:10px 14px; border:none; border-radius:12px; background:linear-gradient(90deg, #f7c948, #6ee7e7); color:#0b1020; font-weight:700; cursor:pointer; }
+
+    .account-bonus__btn[hidden]{ display:none; }
   </style>
 
 <script src="js/analytics.js" defer></script>
@@ -181,6 +189,11 @@
           <div class="account-panel__actions">
             <button type="button" class="account-panel__btn account-panel__btn--primary" id="signOutButton">Sign out</button>
             <button type="button" class="account-panel__btn account-panel__btn--ghost" id="deleteAccountButton">Delete account</button>
+          </div>
+          <div class="account-bonus" id="welcomeBonusPanel" hidden>
+            <div class="account-bonus__title" id="welcomeBonusTitle">Claim your 500 CH welcome bonus</div>
+            <button type="button" class="account-bonus__btn" id="welcomeBonusClaimButton">Claim your 500 CH welcome bonus</button>
+            <p class="account-note" id="welcomeBonusStatus" aria-live="polite"></p>
           </div>
           <p class="account-note" id="deleteAccountNote" tabindex="-1">To request account deletion, contact support and include the email address linked to your Arcade Hub profile.</p>
         </section>

--- a/css/portal.css
+++ b/css/portal.css
@@ -60,6 +60,10 @@ body{margin:0; background:linear-gradient(180deg, #0b1020 0%, #0a0d1a 100%); col
 
 .chip-badge__label{ display:inline-flex; align-items:center; gap:6px; }
 
+.welcome-bonus-badge{ display:inline-flex; align-items:center; min-height:18px; padding:2px 6px; border-radius:999px; background:linear-gradient(90deg, #f7c948, #6ee7e7); color:#0b1020; font:800 10px/1 Poppins, sans-serif; }
+
+.welcome-bonus-badge[hidden]{ display:none; }
+
 #chipBadge{ display:none; }
 
 html[data-auth="in"] #chipBadge{ display:inline-flex; }
@@ -315,6 +319,7 @@ body::before{ content:""; position:fixed; inset:0; pointer-events:none; backgrou
 .search-popup{ min-width:min(520px, calc(100vw - 24px)); max-width:calc(100vw - 24px); left:0; background:rgba(9,12,28,.96); border-color:rgba(50,246,255,.28); box-shadow:0 24px 70px rgba(0,0,0,.58), 0 0 32px rgba(182,92,255,.16); backdrop-filter:blur(18px); }
 .xp-badge{ min-height:32px; padding:8px 10px; border-color:rgba(50,246,255,.42); color:#ddfdff; background:linear-gradient(135deg, rgba(50,246,255,.16), rgba(182,92,255,.12)); box-shadow:0 0 18px rgba(50,246,255,.13); font-size:11px; }
 .chip-pill{ min-height:32px; padding:8px 10px; border-color:rgba(182,92,255,.42); color:#efe7ff; background:rgba(182,92,255,.12); font-size:11px; }
+.welcome-bonus-badge{ min-height:16px; padding:2px 5px; font-size:9px; }
 .avatar-circle{ width:34px; height:34px; border-color:rgba(255,255,255,.22); background:linear-gradient(145deg, rgba(50,246,255,.24), rgba(255,79,216,.18)); color:#fff; box-shadow:0 0 18px rgba(182,92,255,.16); }
 .avatar-menu{ background:rgba(9,12,28,.96); border-color:rgba(50,246,255,.28); box-shadow:0 24px 70px rgba(0,0,0,.58); backdrop-filter:blur(18px); }
 .sidebar{ position:fixed; left:12px; top:calc(var(--topbar-offset) + 10px); bottom:calc(var(--bottom-nav-h) + 14px + env(safe-area-inset-bottom, 0px)); width:min(286px, calc(100vw - 24px)); max-height:none; padding:12px; border-radius:24px; background:linear-gradient(180deg, rgba(18,23,50,.9), rgba(10,12,28,.82)); border:1px solid rgba(50,246,255,.28); box-shadow:0 24px 80px rgba(0,0,0,.5), 0 0 40px rgba(50,246,255,.12), inset 0 1px 0 rgba(255,255,255,.08); backdrop-filter:blur(20px); transform:translateX(calc(-100% - 18px)); transition:transform .26s ease, width .22s ease, box-shadow .22s ease; z-index:80; overflow-x:hidden; overflow-y:auto; overscroll-behavior:contain; -webkit-overflow-scrolling:touch; }

--- a/docs/bonus-campaigns-implementation-plan.md
+++ b/docs/bonus-campaigns-implementation-plan.md
@@ -1,0 +1,797 @@
+# Bonus Campaigns Implementation Plan
+
+## Decision
+
+Refactor the current PR3 welcome bonus implementation into a small `bonus_campaigns` system before merge.
+
+Reason:
+
+- Arcade Hub plans to support anniversaries, seasonal events, returning-player bonuses, selected-account rewards, and future promotional campaigns.
+- The current PR3 implementation is safe for one `WELCOME_BONUS`, but it hardcodes one campaign in code, env names, endpoint names, UI copy, and transaction type.
+- A minimal campaign system avoids cloning `welcome-bonus` into `anniversary-bonus`, `winter-bonus`, `returning-player-bonus`, etc.
+
+This plan keeps scope intentionally small. It does not introduce a full rule engine or complete admin CRUD in the first PR.
+
+## Current Code Analysis
+
+### Existing PR3 Welcome Bonus
+
+Files:
+
+- `netlify/functions/_shared/welcome-bonus.mjs`
+- `netlify/functions/welcome-bonus.mjs`
+- `js/chips/client.js`
+- `js/account-page.js`
+- `js/topbar.js`
+- `poker/index.html`
+- `poker/poker.js`
+- `supabase/migrations/20260702000000_chips_welcome_bonus_tx_type.sql`
+- `tests/welcome-bonus.behavior.test.mjs`
+- `tests/account-page.test.mjs`
+
+Current behavior:
+
+- `GET /.netlify/functions/welcome-bonus` returns eligibility.
+- `POST /.netlify/functions/welcome-bonus` claims the bonus.
+- Eligibility is hardcoded from `auth.users.created_at >= WELCOME_BONUS_START_AT`.
+- Amount comes from `WELCOME_BONUS_CHIPS`, defaulting to `500`.
+- Idempotency key is `welcome-bonus:<userId>`.
+- Ledger transaction type is `WELCOME_BONUS`.
+- Entries use `USER +amount` and `SYSTEM/GENESIS -amount`.
+- UI shows claim affordances only after backend status says the account is eligible.
+
+Good parts to reuse:
+
+- Backend decides eligibility.
+- Frontend never grants chips.
+- Success copy is shown only after a real successful POST.
+- Guest chips are not transferred.
+- Existing `postTransaction` ledger helper handles balanced entries, idempotency, and account creation.
+- `SYSTEM/GENESIS` is the existing mint-like offset convention.
+- `klog` events avoid secrets and provide operational visibility.
+
+Limitations:
+
+- One campaign only.
+- One hardcoded eligibility rule.
+- One hardcoded endpoint.
+- One hardcoded transaction type.
+- Env-based campaign config is not suitable for many campaigns.
+- No campaign table, allowlist, claim table, preview, or admin lifecycle.
+
+### Ledger
+
+Relevant files:
+
+- `netlify/functions/_shared/chips-ledger.mjs`
+- `supabase/migrations/20251218213520_chips_ledger.sql`
+- `supabase/migrations/20251218230000_chips_ledger_fixups.sql`
+- `supabase/migrations/20251220000000_chips_allow_genesis_overdraft.sql`
+- `supabase/migrations/20251221000000_chips_seed_treasury_genesis.sql`
+
+Existing ledger strengths:
+
+- Transactions are balanced.
+- User balances cannot go negative.
+- `SYSTEM/GENESIS` can go negative and is already seeded.
+- Transactions support `idempotency_key`.
+- Admin ledger filters already expose `tx_type`, `source`, metadata, user, and time range.
+
+Needed change:
+
+- Prefer one generic promotional transaction type:
+
+```text
+PROMO_BONUS
+```
+
+Campaign identity belongs in transaction metadata:
+
+```json
+{
+  "source": "bonus_campaign",
+  "campaign_code": "welcome-2026",
+  "campaign_type": "welcome"
+}
+```
+
+Do not add a new enum value for every campaign.
+
+### Admin
+
+Relevant files:
+
+- `admin.html`
+- `js/admin-page.js`
+- `netlify/functions/_shared/admin-auth.mjs`
+- `netlify/functions/admin-users-list.mjs`
+- `netlify/functions/admin-ledger-list.mjs`
+
+Existing admin patterns:
+
+- Admin access is allowlisted through `requireAdminUser`.
+- Admin UI is tab-based.
+- Admin endpoints use `CHIPS_ENABLED`, CORS, auth, query parsing helpers, pagination, and safe errors.
+- User search already supports exact `userId`, email/text search, created date, sign-in date, balance, and active poker state.
+
+Recommended admin direction:
+
+- Start with read/preview/admin visibility first.
+- Add mutating campaign management only after campaign claims are proven safe.
+
+## Target Model
+
+### Tables
+
+#### `public.bonus_campaigns`
+
+Purpose:
+
+- Defines a claimable bonus campaign.
+
+Suggested columns:
+
+```text
+id uuid primary key
+code text unique not null
+title text not null
+description text
+campaign_type text not null
+amount bigint not null
+status text not null
+starts_at timestamptz not null
+ends_at timestamptz
+eligibility_type text not null
+eligibility_config jsonb not null default '{}'
+max_total_claims bigint
+created_by uuid
+created_at timestamptz not null default now()
+updated_at timestamptz not null default now()
+```
+
+Suggested statuses:
+
+```text
+draft
+scheduled
+active
+paused
+ended
+```
+
+Suggested eligibility types for MVP:
+
+```text
+all_accounts
+created_after
+created_before
+allowlist
+```
+
+Future eligibility types:
+
+```text
+inactive_since
+played_poker_at_least_n_hands
+no_bonus_claimed_since
+```
+
+#### `public.bonus_claims`
+
+Purpose:
+
+- Records one claim per user per campaign.
+
+Suggested columns:
+
+```text
+id uuid primary key
+campaign_id uuid not null references public.bonus_campaigns(id)
+user_id uuid not null references auth.users(id)
+transaction_id uuid not null references public.chips_transactions(id)
+idempotency_key text not null
+claimed_at timestamptz not null default now()
+metadata jsonb not null default '{}'
+```
+
+Constraints:
+
+```text
+unique (campaign_id, user_id)
+unique (idempotency_key)
+```
+
+#### `public.bonus_campaign_eligible_users`
+
+Purpose:
+
+- Allowlist selected accounts for targeted campaigns.
+
+Suggested columns:
+
+```text
+campaign_id uuid not null references public.bonus_campaigns(id)
+user_id uuid not null references auth.users(id)
+reason text
+created_by uuid
+created_at timestamptz not null default now()
+primary key (campaign_id, user_id)
+```
+
+### Idempotency
+
+Use stable campaign-scoped keys:
+
+```text
+bonus:<campaignCode>:<userId>
+```
+
+Examples:
+
+```text
+bonus:welcome-2026:00000000-0000-4000-8000-000000000003
+bonus:anniversary-2026:00000000-0000-4000-8000-000000000003
+```
+
+### Ledger Entries
+
+Every successful claim creates one balanced `PROMO_BONUS` transaction:
+
+```text
+USER +amount
+SYSTEM/GENESIS -amount
+```
+
+Transaction fields:
+
+```text
+tx_type = PROMO_BONUS
+idempotency_key = bonus:<campaignCode>:<userId>
+reference = bonus:<campaignCode>:<userId>
+description = campaign title
+created_by = userId
+```
+
+Metadata:
+
+```json
+{
+  "source": "bonus_campaign",
+  "campaign_id": "...",
+  "campaign_code": "welcome-2026",
+  "campaign_type": "welcome",
+  "amount": 500
+}
+```
+
+## Seeded Welcome Campaign
+
+The current welcome bonus becomes a seeded campaign.
+
+Suggested seed:
+
+```text
+code = welcome-2026
+title = 500 CH Welcome Bonus
+description = Create an account and claim your starter chips.
+campaign_type = welcome
+amount = 500
+status = active
+starts_at = 2025-06-01T00:00:00Z
+ends_at = null
+eligibility_type = created_after
+eligibility_config = { "created_at_gte": "2025-06-01T00:00:00Z" }
+```
+
+Eligibility:
+
+- Account must be authenticated.
+- Campaign must be active and within time window.
+- `auth.users.created_at >= eligibility_config.created_at_gte`.
+- User must not have a row in `bonus_claims` for this campaign.
+- User must not have an existing ledger transaction with the same idempotency key.
+
+## API Shape
+
+### Public user endpoints
+
+Use one generic endpoint family instead of `welcome-bonus`:
+
+```text
+GET  /.netlify/functions/bonus-campaigns
+POST /.netlify/functions/bonus-campaigns-claim
+```
+
+`GET` response:
+
+```json
+{
+  "items": [
+    {
+      "code": "welcome-2026",
+      "title": "500 CH Welcome Bonus",
+      "description": "Create an account and claim your starter chips.",
+      "campaignType": "welcome",
+      "amount": 500,
+      "eligible": true,
+      "alreadyClaimed": false,
+      "reason": "eligible"
+    }
+  ]
+}
+```
+
+`POST` body:
+
+```json
+{
+  "code": "welcome-2026"
+}
+```
+
+`POST` success:
+
+```json
+{
+  "claimed": true,
+  "code": "welcome-2026",
+  "amount": 500,
+  "transactionId": "..."
+}
+```
+
+Compatibility option:
+
+- Keep `/.netlify/functions/welcome-bonus` as a thin wrapper around campaign `welcome-2026` for one PR if that reduces frontend churn.
+- Preferred final state: remove PR3-specific endpoint before merge and update clients to generic campaign APIs.
+
+### Admin endpoints
+
+Add admin endpoints incrementally:
+
+```text
+GET  /.netlify/functions/admin-bonus-campaigns
+GET  /.netlify/functions/admin-bonus-campaign-preview
+GET  /.netlify/functions/admin-bonus-campaign-claims
+POST /.netlify/functions/admin-bonus-campaigns
+POST /.netlify/functions/admin-bonus-campaign-eligible-users
+POST /.netlify/functions/admin-bonus-campaign-status
+```
+
+Do not build every endpoint in the first PR. Start with read/preview.
+
+## klog Diagnostics
+
+Use safe events:
+
+```text
+bonus_campaign_status_checked
+bonus_campaign_claimed
+bonus_campaign_skipped
+bonus_campaign_failed
+bonus_campaign_previewed
+bonus_campaign_admin_updated
+```
+
+Allowed metadata:
+
+```text
+userId
+adminUserId
+campaignId
+campaignCode
+campaignType
+eligible
+alreadyClaimed
+amount
+reason
+transactionId
+estimatedEligibleCount
+estimatedLiability
+```
+
+Never log:
+
+```text
+emails
+JWTs
+access tokens
+raw authorization headers
+full allowlist uploads
+```
+
+## Admin Control Strategy
+
+### Phase 1: Git/migration-controlled campaigns
+
+Use migrations to create campaigns.
+
+Good for:
+
+- Welcome bonus.
+- Anniversary event.
+- Seasonal event.
+- Manually reviewed allowlist import.
+
+Pros:
+
+- Changes are reviewed in PR.
+- Audit exists in git.
+- Lower risk of accidental mass payout.
+
+Recommendation:
+
+- Use this for the first campaign system PR.
+
+### Phase 2: Admin read/preview UI
+
+Add an Admin tab:
+
+```text
+Bonus Campaigns
+```
+
+Views:
+
+- Campaign list.
+- Campaign detail.
+- Claim list.
+- Eligibility preview.
+- Estimated liability.
+
+Preview must show:
+
+```text
+Estimated eligible users
+Already claimed users
+Max liability = eligibleCount * amount
+Campaign status
+Time window
+Eligibility rule summary
+```
+
+### Phase 3: Admin mutating UI
+
+Only after Phase 1 and Phase 2 are proven:
+
+- Create draft campaign.
+- Edit draft campaign.
+- Upload allowlist.
+- Preview eligible users.
+- Activate campaign.
+- Pause campaign.
+- End campaign.
+
+Safety controls:
+
+- Mutating actions require admin auth.
+- Activation requires preview.
+- Activation should show estimated liability.
+- Campaign `code` is immutable after activation.
+- `amount` is immutable after activation.
+- `eligibility_type` and `eligibility_config` are immutable after activation.
+- `status` can move `draft -> scheduled/active -> paused/ended`.
+- Avoid editing active campaigns except pausing/ending.
+
+## PR Breakdown
+
+### PR A: Bonus Campaign Schema and Ledger Foundation
+
+Goal:
+
+- Replace single-bonus data model with generic campaign tables and generic ledger transaction type.
+
+Backend/database:
+
+- Add `PROMO_BONUS` to `public.chips_tx_type`.
+- Add `bonus_campaigns`.
+- Add `bonus_claims`.
+- Add `bonus_campaign_eligible_users`.
+- Add indexes and unique constraints.
+- Add RLS deny-all policies, matching ledger/admin tables.
+- Seed `welcome-2026` campaign.
+- Keep or remove `WELCOME_BONUS` migration decision:
+  - Preferred before merge: replace `WELCOME_BONUS` usage with `PROMO_BONUS`.
+  - If migration already reached remote DB, keep enum value but stop using it.
+
+Shared backend:
+
+- Add `netlify/functions/_shared/bonus-campaigns.mjs`.
+- Implement campaign loading.
+- Implement eligibility checks for:
+  - `all_accounts`
+  - `created_after`
+  - `created_before`
+  - `allowlist`
+- Implement claim helper using `postTransaction`.
+- Use `SYSTEM/GENESIS` offset.
+- Use idempotency `bonus:<campaignCode>:<userId>`.
+- Insert `bonus_claims` after successful ledger transaction.
+- Handle retry/idempotent existing transaction safely.
+
+Tests:
+
+- Campaign active window is enforced.
+- Created-after welcome campaign eligibility matches current PR3 rules.
+- Allowlist eligibility works.
+- Repeated claim does not grant a second bonus.
+- Ledger uses `PROMO_BONUS` and `SYSTEM/GENESIS`.
+- Guest chips are never transferred.
+
+Acceptance:
+
+- `welcome-2026` can be evaluated from DB.
+- Claim writes one ledger transaction and one claim row.
+- Repeated claim is idempotent/no second grant.
+- Existing welcome bonus semantics are preserved.
+
+Breaking impact:
+
+- Existing PR3 `WELCOME_BONUS_*` envs are no longer campaign source of truth.
+- If `WELCOME_BONUS` enum migration was applied remotely, it remains harmless but deprecated.
+
+### PR B: Public Campaign API and Client Refactor
+
+Goal:
+
+- Replace `welcome-bonus` endpoint/client with generic bonus campaign status/claim.
+
+Backend:
+
+- Add `netlify/functions/bonus-campaigns.mjs` for `GET`.
+- Add `netlify/functions/bonus-campaigns-claim.mjs` for `POST`.
+- Optional compatibility wrapper:
+  - `welcome-bonus.mjs` calls campaign code `welcome-2026`.
+  - Remove wrapper before final merge if frontend is fully generic.
+
+Frontend:
+
+- Update `js/chips/client.js`:
+  - `fetchBonusCampaigns()`
+  - `claimBonusCampaign(code)`
+- Keep temporary aliases only if useful:
+  - `fetchWelcomeBonusStatus()` maps to first/known welcome campaign.
+  - `claimWelcomeBonus()` maps to `welcome-2026`.
+- Update account page to render claimable campaigns.
+- Update topbar badge to show a campaign indicator from generic campaign list.
+- Update poker lobby banner to use generic campaign list.
+
+Tests:
+
+- Public `GET` returns claimable campaigns.
+- Public `POST` claims by code.
+- Unknown/inactive/ineligible campaign does not claim.
+- Account page success appears only after successful POST.
+- Topbar/lobby hide campaign after claim.
+
+Acceptance:
+
+- Current UI behavior remains: eligible welcome users see `500 CH` claim affordances.
+- The UI is no longer hardcoded to `WELCOME_BONUS_*` endpoint names.
+
+Breaking impact:
+
+- None expected for users.
+
+### PR C: Admin Read and Preview
+
+Goal:
+
+- Let admins inspect campaigns and estimate impact before activation.
+
+Backend:
+
+- Add `admin-bonus-campaigns` list/detail endpoint.
+- Add `admin-bonus-campaign-preview` endpoint.
+- Add `admin-bonus-campaign-claims` endpoint.
+- Reuse `requireAdminUser`.
+- Reuse admin pagination and timestamp parsing helpers.
+
+Admin UI:
+
+- Add `Bonus Campaigns` tab to `admin.html`.
+- Add campaign list with status, amount, start/end, claimed count.
+- Add campaign detail panel.
+- Add preview panel:
+  - estimated eligible users,
+  - already claimed,
+  - max liability,
+  - sample users if useful.
+- Add claims table.
+
+Tests:
+
+- Admin endpoints require admin.
+- Preview returns estimated eligible count and liability.
+- Claims list filters by campaign.
+
+Acceptance:
+
+- Admin can review campaign state and risk without mutating anything.
+
+Breaking impact:
+
+- None expected.
+
+### PR D: Admin Allowlist Management
+
+Goal:
+
+- Safely support bonuses for selected accounts.
+
+Backend:
+
+- Add admin endpoint to add/remove/list allowlisted users.
+- Support exact user ID and admin-side email lookup.
+- Store only `user_id` in allowlist rows.
+- Validate campaign is `draft`, `scheduled`, or `paused` before allowlist mutation.
+
+Admin UI:
+
+- Add allowlist section in campaign detail.
+- Add exact user ID input.
+- Add email/user search picker.
+- Add CSV paste/upload only if parsing can stay simple and safe.
+
+Tests:
+
+- Non-admin cannot mutate allowlist.
+- Allowlisted user is eligible.
+- Non-allowlisted user is not eligible.
+- Removing a user prevents future claim if not already claimed.
+- Removing does not revoke already-claimed chips.
+
+Acceptance:
+
+- Admin can target selected accounts without touching ledger manually.
+
+Breaking impact:
+
+- None expected.
+
+### PR E: Admin Campaign Draft/Create/Status Controls
+
+Goal:
+
+- Move from migration-controlled campaigns to controlled admin-created campaigns.
+
+Backend:
+
+- Add create draft campaign endpoint.
+- Add update draft campaign endpoint.
+- Add status transition endpoint:
+  - `draft -> scheduled`
+  - `draft -> active`
+  - `scheduled -> active`
+  - `active -> paused`
+  - `paused -> active`
+  - `active/paused -> ended`
+- Enforce immutable fields after activation.
+- Require preview before activation if practical.
+
+Admin UI:
+
+- Add create campaign form.
+- Add status buttons with confirmation.
+- Display max liability before activation.
+
+Tests:
+
+- Invalid transitions rejected.
+- Active campaign immutable fields cannot change.
+- Admin action klogs are emitted safely.
+
+Acceptance:
+
+- Admin can run normal campaigns without migrations.
+
+Breaking impact:
+
+- Higher operational power in admin panel; requires careful review.
+
+### PR F: Advanced Segments and Returning Player Campaigns
+
+Goal:
+
+- Add richer eligibility for future lifecycle campaigns.
+
+Potential rules:
+
+- `inactive_since`
+- `last_sign_in_before`
+- `played_poker_at_least_n_hands`
+- `no_bonus_claimed_since`
+- `balance_below`
+
+Recommendation:
+
+- Add one rule per PR.
+- Each rule needs preview, tests, and clear liability estimate.
+- Do not implement a free-form SQL rule editor.
+
+Acceptance:
+
+- Returning-player and lifecycle campaigns can be configured without custom endpoints.
+
+Breaking impact:
+
+- None expected if rules are additive.
+
+## Rewrite Scope for Current PR3
+
+Since this current PR is not merged yet, recommended rewrite target is:
+
+- Implement PR A and PR B in the current PR3 branch.
+- Keep PR C+ as follow-up PRs.
+
+That means the current PR3 should deliver:
+
+- Generic campaign schema.
+- Seeded `welcome-2026`.
+- Generic public campaign status/claim.
+- Account page/topbar/poker lobby consuming generic campaigns.
+- Current welcome bonus UX preserved.
+
+Do not include in current PR3:
+
+- Full admin CRUD.
+- CSV upload.
+- Advanced returning-player rules.
+- Email reminders.
+- Notification persistence.
+
+## Manual Test Plan for Rewritten PR3
+
+Eligible welcome account:
+
+1. Account created at or after `2025-06-01T00:00:00Z`.
+2. No `bonus_claims` row for `welcome-2026`.
+3. Log in.
+4. Account page/topbar/lobby show claim affordance.
+5. Claim.
+6. Balance increases by `500`.
+7. Ledger shows `PROMO_BONUS`.
+8. `bonus_claims` contains one row.
+9. UI affordances disappear after refresh.
+
+Already claimed account:
+
+1. Claim once.
+2. Refresh.
+3. No claim affordance.
+4. Repeated POST returns no second grant.
+
+Ineligible old account:
+
+1. Account created before `2025-06-01T00:00:00Z`.
+2. Log in.
+3. No claim affordance.
+4. POST cannot claim.
+
+Allowlist campaign:
+
+1. Seed test allowlist campaign.
+2. Add one user to allowlist.
+3. Only that user sees and claims campaign.
+4. Non-allowlisted user cannot claim.
+
+## Open Decisions Before Runtime Implementation
+
+These do not block this planning document, but should be confirmed before coding:
+
+1. Should the current remote `WELCOME_BONUS` enum migration be kept as deprecated if already applied?
+2. Should the first campaign transaction type be named `PROMO_BONUS` or `BONUS`?
+3. Should `welcome-2026` have no `ends_at`, or should it expire?
+4. Should public `GET bonus-campaigns` return all visible campaigns or only claimable campaigns?
+5. Should topbar show only the highest-priority campaign if multiple are claimable?
+6. Should admin mutating controls wait until a separate PR after the generic public claim path is merged?
+
+Recommended answers:
+
+1. Keep `WELCOME_BONUS` enum if already applied, but do not use it going forward.
+2. Use `PROMO_BONUS`.
+3. No `ends_at` for welcome bonus initially.
+4. Return claimable plus already-claimed visible campaign summaries only when useful; hide ineligible campaigns from normal users.
+5. Show one compact topbar indicator using highest priority or soonest-expiring campaign.
+6. Yes, admin mutations should be follow-up PRs.
+

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -1,0 +1,298 @@
+# Poker Guest Mode PR3 - Registration Incentives Implementation Plan
+
+## Goal
+
+PR3 adds a one-time registration incentive for Guest -> Account conversion.
+
+The intended user outcome is:
+
+- Guest players see a clear account-upgrade value proposition.
+- A newly eligible account receives exactly one `500 CH` welcome bonus.
+- Guest chips are never transferred into the real account.
+- The existing authenticated poker and chip ledger flows remain unchanged.
+
+## Scope
+
+Backend:
+
+- Add a chip ledger transaction type: `WELCOME_BONUS`.
+- Grant a one-time `500 CH` welcome bonus.
+- Enforce idempotency with `welcome-bonus:<userId>`.
+- Expose bonus status and claim data:
+  - `eligible`
+  - `alreadyClaimed`
+  - `amount`
+
+Frontend:
+
+- Replace plain `Create account` guest CTAs with `Create account +500 CH Welcome Bonus`.
+- Update the Guest poker panel to show the account unlock value.
+- After first login from Guest conversion, show: `Welcome! 500 CH have been added to your account.`
+
+Out of scope:
+
+- No Guest chip transfer.
+- No in-place Guest -> Account table upgrade.
+- No smart conversion prompt trigger system; that remains PR4.
+- No full guest landing redesign; that remains PR5.
+
+## Backend Plan
+
+### 1. Extend Ledger Transaction Types
+
+File: `netlify/functions/_shared/chips-ledger.mjs`
+
+Add `WELCOME_BONUS` to `VALID_TX_TYPES`.
+
+Ledger transaction shape:
+
+- `txType`: `WELCOME_BONUS`
+- `idempotencyKey`: `welcome-bonus:<userId>`
+- `reference`: `guest_registration_incentive`
+- `description`: `Welcome bonus`
+- user entry: `+500`
+- treasury/system entry: `-500`
+- metadata:
+  - `source: "guest_registration_incentive"`
+  - `bonus_chips: 500`
+
+Use the existing `postTransaction()` path rather than creating a separate ledger write mechanism.
+
+### 2. Add Welcome Bonus Shared Helper
+
+Proposed file: `netlify/functions/_shared/welcome-bonus.mjs`
+
+Exports:
+
+- `getWelcomeBonusStatus(userId, options)`
+- `claimWelcomeBonus(userId, options)`
+
+Status response:
+
+```json
+{
+  "eligible": true,
+  "alreadyClaimed": false,
+  "amount": 500
+}
+```
+
+Claim response:
+
+```json
+{
+  "claimed": true,
+  "eligible": false,
+  "alreadyClaimed": true,
+  "amount": 500
+}
+```
+
+Implementation details:
+
+- Bonus amount should come from env with a sane default:
+  - `WELCOME_BONUS_CHIPS=500`
+- Eligibility should be gated by a rollout timestamp:
+  - `WELCOME_BONUS_START_AT`
+- New-account detection should query `auth.users.created_at` through `SUPABASE_DB_URL`.
+- A user is eligible when:
+  - the account exists,
+  - `auth.users.created_at >= WELCOME_BONUS_START_AT`,
+  - no transaction exists for `welcome-bonus:<userId>`.
+
+Important product decision:
+
+- If the business wants to grant the bonus to every existing account that has never claimed it, skip the `created_at` gate.
+- If the bonus must apply only to new registrations after PR3, keep the `created_at` gate.
+
+The safer default for PR3 is to keep the `created_at` gate.
+
+### 3. Add API Endpoint
+
+Proposed file: `netlify/functions/welcome-bonus.mjs`
+
+Methods:
+
+- `GET`: return bonus status.
+- `POST`: claim the welcome bonus.
+
+API behavior:
+
+- `CHIPS_ENABLED !== "1"` returns `404`.
+- Missing or invalid auth returns `401`.
+- Ineligible user returns `200` with `eligible: false`.
+- Already claimed user returns `200` with `alreadyClaimed: true`.
+- First successful claim returns `200` with transaction/account details.
+- Repeated claim must not create a second ledger transaction.
+
+Implementation patterns to reuse:
+
+- CORS and auth from `netlify/functions/chips-balance.mjs`.
+- Ledger write and error mapping style from `netlify/functions/admin-ledger-adjust.mjs`.
+
+### 4. Idempotency and Race Safety
+
+Use `postTransaction()` with:
+
+```text
+welcome-bonus:<userId>
+```
+
+The existing chips ledger already has unique idempotency constraints. A duplicate request should resolve as an already-claimed outcome when the payload matches, or as an idempotency conflict if payloads differ.
+
+## Frontend Plan
+
+### 1. Add Welcome Bonus Client
+
+Proposed file: `js/welcome-bonus-client.js`
+
+Expose a small browser API:
+
+- `window.WelcomeBonusClient.fetchStatus()`
+- `window.WelcomeBonusClient.claim()`
+
+Auth:
+
+- Reuse `SupabaseAuthBridge.getAccessToken()` or the same auth lookup pattern used by `js/chips/client.js`.
+
+Events:
+
+- Dispatch `chips:tx-complete` after a successful claim so topbar/account chip balance can refresh.
+- Optionally dispatch `welcome-bonus:claimed` for page-local UI messaging.
+
+### 2. Update Guest Table CTA and Panel
+
+Files:
+
+- `poker/table-v2.html`
+- `poker/poker-v2.js`
+- `poker/poker-v2.css`
+
+Update Guest panel copy to:
+
+- `Guest account`
+- `Practice poker`
+- `Unlimited bot games`
+- `Create account to unlock:`
+- `+500 CH welcome bonus`
+- `Multiplayer`
+- `XP progression`
+- `Persistent chips`
+
+Add CTA text:
+
+```text
+Create account +500 CH Welcome Bonus
+```
+
+CTA behavior:
+
+- Navigate to `/account.html`.
+- Store a session marker before navigation:
+
+```text
+poker:guestConversionIntent=welcome_bonus
+```
+
+This marker lets account page auto-claim the bonus after login.
+
+### 3. Update Poker Lobby CTA
+
+Files:
+
+- `poker/index.html`
+- `poker/poker.js`
+
+Change signed-out account CTA copy from plain sign-in/account text to:
+
+```text
+Create account +500 CH Welcome Bonus
+```
+
+Keep PR3 limited to copy and bonus wiring. The larger lobby split remains PR5.
+
+### 4. Claim After First Login
+
+Files:
+
+- `account.html`
+- `js/account-page.js`
+
+Flow:
+
+1. Guest clicks bonus CTA.
+2. UI stores `poker:guestConversionIntent=welcome_bonus`.
+3. User reaches account page and signs in or creates an account.
+4. Account page detects authenticated user and the conversion marker.
+5. Account page calls `GET /.netlify/functions/welcome-bonus`.
+6. If `eligible`, account page calls `POST /.netlify/functions/welcome-bonus`.
+7. Account page shows:
+
+```text
+Welcome! 500 CH have been added to your account.
+```
+
+8. Account page clears the session marker.
+9. Chip balance refreshes via `chips:tx-complete`.
+
+If the user is not eligible or already claimed, clear the marker without showing a misleading success message.
+
+## Tests and Validation
+
+Although the roadmap originally said not to write tests unless explicitly requested, PR3 touches the economy ledger. Add focused tests.
+
+Backend tests:
+
+- `GET welcome-bonus` returns `eligible: true` for a new account without prior bonus.
+- `POST welcome-bonus` creates one `WELCOME_BONUS` transaction.
+- Repeated `POST welcome-bonus` does not create a second transaction.
+- Already claimed status returns `alreadyClaimed: true`.
+- Account before `WELCOME_BONUS_START_AT` is not eligible when the cutover gate is enabled.
+- Missing auth returns `401`.
+- `CHIPS_ENABLED !== "1"` returns `404`.
+
+Frontend/static tests:
+
+- Guest panel contains `+500 CH welcome bonus`.
+- Guest account CTA contains `Create account +500 CH Welcome Bonus`.
+- Account page claim flow dispatches chip refresh after success.
+
+Suggested commands:
+
+```bash
+node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.test.mjs tests/static-html.behavior.test.mjs tests/account-page.test.mjs
+```
+
+## Acceptance Criteria
+
+- Guest users see the `+500 CH` account incentive.
+- A newly eligible account receives exactly one `WELCOME_BONUS` transaction.
+- Reloading or retrying does not grant another bonus.
+- Guest chips remain temporary and are not transferred.
+- Topbar/account chip balance refreshes after bonus claim.
+- Existing authenticated poker flow is unchanged.
+- Existing ledger integrity and idempotency behavior are preserved.
+
+## Risks
+
+- The phrase "new account" must be implemented explicitly. Do not infer it from a JWT alone.
+- Without `WELCOME_BONUS_START_AT`, existing users may become eligible if they have not claimed a bonus before.
+- Do not expose arbitrary ledger entries through a user-facing endpoint.
+- Do not add the bonus to guest table state or guest stacks.
+- Keep the idempotency key account-scoped and stable.
+
+## PR Summary Template
+
+```markdown
+## What changed
+- Added `WELCOME_BONUS` ledger support.
+- Added welcome bonus status/claim endpoint.
+- Added Guest -> Account bonus CTA copy.
+- Added account-page claim flow after Guest conversion login.
+
+## Validation
+- `node --test ...`
+
+## Breaking impact
+- None expected.
+```

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -210,11 +210,13 @@ Files:
 - `poker/index.html`
 - `poker/poker.js`
 
-Change signed-out account CTA copy from plain sign-in/account text to:
+Keep signed-out lobby auth CTA neutral because the button can open either account creation or normal sign-in, and existing users may be ineligible:
 
 ```text
-Create account and get 500 CH Welcome Bonus
+Create account or sign in
 ```
+
+Show the bonus in the lobby only after backend eligibility is known through the signed-in welcome bonus banner.
 
 Keep PR3 limited to copy and bonus wiring. The larger lobby split remains PR5.
 
@@ -268,6 +270,7 @@ Frontend/static tests:
 
 - Guest panel contains `+500 CH welcome bonus`.
 - Guest account CTA contains `Create account and get 500 CH Welcome Bonus`.
+- Signed-out poker lobby CTA contains `Create account or sign in`.
 - Account page claim flow dispatches chip refresh after success.
 - Ineligible or already-claimed account flow does not show the success message.
 
@@ -279,7 +282,8 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 
 ## Acceptance Criteria
 
-- Guest users see the `Create account and get 500 CH Welcome Bonus` account incentive.
+- Guest users see the `Create account and get 500 CH Welcome Bonus` account incentive in the Guest table experience.
+- Signed-out poker lobby users see a neutral `Create account or sign in` CTA until backend eligibility is known.
 - An eligible account receives exactly one `WELCOME_BONUS` transaction.
 - For the initial rollout, `WELCOME_BONUS_START_AT` is `2025-06-01T00:00:00Z`.
 - Existing Arcade accounts created at or after `WELCOME_BONUS_START_AT` can claim the bonus once.

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -7,7 +7,7 @@ PR3 adds a one-time registration incentive for Guest -> Account conversion.
 The intended user outcome is:
 
 - Guest players see a clear account-upgrade value proposition.
-- A newly eligible account receives exactly one `500 CH` welcome bonus.
+- An eligible account receives exactly one `500 CH` welcome bonus.
 - Guest chips are never transferred into the real account.
 - The existing authenticated poker and chip ledger flows remain unchanged.
 
@@ -96,12 +96,15 @@ Implementation details:
   - `WELCOME_BONUS_CHIPS=500`
 - Eligibility must be gated by a required rollout timestamp:
   - `WELCOME_BONUS_START_AT`
+- For the initial rollout, set:
+  - `WELCOME_BONUS_START_AT=2025-06-01T00:00:00Z`
 - New-account detection should query `auth.users.created_at` through `SUPABASE_DB_URL`.
 - A user is eligible when:
   - the account exists,
   - `auth.users.created_at >= WELCOME_BONUS_START_AT`,
   - no transaction exists for `welcome-bonus:<userId>`.
-- Accounts created before `WELCOME_BONUS_START_AT` are never eligible, even if they have never claimed a welcome bonus.
+- Existing Arcade accounts created at or after `WELCOME_BONUS_START_AT` are eligible for the initial rollout if they have not already claimed the bonus.
+- Accounts created before `WELCOME_BONUS_START_AT` are outside the rollout window.
 - The endpoint should fail closed when `WELCOME_BONUS_START_AT` is missing or invalid.
 
 ### 3. Add API Endpoint
@@ -258,11 +261,11 @@ Although the roadmap originally said not to write tests unless explicitly reques
 
 Backend tests:
 
-- `GET welcome-bonus` returns `eligible: true` for a new account without prior bonus.
+- `GET welcome-bonus` returns `eligible: true` for an account created at or after `WELCOME_BONUS_START_AT` without prior bonus.
 - `POST welcome-bonus` creates one `WELCOME_BONUS` transaction.
 - Repeated `POST welcome-bonus` does not create a second transaction.
 - Already claimed status returns `alreadyClaimed: true`.
-- Account created before `WELCOME_BONUS_START_AT` is not eligible.
+- Account created before `WELCOME_BONUS_START_AT` is outside the rollout window and is not eligible.
 - Account created at or after `WELCOME_BONUS_START_AT` is eligible when it has not claimed the bonus.
 - Missing auth returns `401`.
 - `CHIPS_ENABLED !== "1"` returns `404`.
@@ -283,8 +286,10 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 ## Acceptance Criteria
 
 - Guest users see the `Create account and get 500 CH Welcome Bonus` account incentive.
-- A newly eligible account receives exactly one `WELCOME_BONUS` transaction.
-- Account created before `WELCOME_BONUS_START_AT` is not eligible.
+- An eligible account receives exactly one `WELCOME_BONUS` transaction.
+- For the initial rollout, `WELCOME_BONUS_START_AT` is `2025-06-01T00:00:00Z`.
+- Existing Arcade accounts created at or after `WELCOME_BONUS_START_AT` can claim the bonus once.
+- Account created before `WELCOME_BONUS_START_AT` is outside the rollout window and is not eligible.
 - Account created at or after `WELCOME_BONUS_START_AT` is eligible if it has not claimed the bonus.
 - Reloading or retrying does not grant another bonus.
 - Repeated `POST` does not grant a second bonus.
@@ -298,8 +303,8 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 
 ## Risks
 
-- The phrase "new account" must be implemented explicitly. Do not infer it from a JWT alone.
-- `WELCOME_BONUS_START_AT` is required. Missing or invalid configuration must not make existing accounts eligible.
+- Eligibility must be implemented from `auth.users.created_at`; do not infer it from a JWT alone.
+- `WELCOME_BONUS_START_AT` is required. Missing or invalid configuration must fail closed.
 - Do not expose arbitrary ledger entries through a user-facing endpoint.
 - Do not add the bonus to guest table state or guest stacks.
 - Keep the idempotency key account-scoped and stable.

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -160,16 +160,12 @@ The existing chips ledger already has unique idempotency constraints. A duplicat
 
 ### 1. Add Welcome Bonus Client
 
-Proposed file: `js/welcome-bonus-client.js`
+Reuse the existing `js/chips/client.js` browser API and auth lookup pattern.
 
-Expose a small browser API:
+Expose:
 
-- `window.WelcomeBonusClient.fetchStatus()`
-- `window.WelcomeBonusClient.claim()`
-
-Auth:
-
-- Reuse `SupabaseAuthBridge.getAccessToken()` or the same auth lookup pattern used by `js/chips/client.js`.
+- `window.ChipsClient.fetchWelcomeBonusStatus()`
+- `window.ChipsClient.claimWelcomeBonus()`
 
 Events:
 
@@ -204,13 +200,8 @@ Create account and get 500 CH Welcome Bonus
 CTA behavior:
 
 - Navigate to `/account.html`.
-- Store a session marker before navigation:
-
-```text
-poker:guestConversionIntent=welcome_bonus
-```
-
-This marker lets account page auto-claim the bonus after login.
+- Do not store a guest conversion marker for welcome bonus eligibility.
+- Backend status decides whether the signed-in account can claim the bonus.
 
 ### 3. Update Poker Lobby CTA
 
@@ -229,7 +220,7 @@ Keep PR3 limited to copy and bonus wiring. The larger lobby split remains PR5.
 
 Do not use `Sign in and get 500 CH` copy. Existing users may sign in, but they must not see misleading bonus claim or success copy.
 
-### 4. Claim After First Login
+### 4. Claim From Backend Eligibility
 
 Files:
 
@@ -238,22 +229,25 @@ Files:
 
 Flow:
 
-1. Guest clicks bonus CTA.
-2. UI stores `poker:guestConversionIntent=welcome_bonus`.
-3. User reaches account page and signs in or creates an account.
-4. Account page detects authenticated user and the conversion marker.
-5. Account page calls `GET /.netlify/functions/welcome-bonus`.
-6. If `eligible`, account page calls `POST /.netlify/functions/welcome-bonus`.
-7. Account page shows the success message only after the `POST` returns a real successful claim:
+1. User reaches the account page and signs in or creates an account.
+2. Account page detects an authenticated user.
+3. Account page calls `GET /.netlify/functions/welcome-bonus`.
+4. If `eligible` and not `alreadyClaimed`, account page shows a manual CTA:
+
+```text
+Claim your 500 CH welcome bonus
+```
+
+5. Account page calls `POST /.netlify/functions/welcome-bonus` only after the user clicks the claim CTA.
+6. Account page shows the success message only after the `POST` returns a real successful claim:
 
 ```text
 Welcome! 500 CH have been added to your account.
 ```
 
-8. Account page clears the session marker.
-9. Chip balance refreshes via `chips:tx-complete`.
+7. Chip balance refreshes via `chips:tx-complete`.
 
-If the user is not eligible or already claimed, clear the marker without showing a success message. Existing signed-in users who are not eligible may continue normally, but the UI must not imply they received the bonus.
+If the user is not eligible or already claimed, hide the claim CTA without showing a success message. This works for accounts created through any route, not only through Guest Poker.
 
 ## Tests and Validation
 
@@ -326,7 +320,7 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 - Added `WELCOME_BONUS` ledger support.
 - Added welcome bonus status/claim endpoint.
 - Added Guest -> Account bonus CTA copy.
-- Added account-page claim flow after Guest conversion login.
+- Added backend-driven account-page claim CTA for eligible signed-in accounts.
 
 ## Validation
 - `node --test ...`

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -25,9 +25,9 @@ Backend:
 
 Frontend:
 
-- Replace plain `Create account` guest CTAs with `Create account +500 CH Welcome Bonus`.
+- Replace plain `Create account` guest CTAs with `Create account and get 500 CH Welcome Bonus`.
 - Update the Guest poker panel to show the account unlock value.
-- After first login from Guest conversion, show: `Welcome! 500 CH have been added to your account.`
+- Show `Welcome! 500 CH have been added to your account.` only after a real successful bonus claim.
 
 Out of scope:
 
@@ -51,12 +51,14 @@ Ledger transaction shape:
 - `reference`: `guest_registration_incentive`
 - `description`: `Welcome bonus`
 - user entry: `+500`
-- treasury/system entry: `-500`
+- system offset entry: `-500`, using the existing ledger/system account convention from the current chip ledger implementation
 - metadata:
   - `source: "guest_registration_incentive"`
   - `bonus_chips: 500`
 
 Use the existing `postTransaction()` path rather than creating a separate ledger write mechanism.
+
+Before coding, identify the existing system account convention used by chip ledger helpers and document the chosen system account/reference in the implementation PR. If the repository does not expose a clear explicit system account for this source, resolve that first instead of inventing a new ledger source for the bonus.
 
 ### 2. Add Welcome Bonus Shared Helper
 
@@ -92,20 +94,15 @@ Implementation details:
 
 - Bonus amount should come from env with a sane default:
   - `WELCOME_BONUS_CHIPS=500`
-- Eligibility should be gated by a rollout timestamp:
+- Eligibility must be gated by a required rollout timestamp:
   - `WELCOME_BONUS_START_AT`
 - New-account detection should query `auth.users.created_at` through `SUPABASE_DB_URL`.
 - A user is eligible when:
   - the account exists,
   - `auth.users.created_at >= WELCOME_BONUS_START_AT`,
   - no transaction exists for `welcome-bonus:<userId>`.
-
-Important product decision:
-
-- If the business wants to grant the bonus to every existing account that has never claimed it, skip the `created_at` gate.
-- If the bonus must apply only to new registrations after PR3, keep the `created_at` gate.
-
-The safer default for PR3 is to keep the `created_at` gate.
+- Accounts created before `WELCOME_BONUS_START_AT` are never eligible, even if they have never claimed a welcome bonus.
+- The endpoint should fail closed when `WELCOME_BONUS_START_AT` is missing or invalid.
 
 ### 3. Add API Endpoint
 
@@ -124,6 +121,22 @@ API behavior:
 - Already claimed user returns `200` with `alreadyClaimed: true`.
 - First successful claim returns `200` with transaction/account details.
 - Repeated claim must not create a second ledger transaction.
+- Safe klog diagnostics are required:
+  - `welcome_bonus_claimed`
+  - `welcome_bonus_skipped`
+  - `welcome_bonus_failed`
+
+Logging rules:
+
+- Use `klog`; do not use `console.log`.
+- Logs must not contain secrets, JWTs, emails, or access tokens.
+- Allowed metadata:
+  - `userId`
+  - `eligible`
+  - `alreadyClaimed`
+  - `amount`
+  - `reason`
+  - `transactionId` when available
 
 Implementation patterns to reuse:
 
@@ -182,7 +195,7 @@ Update Guest panel copy to:
 Add CTA text:
 
 ```text
-Create account +500 CH Welcome Bonus
+Create account and get 500 CH Welcome Bonus
 ```
 
 CTA behavior:
@@ -206,10 +219,12 @@ Files:
 Change signed-out account CTA copy from plain sign-in/account text to:
 
 ```text
-Create account +500 CH Welcome Bonus
+Create account and get 500 CH Welcome Bonus
 ```
 
 Keep PR3 limited to copy and bonus wiring. The larger lobby split remains PR5.
+
+Do not use `Sign in and get 500 CH` copy. Existing users may sign in, but they must not see misleading bonus claim or success copy.
 
 ### 4. Claim After First Login
 
@@ -226,7 +241,7 @@ Flow:
 4. Account page detects authenticated user and the conversion marker.
 5. Account page calls `GET /.netlify/functions/welcome-bonus`.
 6. If `eligible`, account page calls `POST /.netlify/functions/welcome-bonus`.
-7. Account page shows:
+7. Account page shows the success message only after the `POST` returns a real successful claim:
 
 ```text
 Welcome! 500 CH have been added to your account.
@@ -235,7 +250,7 @@ Welcome! 500 CH have been added to your account.
 8. Account page clears the session marker.
 9. Chip balance refreshes via `chips:tx-complete`.
 
-If the user is not eligible or already claimed, clear the marker without showing a misleading success message.
+If the user is not eligible or already claimed, clear the marker without showing a success message. Existing signed-in users who are not eligible may continue normally, but the UI must not imply they received the bonus.
 
 ## Tests and Validation
 
@@ -247,15 +262,17 @@ Backend tests:
 - `POST welcome-bonus` creates one `WELCOME_BONUS` transaction.
 - Repeated `POST welcome-bonus` does not create a second transaction.
 - Already claimed status returns `alreadyClaimed: true`.
-- Account before `WELCOME_BONUS_START_AT` is not eligible when the cutover gate is enabled.
+- Account created before `WELCOME_BONUS_START_AT` is not eligible.
+- Account created at or after `WELCOME_BONUS_START_AT` is eligible when it has not claimed the bonus.
 - Missing auth returns `401`.
 - `CHIPS_ENABLED !== "1"` returns `404`.
 
 Frontend/static tests:
 
 - Guest panel contains `+500 CH welcome bonus`.
-- Guest account CTA contains `Create account +500 CH Welcome Bonus`.
+- Guest account CTA contains `Create account and get 500 CH Welcome Bonus`.
 - Account page claim flow dispatches chip refresh after success.
+- Ineligible or already-claimed account flow does not show the success message.
 
 Suggested commands:
 
@@ -265,10 +282,16 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 
 ## Acceptance Criteria
 
-- Guest users see the `+500 CH` account incentive.
+- Guest users see the `Create account and get 500 CH Welcome Bonus` account incentive.
 - A newly eligible account receives exactly one `WELCOME_BONUS` transaction.
+- Account created before `WELCOME_BONUS_START_AT` is not eligible.
+- Account created at or after `WELCOME_BONUS_START_AT` is eligible if it has not claimed the bonus.
 - Reloading or retrying does not grant another bonus.
+- Repeated `POST` does not grant a second bonus.
+- Ineligible or already-claimed users do not see `Welcome! 500 CH have been added to your account.`
+- Existing signed-in users do not see misleading `get 500 CH` claim-result copy.
 - Guest chips remain temporary and are not transferred.
+- Guest chips are never transferred into the registered account.
 - Topbar/account chip balance refreshes after bonus claim.
 - Existing authenticated poker flow is unchanged.
 - Existing ledger integrity and idempotency behavior are preserved.
@@ -276,10 +299,20 @@ node --test tests/welcome-bonus.behavior.test.mjs tests/poker-v2-live.behavior.t
 ## Risks
 
 - The phrase "new account" must be implemented explicitly. Do not infer it from a JWT alone.
-- Without `WELCOME_BONUS_START_AT`, existing users may become eligible if they have not claimed a bonus before.
+- `WELCOME_BONUS_START_AT` is required. Missing or invalid configuration must not make existing accounts eligible.
 - Do not expose arbitrary ledger entries through a user-facing endpoint.
 - Do not add the bonus to guest table state or guest stacks.
 - Keep the idempotency key account-scoped and stable.
+- Future implementation must reuse existing ledger/auth/chips concepts from the repository and avoid duplicate abstractions.
+
+## Documentation-Only Update Notes
+
+- Do not implement runtime code in this PR.
+- Do not change backend or frontend files in this PR.
+- Do not add JavaScript.
+- Do not add CSS.
+- Do not write tests for this documentation-only update.
+- Any future runtime logging for this feature must use `klog`.
 
 ## PR Summary Template
 

--- a/docs/poker-guest-mode-pr3-implementation-plan.md
+++ b/docs/poker-guest-mode-pr3-implementation-plan.md
@@ -51,14 +51,14 @@ Ledger transaction shape:
 - `reference`: `guest_registration_incentive`
 - `description`: `Welcome bonus`
 - user entry: `+500`
-- system offset entry: `-500`, using the existing ledger/system account convention from the current chip ledger implementation
+- system offset entry: `-500`, using `SYSTEM/GENESIS`
 - metadata:
   - `source: "guest_registration_incentive"`
   - `bonus_chips: 500`
 
 Use the existing `postTransaction()` path rather than creating a separate ledger write mechanism.
 
-Before coding, identify the existing system account convention used by chip ledger helpers and document the chosen system account/reference in the implementation PR. If the repository does not expose a clear explicit system account for this source, resolve that first instead of inventing a new ledger source for the bonus.
+Chosen ledger source: `SYSTEM/GENESIS`. The current ledger guard allows negative balance only for `SYSTEM/GENESIS`, so it is the correct existing convention for mint-like incentives. Do not use `SYSTEM/TREASURY` for this bonus unless a future migration explicitly funds it for welcome bonuses; `TREASURY` can fail with `insufficient_funds` when its balance is too low.
 
 ### 2. Add Welcome Bonus Shared Helper
 

--- a/docs/welcome-bonus-notification-concepts.md
+++ b/docs/welcome-bonus-notification-concepts.md
@@ -1,0 +1,312 @@
+# Welcome Bonus Notification Concepts
+
+## Goal
+
+Notify eligible users that a `500 CH` Welcome Bonus is waiting for them without creating spam, dark patterns, or misleading account messaging.
+
+The bonus should feel like a clear account benefit, not a forced promotion. The current backend-driven eligibility model is a good base: the product can ask the backend whether a signed-in account can claim the bonus, then show the notification only when the account is actually eligible.
+
+## Recommended Approach
+
+Use in-product notifications first. Email should be optional and conservative.
+
+Best initial stack:
+
+1. Account page bonus card.
+2. Topbar chip/bell indicator.
+3. Poker lobby/table lightweight banner.
+4. Optional notification center entry.
+5. Email only if the user has marketing consent or if legal review confirms it can be sent as a service/account message in the target jurisdiction.
+
+This keeps the highest-value notification inside the product, where the user can claim immediately and where the eligibility check is fresh.
+
+## Pattern 1: Account Page Bonus Card
+
+Where:
+
+- `/account.html`
+- Near chip balance/account details.
+
+Copy:
+
+```text
+500 CH Welcome Bonus is waiting for you
+Claim your bonus and start playing with persistent chips.
+```
+
+CTA:
+
+```text
+Claim 500 CH
+```
+
+Pros:
+
+- Clear and low-risk.
+- Already close to account/chip context.
+- Good place for a persistent reward state.
+
+Cons:
+
+- User must visit account page.
+
+Recommendation:
+
+- Keep this as the canonical claim location.
+- Hide after claimed, ineligible, or failed closed.
+
+## Pattern 2: Topbar Chip/Bell Indicator
+
+Where:
+
+- Topbar near chip balance/avatar.
+
+Behavior:
+
+- Show a small badge or dot only for eligible users.
+- Click opens account page or a compact popover with claim CTA.
+
+Copy:
+
+```text
+500 CH bonus available
+```
+
+Pros:
+
+- Visible across the app.
+- Common SaaS/game pattern for pending rewards.
+- Does not interrupt gameplay.
+
+Cons:
+
+- Needs careful rate limiting so it does not feel noisy.
+
+Recommendation:
+
+- Use a subtle badge, not a modal.
+- Badge disappears immediately after successful claim.
+- If dismissed, keep a small non-intrusive indicator for the session or day.
+
+## Pattern 3: Poker Lobby Banner
+
+Where:
+
+- Poker lobby.
+- Above table list or near Guest/Account panel.
+
+Copy:
+
+```text
+Your 500 CH Welcome Bonus is ready.
+Claim it to use persistent chips across Arcade Hub.
+```
+
+CTA:
+
+```text
+Claim bonus
+```
+
+Pros:
+
+- Strong context: user is already thinking about poker/chips.
+- Good conversion point after Guest Mode.
+
+Cons:
+
+- Should not block table entry.
+
+Recommendation:
+
+- Use a lightweight inline banner.
+- Never modal.
+- Show only if backend status says `eligible`.
+
+## Pattern 4: Poker Table Toast/Banner
+
+Where:
+
+- Poker table, after hand end or on first table load for authenticated eligible users.
+
+Copy:
+
+```text
+500 CH Welcome Bonus available
+Claim after this hand.
+```
+
+Pros:
+
+- Timely and game-like.
+- Good fit after a hand or win.
+
+Cons:
+
+- Risk of distracting the player during gameplay.
+
+Recommendation:
+
+- Do not show during an active decision.
+- Show only after hand completion or in a passive table header area.
+- Limit to once per session.
+
+## Pattern 5: Notification Center / Messages
+
+Where:
+
+- A small topbar bell or account dropdown.
+
+Message:
+
+```text
+Welcome Bonus
+500 CH is waiting for your account.
+```
+
+CTA:
+
+```text
+Claim
+```
+
+Pros:
+
+- Scales beyond welcome bonus: daily rewards, achievements, maintenance, tournaments.
+- Lets users revisit dismissed messages.
+- Cleaner than scattering banners everywhere.
+
+Cons:
+
+- Requires a small notification model and UI.
+- Overkill if only used for one bonus.
+
+Recommendation:
+
+- Good PR4/PR5 candidate, not required for the bonus itself.
+- Start with local/backend-derived virtual notifications before adding a persisted messages table.
+
+Minimal first version:
+
+- Build notifications client-side from existing API state.
+- Example: if `welcome-bonus` status is eligible, add one virtual notification.
+- No new DB table yet.
+
+Future persisted version:
+
+- `notifications` table with `user_id`, `type`, `status`, `created_at`, `read_at`, `dismissed_at`, `metadata`.
+- Useful for multi-device read/dismiss sync.
+
+## Pattern 6: Email Reminder
+
+Email can work, but it is the riskiest channel from a compliance and trust perspective.
+
+Potential subject:
+
+```text
+Your 500 CH Welcome Bonus is waiting
+```
+
+Potential body:
+
+```text
+You have a 500 CH Welcome Bonus available in Arcade Hub.
+Sign in to claim it from your account page.
+```
+
+Important:
+
+- Do not say the bonus was added unless the user already claimed it.
+- Do not imply urgency unless there is a real expiration date.
+- Include unsubscribe/marketing preferences if the email is commercial/marketing.
+
+Legal/compliance note:
+
+- In the US, the FTC explains that CAN-SPAM covers commercial email and requires accurate headers, non-deceptive subjects, clear ad identification where applicable, a physical postal address, and an opt-out mechanism. Transactional or relationship messages are treated differently, but the FTC warns those categories are narrow.
+- In the EU/UK-style ePrivacy model, unsolicited marketing email generally requires prior consent, with limited existing-customer or similar-product exceptions depending on local law and how consent was collected.
+
+Practical recommendation:
+
+- Do not send a newsletter-style bonus email to users who did not opt into marketing.
+- If using email, prefer one of these safer variants:
+  - Send only to users with explicit marketing consent.
+  - Include the bonus mention inside a legitimate account/service email only after legal review confirms the primary purpose is transactional/relationship.
+  - Add a user setting for product/reward emails and use that consent going forward.
+
+For the current PR3/PR4 path, in-product notification is the better first move.
+
+## Good Product Pattern
+
+The strongest pattern for Arcade Hub:
+
+1. User logs in.
+2. Backend returns `eligible: true`.
+3. Topbar shows a small chip badge: `+500`.
+4. Account page and poker lobby show a clear claim card.
+5. User clicks `Claim 500 CH`.
+6. Success toast confirms: `Welcome! 500 CH have been added to your account.`
+7. Badge/card disappear everywhere after the next status refresh.
+
+This matches common free-to-play and SaaS reward patterns:
+
+- Reward is visible but not blocking.
+- Claim is explicit.
+- No fake urgency.
+- No success copy before the ledger transaction exists.
+- State is driven by backend eligibility, not local storage.
+
+## Anti-Patterns To Avoid
+
+- Modal on login.
+- Full-screen interstitial before gameplay.
+- Repeated banners every page load.
+- “You received 500 CH” before successful claim.
+- “Sign in and get 500 CH” for users who may be ineligible.
+- Email blast to all users without consent review.
+- Countdown timers unless the bonus really expires.
+- Persisting a notification after `alreadyClaimed`.
+
+## Proposed Rollout
+
+### PR4A: In-Product Bonus Notification
+
+Scope:
+
+- Account page claim card polish.
+- Topbar badge for eligible users.
+- Poker lobby inline banner.
+- Dismiss once per session/day.
+
+No new DB table required.
+
+### PR4B: Notification Center Foundation
+
+Scope:
+
+- Bell/dropdown UI.
+- Virtual notification for welcome bonus.
+- Optional persisted read/dismiss state later.
+
+### PR4C: Email Consent Strategy
+
+Scope:
+
+- Add marketing/reward email preference.
+- Update privacy/cookie/consent copy if needed.
+- Send bonus reminder only to consented users or after legal approval.
+
+## Open Decisions
+
+- Should the bonus notification be dismissible permanently or only for the current session?
+- Should the bonus ever expire?
+- Should topbar show a numeric `+500` badge or a neutral dot?
+- Should reward notifications become a generic system for daily rewards and achievements?
+- Is Arcade Hub targeting EU/UK users, US users, or both for email compliance?
+
+## Sources
+
+- FTC, CAN-SPAM Act: A Compliance Guide for Business: https://www.ftc.gov/business-guidance/resources/can-spam-act-compliance-guide-business
+- EU ePrivacy Directive: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32002L0058
+- UK ICO direct marketing and PECR guidance entry points:
+  - https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/
+  - https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/direct-marketing-and-pecr/

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -6,6 +6,10 @@
   var nodes = {};
   var currentUser = null;
   var chipsInFlight = null;
+  var welcomeBonusInFlight = null;
+  var welcomeBonusProcessedFor = {};
+  var GUEST_CONVERSION_KEY = 'poker:guestConversionIntent';
+  var WELCOME_BONUS_SUCCESS = 'Welcome! 500 CH have been added to your account.';
   var ledgerState = {
     entries: [],
     nextCursor: null,
@@ -62,6 +66,26 @@
         window.KLog.log(kind, data || {});
       }
     } catch (_err){}
+  }
+
+  function getGuestConversionIntent(){
+    try {
+      if (!window.sessionStorage) return '';
+      return window.sessionStorage.getItem(GUEST_CONVERSION_KEY) || '';
+    } catch (_err){
+      return '';
+    }
+  }
+
+  function clearGuestConversionIntent(){
+    try {
+      if (window.sessionStorage) window.sessionStorage.removeItem(GUEST_CONVERSION_KEY);
+    } catch (_err){}
+  }
+
+  function getUserKey(user){
+    if (!user) return '';
+    return String(user.id || user.user_id || user.sub || 'current');
   }
 
   function parseSortId(value){
@@ -496,6 +520,47 @@
     return chipsInFlight;
   }
 
+  async function processWelcomeBonus(user){
+    var userKey = getUserKey(user);
+    if (!userKey || getGuestConversionIntent() !== 'welcome_bonus') return null;
+    if (
+      !window ||
+      !window.ChipsClient ||
+      typeof window.ChipsClient.fetchWelcomeBonusStatus !== 'function' ||
+      typeof window.ChipsClient.claimWelcomeBonus !== 'function'
+    ) return null;
+    if (welcomeBonusProcessedFor[userKey]) return welcomeBonusProcessedFor[userKey];
+    if (welcomeBonusInFlight) return welcomeBonusInFlight;
+
+    welcomeBonusInFlight = (async function(){
+      try {
+        var status = await window.ChipsClient.fetchWelcomeBonusStatus();
+        if (!status || !status.eligible || status.alreadyClaimed){
+          clearGuestConversionIntent();
+          return status || null;
+        }
+
+        var result = await window.ChipsClient.claimWelcomeBonus();
+        if (result && result.claimed){
+          clearGuestConversionIntent();
+          setStatus(WELCOME_BONUS_SUCCESS, 'success');
+          loadChips();
+          return result;
+        }
+
+        clearGuestConversionIntent();
+        return result || null;
+      } catch (err){
+        return null;
+      } finally {
+        welcomeBonusInFlight = null;
+      }
+    })();
+
+    welcomeBonusProcessedFor[userKey] = welcomeBonusInFlight;
+    return welcomeBonusInFlight;
+  }
+
   function handleSignIn(e){
     e.preventDefault();
     var email = nodes.signInEmail && nodes.signInEmail.value ? nodes.signInEmail.value.trim() : '';
@@ -517,6 +582,7 @@
         setStatus('Signed in successfully.', 'success');
         renderUser(user);
         loadChips();
+        processWelcomeBonus(user);
       } else {
         setStatus('Signed in. Redirecting…', 'success');
       }
@@ -548,7 +614,10 @@
       } else {
         setStatus('Account created. You are signed in.', 'success');
       }
+      var user = res && res.data && res.data.user ? res.data.user : null;
+      if (user){ renderUser(user); }
       loadChips();
+      processWelcomeBonus(user || currentUser);
     }).catch(function(err){
       var msg = err && err.message ? String(err.message) : 'Could not sign up. Please try again.';
       setStatus(msg, 'error');
@@ -607,6 +676,7 @@
       setStatus(user ? 'Signed in.' : '', user ? 'success' : '');
       if (user){
         loadChips();
+        processWelcomeBonus(user);
       } else {
         clearChips();
         setBlockVisibility(nodes.chipPanel, false);
@@ -622,6 +692,7 @@
         if (user){
           setStatus('Signed in.', 'success');
           loadChips();
+          processWelcomeBonus(user);
         } else {
           setStatus('You have been signed out.', 'info');
           clearChips();

--- a/js/account-page.js
+++ b/js/account-page.js
@@ -7,8 +7,6 @@
   var currentUser = null;
   var chipsInFlight = null;
   var welcomeBonusInFlight = null;
-  var welcomeBonusProcessedFor = {};
-  var GUEST_CONVERSION_KEY = 'poker:guestConversionIntent';
   var WELCOME_BONUS_SUCCESS = 'Welcome! 500 CH have been added to your account.';
   var ledgerState = {
     entries: [],
@@ -45,6 +43,10 @@
     nodes.chipLedgerSpacer = doc.getElementById('chipLedgerSpacer');
     nodes.chipLedgerList = doc.getElementById('chipLedgerList');
     nodes.chipLedgerEmpty = doc.getElementById('chipLedgerEmpty');
+    nodes.welcomeBonusPanel = doc.getElementById('welcomeBonusPanel');
+    nodes.welcomeBonusTitle = doc.getElementById('welcomeBonusTitle');
+    nodes.welcomeBonusClaimButton = doc.getElementById('welcomeBonusClaimButton');
+    nodes.welcomeBonusStatus = doc.getElementById('welcomeBonusStatus');
   }
 
   function setBlockVisibility(node, isVisible){
@@ -65,21 +67,6 @@
       if (window && window.KLog && typeof window.KLog.log === 'function'){
         window.KLog.log(kind, data || {});
       }
-    } catch (_err){}
-  }
-
-  function getGuestConversionIntent(){
-    try {
-      if (!window.sessionStorage) return '';
-      return window.sessionStorage.getItem(GUEST_CONVERSION_KEY) || '';
-    } catch (_err){
-      return '';
-    }
-  }
-
-  function clearGuestConversionIntent(){
-    try {
-      if (window.sessionStorage) window.sessionStorage.removeItem(GUEST_CONVERSION_KEY);
     } catch (_err){}
   }
 
@@ -139,6 +126,7 @@
 
     if (!hasUser){
       clearChips();
+      setWelcomeBonusVisibility(false);
       return;
     }
 
@@ -163,6 +151,24 @@
     nodes.chipStatus.textContent = message || '';
     nodes.chipStatus.dataset.tone = tone || '';
     nodes.chipStatus.hidden = !message;
+  }
+
+  function setWelcomeBonusStatus(message, tone){
+    if (!nodes.welcomeBonusStatus) return;
+    nodes.welcomeBonusStatus.textContent = message || '';
+    nodes.welcomeBonusStatus.dataset.tone = tone || '';
+    nodes.welcomeBonusStatus.hidden = !message;
+  }
+
+  function setWelcomeBonusVisibility(isVisible){
+    setBlockVisibility(nodes.welcomeBonusPanel, isVisible);
+    if (nodes.welcomeBonusTitle){ nodes.welcomeBonusTitle.textContent = 'Claim your 500 CH welcome bonus'; }
+    if (nodes.welcomeBonusClaimButton){
+      nodes.welcomeBonusClaimButton.hidden = !isVisible;
+      nodes.welcomeBonusClaimButton.disabled = false;
+      nodes.welcomeBonusClaimButton.textContent = 'Claim your 500 CH welcome bonus';
+    }
+    if (!isVisible) setWelcomeBonusStatus('', '');
   }
 
   function renderChipBalance(balance){
@@ -520,45 +526,61 @@
     return chipsInFlight;
   }
 
-  async function processWelcomeBonus(user){
+  async function refreshWelcomeBonus(user){
     var userKey = getUserKey(user);
-    if (!userKey || getGuestConversionIntent() !== 'welcome_bonus') return null;
+    if (!userKey){
+      setWelcomeBonusVisibility(false);
+      return null;
+    }
     if (
       !window ||
       !window.ChipsClient ||
-      typeof window.ChipsClient.fetchWelcomeBonusStatus !== 'function' ||
-      typeof window.ChipsClient.claimWelcomeBonus !== 'function'
-    ) return null;
-    if (welcomeBonusProcessedFor[userKey]) return welcomeBonusProcessedFor[userKey];
+      typeof window.ChipsClient.fetchWelcomeBonusStatus !== 'function'
+    ){
+      setWelcomeBonusVisibility(false);
+      return null;
+    }
     if (welcomeBonusInFlight) return welcomeBonusInFlight;
 
     welcomeBonusInFlight = (async function(){
       try {
         var status = await window.ChipsClient.fetchWelcomeBonusStatus();
-        if (!status || !status.eligible || status.alreadyClaimed){
-          clearGuestConversionIntent();
-          return status || null;
-        }
-
-        var result = await window.ChipsClient.claimWelcomeBonus();
-        if (result && result.claimed){
-          clearGuestConversionIntent();
-          setStatus(WELCOME_BONUS_SUCCESS, 'success');
-          loadChips();
-          return result;
-        }
-
-        clearGuestConversionIntent();
-        return result || null;
-      } catch (err){
+        var canClaim = !!(status && status.eligible && !status.alreadyClaimed);
+        setWelcomeBonusVisibility(canClaim);
+        if (canClaim) setWelcomeBonusStatus('', '');
+        return status || null;
+      } catch (_err){
+        setWelcomeBonusVisibility(false);
         return null;
       } finally {
         welcomeBonusInFlight = null;
       }
     })();
 
-    welcomeBonusProcessedFor[userKey] = welcomeBonusInFlight;
     return welcomeBonusInFlight;
+  }
+
+  async function handleWelcomeBonusClaim(e){
+    if (e && typeof e.preventDefault === 'function') e.preventDefault();
+    if (!currentUser || !window || !window.ChipsClient || typeof window.ChipsClient.claimWelcomeBonus !== 'function') return;
+    if (nodes.welcomeBonusClaimButton) nodes.welcomeBonusClaimButton.disabled = true;
+    setWelcomeBonusStatus('Claiming your 500 CH welcome bonus...', 'info');
+    try {
+      var result = await window.ChipsClient.claimWelcomeBonus();
+      if (result && result.claimed){
+        setStatus(WELCOME_BONUS_SUCCESS, 'success');
+        setWelcomeBonusStatus('Welcome bonus added to your account.', 'success');
+        loadChips();
+        await refreshWelcomeBonus(currentUser);
+        return result;
+      }
+      setWelcomeBonusVisibility(false);
+      return result || null;
+    } catch (_err){
+      setWelcomeBonusStatus('Could not claim your welcome bonus right now.', 'error');
+      if (nodes.welcomeBonusClaimButton) nodes.welcomeBonusClaimButton.disabled = false;
+      return null;
+    }
   }
 
   function handleSignIn(e){
@@ -582,7 +604,7 @@
         setStatus('Signed in successfully.', 'success');
         renderUser(user);
         loadChips();
-        processWelcomeBonus(user);
+        refreshWelcomeBonus(user);
       } else {
         setStatus('Signed in. Redirecting…', 'success');
       }
@@ -617,7 +639,7 @@
       var user = res && res.data && res.data.user ? res.data.user : null;
       if (user){ renderUser(user); }
       loadChips();
-      processWelcomeBonus(user || currentUser);
+      refreshWelcomeBonus(user || currentUser);
     }).catch(function(err){
       var msg = err && err.message ? String(err.message) : 'Could not sign up. Please try again.';
       setStatus(msg, 'error');
@@ -644,6 +666,7 @@
     if (nodes.signInForm){ nodes.signInForm.addEventListener('submit', handleSignIn); }
     if (nodes.signUpForm){ nodes.signUpForm.addEventListener('submit', handleSignUp); }
     if (nodes.signOut){ nodes.signOut.addEventListener('click', handleSignOut); }
+    if (nodes.welcomeBonusClaimButton){ nodes.welcomeBonusClaimButton.addEventListener('click', handleWelcomeBonusClaim); }
     if (nodes.deleteBtn && nodes.deleteNote){
       nodes.deleteBtn.addEventListener('click', function(e){
         e.preventDefault();
@@ -676,9 +699,10 @@
       setStatus(user ? 'Signed in.' : '', user ? 'success' : '');
       if (user){
         loadChips();
-        processWelcomeBonus(user);
+        refreshWelcomeBonus(user);
       } else {
         clearChips();
+        setWelcomeBonusVisibility(false);
         setBlockVisibility(nodes.chipPanel, false);
       }
     }).catch(function(err){
@@ -692,10 +716,11 @@
         if (user){
           setStatus('Signed in.', 'success');
           loadChips();
-          processWelcomeBonus(user);
+          refreshWelcomeBonus(user);
         } else {
           setStatus('You have been signed out.', 'info');
           clearChips();
+          setWelcomeBonusVisibility(false);
           setBlockVisibility(nodes.chipPanel, false);
         }
       });

--- a/js/chips/client.js
+++ b/js/chips/client.js
@@ -4,6 +4,7 @@
   var BALANCE_URL = '/.netlify/functions/chips-balance';
   var LEDGER_URL = '/.netlify/functions/chips-ledger';
   var TX_URL = '/.netlify/functions/chips-tx';
+  var WELCOME_BONUS_URL = '/.netlify/functions/welcome-bonus';
   var AUTH_CACHE_MS = 60000;
 
   var state = { token: null, checkedAt: 0, tokenPromise: null };
@@ -264,6 +265,19 @@
     return payload.data;
   }
 
+  async function fetchWelcomeBonusStatus(){
+    var payload = await authedFetchWithRetry(WELCOME_BONUS_URL, { method: 'GET' });
+    return payload.data;
+  }
+
+  async function claimWelcomeBonus(){
+    var payload = await authedFetchWithRetry(WELCOME_BONUS_URL, { method: 'POST', body: JSON.stringify({}) });
+    if (payload && payload.data && payload.data.claimed){
+      emit('chips:tx-complete', payload.data);
+    }
+    return payload.data;
+  }
+
   async function fetchState(options){
     var limit = options && Number.isInteger(options.limit) ? options.limit : 10;
     var balance = await fetchBalance();
@@ -277,6 +291,8 @@
     fetchBalance: fetchBalance,
     fetchLedger: fetchLedger,
     postTransaction: postTransaction,
+    fetchWelcomeBonusStatus: fetchWelcomeBonusStatus,
+    claimWelcomeBonus: claimWelcomeBonus,
     fetchState: fetchState,
     refreshAuth: function(){ return fetchAuthToken(true); }
   };

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -4,9 +4,11 @@
   const win = window;
   if (win.__topbarBooted) return;
   win.__topbarBooted = true;
-  const chipNodes = { badge: null, amount: null, ready: false };
+  const chipNodes = { badge: null, amount: null, bonus: null, ready: false };
   let chipInFlight = null;
+  let welcomeBonusInFlight = null;
   let chipsClientWaitTries = 0;
+  let welcomeBonusClientWaitTries = 0;
   const AuthState = { UNKNOWN: 0, SIGNED_OUT: 1, SIGNED_IN: 2 };
   let authState = AuthState.SIGNED_OUT;
   let authWired = false;
@@ -134,6 +136,12 @@
       amount.id = 'chipBadgeAmount';
       amount.textContent = '';
       label.appendChild(amount);
+      const bonus = doc.createElement('span');
+      bonus.id = 'welcomeBonusTopbarBadge';
+      bonus.className = 'welcome-bonus-badge';
+      bonus.textContent = '+500';
+      bonus.hidden = true;
+      label.appendChild(bonus);
       badge.appendChild(label);
     } else if (badge.getAttribute('href') !== CHIP_BADGE_HREF){
       badge.setAttribute('href', CHIP_BADGE_HREF);
@@ -156,6 +164,20 @@
         wrap.appendChild(amount);
         badge.textContent = '';
         badge.appendChild(wrap);
+      }
+    }
+    let bonus = doc.getElementById('welcomeBonusTopbarBadge');
+    if (!bonus){
+      const label = badge.querySelector('.chip-badge__label');
+      bonus = doc.createElement('span');
+      bonus.id = 'welcomeBonusTopbarBadge';
+      bonus.className = 'welcome-bonus-badge';
+      bonus.textContent = '+500';
+      bonus.hidden = true;
+      if (label){
+        label.appendChild(bonus);
+      } else {
+        badge.appendChild(bonus);
       }
     }
     if (topbarRight && badge.parentNode !== topbarRight){
@@ -186,9 +208,10 @@
   }
 
   function ensureChipNodes(){
-    if (chipNodes.ready) return;
+    if (chipNodes.ready && chipNodes.badge && chipNodes.amount && chipNodes.bonus) return;
     chipNodes.badge = doc.getElementById('chipBadge');
     chipNodes.amount = doc.getElementById('chipBadgeAmount');
+    chipNodes.bonus = doc.getElementById('welcomeBonusTopbarBadge');
     chipNodes.ready = true;
   }
 
@@ -219,6 +242,24 @@
     if (chipNodes.amount){ chipNodes.amount.textContent = ''; }
   }
 
+  function hideWelcomeBonusBadge(){
+    ensureChipNodes();
+    if (chipNodes.bonus){ chipNodes.bonus.hidden = true; }
+  }
+
+  function setWelcomeBonusBadgeVisible(isVisible, amount){
+    ensureChipNodes();
+    if (!chipNodes.bonus) return;
+    if (!isAuthed() || !isVisible){
+      chipNodes.bonus.hidden = true;
+      return;
+    }
+    const raw = amount == null ? 500 : Number(amount);
+    const value = Number.isFinite(raw) && raw > 0 ? Math.trunc(raw) : 500;
+    chipNodes.bonus.textContent = '+' + value;
+    chipNodes.bonus.hidden = false;
+  }
+
   function renderChipBadgeBalance(amount){
     const formatKey = 'format' + 'CompactNumber';
     const formatter = window && window.ArcadeFormat && typeof window.ArcadeFormat[formatKey] === 'function'
@@ -242,11 +283,13 @@
     if (amount){ amount.textContent = ''; }
     if (!isAuthed()){
       hideChipBadge();
+      hideWelcomeBonusBadge();
       return;
     }
     if (badge){ badge.hidden = false; }
     setChipBadge('', { loading: true });
     refreshChipBadge();
+    refreshWelcomeBonusBadge();
   }
 
   function resolveInitialAuth(){
@@ -259,10 +302,49 @@
       }
       refreshXpBadge();
       refreshChipBadge();
+      refreshWelcomeBonusBadge();
     }).catch(function(){
       setAuthState(AuthState.SIGNED_OUT);
       hideChipBadge();
+      hideWelcomeBonusBadge();
     });
+  }
+
+  async function refreshWelcomeBonusBadge(){
+    normalizeTopbarBadges();
+    ensureChipNodes();
+    if (!isAuthed()){
+      hideWelcomeBonusBadge();
+      return;
+    }
+    if (!window || !window.ChipsClient || typeof window.ChipsClient.fetchWelcomeBonusStatus !== 'function'){
+      if (welcomeBonusClientWaitTries < 6){
+        welcomeBonusClientWaitTries += 1;
+        setTimeout(refreshWelcomeBonusBadge, 150);
+        return;
+      }
+      welcomeBonusClientWaitTries = 0;
+      hideWelcomeBonusBadge();
+      return;
+    }
+    welcomeBonusClientWaitTries = 0;
+    if (welcomeBonusInFlight){ return welcomeBonusInFlight; }
+    welcomeBonusInFlight = (async function(){
+      try {
+        const status = await window.ChipsClient.fetchWelcomeBonusStatus();
+        const canClaim = !!(status && status.eligible && !status.alreadyClaimed);
+        setWelcomeBonusBadgeVisible(canClaim, status && status.amount);
+      } catch (err){
+        if (err && err.code === 'not_authenticated'){
+          setAuthState(AuthState.SIGNED_OUT);
+        }
+        hideWelcomeBonusBadge();
+      } finally {
+        welcomeBonusInFlight = null;
+      }
+    })();
+
+    return welcomeBonusInFlight;
   }
 
   async function refreshChipBadge(){
@@ -331,16 +413,19 @@
     if (event === 'SIGNED_OUT'){
       setAuthState(AuthState.SIGNED_OUT);
       hideChipBadge();
+      hideWelcomeBonusBadge();
       return;
     }
     if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION'){
       setAuthState(hasUser ? AuthState.SIGNED_IN : AuthState.SIGNED_OUT);
       if (!isAuthed()){
         hideChipBadge();
+        hideWelcomeBonusBadge();
         return;
       }
       refreshXpBadge();
       refreshChipBadge();
+      refreshWelcomeBonusBadge();
       return;
     }
   }
@@ -355,7 +440,10 @@
 
   function wireChipEvents(){
     if (!doc || typeof doc.addEventListener !== 'function') return;
-    doc.addEventListener('chips:tx-complete', refreshChipBadge);
+    doc.addEventListener('chips:tx-complete', function(){
+      refreshChipBadge();
+      refreshWelcomeBonusBadge();
+    });
   }
 
   function tryWireAuthBridge(){

--- a/netlify.toml
+++ b/netlify.toml
@@ -56,12 +56,16 @@
   XP_SESSION_RATE_LIMIT_ENABLED = "0"
   XP_SERVER_SESSION_WARN_MODE = "0"
   XP_REQUIRE_SERVER_SESSION = "0"
+  WELCOME_BONUS_START_AT = "2025-06-01T00:00:00Z"
+  WELCOME_BONUS_CHIPS = "500"
 
 # Branch deploy context - same as production
 [context.branch-deploy.environment]
   XP_DEBUG = "0"
   XP_RATE_LIMIT_ENABLED = "1"
   XP_SESSION_RATE_LIMIT_ENABLED = "1"
+  WELCOME_BONUS_START_AT = "2025-06-01T00:00:00Z"
+  WELCOME_BONUS_CHIPS = "500"
 
 # Deploy preview context - relaxed for testing
 [context.deploy-preview.environment]
@@ -70,6 +74,8 @@
   XP_SESSION_RATE_LIMIT_ENABLED = "1"
   XP_SERVER_SESSION_WARN_MODE = "1"
   XP_REQUIRE_SERVER_SESSION = "0"
+  WELCOME_BONUS_START_AT = "2025-06-01T00:00:00Z"
+  WELCOME_BONUS_CHIPS = "500"
 
 # Production context - secure defaults
 # NOTE: These are baseline values. Override in Netlify UI for sensitive settings.
@@ -80,6 +86,8 @@
   # Server session enforcement - enable gradually:
   # Step 1: Start with warn mode to monitor
   XP_SERVER_SESSION_WARN_MODE = "1"
+  WELCOME_BONUS_START_AT = "2025-06-01T00:00:00Z"
+  WELCOME_BONUS_CHIPS = "500"
   # Step 2: After verification, enable enforcement (set in Netlify UI)
   # XP_REQUIRE_SERVER_SESSION = "1"
   XP_REQUIRE_SERVER_SESSION = "0"

--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -12,6 +12,7 @@ const VALID_TX_TYPES = new Set([
   "HAND_SETTLEMENT",
   "RAKE_FEE",
   "PRIZE_PAYOUT",
+  "WELCOME_BONUS",
 ]);
 
 // Loose integer parsing for non-sequence fields only (balances, etc.).

--- a/netlify/functions/_shared/welcome-bonus.mjs
+++ b/netlify/functions/_shared/welcome-bonus.mjs
@@ -2,7 +2,7 @@ import { executeSql, klog } from "./supabase-admin.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 
 const DEFAULT_BONUS_AMOUNT = 500;
-const TREASURY_SYSTEM_KEY = "TREASURY";
+const GENESIS_SYSTEM_KEY = "GENESIS";
 
 function parsePositiveInt(value, fallback) {
   const raw = value == null || value === "" ? fallback : value;
@@ -137,9 +137,9 @@ function buildWelcomeBonusEntries(userId, amount) {
     },
     {
       accountType: "SYSTEM",
-      systemKey: TREASURY_SYSTEM_KEY,
+      systemKey: GENESIS_SYSTEM_KEY,
       amount: -amount,
-      metadata: { source: "welcome_bonus", entry_role: "treasury_offset" },
+      metadata: { source: "welcome_bonus", entry_role: "genesis_offset" },
     },
   ];
 }
@@ -206,7 +206,7 @@ async function claimWelcomeBonus(userId, deps = {}) {
 
 export {
   DEFAULT_BONUS_AMOUNT,
-  TREASURY_SYSTEM_KEY,
+  GENESIS_SYSTEM_KEY,
   buildIdempotencyKey,
   claimWelcomeBonus,
   getConfig,

--- a/netlify/functions/_shared/welcome-bonus.mjs
+++ b/netlify/functions/_shared/welcome-bonus.mjs
@@ -1,0 +1,214 @@
+import { executeSql, klog } from "./supabase-admin.mjs";
+import { postTransaction } from "./chips-ledger.mjs";
+
+const DEFAULT_BONUS_AMOUNT = 500;
+const TREASURY_SYSTEM_KEY = "TREASURY";
+
+function parsePositiveInt(value, fallback) {
+  const raw = value == null || value === "" ? fallback : value;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || Math.trunc(parsed) !== parsed || parsed <= 0) return null;
+  if (Math.abs(parsed) > Number.MAX_SAFE_INTEGER) return null;
+  return parsed;
+}
+
+function parseRequiredStartAt(value) {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function toIso(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value !== "string") return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function getConfig(env = process.env) {
+  const amount = parsePositiveInt(env.WELCOME_BONUS_CHIPS, DEFAULT_BONUS_AMOUNT);
+  const startAt = parseRequiredStartAt(env.WELCOME_BONUS_START_AT);
+  return {
+    amount,
+    startAt,
+    configured: !!(amount && startAt),
+  };
+}
+
+function buildIdempotencyKey(userId) {
+  return `welcome-bonus:${userId}`;
+}
+
+async function fetchUserCreatedAt(userId, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select created_at
+from auth.users
+where id = $1
+limit 1;
+`,
+    [userId],
+  );
+  return toIso(rows?.[0]?.created_at);
+}
+
+async function fetchClaimTransaction(userId, idempotencyKey, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select id, created_at
+from public.chips_transactions
+where user_id = $1
+  and tx_type = 'WELCOME_BONUS'
+  and idempotency_key = $2
+limit 1;
+`,
+    [userId, idempotencyKey],
+  );
+  return rows?.[0] || null;
+}
+
+async function getWelcomeBonusStatus(userId, deps = {}) {
+  const env = deps.env || process.env;
+  const runSql = deps.executeSql || executeSql;
+  const config = getConfig(env);
+  const idempotencyKey = buildIdempotencyKey(userId);
+
+  if (!config.configured) {
+    return {
+      eligible: false,
+      alreadyClaimed: false,
+      amount: config.amount || DEFAULT_BONUS_AMOUNT,
+      reason: "missing_or_invalid_config",
+      idempotencyKey,
+    };
+  }
+
+  const createdAt = await fetchUserCreatedAt(userId, runSql);
+  if (!createdAt) {
+    return {
+      eligible: false,
+      alreadyClaimed: false,
+      amount: config.amount,
+      reason: "user_not_found",
+      idempotencyKey,
+      startAt: config.startAt,
+    };
+  }
+
+  const claimed = await fetchClaimTransaction(userId, idempotencyKey, runSql);
+  if (claimed) {
+    return {
+      eligible: false,
+      alreadyClaimed: true,
+      amount: config.amount,
+      reason: "already_claimed",
+      idempotencyKey,
+      startAt: config.startAt,
+      createdAt,
+      transactionId: claimed.id,
+    };
+  }
+
+  const eligible = Date.parse(createdAt) >= Date.parse(config.startAt);
+  return {
+    eligible,
+    alreadyClaimed: false,
+    amount: config.amount,
+    reason: eligible ? "eligible" : "created_before_start",
+    idempotencyKey,
+    startAt: config.startAt,
+    createdAt,
+  };
+}
+
+function buildWelcomeBonusEntries(userId, amount) {
+  const metadata = { source: "welcome_bonus", entry_role: "welcome_bonus" };
+  return [
+    {
+      accountType: "USER",
+      userId,
+      amount,
+      metadata,
+    },
+    {
+      accountType: "SYSTEM",
+      systemKey: TREASURY_SYSTEM_KEY,
+      amount: -amount,
+      metadata: { source: "welcome_bonus", entry_role: "treasury_offset" },
+    },
+  ];
+}
+
+async function claimWelcomeBonus(userId, deps = {}) {
+  const writeTransaction = deps.postTransaction || postTransaction;
+  const status = await getWelcomeBonusStatus(userId, deps);
+  const baseLog = {
+    userId,
+    eligible: status.eligible,
+    alreadyClaimed: status.alreadyClaimed,
+    amount: status.amount,
+    reason: status.reason,
+  };
+
+  if (!status.eligible) {
+    klog("welcome_bonus_skipped", {
+      ...baseLog,
+      transactionId: status.transactionId || null,
+    });
+    return { ...status, claimed: false, transaction: null, entries: [], account: null };
+  }
+
+  try {
+    const metadata = {
+      source: "guest_conversion",
+      amount: status.amount,
+      welcome_bonus_start_at: status.startAt,
+    };
+    const result = await writeTransaction({
+      userId,
+      txType: "WELCOME_BONUS",
+      idempotencyKey: status.idempotencyKey,
+      reference: `welcome_bonus:${userId}`,
+      description: "Welcome Bonus",
+      metadata,
+      entries: buildWelcomeBonusEntries(userId, status.amount),
+      createdBy: userId,
+    });
+    const transactionId = result?.transaction?.id || null;
+    klog("welcome_bonus_claimed", {
+      ...baseLog,
+      transactionId,
+    });
+    return {
+      ...status,
+      eligible: false,
+      alreadyClaimed: true,
+      claimed: true,
+      reason: "claimed",
+      transactionId,
+      transaction: result?.transaction || null,
+      entries: result?.entries || [],
+      account: result?.account || null,
+    };
+  } catch (error) {
+    klog("welcome_bonus_failed", {
+      ...baseLog,
+      reason: error?.code || error?.message || "server_error",
+    });
+    throw error;
+  }
+}
+
+export {
+  DEFAULT_BONUS_AMOUNT,
+  TREASURY_SYSTEM_KEY,
+  buildIdempotencyKey,
+  claimWelcomeBonus,
+  getConfig,
+  getWelcomeBonusStatus,
+};

--- a/netlify/functions/welcome-bonus.mjs
+++ b/netlify/functions/welcome-bonus.mjs
@@ -1,0 +1,92 @@
+import { claimWelcomeBonus, getWelcomeBonusStatus } from "./_shared/welcome-bonus.mjs";
+import { baseHeaders, corsHeaders, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
+
+function json(statusCode, headers, body) {
+  return { statusCode, headers, body: JSON.stringify(body) };
+}
+
+function mapClaimError(error) {
+  const safeCodes = new Set([
+    "idempotency_conflict",
+    "invalid_tx_type",
+    "missing_idempotency_key",
+    "system_account_missing",
+    "system_account_inactive",
+    "insufficient_funds",
+  ]);
+  if (error?.status === 409) return { statusCode: 409, error: "idempotency_conflict" };
+  if (error?.status === 400 && safeCodes.has(error?.code)) return { statusCode: 400, error: error.code };
+  return { statusCode: error?.status || 500, error: "server_error" };
+}
+
+function createWelcomeBonusHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const getStatus = deps.getWelcomeBonusStatus || getWelcomeBonusStatus;
+  const claimBonus = deps.claimWelcomeBonus || claimWelcomeBonus;
+  const verifyJwt = deps.verifySupabaseJwt || verifySupabaseJwt;
+
+  return async function handler(event) {
+    if (env.CHIPS_ENABLED !== "1") {
+      return json(404, baseHeaders(), { error: "not_found" });
+    }
+
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) {
+      return json(403, baseHeaders(), { error: "forbidden_origin" });
+    }
+    if (event.httpMethod === "OPTIONS") {
+      return { statusCode: 204, headers: cors, body: "" };
+    }
+    if (event.httpMethod !== "GET" && event.httpMethod !== "POST") {
+      return json(405, cors, { error: "method_not_allowed" });
+    }
+
+    const token = extractBearerToken(event.headers);
+    const auth = await verifyJwt(token);
+    if (!auth.valid || !auth.userId) {
+      klog("welcome_bonus_failed", { userId: null, reason: auth.reason || "unauthorized" });
+      return json(401, cors, { error: "unauthorized", reason: auth.reason });
+    }
+
+    try {
+      if (event.httpMethod === "GET") {
+        const status = await getStatus(auth.userId, { env });
+        return json(200, cors, {
+          eligible: status.eligible,
+          alreadyClaimed: status.alreadyClaimed,
+          amount: status.amount,
+          reason: status.reason,
+          transactionId: status.transactionId || null,
+        });
+      }
+
+      const result = await claimBonus(auth.userId, { env });
+      return json(200, cors, {
+        claimed: result.claimed,
+        eligible: result.eligible,
+        alreadyClaimed: result.alreadyClaimed,
+        amount: result.amount,
+        reason: result.reason,
+        transactionId: result.transactionId || null,
+        transaction: result.transaction || null,
+        account: result.account || null,
+      });
+    } catch (error) {
+      const mapped = mapClaimError(error);
+      klog("welcome_bonus_failed", {
+        userId: auth.userId,
+        reason: mapped.error,
+        transactionId: null,
+      });
+      return json(mapped.statusCode, cors, { error: mapped.error });
+    }
+  };
+}
+
+const handler = createWelcomeBonusHandler();
+
+export {
+  createWelcomeBonusHandler,
+  handler,
+};

--- a/poker/index.html
+++ b/poker/index.html
@@ -87,7 +87,7 @@
       <div class="poker-auth-text" data-i18n="pokerAuthLobby">Please log in to access the poker lobby.</div>
       <div class="poker-auth-actions">
         <button id="pokerGuestPlay" class="poker-btn poker-btn--primary">Play as Guest</button>
-        <button id="pokerSignIn" class="poker-btn poker-btn--primary">Create account and get 500 CH Welcome Bonus</button>
+        <button id="pokerSignIn" class="poker-btn poker-btn--primary">Create account or sign in</button>
       </div>
     </div>
 

--- a/poker/index.html
+++ b/poker/index.html
@@ -87,7 +87,7 @@
       <div class="poker-auth-text" data-i18n="pokerAuthLobby">Please log in to access the poker lobby.</div>
       <div class="poker-auth-actions">
         <button id="pokerGuestPlay" class="poker-btn poker-btn--primary">Play as Guest</button>
-        <button id="pokerSignIn" class="poker-btn poker-btn--primary" data-i18n="signIn">Sign In</button>
+        <button id="pokerSignIn" class="poker-btn poker-btn--primary">Create account and get 500 CH Welcome Bonus</button>
       </div>
     </div>
 

--- a/poker/index.html
+++ b/poker/index.html
@@ -100,6 +100,14 @@
         </div>
       </div>
 
+      <div id="pokerWelcomeBonusBanner" class="poker-bonus-banner" hidden>
+        <div class="poker-bonus-banner__copy">
+          <strong>Your 500 CH Welcome Bonus is ready.</strong>
+          <span>Claim it to use persistent chips across Arcade Hub.</span>
+        </div>
+        <button id="pokerWelcomeBonusClaim" class="poker-btn poker-btn--primary" type="button">Claim bonus</button>
+      </div>
+
       <div class="poker-panel">
         <h3 data-i18n="createTable">Create Table</h3>
         <div class="poker-form-row">

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -361,7 +361,6 @@
   }
 
   function openSignIn(){
-    storeGuestConversionIntent();
     var bridge = window.SupabaseAuthBridge;
     var methods = ['signIn', 'openSignIn', 'showAuth', 'startLogin'];
     if (bridge){
@@ -375,13 +374,6 @@
       }
     }
     window.location.href = '/account.html';
-  }
-
-  function storeGuestConversionIntent(){
-    if (!isGuestMode) return;
-    try {
-      if (window.sessionStorage) window.sessionStorage.setItem('poker:guestConversionIntent', 'welcome_bonus');
-    } catch (_err){}
   }
 
   function isObject(value){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -361,6 +361,7 @@
   }
 
   function openSignIn(){
+    storeGuestConversionIntent();
     var bridge = window.SupabaseAuthBridge;
     var methods = ['signIn', 'openSignIn', 'showAuth', 'startLogin'];
     if (bridge){
@@ -374,6 +375,13 @@
       }
     }
     window.location.href = '/account.html';
+  }
+
+  function storeGuestConversionIntent(){
+    if (!isGuestMode) return;
+    try {
+      if (window.sessionStorage) window.sessionStorage.setItem('poker:guestConversionIntent', 'welcome_bonus');
+    } catch (_err){}
   }
 
   function isObject(value){
@@ -2143,7 +2151,10 @@
       });
     }
 
-    if (els.signInBtn) els.signInBtn.hidden = signedIn;
+    if (els.signInBtn) {
+      els.signInBtn.hidden = signedIn && !isGuestMode;
+      els.signInBtn.textContent = isGuestMode ? 'Create account and get 500 CH Welcome Bonus' : 'Sign in';
+    }
     if (els.guestBadge) els.guestBadge.hidden = !isGuestMode;
     if (els.joinBtn) els.joinBtn.hidden = false;
     if (els.joinBtn) els.joinBtn.disabled = joinDisabled;

--- a/poker/poker.css
+++ b/poker/poker.css
@@ -234,6 +234,16 @@
 
 .poker-form-row:last-child{margin-bottom:0;}
 
+.poker-bonus-banner{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px; padding:14px 16px; border:1px solid rgba(247,201,72,.34); border-radius:14px; background:linear-gradient(135deg, rgba(247,201,72,.14), rgba(110,231,231,.08)); box-shadow:0 12px 32px rgba(0,0,0,.18);}
+
+.poker-bonus-banner[hidden]{display:none;}
+
+.poker-bonus-banner__copy{display:flex; flex-direction:column; gap:4px; min-width:0;}
+
+.poker-bonus-banner__copy strong{font:800 14px Poppins, sans-serif; color:#fff4c2;}
+
+.poker-bonus-banner__copy span{font:600 12px/1.45 Poppins, sans-serif; color:#cdd6ff;}
+
 .poker-actions-row{display:flex; align-items:center; flex-wrap:wrap; gap:6px;}
 
 .poker-actions-row .poker-btn{padding:6px 12px; font-size:12px;}
@@ -327,6 +337,10 @@
 .poker-card__suit{font-size:1.05em;}
 
 @media (max-width:700px){
+  .poker-bonus-banner{align-items:stretch; flex-direction:column;}
+
+  .poker-bonus-banner .poker-btn{width:100%;}
+
   .poker-showdown-flyout{
     right:12px;
     left:12px;

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -154,7 +154,6 @@
   }
 
   function openSignIn(){
-    storeGuestConversionIntent();
     var bridge = getSignInBridge();
     if (bridge){
       var methods = ['signIn', 'openSignIn', 'showAuth', 'startLogin'];
@@ -171,12 +170,6 @@
       }
     }
     window.location.href = '/account.html';
-  }
-
-  function storeGuestConversionIntent(){
-    try {
-      if (window.sessionStorage) window.sessionStorage.setItem('poker:guestConversionIntent', 'welcome_bonus');
-    } catch (_err){}
   }
 
   async function authedFetch(url, options){

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1479,9 +1479,12 @@
     var maxPlayersInput = document.getElementById('pokerMaxPlayers');
     var signInBtn = document.getElementById('pokerSignIn');
     var guestPlayBtn = document.getElementById('pokerGuestPlay');
+    var welcomeBonusBanner = document.getElementById('pokerWelcomeBonusBanner');
+    var welcomeBonusClaimBtn = document.getElementById('pokerWelcomeBonusClaim');
 
     var LOBBY_RECONNECT_DELAYS_MS = [1000, 2000, 5000, 10000];
     var authTimer = null;
+    var welcomeBonusInFlight = null;
     var lobbyWsClient = null;
     var lobbyReconnectTimer = null;
     var lobbyReconnectAttempt = 0;
@@ -1597,6 +1600,34 @@
       }, 3000);
     }
 
+    function setWelcomeBonusBannerVisible(isVisible){
+      if (!welcomeBonusBanner) return;
+      welcomeBonusBanner.hidden = !isVisible;
+    }
+
+    async function refreshWelcomeBonusBanner(){
+      if (!welcomeBonusBanner) return null;
+      if (!window || !window.ChipsClient || typeof window.ChipsClient.fetchWelcomeBonusStatus !== 'function'){
+        setWelcomeBonusBannerVisible(false);
+        return null;
+      }
+      if (welcomeBonusInFlight) return welcomeBonusInFlight;
+      welcomeBonusInFlight = (async function(){
+        try {
+          var status = await window.ChipsClient.fetchWelcomeBonusStatus();
+          var canClaim = !!(status && status.eligible && !status.alreadyClaimed);
+          setWelcomeBonusBannerVisible(canClaim);
+          return status || null;
+        } catch (_err){
+          setWelcomeBonusBannerVisible(false);
+          return null;
+        } finally {
+          welcomeBonusInFlight = null;
+        }
+      })();
+      return welcomeBonusInFlight;
+    }
+
     function isLobbyAuthProtocolError(code){
       var normalized = typeof code === 'string' ? code.trim().toLowerCase() : '';
       return normalized === 'missing_access_token'
@@ -1614,6 +1645,7 @@
       var token = await getAccessToken();
       if (!token){
         stopLobbyWs();
+        setWelcomeBonusBannerVisible(false);
         if (authMsg) authMsg.hidden = false;
         if (lobbyContent) lobbyContent.hidden = true;
         if (tableList) tableList.innerHTML = '';
@@ -1623,6 +1655,7 @@
       if (authMsg) authMsg.hidden = true;
       if (lobbyContent) lobbyContent.hidden = false;
       stopAuthWatch();
+      refreshWelcomeBonusBanner();
       return true;
     }
 
@@ -1889,10 +1922,16 @@
     if (signInBtn){
       signInBtn.addEventListener('click', openSignIn);
     }
+    if (welcomeBonusClaimBtn){
+      welcomeBonusClaimBtn.addEventListener('click', function(){
+        window.location.href = '/account.html';
+      });
+    }
 
     window.addEventListener('beforeunload', stopAuthWatch); // xp-lifecycle-allow:poker-lobby(2026-01-01)
     window.addEventListener('beforeunload', stopLobbyWs); // xp-lifecycle-allow:poker-lobby-ws(2026-01-01)
     document.addEventListener('visibilitychange', handleLobbyVisibilityChange); // xp-lifecycle-allow:poker-lobby-visibility(2027-01-01)
+    document.addEventListener('chips:tx-complete', refreshWelcomeBonusBanner);
 
     checkAuth().then(function(authed){
       if (authed) requestLiveLobbySnapshot('initial');

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -154,6 +154,7 @@
   }
 
   function openSignIn(){
+    storeGuestConversionIntent();
     var bridge = getSignInBridge();
     if (bridge){
       var methods = ['signIn', 'openSignIn', 'showAuth', 'startLogin'];
@@ -170,6 +171,12 @@
       }
     }
     window.location.href = '/account.html';
+  }
+
+  function storeGuestConversionIntent(){
+    try {
+      if (window.sessionStorage) window.sessionStorage.setItem('poker:guestConversionIntent', 'welcome_bonus');
+    } catch (_err){}
   }
 
   async function authedFetch(url, options){

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -50,7 +50,7 @@
       </div>
       <div class="poker-live-actions">
         <div class="poker-live-pill" id="pokerV2GuestBadge" hidden>Guest account</div>
-        <button type="button" class="poker-live-btn" id="pokerV2SignInBtn">Sign in</button>
+        <button type="button" class="poker-live-btn" id="pokerV2SignInBtn">Create account and get 500 CH Welcome Bonus</button>
         <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2JoinBtn">Join</button>
         <button type="button" class="poker-live-btn" id="pokerV2LeaveBtn" hidden>Leave</button>
         <input type="hidden" id="pokerV2SeatNo" value="1">
@@ -59,13 +59,13 @@
       <section class="poker-guest-panel" id="pokerV2GuestPanel" hidden aria-labelledby="pokerV2GuestPanelTitle">
         <div class="poker-guest-panel__title" id="pokerV2GuestPanelTitle">Guest account</div>
         <ul class="poker-guest-panel__list">
-          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Play Poker</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Learn the game</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No saved chips</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No XP</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No achievements</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">No rankings</li>
-          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">Multiplayer requires account</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Practice poker</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Unlimited bot games</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--blocked">Create account to unlock:</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">+500 CH welcome bonus</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Multiplayer</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">XP progression</li>
+          <li class="poker-guest-panel__item poker-guest-panel__item--allowed">Persistent chips</li>
         </ul>
       </section>
       <div class="poker-live-error" id="pokerV2ErrorText" hidden></div>

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -47,6 +47,7 @@ run("node", ["tests/poker-bot-cashout.seat-missing.unit.test.mjs"], "poker-bot-c
 run("node", ["tests/poker-bot-cashout.not-bot.unit.test.mjs"], "poker-bot-cashout-not-bot-unit");
 run("node", ["tests/chips-ledger.escrow-only.null-user.unit.test.mjs"], "chips-ledger-escrow-only-null-user");
 run("node", ["tests/chips-ledger.human.buyin.unit.test.mjs"], "chips-ledger-human-buyin");
+run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/poker-stakes-ui.test.mjs"], "poker-stakes-ui");
 run("node", ["tests/poker-ws-client.test.mjs"], "poker-ws-client");
 run("node", ["tests/poker-csp-ws-allowlist.test.mjs"], "poker-csp-ws-allowlist");

--- a/supabase/migrations/20260702000000_chips_welcome_bonus_tx_type.sql
+++ b/supabase/migrations/20260702000000_chips_welcome_bonus_tx_type.sql
@@ -1,0 +1,1 @@
+alter type public.chips_tx_type add value if not exists 'WELCOME_BONUS';

--- a/tests/account-page.test.mjs
+++ b/tests/account-page.test.mjs
@@ -111,10 +111,11 @@ function seedNodes(document) {
   });
 }
 
-function buildContext(chipsClient) {
+function buildContext(chipsClient, options = {}) {
   const document = createDocument();
   seedNodes(document);
   const logs = [];
+  const sessionValues = new Map(Object.entries(options.sessionStorage || {}));
   const windowObj = {
     document,
     addEventListener() {},
@@ -128,13 +129,24 @@ function buildContext(chipsClient) {
     },
     SupabaseAuth: {
       getCurrentUser() {
-        return Promise.resolve({ user_metadata: { name: "Tester" }, email: "tester@example.com" });
+        return Promise.resolve({ id: "00000000-0000-4000-8000-000000000111", user_metadata: { name: "Tester" }, email: "tester@example.com" });
       },
       onAuthChange() {},
     },
     ChipsClient: chipsClient,
+    sessionStorage: {
+      getItem(key) {
+        return sessionValues.has(key) ? sessionValues.get(key) : null;
+      },
+      setItem(key, value) {
+        sessionValues.set(key, String(value));
+      },
+      removeItem(key) {
+        sessionValues.delete(key);
+      },
+    },
   };
-  return { windowObj, document, logs };
+  return { windowObj, document, logs, sessionValues };
 }
 
 function findByClass(node, className) {
@@ -826,4 +838,117 @@ test("chip-panel min-height is scoped to page-account", () => {
     assert.ok(!/min-height/.test(globalChipPanel[0]), "chip-panel min-height should not be global");
   }
   assert.ok(/\.page-account\s+\.chip-panel\{[^}]*min-height\s*:\s*0/.test(normalized), "chip-panel min-height must be scoped");
+});
+
+test("claims welcome bonus from guest conversion marker and shows success after POST", async () => {
+  const calls = [];
+  const chipsClient = {
+    fetchBalance() {
+      return Promise.resolve({ balance: 1700 });
+    },
+    fetchLedger() {
+      return Promise.resolve({ items: [], nextCursor: null });
+    },
+    fetchWelcomeBonusStatus() {
+      calls.push("status");
+      return Promise.resolve({ eligible: true, alreadyClaimed: false, amount: 500 });
+    },
+    claimWelcomeBonus() {
+      calls.push("claim");
+      return Promise.resolve({ claimed: true, amount: 500, transactionId: "tx-1" });
+    },
+  };
+  const { windowObj, document, sessionValues } = buildContext(chipsClient, {
+    sessionStorage: { "poker:guestConversionIntent": "welcome_bonus" },
+  });
+  const context = vm.createContext({
+    window: windowObj,
+    document,
+    requestAnimationFrame: windowObj.requestAnimationFrame,
+    CustomEvent: function() {},
+  });
+  vm.runInContext(source, context);
+
+  await flush();
+  await flush();
+  await flush();
+  await flush();
+
+  assert.deepEqual(calls, ["status", "claim"]);
+  assert.equal(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
+  assert.equal(sessionValues.has("poker:guestConversionIntent"), false);
+});
+
+test("clears welcome marker without success for already claimed account", async () => {
+  const calls = [];
+  const chipsClient = {
+    fetchBalance() {
+      return Promise.resolve({ balance: 1200 });
+    },
+    fetchLedger() {
+      return Promise.resolve({ items: [], nextCursor: null });
+    },
+    fetchWelcomeBonusStatus() {
+      calls.push("status");
+      return Promise.resolve({ eligible: false, alreadyClaimed: true, amount: 500 });
+    },
+    claimWelcomeBonus() {
+      calls.push("claim");
+      return Promise.resolve({ claimed: true });
+    },
+  };
+  const { windowObj, document, sessionValues } = buildContext(chipsClient, {
+    sessionStorage: { "poker:guestConversionIntent": "welcome_bonus" },
+  });
+  const context = vm.createContext({
+    window: windowObj,
+    document,
+    requestAnimationFrame: windowObj.requestAnimationFrame,
+    CustomEvent: function() {},
+  });
+  vm.runInContext(source, context);
+
+  await flush();
+  await flush();
+  await flush();
+  await flush();
+
+  assert.deepEqual(calls, ["status"]);
+  assert.notEqual(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
+  assert.equal(sessionValues.has("poker:guestConversionIntent"), false);
+});
+
+test("does not fetch welcome bonus status without guest conversion marker", async () => {
+  const calls = [];
+  const chipsClient = {
+    fetchBalance() {
+      return Promise.resolve({ balance: 1200 });
+    },
+    fetchLedger() {
+      return Promise.resolve({ items: [], nextCursor: null });
+    },
+    fetchWelcomeBonusStatus() {
+      calls.push("status");
+      return Promise.resolve({ eligible: true, alreadyClaimed: false, amount: 500 });
+    },
+    claimWelcomeBonus() {
+      calls.push("claim");
+      return Promise.resolve({ claimed: true });
+    },
+  };
+  const { windowObj, document } = buildContext(chipsClient);
+  const context = vm.createContext({
+    window: windowObj,
+    document,
+    requestAnimationFrame: windowObj.requestAnimationFrame,
+    CustomEvent: function() {},
+  });
+  vm.runInContext(source, context);
+
+  await flush();
+  await flush();
+  await flush();
+
+  assert.deepEqual(calls, []);
+  assert.notEqual(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
 });

--- a/tests/account-page.test.mjs
+++ b/tests/account-page.test.mjs
@@ -105,6 +105,10 @@ function seedNodes(document) {
     "chipLedgerSpacer",
     "chipLedgerList",
     "chipLedgerEmpty",
+    "welcomeBonusPanel",
+    "welcomeBonusTitle",
+    "welcomeBonusClaimButton",
+    "welcomeBonusStatus",
   ];
   ids.forEach(id => {
     document.__nodes.set(id, createElement("div", id));
@@ -840,7 +844,7 @@ test("chip-panel min-height is scoped to page-account", () => {
   assert.ok(/\.page-account\s+\.chip-panel\{[^}]*min-height\s*:\s*0/.test(normalized), "chip-panel min-height must be scoped");
 });
 
-test("claims welcome bonus from guest conversion marker and shows success after POST", async () => {
+test("shows welcome bonus claim from backend eligibility and claims on click", async () => {
   const calls = [];
   const chipsClient = {
     fetchBalance() {
@@ -858,9 +862,7 @@ test("claims welcome bonus from guest conversion marker and shows success after 
       return Promise.resolve({ claimed: true, amount: 500, transactionId: "tx-1" });
     },
   };
-  const { windowObj, document, sessionValues } = buildContext(chipsClient, {
-    sessionStorage: { "poker:guestConversionIntent": "welcome_bonus" },
-  });
+  const { windowObj, document } = buildContext(chipsClient);
   const context = vm.createContext({
     window: windowObj,
     document,
@@ -874,12 +876,20 @@ test("claims welcome bonus from guest conversion marker and shows success after 
   await flush();
   await flush();
 
-  assert.deepEqual(calls, ["status", "claim"]);
+  assert.deepEqual(calls, ["status"]);
+  assert.equal(document.getElementById("welcomeBonusPanel").hidden, false);
+  assert.equal(document.getElementById("welcomeBonusClaimButton").textContent, "Claim your 500 CH welcome bonus");
+
+  document.getElementById("welcomeBonusClaimButton").dispatchEvent({ type: "click", preventDefault() {} });
+  await flush();
+  await flush();
+  await flush();
+
+  assert.deepEqual(calls, ["status", "claim", "status"]);
   assert.equal(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
-  assert.equal(sessionValues.has("poker:guestConversionIntent"), false);
 });
 
-test("clears welcome marker without success for already claimed account", async () => {
+test("hides welcome bonus panel without success for already claimed account", async () => {
   const calls = [];
   const chipsClient = {
     fetchBalance() {
@@ -897,9 +907,7 @@ test("clears welcome marker without success for already claimed account", async 
       return Promise.resolve({ claimed: true });
     },
   };
-  const { windowObj, document, sessionValues } = buildContext(chipsClient, {
-    sessionStorage: { "poker:guestConversionIntent": "welcome_bonus" },
-  });
+  const { windowObj, document } = buildContext(chipsClient);
   const context = vm.createContext({
     window: windowObj,
     document,
@@ -914,11 +922,11 @@ test("clears welcome marker without success for already claimed account", async 
   await flush();
 
   assert.deepEqual(calls, ["status"]);
+  assert.equal(document.getElementById("welcomeBonusPanel").hidden, true);
   assert.notEqual(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
-  assert.equal(sessionValues.has("poker:guestConversionIntent"), false);
 });
 
-test("does not fetch welcome bonus status without guest conversion marker", async () => {
+test("does not auto-claim welcome bonus after eligible status", async () => {
   const calls = [];
   const chipsClient = {
     fetchBalance() {
@@ -949,6 +957,7 @@ test("does not fetch welcome bonus status without guest conversion marker", asyn
   await flush();
   await flush();
 
-  assert.deepEqual(calls, []);
+  assert.deepEqual(calls, ["status"]);
+  assert.equal(document.getElementById("welcomeBonusPanel").hidden, false);
   assert.notEqual(document.getElementById("accountStatus").textContent, "Welcome! 500 CH have been added to your account.");
 });

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -33,6 +33,8 @@ assert.match(tableV2Html, /id="pokerLobbyLink"/, 'poker table v2 should include 
 assert.match(tableV2Html, /id="pokerV2ClosedTableModal"/, 'poker table v2 should render the closed-table redirect notice');
 assert.match(tableV2Html, /id="pokerV2GuestPanel"/, 'poker table v2 should render the guest restrictions panel');
 assert.match(indexHtml, /Create account and get 500 CH Welcome Bonus/, 'poker lobby guest CTA should advertise the welcome bonus');
+assert.match(indexHtml, /id="pokerWelcomeBonusBanner"/, 'poker lobby should render an eligible-user welcome bonus banner');
+assert.match(indexHtml, /Claim bonus/, 'poker lobby welcome bonus banner should include a claim CTA');
 assert.match(tableV2Html, /Create account and get 500 CH Welcome Bonus/, 'poker table guest CTA should advertise the welcome bonus');
 assert.match(tableV2Html, /\+500 CH welcome bonus/, 'guest panel should list the welcome bonus as an account unlock');
 assert.doesNotMatch(indexHtml + tableV2Html, /Sign in and get 500 CH/i, 'guest bonus copy should not promise a sign-in reward');

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -32,6 +32,10 @@ assert.match(tableV2Html, /id="pokerV2JoinBtn"/, 'poker table v2 should include 
 assert.match(tableV2Html, /id="pokerLobbyLink"/, 'poker table v2 should include a back-to-lobby link in the hamburger menu');
 assert.match(tableV2Html, /id="pokerV2ClosedTableModal"/, 'poker table v2 should render the closed-table redirect notice');
 assert.match(tableV2Html, /id="pokerV2GuestPanel"/, 'poker table v2 should render the guest restrictions panel');
+assert.match(indexHtml, /Create account and get 500 CH Welcome Bonus/, 'poker lobby guest CTA should advertise the welcome bonus');
+assert.match(tableV2Html, /Create account and get 500 CH Welcome Bonus/, 'poker table guest CTA should advertise the welcome bonus');
+assert.match(tableV2Html, /\+500 CH welcome bonus/, 'guest panel should list the welcome bonus as an account unlock');
+assert.doesNotMatch(indexHtml + tableV2Html, /Sign in and get 500 CH/i, 'guest bonus copy should not promise a sign-in reward');
 assert.doesNotMatch(tableV2Html, /pokerClassicLink/, 'poker table v2 should not expose the classic table link');
 assert.doesNotMatch(tableV2Html, /pokerV2Link/, 'poker table v2 should not expose a self-link in the hamburger menu');
 assert.doesNotMatch(tableV2Html, /pokerV2DemoPill/, 'poker table v2 should not render the legacy demo pill');
@@ -109,6 +113,8 @@ assert.match(netlifyToml, /for = "\/games-open\/freedoom\/\*"/, 'Netlify should 
 assert.doesNotMatch(netlifyToml, /dwasm\.m-h\.org\.uk/, 'Netlify Freedoom CSP should not rely on a remote WAD mirror');
 assert.ok(netlifyToml.includes('Content-Security-Policy = "'), 'Netlify deploys should emit a CSP header');
 assert.doesNotMatch(netlifyToml, /cookiebot/i, 'Netlify CSP should not require Cookiebot hosts after the Klaro migration');
+assert.match(netlifyToml, /WELCOME_BONUS_START_AT = "2025-06-01T00:00:00Z"/, 'Netlify config should set the welcome bonus rollout date');
+assert.match(netlifyToml, /WELCOME_BONUS_CHIPS = "500"/, 'Netlify config should set the welcome bonus amount');
 assert.match(netlifyToml, /for = "\/css\/\*"[\s\S]*?Cache-Control = "public, max-age=0, must-revalidate"/, 'CSS files use stable names and should revalidate after deploys');
 assert.match(netlifyToml, /for = "\/js\/\*"[\s\S]*?Cache-Control = "public, max-age=0, must-revalidate"/, 'JS files use stable names and should revalidate after deploys');
 const cssHeaderBlock = netlifyToml.match(/\[\[headers\]\]\s+for = "\/css\/\*"[\s\S]*?(?=\n\[\[headers\]\]|$)/)?.[0] || '';

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -32,7 +32,7 @@ assert.match(tableV2Html, /id="pokerV2JoinBtn"/, 'poker table v2 should include 
 assert.match(tableV2Html, /id="pokerLobbyLink"/, 'poker table v2 should include a back-to-lobby link in the hamburger menu');
 assert.match(tableV2Html, /id="pokerV2ClosedTableModal"/, 'poker table v2 should render the closed-table redirect notice');
 assert.match(tableV2Html, /id="pokerV2GuestPanel"/, 'poker table v2 should render the guest restrictions panel');
-assert.match(indexHtml, /Create account and get 500 CH Welcome Bonus/, 'poker lobby guest CTA should advertise the welcome bonus');
+assert.match(indexHtml, /Create account or sign in/, 'poker lobby signed-out CTA should not promise the welcome bonus before eligibility is known');
 assert.match(indexHtml, /id="pokerWelcomeBonusBanner"/, 'poker lobby should render an eligible-user welcome bonus banner');
 assert.match(indexHtml, /Claim bonus/, 'poker lobby welcome bonus banner should include a claim CTA');
 assert.match(tableV2Html, /Create account and get 500 CH Welcome Bonus/, 'poker table guest CTA should advertise the welcome bonus');

--- a/tests/test-all.runner-registration.guard.test.mjs
+++ b/tests/test-all.runner-registration.guard.test.mjs
@@ -8,6 +8,7 @@ const source = await readFile(path.join(root, "scripts", "test-all.mjs"), "utf8"
 assert.match(source, /run\("node", \["tests\/poker-ui\.behavior\.test\.mjs"\],/, "runner should include poker-ui.behavior test");
 assert.doesNotMatch(source, /run\("node", \["tests\/poker-ui-turn-actions\.test\.mjs"\],/, "runner should not include removed classic poker-ui turn-actions test");
 assert.match(source, /run\("node", \["tests\/poker-v2-live\.behavior\.test\.mjs"\],/, "runner should include poker v2 live behavior test");
+assert.match(source, /run\("node", \["tests\/welcome-bonus\.behavior\.test\.mjs"\],/, "runner should include welcome bonus behavior test");
 assert.doesNotMatch(
   source,
   /tests\/poker-ui-amount-actions-dom\.behavior\.test\.mjs/,

--- a/tests/topbar-contract.test.mjs
+++ b/tests/topbar-contract.test.mjs
@@ -54,6 +54,9 @@ test('topbar ensures chip badge creation when missing', () => {
   assert.match(topbarSource, /ensureChipBadge/);
   assert.match(topbarSource, /badge\.id\s*=\s*['"]chipBadge['"]/);
   assert.match(topbarSource, /amount\.id\s*=\s*['"]chipBadgeAmount['"]/);
+  assert.match(topbarSource, /bonus\.id\s*=\s*['"]welcomeBonusTopbarBadge['"]/);
+  assert.match(topbarSource, /fetchWelcomeBonusStatus/);
+  assert.match(topbarSource, /refreshWelcomeBonusBadge/);
   assert.match(topbarSource, /badge\.hidden\s*=\s*true/);
   assert.match(topbarSource, /if\s*\(!isAuthed\(\)\)/);
   assert.match(topbarSource, /CH:\s/);
@@ -200,6 +203,7 @@ test('chip badge is only provided by topbar', () => {
 
 test('chip badge styles only live in portal css', () => {
   assert.match(portalCss, /\.chip-pill/);
+  assert.match(portalCss, /\.welcome-bonus-badge/);
   assert.match(portalCss, /--topbar-offset/);
   assert.match(portalCss, /safe-area-inset-top/);
   assert.match(portalCss, /html\[data-auth="in"\]\s*#chipBadge/);

--- a/tests/welcome-bonus.behavior.test.mjs
+++ b/tests/welcome-bonus.behavior.test.mjs
@@ -93,7 +93,7 @@ test("repeated POST does not grant a second welcome bonus", async () => {
   assert.equal(deps.posts[0].idempotencyKey, `welcome-bonus:${AFTER_USER}`);
 });
 
-test("welcome bonus uses treasury ledger offset and never transfers guest chips", async () => {
+test("welcome bonus uses genesis ledger offset and never transfers guest chips", async () => {
   const deps = createDeps();
   const result = await claimWelcomeBonus(AFTER_USER, deps);
   const payload = deps.posts[0];
@@ -104,7 +104,7 @@ test("welcome bonus uses treasury ledger offset and never transfers guest chips"
     payload.entries.map(entry => ({ accountType: entry.accountType, userId: entry.userId || null, systemKey: entry.systemKey || null, amount: entry.amount })),
     [
       { accountType: "USER", userId: AFTER_USER, systemKey: null, amount: 500 },
-      { accountType: "SYSTEM", userId: null, systemKey: "TREASURY", amount: -500 },
+      { accountType: "SYSTEM", userId: null, systemKey: "GENESIS", amount: -500 },
     ],
   );
   assert.equal(JSON.stringify(payload).includes("guestChips"), false);

--- a/tests/welcome-bonus.behavior.test.mjs
+++ b/tests/welcome-bonus.behavior.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildIdempotencyKey,
+  claimWelcomeBonus,
+  getWelcomeBonusStatus,
+} from "../netlify/functions/_shared/welcome-bonus.mjs";
+import { createWelcomeBonusHandler } from "../netlify/functions/welcome-bonus.mjs";
+
+const START_AT = "2025-06-01T00:00:00Z";
+const BEFORE_USER = "00000000-0000-4000-8000-000000000001";
+const AT_USER = "00000000-0000-4000-8000-000000000002";
+const AFTER_USER = "00000000-0000-4000-8000-000000000003";
+
+function createDeps() {
+  const users = new Map([
+    [BEFORE_USER, "2025-05-31T23:59:59.000Z"],
+    [AT_USER, START_AT],
+    [AFTER_USER, "2025-06-02T12:00:00.000Z"],
+  ]);
+  const txByKey = new Map();
+  const posts = [];
+  const deps = {
+    env: {
+      WELCOME_BONUS_START_AT: START_AT,
+      WELCOME_BONUS_CHIPS: "500",
+    },
+    async executeSql(query, params) {
+      const text = String(query).toLowerCase().replace(/\s+/g, " ");
+      if (text.includes("from auth.users")) {
+        const createdAt = users.get(params[0]);
+        return createdAt ? [{ created_at: createdAt }] : [];
+      }
+      if (text.includes("from public.chips_transactions")) {
+        const row = txByKey.get(params[1]);
+        return row && row.user_id === params[0] ? [row] : [];
+      }
+      throw new Error(`unexpected query: ${text}`);
+    },
+    async postTransaction(payload) {
+      posts.push(payload);
+      const existing = txByKey.get(payload.idempotencyKey);
+      if (existing) {
+        return { transaction: existing, entries: [], account: { balance: 500 } };
+      }
+      const transaction = {
+        id: `tx-${posts.length}`,
+        user_id: payload.userId,
+        tx_type: payload.txType,
+        idempotency_key: payload.idempotencyKey,
+      };
+      txByKey.set(payload.idempotencyKey, transaction);
+      return { transaction, entries: payload.entries, account: { balance: 500 } };
+    },
+    posts,
+    txByKey,
+  };
+  return deps;
+}
+
+test("account created before WELCOME_BONUS_START_AT is not eligible", async () => {
+  const deps = createDeps();
+  const status = await getWelcomeBonusStatus(BEFORE_USER, deps);
+
+  assert.equal(status.eligible, false);
+  assert.equal(status.alreadyClaimed, false);
+  assert.equal(status.reason, "created_before_start");
+});
+
+test("account created at or after WELCOME_BONUS_START_AT is eligible if not claimed", async () => {
+  const deps = createDeps();
+  const atStatus = await getWelcomeBonusStatus(AT_USER, deps);
+  const afterStatus = await getWelcomeBonusStatus(AFTER_USER, deps);
+
+  assert.equal(atStatus.eligible, true);
+  assert.equal(afterStatus.eligible, true);
+  assert.equal(atStatus.amount, 500);
+  assert.equal(atStatus.idempotencyKey, buildIdempotencyKey(AT_USER));
+});
+
+test("repeated POST does not grant a second welcome bonus", async () => {
+  const deps = createDeps();
+
+  const first = await claimWelcomeBonus(AFTER_USER, deps);
+  const second = await claimWelcomeBonus(AFTER_USER, deps);
+
+  assert.equal(first.claimed, true);
+  assert.equal(second.claimed, false);
+  assert.equal(second.alreadyClaimed, true);
+  assert.equal(deps.posts.length, 1);
+  assert.equal(deps.posts[0].txType, "WELCOME_BONUS");
+  assert.equal(deps.posts[0].idempotencyKey, `welcome-bonus:${AFTER_USER}`);
+});
+
+test("welcome bonus uses treasury ledger offset and never transfers guest chips", async () => {
+  const deps = createDeps();
+  const result = await claimWelcomeBonus(AFTER_USER, deps);
+  const payload = deps.posts[0];
+
+  assert.equal(result.claimed, true);
+  assert.equal(payload.entries.length, 2);
+  assert.deepEqual(
+    payload.entries.map(entry => ({ accountType: entry.accountType, userId: entry.userId || null, systemKey: entry.systemKey || null, amount: entry.amount })),
+    [
+      { accountType: "USER", userId: AFTER_USER, systemKey: null, amount: 500 },
+      { accountType: "SYSTEM", userId: null, systemKey: "TREASURY", amount: -500 },
+    ],
+  );
+  assert.equal(JSON.stringify(payload).includes("guestChips"), false);
+});
+
+test("welcome bonus API exposes status and claim results for authenticated users", async () => {
+  const calls = [];
+  const handler = createWelcomeBonusHandler({
+    env: { CHIPS_ENABLED: "1", WELCOME_BONUS_START_AT: START_AT, WELCOME_BONUS_CHIPS: "500" },
+    verifySupabaseJwt: async (token) => ({ valid: !!token, userId: token || null, reason: token ? "ok" : "missing_token" }),
+    getWelcomeBonusStatus: async (userId) => {
+      calls.push(["GET", userId]);
+      return { eligible: true, alreadyClaimed: false, amount: 500, reason: "eligible" };
+    },
+    claimWelcomeBonus: async (userId) => {
+      calls.push(["POST", userId]);
+      return {
+        claimed: true,
+        eligible: false,
+        alreadyClaimed: true,
+        amount: 500,
+        reason: "claimed",
+        transactionId: "tx-api",
+      };
+    },
+  });
+
+  const getRes = await handler({ httpMethod: "GET", headers: { authorization: `Bearer ${AFTER_USER}` } });
+  const postRes = await handler({ httpMethod: "POST", headers: { authorization: `Bearer ${AFTER_USER}` } });
+
+  assert.equal(getRes.statusCode, 200);
+  assert.equal(JSON.parse(getRes.body).eligible, true);
+  assert.equal(postRes.statusCode, 200);
+  assert.equal(JSON.parse(postRes.body).claimed, true);
+  assert.deepEqual(calls, [["GET", AFTER_USER], ["POST", AFTER_USER]]);
+});


### PR DESCRIPTION
Implements Guest Poker PR3: Registration Incentives.

What changed:
- Added `docs/poker-guest-mode-pr3-implementation-plan.md` and updated it with the final rollout rules.
- Added `WELCOME_BONUS` ledger transaction support and DB enum migration.
- Added authenticated `welcome-bonus` GET/POST endpoint for eligibility and idempotent claim.
- Uses `welcome-bonus:<userId>` idempotency and `auth.users.created_at >= WELCOME_BONUS_START_AT` eligibility.
- Uses the existing mint-like ledger convention: `SYSTEM/GENESIS` offsets the `+500 CH` user entry.
- Added Guest conversion CTA copy and account-page claim handling.
- Ensures success copy is shown only after a real successful POST claim and guest chips are never transferred.

Validation:
- `node --test tests/welcome-bonus.behavior.test.mjs tests/account-page.test.mjs tests/static-html.behavior.test.mjs tests/test-all.runner-registration.guard.test.mjs`
- `node scripts/syntax-check.mjs`
- `npm run -s check:all`

Breaking impact:
- None expected.
- Requires DB migration `20260702000000_chips_welcome_bonus_tx_type.sql` before runtime claims can insert `WELCOME_BONUS` transactions.