### PR TITLE
refactor: move XP status to authoritative endpoint

### DIFF
--- a/docs/xp-anon-to-account-conversion.md
+++ b/docs/xp-anon-to-account-conversion.md
@@ -3,7 +3,7 @@
 
 ## Implemented behavior
 
-The authoritative gameplay endpoint is `calculate-xp`. Both it and the `award-xp` status endpoint run the same conversion helper before reading or awarding authenticated totals.
+The authoritative XP endpoint is `calculate-xp`. Its `operation: "status"` and award path run the same conversion helper before reading or awarding authenticated totals. The temporary `award-xp statusOnly` compatibility adapter uses the same helper and status projection until that adapter is retired.
 
 - A valid Supabase JWT subject is the destination account; the browser anon id is the source.
 - Conversion atomically transfers `min(anon lifetime XP, XP_ANON_CONVERSION_MAX_XP)`.

--- a/docs/xp-service.md
+++ b/docs/xp-service.md
@@ -1,6 +1,6 @@
 # XP service
 
-## Authoritative gameplay endpoint
+## Authoritative XP endpoint
 
 Playable pages use `js/xpClient.js` and `js/xp/core.js`; they must not call XP functions directly. The authoritative gameplay endpoint is:
 
@@ -8,9 +8,9 @@ Playable pages use `js/xpClient.js` and `js/xp/core.js`; they must not call XP f
 POST /.netlify/functions/calculate-xp
 ```
 
-It receives a bounded activity window and calculates the grant on the server. The browser sends its anon id, session id, optional signed server-session token, and Supabase bearer token when authenticated. The JWT subject is the authoritative account identity.
+For gameplay, it receives `operation: "award"` (or the default operation), validates a bounded activity window, and calculates the grant on the server. For reads, `operation: "status"` returns the canonical totals without creating, registering, or touching an award session. The browser sends its anon id and Supabase bearer token when authenticated; award requests additionally send session data. The JWT subject is the authoritative account identity.
 
-`/.netlify/functions/award-xp` is retained for status reads and legacy compatibility. It shares XP policy, identity resolution, and one-time anonymous conversion with `calculate-xp`; new gameplay code must not use it for awards.
+`/.netlify/functions/award-xp` is retained only for legacy compatibility. Its `statusOnly` adapter temporarily preserves generated/registered session IDs for cached clients, but delegates canonical status projection to the shared status service. Supported clients read status from `calculate-xp`; new code must not use `award-xp`.
 
 ## Required configuration
 

--- a/docs/xp-system.md
+++ b/docs/xp-system.md
@@ -9,7 +9,7 @@ This document preserves the XP-related technical details that previously lived i
 
 ## Authoritative award path and identity
 
-- Gameplay XP is awarded through `/.netlify/functions/calculate-xp`. `award-xp` remains the status/legacy compatibility endpoint and must not be used by new playable integrations.
+- Gameplay XP is awarded and canonical XP status is read through `/.netlify/functions/calculate-xp`. `operation: "status"` is read-only with respect to daily, session, and lifetime counters and does not register, touch, or generate an award session. `award-xp` remains only as a legacy compatibility adapter and must not be used by supported clients.
 - The XP badge and `+N XP` overlay animate only after `calculate-xp` returns a positive authoritative `awarded` value. Status reads, auth refreshes, focus changes, cache hydration, zero awards, and rejected windows update state without award animation.
 - `calculate-xp`, `award-xp`, and `start-session` must use the shared Supabase auth verifier from `_shared/supabase-admin.mjs`. This keeps HS256/HS512 and Supabase ES256 remote verification aligned with profile, chips, and poker APIs. A request without Authorization may use the browser anon id; a request that supplies an invalid Bearer token fails with `401` and must never fall back to anonymous XP.
 - Both award endpoints share XP policy values (`XP_DAILY_CAP`, `XP_SESSION_CAP`, `XP_DELTA_CAP`, `XP_SESSION_TTL_SEC`) and identity resolution: a valid Supabase JWT subject wins over the browser anon id.
@@ -20,7 +20,7 @@ This document preserves the XP-related technical details that previously lived i
 
 ## Legacy local XP synchronization
 
-The old `kcswh:xp:last` and `kcswh:xp:regen` entries are not an account ledger. They can contain an optimistic or anonymous value from one browser and are never accepted as authenticated XP. On a non-game page with an authenticated session, `XPClient` sends a `statusOnly` request with the Supabase bearer token, applies the canonical server `totalLifetime`, and then removes those legacy entries. If the defensively parsed legacy value is greater than the server total, the user sees a localized non-blocking notice once per Supabase user and browser under `kcswh:xp:server-migration-notice:v1:<userId>`. A status/network failure does not force `0 XP`, delete the legacy entries, or set the notice marker. The public profile uses the same canonical server total and does not read browser storage.
+The old `kcswh:xp:last` and `kcswh:xp:regen` entries are not an account ledger. They can contain an optimistic or anonymous value from one browser and are never accepted as authenticated XP. On a non-game page with an authenticated session, `XPClient` sends `operation: "status"` to `calculate-xp` with the Supabase bearer token, applies the canonical server `totalLifetime`, and then removes those legacy entries. If the defensively parsed legacy value is greater than the server total, the user sees a localized non-blocking notice once per Supabase user and browser under `kcswh:xp:server-migration-notice:v1:<userId>`. A status/network failure does not force `0 XP`, delete the legacy entries, or set the notice marker. The public profile uses the same canonical server total and does not read browser storage.
 
 ## GameXpBridge API
 `js/xp-game-hook.js` exposes a `window.GameXpBridge` helper so every game page can wire into the XP service without duplicating lifecycle code.
@@ -60,7 +60,7 @@ The helper survives soft navigations—if you’re swapping views inside an SPA,
 - `XP.addScore()` and the `GameXpBridge` flush path pre-clamp outgoing deltas based on the server-advertised `remaining` value and emit `award_preclamp` / `award_skip { reason: 'daily_cap' }` diagnostics so operators can confirm when the cap halts awards.
 
 ## Legacy compatibility contract: `postWindow`
-`postWindow` targets `award-xp` and is retained for status/legacy callers. New gameplay windows use `postWindowServerCalc` and `calculate-xp` instead.
+`postWindow` targets `award-xp` and is retained only for legacy delta callers. Status reads and new gameplay windows use `calculate-xp`.
 Client → server payload (minimal set, extras allowed):
 - `userId` (string)
 - `sessionId` (string)

--- a/docs/xp-unification-plan.md
+++ b/docs/xp-unification-plan.md
@@ -149,6 +149,8 @@ Exit criteria:
 
 Objective: make reads and writes enter through the same authoritative endpoint.
 
+Implementation status: `XPClient.fetchStatus()` now sends `operation: "status"` to `calculate-xp`. The authoritative status branch runs after identity resolution and optional idempotent anonymous conversion, but before award rate limiting, signed-session validation/touch, gameplay validation, or scoring. `award-xp statusOnly` remains the temporary mutating compatibility adapter described below.
+
 Work:
 
 - Add explicit `operation: "status"` handling to `calculate-xp`.

--- a/js/xpClient.js
+++ b/js/xpClient.js
@@ -937,13 +937,13 @@
 
   async function fetchStatus() {
     const { userId, sessionId } = ensureIds();
-    const body = { userId, sessionId, gameId: "status", statusOnly: true };
+    const body = { anonId: userId, sessionId, operation: "status" };
     const authToken = await ensureAuthTokenWithRetry();
     if (!authToken && await isUserLoggedIn()) {
       throw new Error("XP status requires an authenticated token");
     }
     const headers = await buildAuthHeaders({ "content-type": "application/json" });
-    const res = await fetch(FN_URL, {
+    const res = await fetch(CALC_URL, {
       method: "POST",
       headers,
       body: JSON.stringify(body),

--- a/netlify/functions/_shared/xp-status.mjs
+++ b/netlify/functions/_shared/xp-status.mjs
@@ -2,7 +2,7 @@ import { klog } from "./supabase-admin.mjs";
 import { saveUserProfile } from "./store-upstash.mjs";
 import { sanitizeXpCounter } from "./xp-ledger.mjs";
 
-function buildXpStatusSnapshot({ totals, dailyCap, deltaCap, sessionId, status = "statusOnly" }) {
+function buildXpStatusSnapshot({ totals, dailyCap, deltaCap, sessionId, dayKey, nextReset, status = "statusOnly" }) {
   const source = totals && typeof totals === "object" ? totals : {};
   const snapshot = {
     ok: true,
@@ -16,7 +16,23 @@ function buildXpStatusSnapshot({ totals, dailyCap, deltaCap, sessionId, status =
     status,
   };
   if (typeof sessionId === "string" && sessionId) snapshot.sessionId = sessionId;
+  snapshot.totalToday = Math.min(snapshot.cap, sanitizeXpCounter(source.current));
+  snapshot.remaining = Math.max(0, snapshot.cap - snapshot.totalToday);
+  if (typeof dayKey === "string" && dayKey) snapshot.dayKey = dayKey;
+  if (Number.isFinite(nextReset)) snapshot.nextReset = Math.floor(nextReset);
   return snapshot;
+}
+
+async function readCanonicalXpStatus({ readTotals, dailyCap, deltaCap, sessionId, dayKey, nextReset, supabaseUserId, persistProfile }) {
+  if (typeof readTotals !== "function") throw new TypeError("invalid_xp_status_reader");
+  const totals = await readTotals();
+  if (supabaseUserId && typeof persistProfile === "function") {
+    await persistProfile({ userId: supabaseUserId, totalXp: totals.lifetime });
+  }
+  return {
+    totals,
+    payload: buildXpStatusSnapshot({ totals, dailyCap, deltaCap, sessionId, dayKey, nextReset }),
+  };
 }
 
 async function persistXpProfileSnapshot({ userId, totalXp, now = Date.now(), save = saveUserProfile, logKind = "xp_save_user_profile_failed" }) {
@@ -30,4 +46,4 @@ async function persistXpProfileSnapshot({ userId, totalXp, now = Date.now(), sav
   }
 }
 
-export { buildXpStatusSnapshot, persistXpProfileSnapshot };
+export { buildXpStatusSnapshot, persistXpProfileSnapshot, readCanonicalXpStatus };

--- a/netlify/functions/award-xp.mjs
+++ b/netlify/functions/award-xp.mjs
@@ -6,7 +6,7 @@ import { nextWarsawResetMs, warsawDayKey } from "./_shared/time-utils.mjs";
 import { buildCorsAllowlist, buildCorsHeaders } from "./_shared/xp-cors.mjs";
 import { getXpPolicy, migrateAnonXpToUser, resolveXpIdentity } from "./_shared/xp-identity.mjs";
 import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "./_shared/xp-ledger.mjs";
-import { buildXpStatusSnapshot, persistXpProfileSnapshot } from "./_shared/xp-status.mjs";
+import { persistXpProfileSnapshot, readCanonicalXpStatus } from "./_shared/xp-status.mjs";
 
 const XP_DAY_COOKIE = "xp_day";
 
@@ -622,12 +622,17 @@ export async function handler(event) {
       touchSession(parsedSessionToken.sessionId).catch(() => {});
     }
 
-    const totals = await fetchTotals();
-    if (supabaseUserId) {
-      await persistUserProfile({ userId: supabaseUserId, totalXp: totals.lifetime, now });
-    }
-    const payload = buildXpStatusSnapshot({ totals, dailyCap: DAILY_CAP, deltaCap: DELTA_CAP, sessionId: sessId });
-    return respond(200, payload, { totals, debugExtra: { mode: "statusOnly" } });
+    const result = await readCanonicalXpStatus({
+      readTotals: fetchTotals,
+      dailyCap: DAILY_CAP,
+      deltaCap: DELTA_CAP,
+      sessionId: sessId,
+      dayKey: dayKeyNow,
+      nextReset,
+      supabaseUserId,
+      persistProfile: ({ userId, totalXp }) => persistUserProfile({ userId, totalXp, now }),
+    });
+    return respond(200, result.payload, { totals: result.totals, debugExtra: { mode: "statusOnly" } });
   }
 
   let deltaRaw = Number(body.delta);

--- a/netlify/functions/calculate-xp.mjs
+++ b/netlify/functions/calculate-xp.mjs
@@ -20,7 +20,7 @@ import { verifySessionToken, validateServerSession, touchSession } from "./start
 import { nextWarsawResetMs, warsawDayKey } from "./_shared/time-utils.mjs";
 import { canonicalizeXpGameId, getXpPolicy, migrateAnonXpToUser, resolveXpIdentity } from "./_shared/xp-identity.mjs";
 import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "./_shared/xp-ledger.mjs";
-import { persistXpProfileSnapshot } from "./_shared/xp-status.mjs";
+import { persistXpProfileSnapshot, readCanonicalXpStatus } from "./_shared/xp-status.mjs";
 
 // ============================================================================
 // Configuration Constants
@@ -671,6 +671,10 @@ export async function handler(event) {
     : (typeof body.userId === "string" ? body.userId : null);
   const anonId = bodyAnonIdRaw ? bodyAnonIdRaw.trim() : null;
   const sessionId = typeof body.sessionId === "string" ? body.sessionId.trim() : null;
+  const operation = body.operation === "status" || body.statusOnly === true ? "status" : (body.operation || "award");
+  if (operation !== "award" && operation !== "status") {
+    return json(400, { error: "invalid_operation" }, origin);
+  }
 
   const jwtToken = extractBearerToken(event.headers);
   const authContext = await verifySupabaseJwt(jwtToken);
@@ -679,8 +683,8 @@ export async function handler(event) {
   }
   const { supabaseUserId, identityId, anonId: resolvedAnonId } = resolveXpIdentity({ anonId, authContext });
 
-  if (!identityId || !sessionId) {
-    return json(400, { error: "missing_fields", message: "identity and sessionId required" }, origin);
+  if (!identityId) {
+    return json(400, { error: "missing_fields", message: "identity required" }, origin);
   }
 
   const userId = identityId;
@@ -701,6 +705,31 @@ export async function handler(event) {
     } catch (err) {
       klog("calc_anon_migration_failed", { error: err?.message });
     }
+  }
+
+  if (operation === "status") {
+    const dayKey = getDailyKey(now);
+    try {
+      const result = await readCanonicalXpStatus({
+        readTotals: () => getTotals({ userId, sessionId, now }),
+        dailyCap: DAILY_CAP,
+        deltaCap: DELTA_CAP,
+        sessionId,
+        dayKey,
+        nextReset: getNextResetEpoch(now),
+        supabaseUserId,
+        persistProfile: ({ userId: profileUserId, totalXp }) => persistUserProfile({ userId: profileUserId, totalXp, now }),
+      });
+      if (conversion?.converted > 0) result.payload.conversion = { converted: conversion.converted };
+      return json(200, result.payload, origin);
+    } catch (err) {
+      klog("calc_status_read_failed", { error: err?.message });
+      return json(500, { error: "server_error" }, origin);
+    }
+  }
+
+  if (!sessionId) {
+    return json(400, { error: "missing_fields", message: "sessionId required" }, origin);
   }
 
   // Rate limiting

--- a/tests/calculate-xp.test.mjs
+++ b/tests/calculate-xp.test.mjs
@@ -163,6 +163,40 @@ describe("calculate-xp endpoint", () => {
     });
   });
 
+  describe("authoritative status operation", () => {
+    it("reads status without creating, touching, or requiring a gameplay session", async () => {
+      store._mockData.set("kcswh:xp:v2:total:status-user", "345");
+
+      const response = await handler({
+        httpMethod: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ anonId: "status-user", operation: "status" }),
+      });
+      const payload = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(200);
+      expect(payload.status).toBe("statusOnly");
+      expect(payload.totalLifetime).toBe(345);
+      expect(payload).not.toHaveProperty("sessionId");
+      expect(store.eval).not.toHaveBeenCalled();
+      expect(store.set).not.toHaveBeenCalled();
+      expect(store.setex).not.toHaveBeenCalled();
+      expect(atomicRateLimitIncr).not.toHaveBeenCalled();
+    });
+
+    it("temporarily accepts statusOnly as an alias without generating a session id", async () => {
+      const response = await handler({
+        httpMethod: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "status-alias", statusOnly: true }),
+      });
+      const payload = JSON.parse(response.body);
+      expect(response.statusCode).toBe(200);
+      expect(payload.status).toBe("statusOnly");
+      expect(payload).not.toHaveProperty("sessionId");
+    });
+  });
+
   describe("CORS validation", () => {
     it("should allow same-origin requests (no origin header)", async () => {
       const event = {

--- a/tests/public-profile-xp.e2e.test.mjs
+++ b/tests/public-profile-xp.e2e.test.mjs
@@ -89,9 +89,10 @@ test("authenticated badge and public profile use the same canonical XP total", a
   assert.equal(publicResponse.statusCode, 200);
   assert.equal(publicBody.xp, SNAPSHOT.totalXp);
   assert.equal(publicBody.level, computeXpLevel(SNAPSHOT.totalXp));
-  assert.equal(statusRequest.body.userId, ANON_ID);
-  assert.equal(statusRequest.body.gameId, "status");
-  assert.equal(statusRequest.body.statusOnly, true);
+  assert.equal(statusRequest.body.anonId, ANON_ID);
+  assert.equal(Object.hasOwn(statusRequest.body, "gameId"), false);
+  assert.equal(statusRequest.body.operation, "status");
+  assert.equal(Object.hasOwn(statusRequest.body, "statusOnly"), false);
   assert.equal(typeof statusRequest.body.sessionId, "string");
   assert.ok(statusRequest.body.sessionId.length > 0);
   assert.notEqual(statusRequest.body.sessionId, "session-public-profile-e2e");

--- a/tests/xp-client-bfcache.test.mjs
+++ b/tests/xp-client-bfcache.test.mjs
@@ -50,7 +50,7 @@ async function fetchStub(url, options = {}) {
   }
 
   const body = options.body ? JSON.parse(options.body) : {};
-  if (body.statusOnly) {
+  if (body.operation === "status") {
     statusBootstraps += 1;
     return response(200, { ok: true, status: 'statusOnly', totalToday: 0, totalLifetime: 0, sessionTotal: 0, lastSync: 0, cap: 400, capDelta: 240 });
   }

--- a/tests/xp-client-contract.test.mjs
+++ b/tests/xp-client-contract.test.mjs
@@ -42,7 +42,7 @@ async function loadClientWithFetch(fetchImpl, options = {}) {
   {
     const XPClient = await loadClientWithFetch(async (_url, opts) => {
       const body = opts?.body ? JSON.parse(opts.body) : {};
-      if (body.statusOnly) return response(200, { ok: true, status: 'statusOnly' });
+      if (body.operation === 'status') return response(200, { ok: true, status: 'statusOnly' });
       return response(200, { ok: true, awarded: 10, totalToday: 10, sessionTotal: 10, lastSync: body.ts, cap: 400, capDelta: 240 });
     });
     const res = await XPClient.postWindow({ delta: 10, ts: 111 });
@@ -86,8 +86,8 @@ async function loadClientWithFetch(fetchImpl, options = {}) {
   {
     let applied = null;
     const calls = [];
-    const XPClient = await loadClientWithFetch(async (_url, opts) => {
-      calls.push(JSON.parse(opts?.body || '{}'));
+    const XPClient = await loadClientWithFetch(async (url, opts) => {
+      calls.push({ url, body: JSON.parse(opts?.body || '{}') });
       return response(200, { ok: true, status: 'statusOnly', totalLifetime: 777, cap: 10 });
     }, {
       window: {
@@ -100,7 +100,9 @@ async function loadClientWithFetch(fetchImpl, options = {}) {
     });
     await XPClient.refreshBadgeFromServer({ bumpBadge: true });
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].statusOnly, true);
+    assert.equal(calls[0].url, '/.netlify/functions/calculate-xp');
+    assert.equal(calls[0].body.operation, 'status');
+    assert.equal(calls[0].body.statusOnly, undefined);
     assert.equal(applied.payload.totalLifetime, 777);
     assert.equal(applied.meta.source, 'status');
     assert.equal(applied.meta.bump, undefined);
@@ -111,7 +113,7 @@ async function loadClientWithFetch(fetchImpl, options = {}) {
     const awardCalls = [];
     const XPClient = await loadClientWithFetch(async (url, opts) => {
       const body = JSON.parse(opts?.body || '{}');
-      if (body.statusOnly) return response(200, { ok: true, status: 'statusOnly' });
+      if (body.operation === 'status') return response(200, { ok: true, status: 'statusOnly' });
       if (url === '/.netlify/functions/calculate-xp') {
         awardCalls.push(body);
         return response(200, {

--- a/tests/xp-ledger.behavior.test.mjs
+++ b/tests/xp-ledger.behavior.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createXpLedgerKeys, executeAtomicXpAward, readXpTotals } from "../netlify/functions/_shared/xp-ledger.mjs";
-import { buildXpStatusSnapshot, persistXpProfileSnapshot } from "../netlify/functions/_shared/xp-status.mjs";
+import { buildXpStatusSnapshot, persistXpProfileSnapshot, readCanonicalXpStatus } from "../netlify/functions/_shared/xp-status.mjs";
 
 const keys = createXpLedgerKeys({ namespace: "test:xp", lockPrefix: "test:lock:" });
 
@@ -44,14 +44,35 @@ test("totals error policy is explicit for authoritative and legacy adapters", as
 
 test("canonical status snapshot is allowlisted and preserves a supplied compatibility session id", () => {
   assert.deepEqual(buildXpStatusSnapshot({
-    totals: { lifetime: 320, sessionTotal: 18, lastSync: 123, internalKey: "secret" },
+    totals: { current: 25, lifetime: 320, sessionTotal: 18, lastSync: 123, internalKey: "secret" },
     dailyCap: 3000,
     deltaCap: 300,
     sessionId: "legacy-session",
+    dayKey: "2026-07-12",
+    nextReset: 1783900800000,
   }), {
     ok: true, awarded: 0, granted: 0, cap: 3000, capDelta: 300,
     totalLifetime: 320, sessionTotal: 18, lastSync: 123, status: "statusOnly", sessionId: "legacy-session",
+    totalToday: 25, remaining: 2975, dayKey: "2026-07-12", nextReset: 1783900800000,
   });
+});
+
+test("canonical status read projects totals and persists only the derived authenticated snapshot", async () => {
+  let persisted = null;
+  const result = await readCanonicalXpStatus({
+    readTotals: async () => ({ current: 40, lifetime: 500, sessionTotal: 0, lastSync: 0 }),
+    dailyCap: 3000,
+    deltaCap: 300,
+    dayKey: "2026-07-12",
+    nextReset: 1783900800000,
+    supabaseUserId: "user-1",
+    persistProfile: async (value) => { persisted = value; },
+  });
+  assert.equal(result.payload.totalLifetime, 500);
+  assert.equal(result.payload.totalToday, 40);
+  assert.equal(result.payload.remaining, 2960);
+  assert.equal(Object.hasOwn(result.payload, "userId"), false);
+  assert.deepEqual(persisted, { userId: "user-1", totalXp: 500 });
 });
 
 test("derived profile persistence normalizes totals and fails without changing canonical status", async () => {

--- a/tests/xp-server-migration-notice.test.mjs
+++ b/tests/xp-server-migration-notice.test.mjs
@@ -176,7 +176,8 @@ function status(totalLifetime) {
   assert.equal(result.storage.get(noticeKey("user-a")), "1");
   assert.equal(result.requests[0].options.headers.Authorization, "Bearer stage-jwt");
   const requestBody = JSON.parse(result.requests[0].options.body);
-  assert.equal(requestBody.statusOnly, true);
+  assert.equal(requestBody.operation, "status");
+  assert.equal(Object.hasOwn(requestBody, "statusOnly"), false);
   assert.equal(Object.hasOwn(requestBody, "totalLifetime"), false);
   assert.equal(Object.hasOwn(requestBody, "serverTotalXp"), false);
   assert.equal(result.applied[0].meta.allowServerRegression, true);


### PR DESCRIPTION
## Summary
- add explicit read-only `operation: "status"` handling to `calculate-xp`
- move `XPClient.fetchStatus()` from `award-xp` to the authoritative calculate endpoint
- keep `award-xp statusOnly` as an isolated compatibility adapter with its existing session side effects
- centralize canonical status reads/projection for both route adapters
- update XP documentation and behavior/E2E contracts

## Status semantics
The new calculate status path:
- resolves JWT/anonymous identity and may run the existing idempotent anonymous-to-account conversion
- reads canonical daily, lifetime, and optional supplied-session counters
- may refresh the derived authenticated profile snapshot
- does not invoke award rate limiting, session registration/touch, signed-session validation, gameplay validation, scoring, or atomic award mutation
- does not generate a session ID

## Verification
- `npm test`
- syntax checks through the repository test runner
- status behavior tests prove no Redis eval, session-state write, rate-limit increment, or generated session ID
- client contract proves status targets `/.netlify/functions/calculate-xp`
- authenticated badge/public-profile consistency E2E remains green

## Breaking impact
No intended breaking impact. The response keeps the existing `status: "statusOnly"` compatibility value and status fields. Cached clients may continue using `award-xp statusOnly` during this phase.

No database migration or new environment variable is required.