### PR TITLE
fix: show uploaded avatars across all topbars

### DIFF
--- a/js/auth/supabaseClient.js
+++ b/js/auth/supabaseClient.js
@@ -248,8 +248,12 @@
       window.ProfileClient.applyAvatar(node, profile || { displayName: name, avatar: { variant: 'default' } });
       return;
     }
-    node.textContent = computeInitials(name);
-    node.dataset.avatarVariant = profile && profile.avatar && profile.avatar.variant ? profile.avatar.variant : 'default';
+    var avatar = profile && profile.avatar ? profile.avatar : {};
+    var uploaded = avatar.type === 'uploaded' && typeof avatar.url === 'string' && avatar.url;
+    node.textContent = uploaded ? '' : computeInitials(name);
+    node.dataset.avatarVariant = avatar.variant || 'default';
+    node.classList.toggle('profile-avatar--uploaded', !!uploaded);
+    node.style.backgroundImage = uploaded ? 'url("' + avatar.url.replace(/["\\]/g, '') + '")' : '';
   }
 
   function selectNodes(){

--- a/tests/e2e/topbar-profile-avatar.spec.js
+++ b/tests/e2e/topbar-profile-avatar.spec.js
@@ -1,0 +1,42 @@
+const { test, expect } = require('@playwright/test');
+
+const AVATAR_URL = 'https://stage-test.supabase.co/storage/v1/object/public/profile-avatars/smoke.webp';
+const PAGES = ['/', '/games-open/2048/'];
+
+test.describe('authenticated topbar profile avatar', () => {
+  for (const path of PAGES) {
+    test(`renders uploaded avatar on ${path}`, async ({ page }) => {
+      await page.route('**/js/auth/supabase-config.js', (route) => route.fulfill({
+        contentType: 'application/javascript',
+        body: `
+          window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
+          window.supabase = { createClient: function(){ return { auth: {
+            getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: 'avatar-user', email: 'private@example.test' } } } }); },
+            onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
+            signOut: function(){ return Promise.resolve(); }
+          } }; } };
+        `,
+      }));
+      await page.route('**/.netlify/functions/profile-me', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          handle: 'avatar-player',
+          displayName: 'Avatar Player',
+          bio: '',
+          avatar: { type: 'uploaded', variant: 'fox-blue', url: AVATAR_URL },
+          handleCanCustomize: false,
+        }),
+      }));
+
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
+      const avatar = page.locator('#avatarInitials');
+      const menuAvatar = page.locator('#avatarMenuInitials');
+      await expect(avatar).toHaveClass(/profile-avatar--uploaded/);
+      await expect(avatar).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
+      await expect(avatar).toHaveText('');
+      await expect(menuAvatar).toHaveClass(/profile-avatar--uploaded/);
+      await expect(menuAvatar).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
+    });
+  }
+});

--- a/tests/public-profile-ui.contract.test.mjs
+++ b/tests/public-profile-ui.contract.test.mjs
@@ -116,6 +116,25 @@ test("topbar derives its visible signed-in identity from the public profile", as
   assert.match(source, /name = profile && profile\.displayName \? profile\.displayName : t\('player'/);
   assert.match(source, /email = t\('profileAccountSynced'/);
   assert.match(source, /refreshProfile\(user\)/);
+  assert.match(source, /avatar\.type === 'uploaded'/);
+  assert.match(source, /classList\.toggle\('profile-avatar--uploaded', !!uploaded\)/);
+  assert.match(source, /style\.backgroundImage = uploaded/);
   assert.match(accountSource, /publicProfileGeneration \+= 1/);
   assert.match(accountSource, /requestedUserKey !== getUserKey\(currentUser\)/);
+});
+
+test("every HTML page with a topbar loads the shared auth avatar bridge first", async () => {
+  const { execFileSync } = await import("node:child_process");
+  const files = execFileSync("rg", ["-l", "(?:/|\\b)js/topbar\\.js", "--glob", "*.html", "."], {
+    cwd: new URL("..", import.meta.url), encoding: "utf8"
+  }).trim().split("\n").filter(Boolean);
+  assert.ok(files.length > 30, "expected the full topbar page inventory");
+  for (const file of files){
+    const source = await read(file.replace(/^\.\//, ""));
+    const authIndex = source.indexOf("/js/auth/supabaseClient.js");
+    const topbarIndex = Math.max(source.indexOf("/js/topbar.js"), source.indexOf('src="js/topbar.js"'));
+    assert.match(source, /(?:\/|\b)css\/portal\.css/, `${file} must load uploaded-avatar styles`);
+    assert.ok(authIndex >= 0, `${file} must load the shared auth avatar bridge`);
+    assert.ok(topbarIndex > authIndex, `${file} must load auth before topbar`);
+  }
 });

--- a/tests/public-profile-ui.contract.test.mjs
+++ b/tests/public-profile-ui.contract.test.mjs
@@ -1,10 +1,25 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
 import vm from "node:vm";
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 const { DEFAULT_BASE_XP, DEFAULT_MULTIPLIER } = await import("../netlify/functions/_shared/xp-level.mjs");
+
+async function listHtmlFiles(directory = new URL("../", import.meta.url), prefix = ""){
+  const ignored = new Set([".git", ".copilot-worktrees", "node_modules"]);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries){
+    if (entry.isDirectory()){
+      if (ignored.has(entry.name)) continue;
+      files.push(...await listHtmlFiles(new URL(`${entry.name}/`, directory), `${prefix}${entry.name}/`));
+    } else if (entry.isFile() && entry.name.endsWith(".html")){
+      files.push(`${prefix}${entry.name}`);
+    }
+  }
+  return files;
+}
 
 test("public profile route, editor, and legal release gate are present", async () => {
   const [account, page, config, privacyEn, privacyPl, termsEn, termsPl, portalCss, accountJs, profileClient] = await Promise.all([
@@ -124,13 +139,11 @@ test("topbar derives its visible signed-in identity from the public profile", as
 });
 
 test("every HTML page with a topbar loads the shared auth avatar bridge first", async () => {
-  const { execFileSync } = await import("node:child_process");
-  const files = execFileSync("rg", ["-l", "(?:/|\\b)js/topbar\\.js", "--glob", "*.html", "."], {
-    cwd: new URL("..", import.meta.url), encoding: "utf8"
-  }).trim().split("\n").filter(Boolean);
+  const htmlFiles = await listHtmlFiles();
+  const sources = await Promise.all(htmlFiles.map(async (file) => ({ file, source: await read(file) })));
+  const files = sources.filter(({ source }) => /(?:\/|\b)js\/topbar\.js/.test(source));
   assert.ok(files.length > 30, "expected the full topbar page inventory");
-  for (const file of files){
-    const source = await read(file.replace(/^\.\//, ""));
+  for (const { file, source } of files){
     const authIndex = source.indexOf("/js/auth/supabaseClient.js");
     const topbarIndex = Math.max(source.indexOf("/js/topbar.js"), source.indexOf('src="js/topbar.js"'));
     assert.match(source, /(?:\/|\b)css\/portal\.css/, `${file} must load uploaded-avatar styles`);


### PR DESCRIPTION
## Summary
- render uploaded profile avatars in the shared Supabase auth/topbar fallback used by pages that do not load `profile-client.js`
- clear uploaded background state correctly on logout or default-avatar restore
- verify every HTML page with a topbar loads the shared auth bridge and avatar styles in the correct order
- add browser smoke coverage for the home page and a nested game page, including both topbar avatar elements

## Root cause
`profile-me` was already fetched on every signed-in page, but `supabaseClient.js` rendered only initials when `ProfileClient` was unavailable. Account and public-profile pages loaded `profile-client.js`, which is why the uploaded image worked only there.

## Verification
- `npm run check:all`
- `npm test`
- `PORT=4174 PLAYWRIGHT=1 npm test` (43 tests passed)
- topbar inventory contract covers all 46 HTML pages that load `topbar.js`

## Breaking impact
None expected. Default and signed-out avatars keep their existing initials; signed-in users with an uploaded avatar now see the image consistently.

No database migration or environment change is required.