### PR TITLE
[codex] fix XP score reporting fallback

### DIFF
--- a/games-open/freedoom/index.html
+++ b/games-open/freedoom/index.html
@@ -224,6 +224,9 @@
     <script src="/js/debug.js" defer></script>
     <script src="/js/xp/combo.js" defer></script>
     <script src="/js/xp/scoring.js" defer></script>
+    <script>
+      window.XP_REQUIRE_SCORE = 0;
+    </script>
     <script src="/js/xp/core.js" defer></script>
     <script src="/js/xp.js" defer></script>
     <script src="/js/xp-game-hook.js" defer></script>

--- a/js/xp/core.js
+++ b/js/xp/core.js
@@ -724,6 +724,39 @@ function bootXpCore(window, document) {
     dispatchNewRecordBoost(resolvedGameId);
   }
 
+  function receiveScorePulse(rawGameId, rawScore) {
+    if (!isGameHost()) return;
+    try {
+      const XP = window && window.XP;
+      const running = XP && typeof XP.isRunning === "function" ? !!XP.isRunning() : false;
+      if (!running) {
+        const gid = resolveScorePulseGameId(rawGameId);
+        if (gid && XP && typeof XP.startSession === "function") {
+          try { window.__GAME_ID__ = gid; } catch (_) {}
+          XP.startSession(gid, { resume: true });
+          if (isDiagEnabled()) {
+            logDebug("auto_start_from_score_pulse", { gameId: gid });
+          }
+        }
+      }
+    } catch (_) {}
+    state.lastScorePulseTs = Date.now();
+    logDebug("score_pulse", {
+      gameId: rawGameId || state.gameId || "",
+      score: typeof rawScore === "number" ? rawScore : undefined,
+    });
+    handleScorePulse(rawGameId, rawScore);
+  }
+
+  function installScoreReporterFallback() {
+    try {
+      if (!window || typeof window.reportScoreToPortal === "function") return;
+      window.reportScoreToPortal = function(gameId, score) {
+        receiveScorePulse(gameId, score);
+      };
+    } catch (_) {}
+  }
+
   function accumulateLocalXp(xpDelta) {
     const numeric = Number(xpDelta) || 0;
     if (!Number.isFinite(numeric) || numeric <= 0) return 0;
@@ -2189,6 +2222,7 @@ function bootXpCore(window, document) {
 
     if (typeof window !== "undefined") {
       ensureTimer();
+      installScoreReporterFallback();
 
       window.addEventListener("pageshow", () => {
         try {
@@ -2223,27 +2257,7 @@ function bootXpCore(window, document) {
           if (!event || !event.data || typeof event.data !== "object") return;
           if (event.origin && typeof location !== "undefined" && event.origin !== location.origin) return;
           if (event.data.type !== "game-score") return;
-          if (!isGameHost()) return;
-          state.lastScorePulseTs = Date.now();
-          logDebug("score_pulse", {
-            gameId: event.data.gameId || state.gameId || "",
-            score: typeof event.data.score === "number" ? event.data.score : undefined,
-          });
-          handleScorePulse(event.data.gameId, event.data.score);
-          try {
-            const XP = window && window.XP;
-            const running = XP && typeof XP.isRunning === "function" ? !!XP.isRunning() : false;
-            if (!running) {
-              const gid = resolveScorePulseGameId(event.data.gameId);
-              if (gid && XP && typeof XP.startSession === "function") {
-                try { window.__GAME_ID__ = gid; } catch (_) {}
-                XP.startSession(gid, { resume: true });
-                if (isDiagEnabled()) {
-                  logDebug("auto_start_from_score_pulse", { gameId: gid });
-                }
-              }
-            }
-          } catch (_) {}
+          receiveScorePulse(event.data.gameId, event.data.score);
         } catch (_) {}
       }, { passive: true });
 

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -69,6 +69,7 @@ assert.match(landingGameJs, /landingPixelBest/, 'landing mini game should persis
 assert.equal([landingIndexHtml, landingAboutHtml, landingPrivacyEnHtml, landingPrivacyPlHtml].every((html) => html.includes('href="https://play.kcswh.pl/xp.html"')), true, 'landing XP badges should link to the play subdomain XP panel');
 assert.equal([landingIndexHtml, landingAboutHtml, landingPrivacyEnHtml, landingPrivacyPlHtml].some((html) => /href="\.\.?\/.*xp\.html"|xp-badge--loading/.test(html)), false, 'landing XP badges should not point to missing local XP pages or show a permanent loading state');
 assert.match(freedoomHtml, /id="doomCanvas"/, 'Freedoom should render the Dwasm canvas target');
+assert.match(freedoomHtml, /window\.XP_REQUIRE_SCORE\s*=\s*0;[\s\S]*src="\/js\/xp\/core\.js" defer/, 'Freedoom should allow activity-based XP because the Dwasm runtime does not emit score pulses');
 assert.match(freedoomHtml, /js\/vendor\/klaro\/klaro\.js/, 'Freedoom should use the shared Klaro consent runtime');
 assert.doesNotMatch(freedoomHtml, /Cookiebot|cookiebot-manager|js-dos|v8\.js-dos\.com/, 'Freedoom should not depend on Cookiebot or js-dos assets');
 assert.doesNotMatch(freedoomJs, /freedoom2\.bin|libarchive|Archive\.open|fetchBlob/, 'Freedoom should boot the source-built Dwasm preload instead of extracting a local archive');

--- a/tests/xp-game-hook.test.mjs
+++ b/tests/xp-game-hook.test.mjs
@@ -182,6 +182,27 @@ import { createEnvironment } from './helpers/xp-env.mjs';
   assert.equal(Bridge.getHighScore('record-game'), 12, 'new record should persist the high score');
 }
 
+// report_score_fallback_marks_score_pulse
+{
+  const env = createEnvironment({ bodyGameId: 'brick-breaker' });
+  const { Bridge, drainTimers, installXp } = env;
+
+  const { getState } = installXp();
+  drainTimers();
+
+  assert.equal(
+    typeof env.context.window.reportScoreToPortal,
+    'function',
+    'XP core should provide reportScoreToPortal when game HTML does not define it',
+  );
+
+  env.context.window.reportScoreToPortal('brick-breaker', 20);
+  drainTimers();
+
+  assert.equal(getState().lastScorePulseTs > 0, true, 'fallback score reports should satisfy the XP score pulse gate');
+  assert.equal(Bridge.getHighScore('brick-breaker'), 20, 'fallback score reports should use normal high-score handling');
+}
+
 // no_double_start_in_same_run
 {
   const env = createEnvironment();


### PR DESCRIPTION
## What changed
- Allows Freedoom to earn XP from trusted activity by disabling the score-pulse requirement for that game.
- Adds a shared `reportScoreToPortal` fallback in XP core for games that call the reporter but do not define it in their HTML.
- Reuses the same score-pulse path for `postMessage` and direct fallback reports so high-score boost handling stays consistent.
- Adds tests for Freedoom activity XP config and the reporter fallback.

## Why
Freedoom does not expose score pulses from its Dwasm runtime, so the default XP score gate blocked local XP awards. A second audit found several games that called `window.reportScoreToPortal(...)` but never defined that function, which meant their score updates also did not satisfy the XP score gate.

## Validation
- `rtk node tests/xp-game-hook.test.mjs`
- `rtk node tests/static-html.behavior.test.mjs`
- `rtk npm run check:all`
- `rtk npm run syntax`