### PR TITLE
refactor: centralize XP ledger and status domain

### DIFF
--- a/docs/xp-unification-plan.md
+++ b/docs/xp-unification-plan.md
@@ -115,6 +115,8 @@ Do not create a framework or class hierarchy. Handlers should parse HTTP, call o
 
 Objective: remove duplicated server orchestration while preserving every current route and client contract.
 
+Implementation status in PR #681: the canonical Redis key factory, totals reader, atomic Lua award operation, normalized result mapping, status projection, and derived profile persistence now live under `netlify/functions/_shared/`. Both current handlers use those shared owners. The legacy `award-xp` adapter still owns its request compatibility, session registration/touch, lock retry, and response mapping; `calculate-xp` still owns gameplay scoring. Moving status traffic and removing the adapter are intentionally left to PR 2 and PR 3 below.
+
 Work:
 
 - Inventory duplicated logic in `calculate-xp.mjs` and `award-xp.mjs` before moving it.

--- a/docs/xp-unification-plan.md
+++ b/docs/xp-unification-plan.md
@@ -1,0 +1,303 @@
+# XP System Unification Plan
+
+## Executive summary
+
+Arcade Hub should consolidate XP before implementing the leaderboard. The current product has one authoritative gameplay award route (`calculate-xp`), one legacy award/status route (`award-xp`), and one justified signed-session route (`start-session`). The target is one authoritative XP award/status service plus the separate session service.
+
+This plan intentionally skips the observation/telemetry phase from `docs/xp-complexity-audit.md`. Arcade Hub is still early, has one active operator/user, and does not need a production usage window before removing internal legacy paths. Replacement confidence will come from repository-wide caller inspection, existing guards, deterministic behavior tests, Deploy Preview smoke tests, and a controlled compatibility adapter.
+
+This is a consolidation, not a ground-up rewrite. Existing Redis keys, caps, conversion receipts, public response fields, and signed-session contracts remain stable until their callers are migrated and verified.
+
+## Goals
+
+1. Make `calculate-xp` the only owner of XP award and status orchestration.
+2. Keep one atomic implementation for daily, session, and lifetime totals.
+3. Keep one canonical status snapshot used by badge, public profile, and future leaderboard code.
+4. Reduce `award-xp` to a compatibility adapter and then retire legacy client-delta awards.
+5. Preserve guest XP, authenticated XP, one-time anonymous conversion, the 3,000 daily cap, and session rotation.
+6. Make identity mismatch or invalid JWT fallback structurally impossible.
+7. Reduce client branching without changing gameplay scoring semantics.
+
+## Non-goals
+
+- Do not implement a leaderboard, rankings, daily/weekly aggregates, or XP history.
+- Do not change XP values, game scoring rules, daily reset time, or cap amounts.
+- Do not merge `start-session` into the XP endpoint.
+- Do not rename public payload fields in the first two implementation PRs.
+- Do not migrate canonical XP totals to Postgres.
+- Do not accept browser cache values as authenticated XP.
+- Do not add telemetry infrastructure solely to decide whether legacy code can be removed.
+
+## Fixed decisions
+
+- Canonical authenticated total remains `kcswh:xp:v2:total:<Supabase user id>` in Upstash.
+- `calculate-xp` remains the public authoritative route to avoid breaking playable pages.
+- `start-session` remains separate because session issuance has distinct security and rate-limit behavior.
+- Status reads use the same identity and conversion service as awards but never consume gameplay windows or grant XP.
+- A missing Authorization header may use anonymous identity; a supplied invalid token always returns `401` and never falls back to anonymous identity.
+- `award-xp` may temporarily delegate, but it must not retain independent identity, policy, cap, conversion, or Redis orchestration.
+- Removal decisions use static caller verification and real smoke tests instead of a Phase 0 usage-observation period.
+
+## Required invariants
+
+Every implementation PR must preserve all of these:
+
+1. Authenticated award, authenticated status, public profile, and future leaderboard resolve to the same Supabase user ID and lifetime total.
+2. Anonymous and authenticated totals never share a key accidentally.
+3. Anonymous-to-account conversion is atomic and exactly once when a positive transferable balance exists.
+4. Daily, session, and lifetime updates remain atomic.
+5. Daily cap remains 3,000 XP and resets at 03:00 Europe/Warsaw.
+6. Session cap and session rotation continue allowing progress up to the daily cap.
+7. Status operations do not award XP, consume activity, increment session counters, or trigger award animation. The new authoritative status operation also does not register or touch award/signed sessions; only the temporary `award-xp statusOnly` adapter may preserve that legacy side effect until PR 3.
+8. Badge and overlay animate only after a positive authoritative award response.
+9. Clearing cookies or local storage does not change authenticated account XP.
+10. Guest play remains supported without a Supabase session.
+11. Existing game aliases continue resolving to canonical game IDs.
+12. Public responses never expose Supabase UUIDs, Redis keys, conversion markers, or signed-session identifiers.
+
+## Target architecture
+
+### Public endpoints
+
+#### `POST /.netlify/functions/calculate-xp`
+
+Support an explicit normalized operation:
+
+- `operation: "award"`: validate a semantic gameplay window, calculate the grant, and execute the atomic ledger operation.
+- `operation: "status"`: resolve identity, perform permitted one-time anonymous conversion, and return the canonical snapshot without gameplay mutation.
+
+During migration, existing award payloads without `operation` normalize to `award`. Existing `statusOnly: true` normalizes to `status`.
+
+#### `POST /.netlify/functions/start-session`
+
+Retain the current responsibility: issue and validate signed anti-abuse sessions. It may call shared identity/session helpers but does not read or award XP totals unless required to construct its existing response contract.
+
+#### `POST /.netlify/functions/award-xp`
+
+Temporary compatibility behavior:
+
+- status requests delegate to the same authoritative status service used by `calculate-xp`;
+- legacy delta awards remain isolated only until every repository caller is migrated;
+- after caller verification, legacy delta requests return a controlled `legacy_award_retired` response;
+- the endpoint can be removed later, but only after static checks prove no supported page calls it.
+
+### Status/session compatibility decision
+
+Current `award-xp` requests with `statusOnly: true` are not read-only. They call `registerSession()`, may call `touchSession()` for a valid signed session, generate a `sessionId` when the request has none, and return that ID. This behavior must not be removed implicitly while status ownership moves.
+
+The migration contract is:
+
+1. New `calculate-xp` requests with `operation: "status"` do not call `registerSession()`, `touchSession()`, create signed-session state, or generate a new session identifier. They may temporarily echo a caller-supplied `sessionId` to preserve the response shape, but the field is not authoritative and `XPClient.fetchStatus()` must not consume it.
+2. The `award-xp statusOnly` compatibility adapter delegates canonical identity, conversion, totals, and snapshot projection to the new status service, but temporarily retains legacy session registration/touch and generated `sessionId` behavior during PR 2. Those side effects live only in the adapter and are not part of the authoritative status service.
+3. Anonymous-to-account conversion remains an explicitly permitted status mutation because it is atomic and idempotent. Updating a derived profile snapshot may also remain, but it happens after the canonical read and never mutates daily, session, or lifetime XP totals.
+4. PR 3 removes legacy status session registration/touch and generated response IDs together with client-delta awards. At that point `award-xp` either delegates a fully read-only status response or is removed.
+5. Gameplay signed-session creation remains owned by `start-session`; award-session initialization remains owned by the award path. A status read must never be required to make a later `calculate-xp` award valid.
+
+This staged rule preserves cached legacy callers without allowing hidden session mutations to become part of the new status contract.
+
+### Internal modules
+
+Prefer small concrete modules under `netlify/functions/_shared/`:
+
+- `xp-request.mjs`: normalize operation and legacy request shapes.
+- `xp-identity.mjs`: existing JWT/anon identity, canonical game IDs, and atomic conversion ownership.
+- `xp-calculator.mjs`: pure semantic activity-window to requested grant calculation.
+- `xp-ledger.mjs`: canonical keys and one atomic award operation.
+- `xp-status.mjs`: canonical non-mutating snapshot projection.
+- `xp-response.mjs`: allowlisted response and controlled error mapping.
+- existing session helper(s): signed-session validation and issuance.
+
+Do not create a framework or class hierarchy. Handlers should parse HTTP, call one service operation, and serialize the result.
+
+## Delivery plan
+
+### PR 1: Centralize XP domain operations
+
+Objective: remove duplicated server orchestration while preserving every current route and client contract.
+
+Work:
+
+- Inventory duplicated logic in `calculate-xp.mjs` and `award-xp.mjs` before moving it.
+- Extract canonical identity/conversion invocation into one service boundary using `_shared/supabase-admin.mjs` and `_shared/xp-identity.mjs`.
+- Extract Redis key construction and the atomic award operation into one owner.
+- Extract a normalized canonical status snapshot containing the currently supported totals, caps, reset fields, level inputs, and session fields.
+- Separate canonical status projection from legacy `statusOnly` session setup. Add explicit adapter hooks so `registerSession()`, `touchSession()`, and generated `sessionId` cannot leak into the shared status service.
+- Keep current Lua semantics and Redis key names unless a proven defect requires a separately reviewed change.
+- Make both handlers call shared operations; retain request and response compatibility.
+- Keep `calculate-xp` gameplay calculation separate from ledger mutation so status cannot invoke calculation accidentally.
+- Make public profile reads use the same strict canonical total/status reader where practical, without exposing internal fields.
+
+Verification:
+
+- Existing XP test suite and guards remain green.
+- Add parity tests that run equivalent identities and totals through both route adapters and compare canonical snapshots.
+- Test invalid bearer token plus anon ID returns `401` with no anon mutation.
+- Test concurrent awards cannot exceed daily or session caps.
+- Test conversion conflict/retry remains idempotent.
+- Add characterization tests for current `statusOnly`: requested/generated `sessionId`, registry creation, signed-session touch, conversion, and derived profile persistence. These define what the adapter temporarily preserves, not the target status behavior.
+- Real stage smoke: guest award, authenticated award, conversion, status, public profile, cookie/storage clearing.
+
+Exit criteria:
+
+- There is one implementation of canonical keys, conversion orchestration, atomic cap enforcement, and status projection.
+- Handler-specific code is limited to HTTP compatibility and gameplay calculation selection.
+- No scoring behavior or response contract changes are observed.
+
+### PR 2: Move status to `calculate-xp`
+
+Objective: make reads and writes enter through the same authoritative endpoint.
+
+Work:
+
+- Add explicit `operation: "status"` handling to `calculate-xp`.
+- Accept `statusOnly: true` as a temporary normalization alias if required by cached clients.
+- Change `XPClient.fetchStatus()` to call `calculate-xp` with the authenticated bearer token and current anon identity.
+- Ensure status bypasses award-specific activity, stale-window, and signed-session mutation paths.
+- Do not call `registerSession()` or `touchSession()` and do not generate a new `sessionId` in `calculate-xp operation=status`. Echo a supplied ID only if response compatibility requires it.
+- Change `award-xp` status handling to delegate to the same service, not duplicate it.
+- Keep legacy session registration/touch and generated `sessionId` only in the `award-xp statusOnly` adapter for this PR. Mark that adapter behavior for removal in PR 3.
+- Keep response fields compatible with badge, migration notice, public profile consistency tests, and non-game pages.
+- Update `docs/xp-service.md`, `docs/xp-system.md`, and `docs/xp-anon-to-account-conversion.md` to identify the new status owner.
+
+Verification:
+
+- Badge remains loading until authoritative status is known and never flashes a provisional authenticated zero.
+- Login, logout, account switch, multi-tab, focus/BFCache, and auth-token refresh resolve the correct identity.
+- Badge XP, public profile XP, and computed level match for the same account.
+- Clearing all browser data and signing in again preserves account XP.
+- Network/status failure does not overwrite a known value with zero or delete migration cache prematurely.
+- Status requests produce no award animation and no XP mutation.
+- A new status request followed by normal `start-session` and `calculate-xp operation=award` succeeds without any registry side effect from status.
+- A legacy `award-xp statusOnly` request still returns its compatible `sessionId` and allows the existing legacy award flow during PR 2.
+- Removing `registerSession()` from the new status path does not alter session rotation, the 300 XP session ceiling, or progress toward the 3,000 daily ceiling.
+
+Exit criteria:
+
+- All supported clients read status from `calculate-xp`.
+- `award-xp` status is only a thin delegating adapter.
+- Any remaining status-triggered session mutation is isolated in that adapter and has a mandatory removal task in PR 3.
+- Leaderboard implementation may begin after this PR is stable on production and the identity-consistency smoke passes.
+
+### PR 3: Retire legacy client-delta awards
+
+Objective: remove the second executable award algorithm without waiting for production telemetry.
+
+Work:
+
+- Use `rg`, the XP hook guard, catalog validation, and playable-page inspection to prove every supported game uses semantic activity and server calculation.
+- Verify no production page calls `XPClient.postWindow()` or sends client-authoritative deltas to `award-xp`.
+- Simplify `postWindowAuto` to the server-calculated route.
+- Keep a controlled compatibility response for direct legacy attempts during one deploy cycle, without mutating XP.
+- Remove legacy delta policy, cap, conversion, and Lua orchestration from `award-xp`.
+- Remove adapter-only `statusOnly` calls to `registerSession()`/`touchSession()`, stop generating status `sessionId`, and update compatibility responses after proving no supported client consumes that field.
+- Update tests and docs to reject new references to the legacy award path.
+- Remove the adapter entirely only if static repository checks and Deploy Preview smoke prove it has no supported callers.
+
+Verification:
+
+- Exercise every game category except poker through representative semantic actions; poker retains its established XP contract.
+- Verify paused, idle, background, and random-click states do not earn XP.
+- Verify restarts and score resets continue producing valid semantic activity.
+- Confirm session rotation continues after the 300 XP session ceiling and stops at 3,000 daily XP.
+- Confirm status followed by award works without a status-created registry entry and that `start-session` remains the only signed-session initializer.
+- Add a guard that fails when playable code references the retired transport.
+
+Exit criteria:
+
+- Only `calculate-xp` can mutate gameplay XP.
+- `award-xp` cannot grant a client-provided delta.
+- No supported client references the retired award transport.
+
+### PR 4: Reduce XP client state
+
+Objective: simplify browser code after server ownership is unambiguous.
+
+Work:
+
+- Separate transport/auth/session acquisition from badge presentation and gameplay accumulation using existing plain-script modules.
+- Keep one status reconciliation function and one confirmed-award application function.
+- Remove obsolete legacy transport selection and duplicate retry branches.
+- Remove obsolete cache fields only after compatibility reads have shipped for one release.
+- Clarify internal names for anon identity, award session, signed session, and gameplay run without changing public payload names unnecessarily.
+- Preserve IIFE/plain-script loading and JSP compatibility.
+- Keep `klog` for runtime diagnostics; do not add `console.log`.
+- If an inline script changes, update the CSP SHA allowlist.
+
+Verification:
+
+- Existing lifecycle, badge, XP hook, BFCache, auth-transition, cap, and game behavior tests remain green.
+- Multi-tab and multi-device status convergence remains server-authoritative.
+- Award overlay and badge bump happen exactly once per positive confirmed response.
+- Non-game pages perform no award/session-start requests.
+
+Exit criteria:
+
+- Client has one production award transport and one status transport targeting the same endpoint.
+- Identity-bound caches cannot cross account transitions.
+- Obsolete legacy state and branches are removed or explicitly documented as temporary compatibility reads.
+
+## Verification matrix
+
+Run for every implementation PR:
+
+- `npm test`
+- `npm run check:all`
+- syntax checks from the repository test runner
+- Netlify Deploy Preview
+- existing XP contract, identity, conversion, cap, BFCache, and game-hook tests
+
+Manual smoke matrix:
+
+1. Guest starts at the canonical guest total and earns XP from a real semantic game action.
+2. Random clicks, paused gameplay, idle tabs, and background tabs do not award XP.
+3. Authenticated user earns XP and receives the same total in badge, status, and public profile.
+4. Anonymous XP converts once after login and does not convert twice after refresh or concurrent requests.
+5. Invalid bearer token with a valid anon ID returns `401` and mutates neither identity.
+6. Logout/login and switching between two accounts do not leak badge or cache state.
+7. Clearing cookies and local storage does not reduce authenticated XP.
+8. Two tabs converge to the same canonical total.
+9. A second device reads the same authenticated total.
+10. Session cap rotates correctly; daily cap stops at 3,000 XP and resets at 03:00 Europe/Warsaw.
+11. Status reads do not animate, grant XP, or consume gameplay state.
+12. Public profile returns controlled failure rather than a cacheable false zero when Upstash is unavailable.
+
+## Rollout and rollback
+
+- Each PR must be independently deployable and preserve the previous public HTTP contracts until its exit criteria are met.
+- Do not combine centralization, status migration, and legacy removal in one PR.
+- PR 1 rollback restores handler wiring while retaining shared modules; Redis keys and data require no rollback.
+- PR 2 rollback points `XPClient.fetchStatus()` back to the delegating `award-xp` status adapter, which must remain functional during that PR.
+- PR 3 rollback may temporarily restore the compatibility adapter, but must not restore duplicated identity or atomic ledger implementations.
+- Never roll back by deleting canonical XP totals, conversion receipts, daily keys, or session counters.
+
+## Breaking impacts
+
+Potential breaking impacts requiring explicit review:
+
+- A status request accidentally routed through award validation may fail or mutate counters.
+- Response-shape drift may break badge reconciliation, migration notices, public profiles, or later leaderboard consumers.
+- Incorrect identity normalization may split account XP back into anonymous keys.
+- Lua/key changes may allow duplicate awards or cap races.
+- Retiring client-delta awards may break an uninspected cached page; static checks and one compatibility deploy reduce this risk.
+- Client-state cleanup may reintroduce provisional zeroes or stale cross-account values.
+- Tight invalid-token handling intentionally changes malformed authenticated requests from anonymous success to `401`.
+
+## Leaderboard readiness gate
+
+Leaderboard work must wait until PR 1 and PR 2 are merged, deployed, and pass the identity-consistency smoke. At that point there is one canonical status snapshot and one authoritative identity path suitable for server-side ranking reads.
+
+PR 3 and PR 4 should still be completed, but leaderboard data design may proceed after the PR 2 gate if no XP mismatch remains. The leaderboard must aggregate server-side, expose only rank/handle/display name/avatar/XP/level, and never query Redis or `auth.users` directly from the browser.
+
+## Definition of done
+
+XP unification is complete when:
+
+- `calculate-xp` owns award and status operations;
+- `start-session` remains the only separate session responsibility;
+- `award-xp` is removed or is a non-mutating compatibility adapter with no independent XP logic;
+- all playable pages use semantic server-calculated awards;
+- badge, public profile, and status always agree for authenticated users;
+- authenticated XP survives browser-data deletion and device changes;
+- all invariants and smoke checks pass;
+- documentation no longer describes `award-xp` as the status owner;
+- the system is ready to provide one canonical server-side input to the future leaderboard.

--- a/netlify/functions/_shared/xp-ledger.mjs
+++ b/netlify/functions/_shared/xp-ledger.mjs
@@ -1,0 +1,141 @@
+import crypto from "node:crypto";
+
+const sanitizeXpCounter = (value) => Math.max(0, Math.floor(Number(value) || 0));
+const hashLedgerPart = (value) => crypto.createHash("sha256").update(String(value)).digest("hex");
+
+const XP_ATOMIC_AWARD_SCRIPT = `
+  local sessionKey = KEYS[1]
+  local sessionSyncKey = KEYS[2]
+  local dailyKey = KEYS[3]
+  local totalKey = KEYS[4]
+  local lockKey = KEYS[5]
+  local now = tonumber(ARGV[1])
+  local delta = tonumber(ARGV[2])
+  local dailyCap = tonumber(ARGV[3])
+  local sessionCap = tonumber(ARGV[4])
+  local ts = tonumber(ARGV[5])
+  local lockTtl = tonumber(ARGV[6])
+  local sessionTtl = tonumber(ARGV[7])
+
+  local shouldLock = lockTtl and lockTtl > 0
+  if shouldLock then
+    local locked = redis.call('SET', lockKey, tostring(now), 'PX', lockTtl, 'NX')
+    if locked ~= 'OK' then
+      local currentDaily = tonumber(redis.call('GET', dailyKey) or '0')
+      local sessionTotal = tonumber(redis.call('GET', sessionKey) or '0')
+      local lifetime = tonumber(redis.call('GET', totalKey) or '0')
+      local lastSync = tonumber(redis.call('GET', sessionSyncKey) or '0')
+      local lockedAt = tonumber(redis.call('GET', lockKey) or '0')
+      local lockTtlRemaining = tonumber(redis.call('PTTL', lockKey) or -1)
+      return {0, currentDaily, sessionTotal, lifetime, lastSync, 6, lockedAt, lockTtlRemaining}
+    end
+  end
+
+  local function refreshSessionTtl()
+    if sessionTtl and sessionTtl > 0 then
+      redis.call('PEXPIRE', sessionKey, sessionTtl)
+      redis.call('PEXPIRE', sessionSyncKey, sessionTtl)
+    end
+  end
+
+  local function finish(grant, dailyTotal, sessionTotal, lifetime, sync, status, lockedAt, lockTtlRemaining)
+    if shouldLock then redis.call('DEL', lockKey) end
+    return {grant, dailyTotal, sessionTotal, lifetime, sync, status, lockedAt, lockTtlRemaining}
+  end
+
+  local sessionTotal = tonumber(redis.call('GET', sessionKey) or '0')
+  local lastSync = tonumber(redis.call('GET', sessionSyncKey) or '0')
+  local dailyTotal = tonumber(redis.call('GET', dailyKey) or '0')
+  local lifetime = tonumber(redis.call('GET', totalKey) or '0')
+
+  if lastSync > 0 and ts <= lastSync then return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 2) end
+  local remainingDaily = dailyCap - dailyTotal
+  if remainingDaily <= 0 then return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 3) end
+  local remainingSession = sessionCap - sessionTotal
+  if remainingSession <= 0 then return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 5) end
+
+  local grant = delta
+  local status = 0
+  if grant > remainingDaily then grant = remainingDaily status = 1 end
+  if grant > remainingSession then grant = remainingSession status = 4 end
+  if grant <= 0 then
+    if ts > lastSync then
+      lastSync = ts
+      redis.call('SET', sessionSyncKey, tostring(lastSync))
+      refreshSessionTtl()
+    end
+    return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, status)
+  end
+
+  dailyTotal = tonumber(redis.call('INCRBY', dailyKey, grant))
+  sessionTotal = tonumber(redis.call('INCRBY', sessionKey, grant))
+  lifetime = tonumber(redis.call('INCRBY', totalKey, grant))
+  lastSync = ts
+  redis.call('SET', sessionSyncKey, tostring(lastSync))
+  refreshSessionTtl()
+  return finish(grant, dailyTotal, sessionTotal, lifetime, lastSync, status)
+`;
+
+function createXpLedgerKeys({ namespace = "kcswh:xp:v2", lockPrefix = `${namespace}:lock:` } = {}) {
+  const sessionHash = (userId, sessionId) => hashLedgerPart(`${userId}|${sessionId}`);
+  return Object.freeze({
+    daily: (userId, dayKey) => `${namespace}:daily:${userId}:${dayKey}`,
+    total: (userId) => `${namespace}:total:${userId}`,
+    session: (userId, sessionId) => `${namespace}:session:${sessionHash(userId, sessionId)}`,
+    sessionSync: (userId, sessionId) => `${namespace}:session:last:${sessionHash(userId, sessionId)}`,
+    sessionState: (userId, sessionId) => `${namespace}:session:state:${sessionHash(userId, sessionId)}`,
+    lock: (userId, sessionId) => `${lockPrefix}${sessionHash(userId, sessionId)}`,
+    registry: (userId, sessionId) => `${namespace}:registry:${sessionHash(userId, sessionId)}`,
+  });
+}
+
+async function readXpTotals({ store, keys, userId, sessionId, dayKey, onError = "throw" }) {
+  if (!userId) return { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 };
+  if (!store || typeof store.get !== "function" || !keys || !dayKey) throw new TypeError("invalid_xp_totals_dependencies");
+  const hasSession = typeof sessionId === "string" && sessionId.length > 0;
+  try {
+    const reads = [store.get(keys.daily(userId, dayKey)), store.get(keys.total(userId))];
+    if (hasSession) reads.push(store.get(keys.session(userId, sessionId)), store.get(keys.sessionSync(userId, sessionId)));
+    const values = await Promise.all(reads);
+    return {
+      current: sanitizeXpCounter(values[0]),
+      lifetime: sanitizeXpCounter(values[1]),
+      sessionTotal: hasSession ? sanitizeXpCounter(values[2]) : 0,
+      lastSync: hasSession ? sanitizeXpCounter(values[3]) : 0,
+    };
+  } catch (error) {
+    if (onError === "zero") return { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 };
+    throw error;
+  }
+}
+
+async function executeAtomicXpAward({ store, script = XP_ATOMIC_AWARD_SCRIPT, keys, args, retryLocked = false, retryDelay, onEvalError }) {
+  if (!store || typeof store.eval !== "function" || typeof script !== "string" || !Array.isArray(keys) || !Array.isArray(args)) {
+    throw new TypeError("invalid_xp_award_dependencies");
+  }
+  const run = async () => {
+    try { return await store.eval(script, keys, args.map(String)); }
+    catch (error) { if (typeof onEvalError === "function") onEvalError(error); throw error; }
+  };
+  let result = await run();
+  let status = Number(result?.[5]) || 0;
+  if (status === 6 && retryLocked) {
+    if (typeof retryDelay === "function") await retryDelay();
+    result = await run();
+    status = Number(result?.[5]) || 0;
+  }
+  const lockTtl = Number(result?.[7]);
+  return {
+    granted: sanitizeXpCounter(result?.[0]),
+    dailyTotal: sanitizeXpCounter(result?.[1]),
+    sessionTotal: sanitizeXpCounter(result?.[2]),
+    lifetime: sanitizeXpCounter(result?.[3]),
+    lastSync: sanitizeXpCounter(result?.[4]),
+    status,
+    lockedAt: sanitizeXpCounter(result?.[6]),
+    lockTtlRemainingMs: Number.isFinite(lockTtl) ? lockTtl : null,
+    raw: result,
+  };
+}
+
+export { XP_ATOMIC_AWARD_SCRIPT, createXpLedgerKeys, executeAtomicXpAward, readXpTotals, sanitizeXpCounter };

--- a/netlify/functions/_shared/xp-status.mjs
+++ b/netlify/functions/_shared/xp-status.mjs
@@ -1,0 +1,33 @@
+import { klog } from "./supabase-admin.mjs";
+import { saveUserProfile } from "./store-upstash.mjs";
+import { sanitizeXpCounter } from "./xp-ledger.mjs";
+
+function buildXpStatusSnapshot({ totals, dailyCap, deltaCap, sessionId, status = "statusOnly" }) {
+  const source = totals && typeof totals === "object" ? totals : {};
+  const snapshot = {
+    ok: true,
+    awarded: 0,
+    granted: 0,
+    cap: sanitizeXpCounter(dailyCap),
+    capDelta: sanitizeXpCounter(deltaCap),
+    totalLifetime: sanitizeXpCounter(source.lifetime),
+    sessionTotal: sanitizeXpCounter(source.sessionTotal),
+    lastSync: sanitizeXpCounter(source.lastSync),
+    status,
+  };
+  if (typeof sessionId === "string" && sessionId) snapshot.sessionId = sessionId;
+  return snapshot;
+}
+
+async function persistXpProfileSnapshot({ userId, totalXp, now = Date.now(), save = saveUserProfile, logKind = "xp_save_user_profile_failed" }) {
+  if (!userId) return false;
+  try {
+    await save({ userId, totalXp: sanitizeXpCounter(totalXp), now });
+    return true;
+  } catch (error) {
+    klog(logKind, { error: error?.message });
+    return false;
+  }
+}
+
+export { buildXpStatusSnapshot, persistXpProfileSnapshot };

--- a/netlify/functions/award-xp.mjs
+++ b/netlify/functions/award-xp.mjs
@@ -1,10 +1,12 @@
 import crypto from "node:crypto";
-import { store, saveUserProfile, atomicRateLimitIncr } from "./_shared/store-upstash.mjs";
+import { store, atomicRateLimitIncr } from "./_shared/store-upstash.mjs";
 import { extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
 import { verifySessionToken, validateServerSession, touchSession } from "./start-session.mjs";
 import { nextWarsawResetMs, warsawDayKey } from "./_shared/time-utils.mjs";
 import { buildCorsAllowlist, buildCorsHeaders } from "./_shared/xp-cors.mjs";
 import { getXpPolicy, migrateAnonXpToUser, resolveXpIdentity } from "./_shared/xp-identity.mjs";
+import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "./_shared/xp-ledger.mjs";
+import { buildXpStatusSnapshot, persistXpProfileSnapshot } from "./_shared/xp-status.mjs";
 
 const XP_DAY_COOKIE = "xp_day";
 
@@ -75,12 +77,7 @@ const safeEquals = (a, b) => {
 };
 
 async function persistUserProfile({ userId, totalXp, now }) {
-  if (!userId) return;
-  try {
-    await saveUserProfile({ userId, totalXp, now });
-  } catch (err) {
-    klog("xp_save_user_profile_failed", { error: err?.message });
-  }
+  return persistXpProfileSnapshot({ userId, totalXp, now });
 }
 
 const parseCookies = (header) => {
@@ -179,14 +176,15 @@ function generateFingerprint(headers) {
 
 // NOTE: userId represents the XP storage identity:
 // Supabase userId for logged-in users, or anonId for anonymous users.
-const keyDaily = (u, day = getDailyKey()) => `${KEY_NS}:daily:${u}:${day}`;
-const keyTotal = (u) => `${KEY_NS}:total:${u}`;
-const keySession = (u, s) => `${KEY_NS}:session:${hash(`${u}|${s}`)}`;
-const keySessionSync = (u, s) => `${KEY_NS}:session:last:${hash(`${u}|${s}`)}`;
-const keyLock = (u, s) => `${LOCK_KEY_PREFIX}${hash(`${u}|${s}`)}`;
+const XP_LEDGER_KEYS = createXpLedgerKeys({ namespace: KEY_NS, lockPrefix: LOCK_KEY_PREFIX });
+const keyDaily = (u, day = getDailyKey()) => XP_LEDGER_KEYS.daily(u, day);
+const keyTotal = XP_LEDGER_KEYS.total;
+const keySession = XP_LEDGER_KEYS.session;
+const keySessionSync = XP_LEDGER_KEYS.sessionSync;
+const keyLock = XP_LEDGER_KEYS.lock;
 const keyRateLimitUser = (userId) => `${KEY_NS}:ratelimit:user:${userId}:${Math.floor(Date.now() / (RATE_LIMIT_WINDOW_SEC * 1000))}`;
 const keyRateLimitIp = (ip) => `${KEY_NS}:ratelimit:ip:${hash(ip)}:${Math.floor(Date.now() / (RATE_LIMIT_WINDOW_SEC * 1000))}`;
-const keySessionRegistry = (userId, sessionId) => `${KEY_NS}:registry:${hash(`${userId}|${sessionId}`)}`;
+const keySessionRegistry = XP_LEDGER_KEYS.registry;
 // SECURITY: Session registration
 async function registerSession({ userId, sessionId }) {
   if (!userId || !sessionId) return { registered: false };
@@ -276,24 +274,7 @@ async function checkRateLimit({ userId, ip }) {
 }
 
 async function getTotals({ userId, sessionId, now = Date.now() }) {
-  // userId represents the XP identity (Supabase userId or anonId) for XP aggregation keys.
-  const todayKey = keyDaily(userId, getDailyKey(now));
-  const totalKeyK = keyTotal(userId);
-  const sessionKeyK = sessionId ? keySession(userId, sessionId) : null;
-  const sessionSyncKeyK = sessionId ? keySessionSync(userId, sessionId) : null;
-  try {
-    const reads = [store.get(todayKey), store.get(totalKeyK)];
-    if (sessionKeyK) reads.push(store.get(sessionKeyK));
-    if (sessionSyncKeyK) reads.push(store.get(sessionSyncKeyK));
-    const values = await Promise.all(reads);
-    const current = Number(values[0] ?? "0") || 0;
-    const lifetime = Number(values[1] ?? "0") || 0;
-    const sessionTotal = sessionKeyK ? (Number(values[2] ?? "0") || 0) : 0;
-    const lastSync = sessionSyncKeyK ? (Number(values[sessionKeyK ? 3 : 2] ?? "0") || 0) : 0;
-    return { current, lifetime, sessionTotal, lastSync };
-  } catch {
-    return { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 };
-  }
+  return readXpTotals({ store, keys: XP_LEDGER_KEYS, userId, sessionId, dayKey: getDailyKey(now), onError: "zero" });
 }
 
 export async function handler(event) {
@@ -645,18 +626,7 @@ export async function handler(event) {
     if (supabaseUserId) {
       await persistUserProfile({ userId: supabaseUserId, totalXp: totals.lifetime, now });
     }
-    const payload = {
-      ok: true,
-      awarded: 0,
-      granted: 0,
-      cap: DAILY_CAP,
-      capDelta: DELTA_CAP,
-      totalLifetime: totals.lifetime,
-      sessionTotal: totals.sessionTotal,
-      lastSync: totals.lastSync,
-      status: "statusOnly",
-      sessionId: sessId,
-    };
+    const payload = buildXpStatusSnapshot({ totals, dailyCap: DAILY_CAP, deltaCap: DELTA_CAP, sessionId: sessId });
     return respond(200, payload, { totals, debugExtra: { mode: "statusOnly" } });
   }
 
@@ -782,131 +752,26 @@ export async function handler(event) {
     }
   }
 
-  const script = `
-    local sessionKey = KEYS[1]
-    local sessionSyncKey = KEYS[2]
-    local dailyKey = KEYS[3]
-    local totalKey = KEYS[4]
-    local lockKey = KEYS[5]
-    local now = tonumber(ARGV[1])
-    local delta = tonumber(ARGV[2])
-    local dailyCap = tonumber(ARGV[3])
-    local sessionCap = tonumber(ARGV[4])
-    local ts = tonumber(ARGV[5])
-    local lockTtl = tonumber(ARGV[6])
-    local sessionTtl = tonumber(ARGV[7])
-
-    local shouldLock = lockTtl and lockTtl > 0
-    if shouldLock then
-      local locked = redis.call('SET', lockKey, tostring(now), 'PX', lockTtl, 'NX')
-      if locked ~= 'OK' then
-        local currentDaily = tonumber(redis.call('GET', dailyKey) or '0')
-        local sessionTotal = tonumber(redis.call('GET', sessionKey) or '0')
-        local lifetime = tonumber(redis.call('GET', totalKey) or '0')
-        local lastSync = tonumber(redis.call('GET', sessionSyncKey) or '0')
-        local lockedAt = tonumber(redis.call('GET', lockKey) or '0')
-        local lockTtlRemaining = tonumber(redis.call('PTTL', lockKey) or -1)
-        return {0, currentDaily, sessionTotal, lifetime, lastSync, 6, lockedAt, lockTtlRemaining}
-      end
-    end
-
-    local function refreshSessionTtl()
-      if sessionTtl and sessionTtl > 0 then
-        redis.call('PEXPIRE', sessionKey, sessionTtl)
-        redis.call('PEXPIRE', sessionSyncKey, sessionTtl)
-      end
-    end
-
-    local function finish(grant, dailyTotal, sessionTotal, lifetime, sync, status, lockedAt, lockTtlRemaining)
-      if shouldLock then
-        redis.call('DEL', lockKey)
-      end
-      return {grant, dailyTotal, sessionTotal, lifetime, sync, status, lockedAt, lockTtlRemaining}
-    end
-
-    local sessionTotal = tonumber(redis.call('GET', sessionKey) or '0')
-    local lastSync = tonumber(redis.call('GET', sessionSyncKey) or '0')
-    local dailyTotal = tonumber(redis.call('GET', dailyKey) or '0')
-    local lifetime = tonumber(redis.call('GET', totalKey) or '0')
-
-    if lastSync > 0 and ts <= lastSync then
-      return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 2)
-    end
-
-    local remainingDaily = dailyCap - dailyTotal
-    if remainingDaily <= 0 then
-      return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 3)
-    end
-
-    local remainingSession = sessionCap - sessionTotal
-    if remainingSession <= 0 then
-      return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, 5)
-    end
-
-    local grant = delta
-    local status = 0
-    if grant > remainingDaily then
-      grant = remainingDaily
-      status = 1
-    end
-    if grant > remainingSession then
-      grant = remainingSession
-      status = 4
-    end
-
-    if grant <= 0 then
-      if ts > lastSync then
-        lastSync = ts
-        redis.call('SET', sessionSyncKey, tostring(lastSync))
-        refreshSessionTtl()
-      end
-      return finish(0, dailyTotal, sessionTotal, lifetime, lastSync, status)
-    end
-
-    dailyTotal = tonumber(redis.call('INCRBY', dailyKey, grant))
-    sessionTotal = tonumber(redis.call('INCRBY', sessionKey, grant))
-    lifetime = tonumber(redis.call('INCRBY', totalKey, grant))
-    lastSync = ts
-    redis.call('SET', sessionSyncKey, tostring(lastSync))
-    refreshSessionTtl()
-    return finish(grant, dailyTotal, sessionTotal, lifetime, lastSync, status)
-  `;
-
   const effectiveDelta = supabaseUserId
     ? normalizedDelta
     : Math.min(normalizedDelta, cookieRemainingBefore);
   const cookieClamped = !supabaseUserId && effectiveDelta < normalizedDelta;
 
-  const runAwardScript = () => store.eval(
-    script,
-    [sessionKeyK, sessionSyncKeyK, todayKey, totalKeyK, lockKeyK],
-    [
-      String(now),
-      String(effectiveDelta),
-      String(DAILY_CAP),
-      String(Math.max(0, SESSION_CAP)),
-      String(ts),
-      String(LOCK_TTL_MS),
-      String(SESSION_TTL_MS),
-    ]
-  );
-
-  let res = await runAwardScript();
-  let status = Number(res?.[5]) || 0;
-  if (status === 6) {
-    await sleep(100 + Math.floor(Math.random() * 150));
-    res = await runAwardScript();
-    status = Number(res?.[5]) || 0;
-  }
-
-  const granted = Math.max(0, Math.floor(Number(res?.[0]) || 0));
-  const redisDailyTotalRaw = Number(res?.[1]) || 0;
-  const sessionTotal = Number(res?.[2]) || 0;
-  const totalLifetime = Number(res?.[3]) || 0;
-  const lastSync = Number(res?.[4]) || 0;
-  const lockedAt = Number(res?.[6]) || 0;
-  const lockTtlRemainingRaw = Number(res?.[7]);
-  const lockTtlRemainingMs = Number.isFinite(lockTtlRemainingRaw) ? lockTtlRemainingRaw : null;
+  const awardResult = await executeAtomicXpAward({
+    store,
+    keys: [sessionKeyK, sessionSyncKeyK, todayKey, totalKeyK, lockKeyK],
+    args: [now, effectiveDelta, DAILY_CAP, Math.max(0, SESSION_CAP), ts, LOCK_TTL_MS, SESSION_TTL_MS],
+    retryLocked: true,
+    retryDelay: () => sleep(100 + Math.floor(Math.random() * 150)),
+  });
+  const granted = awardResult.granted;
+  const redisDailyTotalRaw = awardResult.dailyTotal;
+  const sessionTotal = awardResult.sessionTotal;
+  const totalLifetime = awardResult.lifetime;
+  const lastSync = awardResult.lastSync;
+  const status = awardResult.status;
+  const lockedAt = awardResult.lockedAt;
+  const lockTtlRemainingMs = awardResult.lockTtlRemainingMs;
 
   const totalTodayRedis = Math.min(DAILY_CAP, Math.max(0, sanitizeTotal(redisDailyTotalRaw)));
   const remaining = Math.max(0, DAILY_CAP - totalTodayRedis);

--- a/netlify/functions/calculate-xp.mjs
+++ b/netlify/functions/calculate-xp.mjs
@@ -14,11 +14,13 @@
  */
 
 import crypto from "node:crypto";
-import { store, saveUserProfile, atomicRateLimitIncr } from "./_shared/store-upstash.mjs";
+import { store, atomicRateLimitIncr } from "./_shared/store-upstash.mjs";
 import { extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
 import { verifySessionToken, validateServerSession, touchSession } from "./start-session.mjs";
 import { nextWarsawResetMs, warsawDayKey } from "./_shared/time-utils.mjs";
 import { canonicalizeXpGameId, getXpPolicy, migrateAnonXpToUser, resolveXpIdentity } from "./_shared/xp-identity.mjs";
+import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "./_shared/xp-ledger.mjs";
+import { persistXpProfileSnapshot } from "./_shared/xp-status.mjs";
 
 // ============================================================================
 // Configuration Constants
@@ -69,12 +71,7 @@ const RATE_LIMIT_PER_IP_PER_MIN = Math.max(0, asNumber(process.env.XP_RATE_LIMIT
 const RATE_LIMIT_ENABLED = process.env.XP_RATE_LIMIT_ENABLED !== "0";
 
 async function persistUserProfile({ userId, totalXp, now }) {
-  if (!userId) return;
-  try {
-    await saveUserProfile({ userId, totalXp, now });
-  } catch (err) {
-    klog("calc_save_user_profile_failed", { error: err?.message });
-  }
+  return persistXpProfileSnapshot({ userId, totalXp, now, logKind: "calc_save_user_profile_failed" });
 }
 
 // CORS
@@ -208,38 +205,17 @@ const getDailyKey = (ms = Date.now()) => warsawDayKey(ms);
 const getNextResetEpoch = (ms = Date.now()) => nextWarsawResetMs(ms);
 
 // Redis Keys
-const keyDaily = (u, day = getDailyKey()) => `${KEY_NS}:daily:${u}:${day}`;
-const keyTotal = (u) => `${KEY_NS}:total:${u}`;
-const keySession = (u, s) => `${KEY_NS}:session:${hash(`${u}|${s}`)}`;
-const keySessionSync = (u, s) => `${KEY_NS}:session:last:${hash(`${u}|${s}`)}`;
-const keySessionState = (u, s) => `${KEY_NS}:session:state:${hash(`${u}|${s}`)}`;
+const XP_LEDGER_KEYS = createXpLedgerKeys({ namespace: KEY_NS });
+const keyDaily = (u, day = getDailyKey()) => XP_LEDGER_KEYS.daily(u, day);
+const keyTotal = XP_LEDGER_KEYS.total;
+const keySession = XP_LEDGER_KEYS.session;
+const keySessionSync = XP_LEDGER_KEYS.sessionSync;
+const keySessionState = XP_LEDGER_KEYS.sessionState;
 const keyRateLimitUser = (userId) => `${KEY_NS}:ratelimit:user:${userId}:${Math.floor(Date.now() / 60000)}`;
 const keyRateLimitIp = (ip) => `${KEY_NS}:ratelimit:ip:${hash(ip)}:${Math.floor(Date.now() / 60000)}`;
 
 async function getTotals({ userId, sessionId, now }) {
-  if (!userId) {
-    return { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 };
-  }
-
-  const dayKeyNow = getDailyKey(now || Date.now());
-  const todayKey = keyDaily(userId, dayKeyNow);
-  const totalKeyK = keyTotal(userId);
-  const sessionKeyK = keySession(userId, sessionId || "");
-  const sessionSyncKeyK = keySessionSync(userId, sessionId || "");
-
-  const [dailyRaw, totalRaw, sessionRaw, syncRaw] = await Promise.all([
-    store.get(todayKey),
-    store.get(totalKeyK),
-    store.get(sessionKeyK),
-    store.get(sessionSyncKeyK),
-  ]);
-
-  const current = Math.max(0, Math.floor(Number(dailyRaw) || 0));
-  const lifetime = Math.max(0, Math.floor(Number(totalRaw) || 0));
-  const sessionTotal = Math.max(0, Math.floor(Number(sessionRaw) || 0));
-  const lastSync = Math.max(0, Math.floor(Number(syncRaw) || 0));
-
-  return { current, lifetime, sessionTotal, lastSync };
+  return readXpTotals({ store, keys: XP_LEDGER_KEYS, userId, sessionId, dayKey: getDailyKey(now || Date.now()) });
 }
 
 // ============================================================================
@@ -906,102 +882,21 @@ export async function handler(event) {
   const totalKeyK = keyTotal(userId);
   const sessionKeyK = keySession(userId, sessionId);
   const sessionSyncKeyK = keySessionSync(userId, sessionId);
+  const lockKeyK = XP_LEDGER_KEYS.lock(userId, sessionId);
 
   // Award XP atomically with caps
-  const script = `
-    local sessionKey = KEYS[1]
-    local sessionSyncKey = KEYS[2]
-    local dailyKey = KEYS[3]
-    local totalKey = KEYS[4]
-    local now = tonumber(ARGV[1])
-    local delta = tonumber(ARGV[2])
-    local dailyCap = tonumber(ARGV[3])
-    local sessionCap = tonumber(ARGV[4])
-    local ts = tonumber(ARGV[5])
-    local sessionTtl = tonumber(ARGV[6])
-
-    local function refreshSessionTtl()
-      if sessionTtl and sessionTtl > 0 then
-        redis.call('PEXPIRE', sessionKey, sessionTtl)
-        redis.call('PEXPIRE', sessionSyncKey, sessionTtl)
-      end
-    end
-
-    local sessionTotal = tonumber(redis.call('GET', sessionKey) or '0')
-    local lastSync = tonumber(redis.call('GET', sessionSyncKey) or '0')
-    local dailyTotal = tonumber(redis.call('GET', dailyKey) or '0')
-    local lifetime = tonumber(redis.call('GET', totalKey) or '0')
-
-    if lastSync > 0 and ts <= lastSync then
-      return {0, dailyTotal, sessionTotal, lifetime, lastSync, 2}
-    end
-
-    local remainingDaily = dailyCap - dailyTotal
-    if remainingDaily <= 0 then
-      return {0, dailyTotal, sessionTotal, lifetime, lastSync, 3}
-    end
-
-    local remainingSession = sessionCap - sessionTotal
-    if remainingSession <= 0 then
-      return {0, dailyTotal, sessionTotal, lifetime, lastSync, 5}
-    end
-
-    local grant = delta
-    local status = 0
-    if grant > remainingDaily then
-      grant = remainingDaily
-      status = 1
-    end
-    if grant > remainingSession then
-      grant = remainingSession
-      status = 4
-    end
-
-    if grant <= 0 then
-      if ts > lastSync then
-        lastSync = ts
-        redis.call('SET', sessionSyncKey, tostring(lastSync))
-        refreshSessionTtl()
-      end
-      return {0, dailyTotal, sessionTotal, lifetime, lastSync, status}
-    end
-
-    dailyTotal = tonumber(redis.call('INCRBY', dailyKey, grant))
-    sessionTotal = tonumber(redis.call('INCRBY', sessionKey, grant))
-    lifetime = tonumber(redis.call('INCRBY', totalKey, grant))
-    lastSync = ts
-    redis.call('SET', sessionSyncKey, tostring(lastSync))
-    refreshSessionTtl()
-    return {grant, dailyTotal, sessionTotal, lifetime, lastSync, status}
-  `;
-
-  let res;
-  try {
-    res = await store.eval(
-      script,
-      [sessionKeyK, sessionSyncKeyK, todayKey, totalKeyK],
-      [
-        String(now),
-        String(cappedDelta),
-        String(DAILY_CAP),
-        String(Math.max(0, SESSION_CAP)),
-        String(windowEnd),
-        String(SESSION_TTL_MS),
-      ]
-    );
-  } catch (err) {
-    klog("calc_redis_eval_failed", {
-      error: err?.message,
-    });
-    throw err;
-  }
-
-  const granted = Math.max(0, Math.floor(Number(res?.[0]) || 0));
-  const redisDailyTotal = Number(res?.[1]) || 0;
-  const sessionTotal = Number(res?.[2]) || 0;
-  const totalLifetime = Number(res?.[3]) || 0;
-  const lastSync = Number(res?.[4]) || 0;
-  const status = Number(res?.[5]) || 0;
+  const awardResult = await executeAtomicXpAward({
+    store,
+    keys: [sessionKeyK, sessionSyncKeyK, todayKey, totalKeyK, lockKeyK],
+    args: [now, cappedDelta, DAILY_CAP, Math.max(0, SESSION_CAP), windowEnd, 0, SESSION_TTL_MS],
+    onEvalError: (err) => klog("calc_redis_eval_failed", { error: err?.message }),
+  });
+  const granted = awardResult.granted;
+  const redisDailyTotal = awardResult.dailyTotal;
+  const sessionTotal = awardResult.sessionTotal;
+  const totalLifetime = awardResult.lifetime;
+  const lastSync = awardResult.lastSync;
+  const status = awardResult.status;
 
   const remaining = Math.max(0, DAILY_CAP - redisDailyTotal);
 

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -105,6 +105,7 @@ run("node", ["tests/public-profile-xp.e2e.test.mjs"], "public-profile-xp-e2e");
 run("node", ["tests/public-profile-ui.contract.test.mjs"], "public-profile-ui-contract");
 run("node", ["tests/home-bonuses.contract.test.mjs"], "home-bonuses-contract");
 run("node", ["tests/account-auth.contract.test.mjs"], "account-auth-contract");
+run("node", ["tests/xp-ledger.behavior.test.mjs"], "xp-ledger-behavior");
 run("node", ["tests/sidebar-admin-visibility.behavior.test.mjs"], "sidebar-admin-visibility-behavior");
 run("node", ["tests/i18n.behavior.test.mjs"], "i18n-behavior");
 run("node", ["tests/static-html.behavior.test.mjs"], "static-html-behavior");

--- a/tests/xp-ledger.behavior.test.mjs
+++ b/tests/xp-ledger.behavior.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "../netlify/functions/_shared/xp-ledger.mjs";
+import { buildXpStatusSnapshot, persistXpProfileSnapshot } from "../netlify/functions/_shared/xp-status.mjs";
+
+const keys = createXpLedgerKeys({ namespace: "test:xp", lockPrefix: "test:lock:" });
+
+test("XP ledger keys are stable and session-scoped", () => {
+  assert.equal(keys.daily("user-1", "2026-07-12"), "test:xp:daily:user-1:2026-07-12");
+  assert.equal(keys.total("user-1"), "test:xp:total:user-1");
+  assert.match(keys.session("user-1", "session-1"), /^test:xp:session:[0-9a-f]{64}$/);
+  assert.match(keys.sessionSync("user-1", "session-1"), /^test:xp:session:last:[0-9a-f]{64}$/);
+  assert.match(keys.registry("user-1", "session-1"), /^test:xp:registry:[0-9a-f]{64}$/);
+  assert.notEqual(keys.session("user-1", "session-1"), keys.session("user-1", "session-2"));
+});
+
+test("canonical totals reader returns normalized daily lifetime and session counters", async () => {
+  const values = new Map([
+    [keys.daily("user-1", "2026-07-12"), "25.9"],
+    [keys.total("user-1"), "320"],
+    [keys.session("user-1", "session-1"), "18"],
+    [keys.sessionSync("user-1", "session-1"), "1783840000000"],
+  ]);
+  const snapshot = await readXpTotals({ store: { get: async (key) => values.get(key) }, keys, userId: "user-1", sessionId: "session-1", dayKey: "2026-07-12" });
+  assert.deepEqual(snapshot, { current: 25, lifetime: 320, sessionTotal: 18, lastSync: 1783840000000 });
+});
+
+test("status without a session does not read or create session state", async () => {
+  const reads = [];
+  const snapshot = await readXpTotals({ store: { get: async (key) => { reads.push(key); return "0"; } }, keys, userId: "user-1", sessionId: null, dayKey: "2026-07-12" });
+  assert.equal(reads.length, 2);
+  assert.equal(reads.some((key) => key.includes(":session:")), false);
+  assert.deepEqual(snapshot, { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 });
+});
+
+test("totals error policy is explicit for authoritative and legacy adapters", async () => {
+  const failingStore = { get: async () => { throw new Error("redis unavailable"); } };
+  await assert.rejects(() => readXpTotals({ store: failingStore, keys, userId: "user-1", dayKey: "2026-07-12" }), /redis unavailable/);
+  assert.deepEqual(
+    await readXpTotals({ store: failingStore, keys, userId: "user-1", dayKey: "2026-07-12", onError: "zero" }),
+    { current: 0, lifetime: 0, sessionTotal: 0, lastSync: 0 },
+  );
+});
+
+test("canonical status snapshot is allowlisted and preserves a supplied compatibility session id", () => {
+  assert.deepEqual(buildXpStatusSnapshot({
+    totals: { lifetime: 320, sessionTotal: 18, lastSync: 123, internalKey: "secret" },
+    dailyCap: 3000,
+    deltaCap: 300,
+    sessionId: "legacy-session",
+  }), {
+    ok: true, awarded: 0, granted: 0, cap: 3000, capDelta: 300,
+    totalLifetime: 320, sessionTotal: 18, lastSync: 123, status: "statusOnly", sessionId: "legacy-session",
+  });
+});
+
+test("derived profile persistence normalizes totals and fails without changing canonical status", async () => {
+  let saved = null;
+  assert.equal(await persistXpProfileSnapshot({ userId: "user-1", totalXp: 12.9, now: 10, save: async (value) => { saved = value; } }), true);
+  assert.deepEqual(saved, { userId: "user-1", totalXp: 12, now: 10 });
+  assert.equal(await persistXpProfileSnapshot({ userId: "user-1", totalXp: 12, save: async () => { throw new Error("profile unavailable"); } }), false);
+});
+
+test("atomic award executor normalizes results and preserves legacy lock retry", async () => {
+  let calls = 0;
+  let delayed = false;
+  const result = await executeAtomicXpAward({
+    store: { eval: async () => (++calls === 1 ? [0, 10, 2, 20, 100, 6, 90, 50] : [5, 15, 7, 25, 110, 0]) },
+    script: "return {}", keys: ["key"], args: [1], retryLocked: true,
+    retryDelay: async () => { delayed = true; },
+  });
+  assert.equal(calls, 2);
+  assert.equal(delayed, true);
+  assert.deepEqual({ granted: result.granted, dailyTotal: result.dailyTotal, sessionTotal: result.sessionTotal, lifetime: result.lifetime, lastSync: result.lastSync, status: result.status },
+    { granted: 5, dailyTotal: 15, sessionTotal: 7, lifetime: 25, lastSync: 110, status: 0 });
+});


### PR DESCRIPTION
## Summary
- document the XP unification plan without the telemetry-only Phase 0
- centralize Redis XP keys, canonical total reads, and normalized status/profile projection
- replace duplicated award Lua with one shared atomic ledger operation used by both `calculate-xp` and the legacy `award-xp` adapter
- preserve existing routes, response contracts, session behavior, caps, and Redis key names
- add focused behavior coverage and register it in the repository test runner

## Scope
This implements PR 1 of the plan. Client status traffic still uses the existing route, and legacy `statusOnly` session registration/touch remains intact until PR 2/PR 3. No leaderboard work is included.

## Verification
- `npm test`
- Node syntax checks for both XP handlers and shared modules
- focused `xp-ledger.behavior.test.mjs`

## Breaking impact
None expected. Redis keys, caps, scoring rules, API routes, status side effects, and response contracts are unchanged.

No database migration or new environment variable is required.