### PR TITLE
Add generic bonus campaign foundation

### DIFF
--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -188,6 +188,7 @@ jobs:
             command -v tar >/dev/null 2>&1 || { echo "preview VPS missing tar"; exit 1; }
             command -v rsync >/dev/null 2>&1 || { echo "preview VPS missing rsync"; exit 1; }
 
+            sudo -n -v >/dev/null 2>&1 || { echo "preview deploy user must have passwordless sudo for ws-preview deploy"; exit 1; }
             sudo -n systemctl cat "$PREVIEW_SERVICE_NAME" >/dev/null 2>&1 || { echo "missing preview systemd unit: $PREVIEW_SERVICE_NAME"; exit 1; }
             sudo -n test -d "$PREVIEW_BASE_DIR" || { echo "missing preview base dir: $PREVIEW_BASE_DIR"; exit 1; }
             sudo -n test -d "$PREVIEW_APP_DIR" || { echo "missing preview app dir: $PREVIEW_APP_DIR"; exit 1; }

--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -188,7 +188,7 @@ jobs:
             command -v tar >/dev/null 2>&1 || { echo "preview VPS missing tar"; exit 1; }
             command -v rsync >/dev/null 2>&1 || { echo "preview VPS missing rsync"; exit 1; }
 
-            sudo -n -v >/dev/null 2>&1 || { echo "preview deploy user must have passwordless sudo for ws-preview deploy"; exit 1; }
+            sudo -n bash -c 'true' >/dev/null 2>&1 || { echo "preview deploy user must be allowed to run sudo -n bash for ws-preview deploy"; exit 1; }
             sudo -n systemctl cat "$PREVIEW_SERVICE_NAME" >/dev/null 2>&1 || { echo "missing preview systemd unit: $PREVIEW_SERVICE_NAME"; exit 1; }
             sudo -n test -d "$PREVIEW_BASE_DIR" || { echo "missing preview base dir: $PREVIEW_BASE_DIR"; exit 1; }
             sudo -n test -d "$PREVIEW_APP_DIR" || { echo "missing preview app dir: $PREVIEW_APP_DIR"; exit 1; }

--- a/agents.md
+++ b/agents.md
@@ -50,6 +50,14 @@ This is a real-time gaming platform (poker + arcade), not a typical CRUD app.
   - reconnect
 - DB is NOT source of truth
 
+### WS Runtime Logs
+- For preview incidents, agents may inspect:
+  - `sudo journalctl -u ws-server-preview -f`
+  - `journalctl -u ws-server-preview.service`
+- For production WS incidents, agents may inspect:
+  - `journalctl -u ws-server.service`
+- When debugging a specific poker table, filter by `tableId` and correlate `ws_state_persist_*`, `ws_settled_rollover_*`, `ws_bot_autoplay_*`, `ws_table_janitor_*`, and cleanup logs with `poker_state`, `poker_actions`, `poker_seats`, and `poker_tables`.
+
 ---
 
 ## 🧩 Agent Roles

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -150,6 +150,21 @@ The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-i
 The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, or stage Supabase project-ref match is missing.
 Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks.
 
+Minimal preview sudoers coverage for `WS_PREVIEW_USER` must include the concrete programs used by the workflow: `systemctl`, `test`, `grep`, `bash`, `rm`, `mkdir`, `tar`, and `rsync`. On Ubuntu, verify the actual binary paths with `command -v systemctl test grep bash rm mkdir tar rsync`, then keep `/etc/sudoers.d/ws-preview-deploy` mode `0440`.
+
+Quick VPS check for the current `copilot` deploy user:
+
+```sh
+sudo -u copilot sudo -n systemctl cat ws-server-preview.service >/dev/null && echo systemctl-ok
+sudo -u copilot sudo -n test -d /opt/arcade-ws-preview && echo test-ok
+sudo -u copilot sudo -n grep -Eq '^PORT=3001$' /opt/arcade-ws-preview/.env.preview && echo grep-ok
+sudo -u copilot sudo -n bash -c 'test -f "$1"' bash /opt/arcade-ws-preview/.env.preview && echo bash-ok
+sudo -u copilot sudo -n mkdir -p /tmp/arcadeplatform-ws-preview/sudo-check && echo mkdir-ok
+sudo -u copilot sudo -n rm -rf /tmp/arcadeplatform-ws-preview/sudo-check && echo rm-ok
+sudo -u copilot sudo -n rsync --version >/dev/null && echo rsync-ok
+sudo -u copilot sudo -n tar --version >/dev/null && echo tar-ok
+```
+
 ### Preview secrets
 
 Configure these GitHub Actions secrets for preview access only:

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -146,7 +146,7 @@ The preview VPS contract is:
 - Optional close grace: `POKER_TABLE_CLOSE_GRACE_MS=60000` keeps newly created empty tables open for 60s before cleanup may close them
 
 Preview deploys unpack into a temporary directory under `/tmp/arcadeplatform-ws-preview` and then sync the extracted files into `/opt/arcade-ws-preview/ws-server`.
-The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n -v` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`.
+The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n bash -c 'true'` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`. Do not use `sudo -n -v` as the local smoke check here: it can still require a password when the same user has both normal passworded sudo rules and command-specific `NOPASSWD` rules.
 The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, or stage Supabase project-ref match is missing.
 Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks.
 

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -146,7 +146,8 @@ The preview VPS contract is:
 - Optional close grace: `POKER_TABLE_CLOSE_GRACE_MS=60000` keeps newly created empty tables open for 60s before cleanup may close them
 
 Preview deploys unpack into a temporary directory under `/tmp/arcadeplatform-ws-preview` and then sync the extracted files into `/opt/arcade-ws-preview/ws-server`.
-The workflow fails fast before mutating preview app contents when the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, or stage Supabase project-ref match is missing.
+The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n -v` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`.
+The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, or stage Supabase project-ref match is missing.
 Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks.
 
 ### Preview secrets

--- a/netlify/functions/_shared/bonus-campaigns.mjs
+++ b/netlify/functions/_shared/bonus-campaigns.mjs
@@ -1,0 +1,344 @@
+import { executeSql, klog } from "./supabase-admin.mjs";
+import { postTransaction } from "./chips-ledger.mjs";
+
+const GENESIS_SYSTEM_KEY = "GENESIS";
+const PROMO_BONUS_TX_TYPE = "PROMO_BONUS";
+
+function toIso(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+  if (typeof value !== "string") return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function parseJsonObject(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function normalizeCampaign(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    code: row.code,
+    title: row.title,
+    description: row.description || "",
+    campaignType: row.campaign_type,
+    amount: Number(row.amount),
+    status: row.status,
+    startsAt: toIso(row.starts_at),
+    endsAt: toIso(row.ends_at),
+    eligibilityType: row.eligibility_type,
+    eligibilityConfig: parseJsonObject(row.eligibility_config),
+    maxTotalClaims: row.max_total_claims == null ? null : Number(row.max_total_claims),
+  };
+}
+
+function buildCampaignIdempotencyKey(campaignCode, userId) {
+  return `bonus:${campaignCode}:${userId}`;
+}
+
+async function fetchUserCreatedAt(userId, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select created_at
+from auth.users
+where id = $1
+limit 1;
+`,
+    [userId],
+  );
+  return toIso(rows?.[0]?.created_at);
+}
+
+async function fetchActiveCampaignRows(runSql = executeSql, code = null) {
+  return await runSql(
+    `
+select id, code, title, description, campaign_type, amount, status, starts_at, ends_at,
+       eligibility_type, eligibility_config, max_total_claims
+from public.bonus_campaigns
+where status = 'active'
+  and starts_at <= timezone('utc', now())
+  and (ends_at is null or ends_at > timezone('utc', now()))
+  and ($1::text is null or code = $1)
+order by starts_at asc, code asc;
+`,
+    [code],
+  );
+}
+
+async function fetchClaim(campaignId, userId, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select id, campaign_id, user_id, transaction_id, idempotency_key, claimed_at
+from public.bonus_claims
+where campaign_id = $1
+  and user_id = $2
+limit 1;
+`,
+    [campaignId, userId],
+  );
+  return rows?.[0] || null;
+}
+
+async function fetchPromoTransaction(userId, idempotencyKey, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select id, created_at
+from public.chips_transactions
+where user_id = $1
+  and tx_type = 'PROMO_BONUS'
+  and idempotency_key = $2
+limit 1;
+`,
+    [userId, idempotencyKey],
+  );
+  return rows?.[0] || null;
+}
+
+async function isAllowlisted(campaignId, userId, runSql = executeSql) {
+  const rows = await runSql(
+    `
+select 1
+from public.bonus_campaign_eligible_users
+where campaign_id = $1
+  and user_id = $2
+limit 1;
+`,
+    [campaignId, userId],
+  );
+  return rows.length > 0;
+}
+
+async function evaluateEligibility(campaign, userId, userCreatedAt, runSql = executeSql) {
+  if (!userCreatedAt) return { eligible: false, reason: "user_not_found" };
+  const config = campaign.eligibilityConfig || {};
+
+  if (campaign.eligibilityType === "all_accounts") {
+    return { eligible: true, reason: "eligible" };
+  }
+
+  if (campaign.eligibilityType === "created_after") {
+    const threshold = toIso(config.created_at_gte || config.createdAfter || campaign.startsAt);
+    if (!threshold) return { eligible: false, reason: "invalid_eligibility_config" };
+    const eligible = Date.parse(userCreatedAt) >= Date.parse(threshold);
+    return { eligible, reason: eligible ? "eligible" : "created_before_start" };
+  }
+
+  if (campaign.eligibilityType === "created_before") {
+    const threshold = toIso(config.created_at_lte || config.createdBefore || campaign.startsAt);
+    if (!threshold) return { eligible: false, reason: "invalid_eligibility_config" };
+    const eligible = Date.parse(userCreatedAt) <= Date.parse(threshold);
+    return { eligible, reason: eligible ? "eligible" : "created_after_cutoff" };
+  }
+
+  if (campaign.eligibilityType === "allowlist") {
+    const eligible = await isAllowlisted(campaign.id, userId, runSql);
+    return { eligible, reason: eligible ? "eligible" : "not_allowlisted" };
+  }
+
+  return { eligible: false, reason: "unsupported_eligibility_type" };
+}
+
+function publicStatus(status) {
+  return {
+    code: status.campaign.code,
+    title: status.campaign.title,
+    description: status.campaign.description,
+    campaignType: status.campaign.campaignType,
+    amount: status.campaign.amount,
+    eligible: status.eligible,
+    alreadyClaimed: status.alreadyClaimed,
+    reason: status.reason,
+    transactionId: status.transactionId || null,
+  };
+}
+
+async function getBonusCampaignStatus(userId, campaignCode, deps = {}) {
+  const runSql = deps.executeSql || executeSql;
+  const rows = await fetchActiveCampaignRows(runSql, campaignCode);
+  const campaign = normalizeCampaign(rows?.[0]);
+  if (!campaign) {
+    return {
+      eligible: false,
+      alreadyClaimed: false,
+      reason: "campaign_not_found",
+      campaign: null,
+      idempotencyKey: null,
+    };
+  }
+
+  const idempotencyKey = buildCampaignIdempotencyKey(campaign.code, userId);
+  const userCreatedAt = await fetchUserCreatedAt(userId, runSql);
+  const claim = await fetchClaim(campaign.id, userId, runSql);
+  const transaction = claim ? null : await fetchPromoTransaction(userId, idempotencyKey, runSql);
+
+  if (claim || transaction) {
+    return {
+      eligible: false,
+      alreadyClaimed: true,
+      reason: "already_claimed",
+      campaign,
+      idempotencyKey,
+      createdAt: userCreatedAt,
+      transactionId: claim?.transaction_id || transaction?.id || null,
+    };
+  }
+
+  const eligibility = await evaluateEligibility(campaign, userId, userCreatedAt, runSql);
+  return {
+    eligible: eligibility.eligible,
+    alreadyClaimed: false,
+    reason: eligibility.reason,
+    campaign,
+    idempotencyKey,
+    createdAt: userCreatedAt,
+    transactionId: null,
+  };
+}
+
+async function listBonusCampaignStatuses(userId, deps = {}) {
+  const runSql = deps.executeSql || executeSql;
+  const rows = await fetchActiveCampaignRows(runSql, null);
+  const items = [];
+  for (const row of rows) {
+    const status = await getBonusCampaignStatus(userId, row.code, deps);
+    if (status.campaign) items.push(publicStatus(status));
+  }
+  return { items };
+}
+
+function buildBonusCampaignEntries(userId, campaign) {
+  const shared = {
+    source: "bonus_campaign",
+    campaign_id: campaign.id,
+    campaign_code: campaign.code,
+    campaign_type: campaign.campaignType,
+  };
+  return [
+    {
+      accountType: "USER",
+      userId,
+      amount: campaign.amount,
+      metadata: { ...shared, entry_role: "bonus_recipient" },
+    },
+    {
+      accountType: "SYSTEM",
+      systemKey: GENESIS_SYSTEM_KEY,
+      amount: -campaign.amount,
+      metadata: { ...shared, entry_role: "genesis_offset" },
+    },
+  ];
+}
+
+async function insertBonusClaim({ campaign, userId, transactionId, idempotencyKey }, runSql = executeSql) {
+  const metadata = {
+    source: "bonus_campaign",
+    campaign_id: campaign.id,
+    campaign_code: campaign.code,
+    campaign_type: campaign.campaignType,
+    amount: campaign.amount,
+  };
+  const rows = await runSql(
+    `
+insert into public.bonus_claims (campaign_id, user_id, transaction_id, idempotency_key, metadata)
+values ($1, $2, $3, $4, $5::jsonb)
+on conflict (campaign_id, user_id) do update
+set metadata = public.bonus_claims.metadata
+returning id, campaign_id, user_id, transaction_id, idempotency_key, claimed_at;
+`,
+    [campaign.id, userId, transactionId, idempotencyKey, JSON.stringify(metadata)],
+  );
+  return rows?.[0] || null;
+}
+
+async function claimBonusCampaign(userId, campaignCode, deps = {}) {
+  const runSql = deps.executeSql || executeSql;
+  const writeTransaction = deps.postTransaction || postTransaction;
+  const status = await getBonusCampaignStatus(userId, campaignCode, deps);
+  const campaign = status.campaign;
+  const baseLog = {
+    userId,
+    campaignId: campaign?.id || null,
+    campaignCode: campaign?.code || campaignCode || null,
+    campaignType: campaign?.campaignType || null,
+    eligible: status.eligible,
+    alreadyClaimed: status.alreadyClaimed,
+    amount: campaign?.amount || null,
+    reason: status.reason,
+  };
+
+  if (!status.eligible || !campaign) {
+    klog("bonus_campaign_skipped", {
+      ...baseLog,
+      transactionId: status.transactionId || null,
+    });
+    return { ...status, claimed: false, transaction: null, entries: [], account: null };
+  }
+
+  try {
+    const metadata = {
+      source: "bonus_campaign",
+      campaign_id: campaign.id,
+      campaign_code: campaign.code,
+      campaign_type: campaign.campaignType,
+      amount: campaign.amount,
+    };
+    const result = await writeTransaction({
+      userId,
+      txType: PROMO_BONUS_TX_TYPE,
+      idempotencyKey: status.idempotencyKey,
+      reference: status.idempotencyKey,
+      description: campaign.title,
+      metadata,
+      entries: buildBonusCampaignEntries(userId, campaign),
+      createdBy: userId,
+    });
+    const transactionId = result?.transaction?.id || null;
+    const claim = transactionId
+      ? await insertBonusClaim({ campaign, userId, transactionId, idempotencyKey: status.idempotencyKey }, runSql)
+      : null;
+    klog("bonus_campaign_claimed", {
+      ...baseLog,
+      transactionId,
+    });
+    return {
+      ...status,
+      eligible: false,
+      alreadyClaimed: true,
+      claimed: true,
+      reason: "claimed",
+      transactionId,
+      claim,
+      transaction: result?.transaction || null,
+      entries: result?.entries || [],
+      account: result?.account || null,
+    };
+  } catch (error) {
+    klog("bonus_campaign_failed", {
+      ...baseLog,
+      reason: error?.code || error?.message || "server_error",
+    });
+    throw error;
+  }
+}
+
+export {
+  GENESIS_SYSTEM_KEY,
+  PROMO_BONUS_TX_TYPE,
+  buildBonusCampaignEntries,
+  buildCampaignIdempotencyKey,
+  claimBonusCampaign,
+  getBonusCampaignStatus,
+  listBonusCampaignStatuses,
+  publicStatus,
+};

--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -13,6 +13,7 @@ const VALID_TX_TYPES = new Set([
   "RAKE_FEE",
   "PRIZE_PAYOUT",
   "WELCOME_BONUS",
+  "PROMO_BONUS",
 ]);
 
 // Loose integer parsing for non-sequence fields only (balances, etc.).

--- a/scripts/stage-db-migrate.mjs
+++ b/scripts/stage-db-migrate.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { spawnSync } from "node:child_process";
 
 const MIGRATIONS_DIR = path.join(process.cwd(), "supabase", "migrations");
@@ -49,6 +50,10 @@ function sqlLiteral(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
 function loadLocalMigrations() {
   if (!fs.existsSync(MIGRATIONS_DIR)) fail(`Missing migrations directory: ${MIGRATIONS_DIR}`);
   return fs.readdirSync(MIGRATIONS_DIR)
@@ -57,11 +62,14 @@ function loadLocalMigrations() {
     .map((file) => {
       const match = file.match(MIGRATION_RE);
       if (!match) fail(`Invalid migration filename: ${file}`);
+      const fullPath = path.join(MIGRATIONS_DIR, file);
+      const sql = fs.readFileSync(fullPath, "utf8");
       return {
         file,
         version: match[1],
         name: match[2],
-        path: path.join(MIGRATIONS_DIR, file)
+        path: fullPath,
+        sha256: sha256(sql)
       };
     });
 }
@@ -84,6 +92,13 @@ function ensureMigrationTable(dbUrl) {
       "  version text primary key,",
       "  statements text[],",
       "  name text",
+      ");",
+      "create table if not exists supabase_migrations.schema_migration_files (",
+      "  version text primary key,",
+      "  name text,",
+      "  file text,",
+      "  sha256 text not null,",
+      "  recorded_at timestamptz not null default timezone('utc', now())",
       ");"
     ].join("\n")
   ]);
@@ -97,6 +112,45 @@ function readRemoteVersions(dbUrl) {
     "select version from supabase_migrations.schema_migrations order by version;"
   ]);
   return output.split("\n").map((line) => line.trim()).filter(Boolean);
+}
+
+function readRemoteMigrationHashes(dbUrl) {
+  const output = runPsql(dbUrl, [
+    "-v", "ON_ERROR_STOP=1",
+    "-At",
+    "-F", "\t",
+    "-c",
+    "select version, sha256 from supabase_migrations.schema_migration_files order by version;"
+  ]);
+  const hashes = new Map();
+  for (const line of output.split("\n").map((entry) => entry.trim()).filter(Boolean)) {
+    const [version, hash] = line.split("\t");
+    if (version && hash) hashes.set(version, hash);
+  }
+  return hashes;
+}
+
+function recordMigrationHashes(dbUrl, migrations, { updateExisting = false } = {}) {
+  for (const migration of migrations) {
+    const conflictSql = updateExisting
+      ? [
+          "on conflict (version) do update set",
+          "  name = excluded.name,",
+          "  file = excluded.file,",
+          "  sha256 = excluded.sha256,",
+          "  recorded_at = timezone('utc', now());"
+        ].join("\n")
+      : "on conflict (version) do nothing;";
+    runPsql(dbUrl, [
+      "-v", "ON_ERROR_STOP=1",
+      "-c",
+      [
+        "insert into supabase_migrations.schema_migration_files(version, name, file, sha256)",
+        `values (${sqlLiteral(migration.version)}, ${sqlLiteral(migration.name)}, ${sqlLiteral(migration.file)}, ${sqlLiteral(migration.sha256)})`,
+        conflictSql
+      ].join("\n")
+    ]);
+  }
 }
 
 function readChangedMigrationVersions(diffBase) {
@@ -158,12 +212,24 @@ if (unknownRemote.length) {
 }
 
 const remoteSet = new Set(remoteVersions);
-const changedAlreadyApplied = readChangedMigrationVersions(changedFrom)
-  .filter((migration) => remoteSet.has(migration.version));
-if (changedAlreadyApplied.length) {
+let remoteHashes = readRemoteMigrationHashes(dbUrl);
+const missingHashMigrations = remoteVersions
+  .filter((version) => localByVersion.has(version) && !remoteHashes.has(version))
+  .map((version) => localByVersion.get(version));
+if (missingHashMigrations.length) {
+  console.log(`Recording hashes for ${missingHashMigrations.length} already-applied migration(s).`);
+  recordMigrationHashes(dbUrl, missingHashMigrations);
+  remoteHashes = readRemoteMigrationHashes(dbUrl);
+}
+
+const changedAppliedMismatches = readChangedMigrationVersions(changedFrom)
+  .filter((migration) => remoteSet.has(migration.version))
+  .map((migration) => localByVersion.get(migration.version) || migration)
+  .filter((migration) => remoteHashes.has(migration.version) && remoteHashes.get(migration.version) !== migration.sha256);
+if (changedAppliedMismatches.length) {
   fail([
-    "Stage already has this migration version; bump timestamp or reset/recreate stage.",
-    ...changedAlreadyApplied.map((migration) => "- " + migration.file + " (" + migration.version + ")")
+    "Stage already has this migration version with different contents; bump timestamp or reset/recreate stage.",
+    ...changedAppliedMismatches.map((migration) => "- " + migration.file + " (" + migration.version + ")")
   ].join("\n"));
 }
 
@@ -191,6 +257,7 @@ for (const migration of pending) {
       "on conflict (version) do nothing;"
     ].join("\n")
   ]);
+  recordMigrationHashes(dbUrl, [migration], { updateExisting: true });
 }
 
 runSmokeChecks(dbUrl);

--- a/scripts/stage-db-migrate.mjs
+++ b/scripts/stage-db-migrate.mjs
@@ -129,7 +129,7 @@ function runSmokeChecks(dbUrl) {
     "  if to_regclass('public.chips_transactions') is null then raise exception 'missing public.chips_transactions'; end if;",
     "  if to_regclass('public.chips_entries') is null then raise exception 'missing public.chips_entries'; end if;",
     "  if not exists (select 1 from pg_type where typname = 'chips_tx_type') then raise exception 'missing public.chips_tx_type'; end if;",
-    "  if not exists (select 1 from public.chips_accounts where user_id = 'SYSTEM/GENESIS') then raise exception 'missing SYSTEM/GENESIS account'; end if;",
+    "  if not exists (select 1 from public.chips_accounts where account_type = 'SYSTEM' and system_key = 'GENESIS') then raise exception 'missing SYSTEM/GENESIS account'; end if;",
     "end",
     "$$;"
   ].join("\n");

--- a/scripts/stage-db-migrate.mjs
+++ b/scripts/stage-db-migrate.mjs
@@ -213,6 +213,18 @@ if (unknownRemote.length) {
 
 const remoteSet = new Set(remoteVersions);
 let remoteHashes = readRemoteMigrationHashes(dbUrl);
+const changedAppliedMigrations = readChangedMigrationVersions(changedFrom)
+  .filter((migration) => remoteSet.has(migration.version))
+  .map((migration) => localByVersion.get(migration.version) || migration);
+const changedAppliedMissingHashes = changedAppliedMigrations
+  .filter((migration) => !remoteHashes.has(migration.version));
+if (changedAppliedMissingHashes.length) {
+  fail([
+    "Stage already has this migration version but no recorded contents hash; bump timestamp or reset/recreate stage.",
+    ...changedAppliedMissingHashes.map((migration) => "- " + migration.file + " (" + migration.version + ")")
+  ].join("\n"));
+}
+
 const missingHashMigrations = remoteVersions
   .filter((version) => localByVersion.has(version) && !remoteHashes.has(version))
   .map((version) => localByVersion.get(version));
@@ -222,9 +234,7 @@ if (missingHashMigrations.length) {
   remoteHashes = readRemoteMigrationHashes(dbUrl);
 }
 
-const changedAppliedMismatches = readChangedMigrationVersions(changedFrom)
-  .filter((migration) => remoteSet.has(migration.version))
-  .map((migration) => localByVersion.get(migration.version) || migration)
+const changedAppliedMismatches = changedAppliedMigrations
   .filter((migration) => remoteHashes.has(migration.version) && remoteHashes.get(migration.version) !== migration.sha256);
 if (changedAppliedMismatches.length) {
   fail([

--- a/supabase/migrations/20260707090000_bonus_campaigns.sql
+++ b/supabase/migrations/20260707090000_bonus_campaigns.sql
@@ -1,0 +1,154 @@
+create extension if not exists "pgcrypto";
+
+alter type public.chips_tx_type add value if not exists 'PROMO_BONUS';
+
+create table if not exists public.bonus_campaigns (
+  id uuid primary key default gen_random_uuid(),
+  code text unique not null,
+  title text not null,
+  description text,
+  campaign_type text not null,
+  amount bigint not null,
+  status text not null,
+  starts_at timestamptz not null,
+  ends_at timestamptz,
+  eligibility_type text not null,
+  eligibility_config jsonb not null default '{}'::jsonb,
+  max_total_claims bigint,
+  created_by uuid references auth.users (id),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint bonus_campaigns_code_format check (code ~ '^[a-z0-9][a-z0-9_-]*$'),
+  constraint bonus_campaigns_amount_positive check (amount > 0),
+  constraint bonus_campaigns_status_valid check (status in ('draft', 'scheduled', 'active', 'paused', 'ended')),
+  constraint bonus_campaigns_eligibility_type_valid check (eligibility_type in ('all_accounts', 'created_after', 'created_before', 'allowlist')),
+  constraint bonus_campaigns_time_window_valid check (ends_at is null or ends_at > starts_at),
+  constraint bonus_campaigns_max_total_claims_positive check (max_total_claims is null or max_total_claims > 0)
+);
+
+create table if not exists public.bonus_claims (
+  id uuid primary key default gen_random_uuid(),
+  campaign_id uuid not null references public.bonus_campaigns (id) on delete restrict,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  transaction_id uuid not null references public.chips_transactions (id) on delete restrict,
+  idempotency_key text not null,
+  claimed_at timestamptz not null default timezone('utc', now()),
+  metadata jsonb not null default '{}'::jsonb,
+  constraint bonus_claims_idempotency_key_present check (length(idempotency_key) > 0),
+  unique (campaign_id, user_id),
+  unique (idempotency_key)
+);
+
+create table if not exists public.bonus_campaign_eligible_users (
+  campaign_id uuid not null references public.bonus_campaigns (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  reason text,
+  created_by uuid references auth.users (id),
+  created_at timestamptz not null default timezone('utc', now()),
+  primary key (campaign_id, user_id)
+);
+
+create index if not exists bonus_campaigns_status_window_idx
+  on public.bonus_campaigns (status, starts_at, ends_at);
+
+create index if not exists bonus_campaigns_type_idx
+  on public.bonus_campaigns (campaign_type);
+
+create index if not exists bonus_claims_user_idx
+  on public.bonus_claims (user_id, claimed_at desc);
+
+create index if not exists bonus_claims_campaign_idx
+  on public.bonus_claims (campaign_id, claimed_at desc);
+
+create index if not exists bonus_campaign_eligible_users_user_idx
+  on public.bonus_campaign_eligible_users (user_id);
+
+create or replace function public.bonus_campaigns_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists bonus_campaigns_touch_updated_at_trg on public.bonus_campaigns;
+create trigger bonus_campaigns_touch_updated_at_trg
+before update on public.bonus_campaigns
+for each row execute function public.bonus_campaigns_touch_updated_at();
+
+alter table public.bonus_campaigns enable row level security;
+alter table public.bonus_claims enable row level security;
+alter table public.bonus_campaign_eligible_users enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'bonus_campaigns'
+      and policyname = 'deny_all_bonus_campaigns'
+  ) then
+    create policy deny_all_bonus_campaigns on public.bonus_campaigns
+      using (false)
+      with check (false);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'bonus_claims'
+      and policyname = 'deny_all_bonus_claims'
+  ) then
+    create policy deny_all_bonus_claims on public.bonus_claims
+      using (false)
+      with check (false);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'bonus_campaign_eligible_users'
+      and policyname = 'deny_all_bonus_campaign_eligible_users'
+  ) then
+    create policy deny_all_bonus_campaign_eligible_users on public.bonus_campaign_eligible_users
+      using (false)
+      with check (false);
+  end if;
+end $$;
+
+insert into public.bonus_campaigns (
+  code,
+  title,
+  description,
+  campaign_type,
+  amount,
+  status,
+  starts_at,
+  ends_at,
+  eligibility_type,
+  eligibility_config
+)
+values (
+  'welcome-2026',
+  '500 CH Welcome Bonus',
+  'Create an account and claim your starter chips.',
+  'welcome',
+  500,
+  'active',
+  '2025-06-01T00:00:00Z',
+  null,
+  'created_after',
+  '{"created_at_gte":"2025-06-01T00:00:00Z"}'::jsonb
+)
+on conflict (code) do update
+set title = excluded.title,
+    description = excluded.description,
+    campaign_type = excluded.campaign_type,
+    amount = excluded.amount,
+    status = excluded.status,
+    starts_at = excluded.starts_at,
+    ends_at = excluded.ends_at,
+    eligibility_type = excluded.eligibility_type,
+    eligibility_config = excluded.eligibility_config;

--- a/tests/bonus-campaigns.behavior.test.mjs
+++ b/tests/bonus-campaigns.behavior.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCampaignIdempotencyKey,
+  claimBonusCampaign,
+  getBonusCampaignStatus,
+  listBonusCampaignStatuses,
+} from "../netlify/functions/_shared/bonus-campaigns.mjs";
+
+const START_AT = "2025-06-01T00:00:00.000Z";
+const BEFORE_USER = "00000000-0000-4000-8000-000000000001";
+const AFTER_USER = "00000000-0000-4000-8000-000000000003";
+const ALLOWLIST_USER = "00000000-0000-4000-8000-000000000004";
+
+function createDeps() {
+  const welcomeCampaign = {
+    id: "10000000-0000-4000-8000-000000000001",
+    code: "welcome-2026",
+    title: "500 CH Welcome Bonus",
+    description: "Create an account and claim your starter chips.",
+    campaign_type: "welcome",
+    amount: 500,
+    status: "active",
+    starts_at: START_AT,
+    ends_at: null,
+    eligibility_type: "created_after",
+    eligibility_config: { created_at_gte: START_AT },
+    max_total_claims: null,
+  };
+  const allowlistCampaign = {
+    id: "10000000-0000-4000-8000-000000000002",
+    code: "vip-2026",
+    title: "VIP Bonus",
+    description: "Selected account bonus.",
+    campaign_type: "vip",
+    amount: 250,
+    status: "active",
+    starts_at: START_AT,
+    ends_at: null,
+    eligibility_type: "allowlist",
+    eligibility_config: {},
+    max_total_claims: null,
+  };
+  const campaigns = [welcomeCampaign, allowlistCampaign];
+  const users = new Map([
+    [BEFORE_USER, "2025-05-31T23:59:59.000Z"],
+    [AFTER_USER, "2025-06-02T12:00:00.000Z"],
+    [ALLOWLIST_USER, "2025-01-02T12:00:00.000Z"],
+  ]);
+  const allowlist = new Set([`${allowlistCampaign.id}:${ALLOWLIST_USER}`]);
+  const txByKey = new Map();
+  const claimsByCampaignUser = new Map();
+  const posts = [];
+  const deps = {
+    async executeSql(query, params = []) {
+      const text = String(query).toLowerCase().replace(/\s+/g, " ");
+      if (text.includes("from public.bonus_campaigns")) {
+        const code = params[0] || null;
+        return code ? campaigns.filter((campaign) => campaign.code === code) : campaigns;
+      }
+      if (text.includes("from auth.users")) {
+        const createdAt = users.get(params[0]);
+        return createdAt ? [{ created_at: createdAt }] : [];
+      }
+      if (text.includes("from public.bonus_claims")) {
+        const key = `${params[0]}:${params[1]}`;
+        const row = claimsByCampaignUser.get(key);
+        return row ? [row] : [];
+      }
+      if (text.includes("from public.chips_transactions")) {
+        const row = txByKey.get(params[1]);
+        return row && row.user_id === params[0] ? [row] : [];
+      }
+      if (text.includes("from public.bonus_campaign_eligible_users")) {
+        return allowlist.has(`${params[0]}:${params[1]}`) ? [{ "?column?": 1 }] : [];
+      }
+      if (text.includes("insert into public.bonus_claims")) {
+        const row = {
+          id: `claim-${claimsByCampaignUser.size + 1}`,
+          campaign_id: params[0],
+          user_id: params[1],
+          transaction_id: params[2],
+          idempotency_key: params[3],
+          claimed_at: "2026-07-07T00:00:00.000Z",
+        };
+        claimsByCampaignUser.set(`${params[0]}:${params[1]}`, row);
+        return [row];
+      }
+      throw new Error(`unexpected query: ${text}`);
+    },
+    async postTransaction(payload) {
+      posts.push(payload);
+      const existing = txByKey.get(payload.idempotencyKey);
+      if (existing) {
+        return { transaction: existing, entries: [], account: { balance: payload.metadata.amount } };
+      }
+      const transaction = {
+        id: `tx-${posts.length}`,
+        user_id: payload.userId,
+        tx_type: payload.txType,
+        idempotency_key: payload.idempotencyKey,
+      };
+      txByKey.set(payload.idempotencyKey, transaction);
+      return { transaction, entries: payload.entries, account: { balance: payload.metadata.amount } };
+    },
+    posts,
+    claimsByCampaignUser,
+    txByKey,
+  };
+  return deps;
+}
+
+test("created-after welcome campaign preserves current eligibility boundary", async () => {
+  const deps = createDeps();
+  const before = await getBonusCampaignStatus(BEFORE_USER, "welcome-2026", deps);
+  const after = await getBonusCampaignStatus(AFTER_USER, "welcome-2026", deps);
+
+  assert.equal(before.eligible, false);
+  assert.equal(before.reason, "created_before_start");
+  assert.equal(after.eligible, true);
+  assert.equal(after.reason, "eligible");
+  assert.equal(after.campaign.amount, 500);
+  assert.equal(after.idempotencyKey, buildCampaignIdempotencyKey("welcome-2026", AFTER_USER));
+});
+
+test("allowlist campaign only allows selected users", async () => {
+  const deps = createDeps();
+  const selected = await getBonusCampaignStatus(ALLOWLIST_USER, "vip-2026", deps);
+  const other = await getBonusCampaignStatus(AFTER_USER, "vip-2026", deps);
+
+  assert.equal(selected.eligible, true);
+  assert.equal(other.eligible, false);
+  assert.equal(other.reason, "not_allowlisted");
+});
+
+test("claim writes PROMO_BONUS ledger transaction and bonus claim row", async () => {
+  const deps = createDeps();
+  const result = await claimBonusCampaign(AFTER_USER, "welcome-2026", deps);
+  const payload = deps.posts[0];
+
+  assert.equal(result.claimed, true);
+  assert.equal(result.transactionId, "tx-1");
+  assert.equal(payload.txType, "PROMO_BONUS");
+  assert.equal(payload.idempotencyKey, `bonus:welcome-2026:${AFTER_USER}`);
+  assert.equal(payload.reference, payload.idempotencyKey);
+  assert.equal(payload.metadata.source, "bonus_campaign");
+  assert.equal(payload.metadata.campaign_code, "welcome-2026");
+  assert.deepEqual(
+    payload.entries.map((entry) => ({
+      accountType: entry.accountType,
+      userId: entry.userId || null,
+      systemKey: entry.systemKey || null,
+      amount: entry.amount,
+    })),
+    [
+      { accountType: "USER", userId: AFTER_USER, systemKey: null, amount: 500 },
+      { accountType: "SYSTEM", userId: null, systemKey: "GENESIS", amount: -500 },
+    ],
+  );
+  assert.equal(deps.claimsByCampaignUser.size, 1);
+  assert.equal(JSON.stringify(payload).includes("guestChips"), false);
+});
+
+test("repeated claim does not grant a second bonus", async () => {
+  const deps = createDeps();
+  const first = await claimBonusCampaign(AFTER_USER, "welcome-2026", deps);
+  const second = await claimBonusCampaign(AFTER_USER, "welcome-2026", deps);
+
+  assert.equal(first.claimed, true);
+  assert.equal(second.claimed, false);
+  assert.equal(second.alreadyClaimed, true);
+  assert.equal(deps.posts.length, 1);
+  assert.equal(deps.claimsByCampaignUser.size, 1);
+});
+
+test("list helper returns public campaign status summaries", async () => {
+  const deps = createDeps();
+  const list = await listBonusCampaignStatuses(ALLOWLIST_USER, deps);
+
+  assert.equal(list.items.length, 2);
+  assert.deepEqual(
+    list.items.map((item) => ({ code: item.code, eligible: item.eligible, amount: item.amount })),
+    [
+      { code: "welcome-2026", eligible: false, amount: 500 },
+      { code: "vip-2026", eligible: true, amount: 250 },
+    ],
+  );
+});

--- a/tests/db-stage-workflows.guard.test.mjs
+++ b/tests/db-stage-workflows.guard.test.mjs
@@ -65,6 +65,7 @@ test("stage migration helper refuses non-stage targets and unrelated remote migr
   assert.match(text, /SUPABASE_STAGE_PROJECT_REF is required/);
   assert.match(text, /does not contain SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /Stage DB contains migration versions that are not present in this checkout/);
+  assert.match(text, /Stage already has this migration version but no recorded contents hash; bump timestamp or reset\/recreate stage/);
   assert.match(text, /Stage already has this migration version with different contents; bump timestamp or reset\/recreate stage/);
   assert.match(text, /--changed-from/);
   assert.match(text, /schema_migration_files/);

--- a/tests/db-stage-workflows.guard.test.mjs
+++ b/tests/db-stage-workflows.guard.test.mjs
@@ -65,8 +65,9 @@ test("stage migration helper refuses non-stage targets and unrelated remote migr
   assert.match(text, /SUPABASE_STAGE_PROJECT_REF is required/);
   assert.match(text, /does not contain SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /Stage DB contains migration versions that are not present in this checkout/);
-  assert.match(text, /Stage already has this migration version; bump timestamp or reset\/recreate stage/);
+  assert.match(text, /Stage already has this migration version with different contents; bump timestamp or reset\/recreate stage/);
   assert.match(text, /--changed-from/);
+  assert.match(text, /schema_migration_files/);
   assert.match(text, /Refusing to continue/);
   assert.doesNotMatch(text, /drop schema|drop database|truncate/i);
 });

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -9,6 +9,8 @@ import {
 } from "./poker-engine.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitives.mjs";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function initialCore() {
   return {
     roomId: "table_engine_roll",
@@ -167,6 +169,7 @@ test("replaceBrokeBotsForNextHand swaps too-short bot only after settlement", ()
   const replacementBot = recycled.coreState.members.find((member) => member.seat === 2);
   assert.ok(replacementBot);
   assert.notEqual(replacementBot.userId, "bot_old");
+  assert.match(replacementBot.userId, UUID_RE);
   assert.equal(recycled.coreState.seatDetailsByUserId[replacementBot.userId].isBot, true);
   assert.equal(recycled.settledState.stacks[replacementBot.userId], 100);
   assert.equal("bot_old" in recycled.settledState.stacks, false);

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   dealHoleCards,
   deriveDeck,
@@ -12,6 +13,17 @@ const MIN_PLAYERS_TO_BOOTSTRAP = 2;
 const ENGINE_ACTIONS = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE"]);
 const MIN_STACK_TO_JOIN_HAND = 2;
 const BOT_REPLACEMENT_STACK = 100;
+
+function toHex(bytes) {
+  return Buffer.from(bytes).toString("hex");
+}
+
+function toUuidLike(input) {
+  const bytes = Buffer.from(createHash("sha256").update(input).digest().subarray(0, 16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return `${toHex(bytes.subarray(0, 4))}-${toHex(bytes.subarray(4, 6))}-${toHex(bytes.subarray(6, 8))}-${toHex(bytes.subarray(8, 10))}-${toHex(bytes.subarray(10, 16))}`;
+}
 
 function toInt(value) {
   if (!Number.isFinite(value)) {
@@ -184,12 +196,13 @@ export function buildNextHandStateFromSettled({ tableId, coreState, settledState
   });
 }
 
-function nextBotReplacementUserId({ seatNo, version, existingUserIds }) {
-  const base = `bot_auto_${Number(seatNo)}_${Number(version)}`;
+function nextBotReplacementUserId({ tableId, seatNo, version, existingUserIds }) {
+  const baseInput = `bot_replacement:${tableId ?? ""}:${Number(seatNo)}:${Number(version)}`;
+  const base = toUuidLike(baseInput);
   let candidate = base;
   let suffix = 1;
   while (existingUserIds.has(candidate)) {
-    candidate = `${base}_${suffix}`;
+    candidate = toUuidLike(`${baseInput}:${suffix}`);
     suffix += 1;
   }
   existingUserIds.add(candidate);
@@ -229,6 +242,7 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
     if (!Number.isFinite(stack) || stack >= MIN_STACK_TO_JOIN_HAND) continue;
 
     const replacementUserId = nextBotReplacementUserId({
+      tableId: coreState.roomId,
       seatNo: member.seat,
       version: nextVersion,
       existingUserIds

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -903,6 +903,93 @@ test("accepted action that settles a hand schedules delayed rollover", async () 
   }
 });
 
+test("zero settled reveal delay schedules immediate rollover instead of leaving table settled", async () => {
+  const secret = "zero-settled-rollover-secret";
+  const tableId = "table_zero_settled_rollover";
+  const settledAt = new Date(Date.now() - 1_000).toISOString();
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: "user_zero_a", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 104 },
+          { user_id: "user_zero_b", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 96 }
+        ],
+        stateRow: {
+          version: 11,
+          state: {
+            tableId,
+            roomId: tableId,
+            handId: "hand_zero_settled_rollover",
+            phase: "SETTLED",
+            dealerSeatNo: 1,
+            seats: [
+              { userId: "user_zero_a", seatNo: 1, status: "ACTIVE" },
+              { userId: "user_zero_b", seatNo: 2, status: "ACTIVE" }
+            ],
+            stacks: { user_zero_a: 104, user_zero_b: 96 },
+            community: ["AS", "KD", "QC", "JH", "TS"],
+            communityDealt: 5,
+            pot: 0,
+            showdown: {
+              handId: "hand_zero_settled_rollover",
+              winners: ["user_zero_a"],
+              potsAwarded: [{ amount: 8, winners: ["user_zero_a"], eligibleUserIds: ["user_zero_a", "user_zero_b"] }],
+              potAwardedTotal: 8,
+              reason: "computed"
+            },
+            handSettlement: {
+              handId: "hand_zero_settled_rollover",
+              settledAt,
+              payouts: { user_zero_a: 8 }
+            },
+            turnUserId: null,
+            turnStartedAt: null,
+            turnDeadlineAt: null
+          }
+        }
+      }
+    }
+  });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_POKER_SETTLED_REVEAL_MS: "0",
+      WS_TIMEOUT_SWEEP_MS: "60000",
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000",
+      WS_OPEN_TABLE_JANITOR_SWEEP_MS: "60000"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: "user_zero_a" }), "auth-zero-settled-rollover");
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "sub-zero-settled-rollover",
+      ts: new Date().toISOString(),
+      payload: { tableId, view: "snapshot" }
+    });
+    const snapshot = await nextMessageOfType(ws, "stateSnapshot");
+    assert.equal(snapshot.payload.public.hand.status, "SETTLED");
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const rolled = await readPersistedFile(filePath);
+    assert.equal(rolled.tables[tableId].stateRow.state.phase, "PREFLOP");
+    assert.equal(rolled.tables[tableId].stateRow.version > 11, true);
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("disconnect cleanup defers fresh settled reveal and can close after reveal grace", async () => {
   const secret = "disconnect-settled-reveal-secret";
   const tableId = "table_disconnect_settled_reveal";

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1451,11 +1451,6 @@ const tableJanitorPrimitives = {
 };
 
 function maybeScheduleSettledRollover(tableId) {
-  if (settledRevealMs <= 0) {
-    clearSettledRolloverTimer(tableId);
-    return;
-  }
-
   const pokerState = tableManager.persistedPokerState(tableId);
   if (!pokerState || pokerState.phase !== "SETTLED") {
     clearSettledRolloverTimer(tableId);

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -13,6 +13,8 @@ test("ws preview deploy remote script matches fixed preview app-dir contract", (
 
   assert.match(text, /PREVIEW_BASE_DIR: \/opt\/arcade-ws-preview/);
   assert.match(text, /PREVIEW_APP_DIR: \/opt\/arcade-ws-preview\/ws-server/);
+  assert.match(text, /sudo -n -v/);
+  assert.match(text, /preview deploy user must have passwordless sudo for ws-preview deploy/);
   assert.match(text, /sudo -n test -d "\$PREVIEW_APP_DIR"/);
   assert.match(text, /cp -R ws-server\/shared\/poker-domain "\$PREVIEW_STAGE_WS_DIR"\/shared\/poker-domain/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/server\.mjs"/);

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -13,8 +13,8 @@ test("ws preview deploy remote script matches fixed preview app-dir contract", (
 
   assert.match(text, /PREVIEW_BASE_DIR: \/opt\/arcade-ws-preview/);
   assert.match(text, /PREVIEW_APP_DIR: \/opt\/arcade-ws-preview\/ws-server/);
-  assert.match(text, /sudo -n -v/);
-  assert.match(text, /preview deploy user must have passwordless sudo for ws-preview deploy/);
+  assert.match(text, /sudo -n bash -c 'true'/);
+  assert.match(text, /preview deploy user must be allowed to run sudo -n bash for ws-preview deploy/);
   assert.match(text, /sudo -n test -d "\$PREVIEW_APP_DIR"/);
   assert.match(text, /cp -R ws-server\/shared\/poker-domain "\$PREVIEW_STAGE_WS_DIR"\/shared\/poker-domain/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/server\.mjs"/);

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -84,8 +84,8 @@ test("ws preview deploy workflow keeps preview runtime contract and does not man
   assert.match(text, /preview env file must define SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env SUPABASE_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env SUPABASE_DB_URL must target SUPABASE_STAGE_PROJECT_REF/);
-  assert.match(text, /sudo -n -v/);
-  assert.match(text, /preview deploy user must have passwordless sudo for ws-preview deploy/);
+  assert.match(text, /sudo -n bash -c 'true'/);
+  assert.match(text, /preview deploy user must be allowed to run sudo -n bash for ws-preview deploy/);
   assert.doesNotMatch(text, /\/etc\/caddy\/Caddyfile/);
   assert.doesNotMatch(text, /infra\/vps\/Caddyfile/);
   assert.doesNotMatch(text, /Caddyfile\.preview\.example/);

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -84,6 +84,8 @@ test("ws preview deploy workflow keeps preview runtime contract and does not man
   assert.match(text, /preview env file must define SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env SUPABASE_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env SUPABASE_DB_URL must target SUPABASE_STAGE_PROJECT_REF/);
+  assert.match(text, /sudo -n -v/);
+  assert.match(text, /preview deploy user must have passwordless sudo for ws-preview deploy/);
   assert.doesNotMatch(text, /\/etc\/caddy\/Caddyfile/);
   assert.doesNotMatch(text, /infra\/vps\/Caddyfile/);
   assert.doesNotMatch(text, /Caddyfile\.preview\.example/);
@@ -122,6 +124,7 @@ test("poker deployment doc states the unified preview Caddy ownership model", ()
   assert.match(text, /\/opt\/arcade-ws-preview\/\.env\.preview/);
   assert.match(text, /ws-server-preview\.service/);
   assert.match(text, /http:\/\/127\.0\.0\.1:3001\/healthz/);
+  assert.match(text, /passwordless sudo/);
   assert.match(text, /WS_AUTHORITATIVE_JOIN_ENABLED=1/);
   assert.match(text, /SUPABASE_DB_URL/);
   assert.match(text, /SUPABASE_STAGE_PROJECT_REF/);


### PR DESCRIPTION
## Summary
- add generic bonus campaign schema, claim table, allowlist table, and seeded welcome-2026 campaign
- add PROMO_BONUS ledger transaction support
- add shared bonus campaign eligibility/claim helper with created_after and allowlist support
- cover generic bonus claim/idempotency behavior while keeping existing welcome bonus tests green

## Stage DB migration workflow
This PR changes `supabase/migrations/20260707090000_bonus_campaigns.sql`, so GitHub should run `DB Migration Check` and `DB Stage Apply PR`.

Local migration checks run:
- `git diff --name-only origin/main...HEAD -- supabase/migrations`
- `node scripts/check-db-migrations.mjs`

After the PR opens, wait for `DB Stage Apply PR` to go green before testing the deploy preview against stage.

## Validation
- `node scripts/check-db-migrations.mjs`
- `node --check netlify/functions/_shared/bonus-campaigns.mjs`
- `node --check netlify/functions/_shared/chips-ledger.mjs`
- `node --test tests/bonus-campaigns.behavior.test.mjs tests/welcome-bonus.behavior.test.mjs`