### PR TITLE
feat: hydrate cached topbar profile state

### DIFF
--- a/about.en.html
+++ b/about.en.html
@@ -15,6 +15,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -39,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/about.pl.html
+++ b/about.pl.html
@@ -15,6 +15,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -39,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/about/licenses.html
+++ b/about/licenses.html
@@ -15,6 +15,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -50,7 +51,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/account.html
+++ b/account.html
@@ -83,6 +83,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/profile-client.js" defer></script>
   <script src="js/chips/client.js" defer></script>
@@ -104,7 +105,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body class="page-account">
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/admin.html
+++ b/admin.html
@@ -16,6 +16,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -36,7 +37,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body class="page-admin">
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/css/portal.css
+++ b/css/portal.css
@@ -178,6 +178,10 @@ html[data-auth="out"] #chipBadge{ display:none !important; }
 .avatar-circle[data-avatar-variant="orbit-green"],.avatar-menu__initials[data-avatar-variant="orbit-green"]{ background:linear-gradient(145deg,#19755d,#74d9a0); }
 .avatar-circle[data-avatar-variant="default"],.avatar-menu__initials[data-avatar-variant="default"]{ background:linear-gradient(145deg,#355070,#6ee7e7); }
 .avatar-circle.profile-avatar--uploaded,.avatar-menu__initials.profile-avatar--uploaded{ background-position:center; background-size:cover; }
+.topbar[data-user-ui-state="pending"] .avatar-circle,.topbar[data-user-ui-state="loading"] .avatar-circle{ color:transparent; background-image:linear-gradient(110deg,rgba(110,231,231,.12) 25%,rgba(167,139,250,.28) 45%,rgba(110,231,231,.12) 65%); background-size:220% 100%; animation:user-ui-placeholder 1.2s linear infinite; }
+.topbar[data-user-ui-state="pending"] .avatar-label,.topbar[data-user-ui-state="loading"] .avatar-label{ visibility:hidden; }
+.topbar[data-user-ui-state="pending"] #xpBadge .xp-badge__label,.topbar[data-user-ui-state="loading"] #xpBadge .xp-badge__label,.topbar[data-user-ui-state="pending"] #chipBadgeAmount,.topbar[data-user-ui-state="loading"] #chipBadgeAmount{ visibility:hidden; }
+@keyframes user-ui-placeholder{ 0%{background-position:100% 0;} 100%{background-position:-100% 0;} }
 .category-bar{display:flex; flex-wrap:wrap; gap:10px; margin:0 0 16px; padding:4px 0;}
 .category-bar .category-button{appearance:none; -webkit-appearance:none; border:1px solid var(--border); background:var(--card-2); color:#cdd6ff; font:600 13px Poppins, sans-serif; padding:8px 14px; border-radius:999px; cursor:pointer; transition:background .18s ease, border-color .18s ease, color .18s ease;}
 .category-bar .category-button:hover{background:rgba(110,231,231,.08); border-color:rgba(110,231,231,.35);}

--- a/docs/user-ui-hydration-plan-v1.1.md
+++ b/docs/user-ui-hydration-plan-v1.1.md
@@ -45,7 +45,7 @@ The target is a small shared `user-ui-state` module that hydrates the last serve
 
 ## Architecture
 
-Add one plain-script module, for example `js/user-ui-state.js`, loaded after the auth bridge and before topbar consumers. It owns only:
+Add one plain-script module, for example `js/user-ui-state.js`, loaded before the auth bridge and topbar consumers. The module has no Supabase dependency and must exist before the auth bridge can resolve a locally cached session during deferred-script execution. It owns only:
 
 - versioned, user-scoped cache reads and writes;
 - defensive schema validation;

--- a/docs/user-ui-hydration-plan-v1.1.md
+++ b/docs/user-ui-hydration-plan-v1.1.md
@@ -118,6 +118,31 @@ These limits are UX controls, not correctness guarantees. Revalidation runs rega
 
 Non-game pages must not start an XP award session. Game pages preserve their current gameplay lifecycle and use hydration only for initial presentation.
 
+## Pre-hydration DOM and first-paint contract
+
+Stale-while-revalidate alone does not prevent a flash if identity-bound HTML is visible before JavaScript resolves the local session. The initial document must therefore enforce this contract before the first observable paint:
+
+- Every topbar starts with `data-user-ui-state="pending"` in its HTML markup. JavaScript must not add the pending state after load.
+- While `pending`, avatar initials, display name, XP numbers, and chips numbers are not visible. Neutral skeletons reserve the final avatar and badge dimensions to prevent layout shift.
+- The pending UI contains no cached or hardcoded account values, including provisional `0 XP`, `CH: 0`, or user initials.
+- Shared `portal.css` selectors own the pending presentation across all pages. Individual pages must not define competing identity-loading behavior.
+- Initials may be rendered only after identity is known and the matching profile is confirmed to have no uploaded or cached uploaded avatar.
+
+After local session resolution, the state machine is:
+
+```text
+pending -> hydrated    matching valid cache was applied
+pending -> loading     authenticated user has no valid cache; neutral placeholders remain
+pending -> anonymous   no authenticated session; render established guest state
+hydrated/loading -> ready   authoritative requests completed successfully
+hydrated/loading -> stale   refresh failed; keep only matching cached values, otherwise error/loading UI
+any authenticated state -> pending/anonymous   logout or account switch clears rendered identity first
+```
+
+The state attribute may live on the topbar or document root, but there must be one canonical owner and one shared selector contract. Hydration may occur only after Supabase returns the current `userId`; synchronous access to cache after that point should be applied in the same task before scheduling network revalidation.
+
+This design does not promise cached account data before identity resolution. It promises that from first paint until resolution the user sees a neutral, dimensionally stable placeholder, never incorrect initials or numeric account values.
+
 ## Avatar strategy
 
 - Before identity is known, show a neutral avatar skeleton rather than initials tied to unknown state.
@@ -197,7 +222,8 @@ Cross-device convergence remains request-based; this plan adds no realtime backe
 
 ### Browser coverage
 
-- Uploaded avatar remains visible across full-page navigation without an initials flash after identity resolution.
+- From the first observable paint through hydration, topbar state is either neutral or the matching cached state; provisional initials and zero account values are never visible.
+- Uploaded avatar remains visible across full-page navigation without an initials flash.
 - Default avatar remains correct and removal clears the uploaded image.
 - XP and chips render cached confirmed values, then reconcile to changed server values.
 - Failed requests retain cached values and do not force zero.
@@ -210,7 +236,7 @@ Cross-device convergence remains request-based; this plan adds no realtime backe
 
 1. Sign in with an uploaded avatar and known XP/chips.
 2. Navigate repeatedly between root, a game, poker, account, and legal pages.
-3. Confirm no initials or zero-value flash after the session resolves locally.
+3. Observe from first paint and confirm only neutral placeholders or matching cached values appear; no initials or zero-value account flash is allowed.
 4. Change avatar and perform XP/chips-producing actions; confirm another tab updates.
 5. Sign out and sign in as a second account; confirm no first-account data appears.
 6. Simulate offline/network failure after one successful load; confirm cached display remains visibly stale rather than resetting.
@@ -220,9 +246,10 @@ Cross-device convergence remains request-based; this plan adds no realtime backe
 ### PR 1: Infrastructure and avatar
 
 - Add `user-ui-state.js`, cache schema, auth generation, and cross-tab transport.
+- Add the initial `data-user-ui-state="pending"` markup contract and shared `portal.css` placeholder styles while reserving final topbar dimensions.
 - Integrate profile publication and topbar avatar hydration.
-- Add the shared script to every topbar page using existing page-validation tooling.
-- Verify uploaded/default avatar, navigation, logout, account switch, and stale requests.
+- Add the shared script to every topbar page and extend the inventory guard to require the pending state, shared styles, and script order.
+- Verify uploaded/default avatar, navigation, logout, account switch, stale requests, and the absence of identity-bound content from first paint.
 
 ### PR 2: XP hydration
 
@@ -250,6 +277,7 @@ Each PR must be independently deployable and pass existing lifecycle, XP, chips,
 | Hydration triggers XP animation | Separate hydration/status application from confirmed positive award effects. |
 | Chips display implies transactional authority | Cache display balance only; all mutations remain server-confirmed. |
 | Added script ordering differs between pages | Extend static page inventory guard and representative nested-page browser tests. |
+| Initial HTML paints identity values before hydration | Put `pending` in source markup, hide identity-bound content in shared CSS, and test from first observable paint. |
 
 ## Breaking impact
 
@@ -260,7 +288,8 @@ The main compatibility risk is script ordering across many static pages. Impleme
 ## Exit criteria
 
 - No authenticated identity slice is rendered before Supabase user resolution.
-- Full-page navigation hydrates valid cached avatar, XP, and chips without provisional initials or zeroes.
+- From first observable paint until hydration completes, the topbar shows either a neutral placeholder or matching cached state, never provisional initials or zero account values.
+- Full-page navigation hydrates valid cached avatar, XP, and chips without layout shift.
 - Profile, XP, and chips revalidate in parallel and remain server-authoritative.
 - Logout, account switch, stale requests, multi-tab updates, and BFCache are deterministic.
 - No cached field can authorize or mutate account state.

--- a/docs/user-ui-hydration-plan-v1.1.md
+++ b/docs/user-ui-hydration-plan-v1.1.md
@@ -1,0 +1,267 @@
+# User UI Hydration Plan v1.1
+
+## Executive summary
+
+Arcade Hub performs full-page navigation. Each page recreates the topbar and its JavaScript state, so authenticated users briefly see avatar initials, loading XP, and loading chips before the same server data arrives again.
+
+The target is a small shared `user-ui-state` module that hydrates the last server-confirmed topbar state after the local Supabase session identifies the current user, then revalidates profile, XP, and chips in parallel. This is stale-while-revalidate presentation only: servers remain authoritative, cached values never authorize actions or mutate balances, and no SPA conversion is required.
+
+## Current problem
+
+- Full-page navigation destroys in-memory state and builds a new topbar.
+- The uploaded avatar temporarily falls back to initials.
+- XP and chips badges return to loading state on every page.
+- `profile-client.js` has only page-memory cache; many pages use the profile fallback in `supabaseClient.js`.
+- `XPClient` and the chips client fetch authoritative values again, but do not share a safe cross-page presentation cache.
+- Browser HTTP caching may retain an avatar image, but the new page does not know which URL to render until profile data is resolved.
+
+## Goals
+
+1. Hydrate an authenticated topbar immediately after the local Supabase session identifies its user.
+2. Use stale-while-revalidate for avatar, display name, XP, level, and chips.
+3. Never show user A's cached state to user B, even briefly.
+4. Keep profile, XP, and chips servers as their respective sources of truth.
+5. Preserve full-page navigation and the existing plain-script/IIFE architecture.
+6. Avoid award animations, chip transaction effects, and other mutation UI during hydration.
+7. Keep loading/error states when no safe cache exists.
+
+## Non-goals
+
+- SPA routing or persistent in-memory application state.
+- Backend, database, Redis-key, Storage, or API contract changes.
+- Realtime infrastructure or guaranteed instant cross-device updates.
+- Using cached XP or chips to authorize gameplay, purchases, claims, or ledger operations.
+- Caching JWTs, email addresses, auth metadata, ledger rows, or private profile fields.
+
+## Fixed design decisions
+
+- Do not render identity-bound cache before `SupabaseAuth.getCurrentUser()` returns a user ID.
+- Cache only successful, server-confirmed responses.
+- Every record includes its `userId`; key and record identity must both match the current session.
+- Revalidation always runs after hydration. Cache freshness changes presentation priority, not server authority.
+- A failed refresh keeps a valid cached value visible and marks it stale internally; it must not replace it with zero or initials.
+- Logout clears rendered identity state immediately. Account switch invalidates pending requests through a generation token before hydrating the new user.
+- Existing clients remain API owners: `ProfileClient`/profile fallback, `XPClient`, and the chips client continue making requests.
+
+## Architecture
+
+Add one plain-script module, for example `js/user-ui-state.js`, loaded after the auth bridge and before topbar consumers. It owns only:
+
+- versioned, user-scoped cache reads and writes;
+- defensive schema validation;
+- hydration and update events;
+- auth-generation race protection;
+- `BroadcastChannel` and storage-event synchronization.
+
+It must not duplicate Supabase auth, profile projection, XP calculation, or chips API code. Existing modules publish confirmed data into it and subscribe to relevant hydrated slices.
+
+Suggested public surface:
+
+```text
+UserUiState.hydrate(userId)
+UserUiState.publish(userId, slice, value, confirmedAt)
+UserUiState.clearUser(userId)
+UserUiState.clearRenderedState()
+UserUiState.onChange(listener)
+```
+
+Supported slices are `profile`, `xp`, and `chips`. Unknown fields and slices are ignored.
+
+## Cache design
+
+Use separate records so one corrupt or expired slice cannot invalidate the others:
+
+```text
+kcswh:user-ui:profile:v1:<userId>
+kcswh:user-ui:xp:v1:<userId>
+kcswh:user-ui:chips:v1:<userId>
+```
+
+Each JSON record contains:
+
+```json
+{
+  "version": 1,
+  "userId": "supabase-user-id",
+  "confirmedAt": 0,
+  "value": {}
+}
+```
+
+Allowlisted values:
+
+- `profile`: `displayName` and the public avatar model (`type`, `variant`, public `url` when uploaded).
+- `xp`: server-confirmed `totalLifetime` and derived/confirmed `level`.
+- `chips`: server-confirmed display balance only.
+
+Never store email, JWT, refresh token, Supabase session, profile `user_id`, avatar storage key, ledger data, or transaction details.
+
+Initial maximum hydration ages:
+
+- profile: 7 days;
+- XP: 15 minutes;
+- chips: 5 minutes.
+
+These limits are UX controls, not correctness guarantees. Revalidation runs regardless of age. Expired or malformed entries are removed and produce the existing loading state. Storage failures must degrade to network-only behavior without throwing.
+
+## Bootstrap sequence
+
+1. Render a neutral, non-identity placeholder. Do not render a previous user's initials.
+2. Resolve the local Supabase session through the existing auth bridge.
+3. Increment an auth-generation token and capture the resolved `userId`.
+4. Read only cache keys ending in that exact `userId` and verify the record's embedded identity.
+5. Hydrate valid profile, XP, and chips slices without animations.
+6. Start profile, `calculate-xp operation=status`, and chips requests in parallel through existing clients.
+7. Before applying each result, confirm that the auth generation and current `userId` still match.
+8. Update UI and cache only for successful, allowlisted responses. Skip DOM work when the normalized value did not change.
+9. Keep hydrated data on individual request failure; expose loading/error only for a slice that had no safe cached value.
+
+Non-game pages must not start an XP award session. Game pages preserve their current gameplay lifecycle and use hydration only for initial presentation.
+
+## Avatar strategy
+
+- Before identity is known, show a neutral avatar skeleton rather than initials tied to unknown state.
+- After identity resolution, render the cached avatar model immediately.
+- Uploaded avatars use the stable public processed URL; normal browser HTTP caching should avoid downloading an unchanged image again.
+- Revalidate through the existing owner-profile endpoint in the background.
+- A new upload publishes the new avatar model immediately after successful finalization.
+- Restoring the default avatar removes the cached uploaded URL after server confirmation.
+- Logout clears avatar DOM state before any asynchronous work. Account switch must never reuse the previous profile cache.
+
+## XP strategy
+
+- Hydrate only a server-confirmed authenticated total previously written after `calculate-xp` status or award success.
+- Never hydrate authenticated XP from legacy optimistic or anonymous browser values.
+- Revalidate with `calculate-xp` using `operation: "status"` and the current Bearer token.
+- Hydration and status reconciliation update badge text without overlay, bump, or `+N XP` animation.
+- A positive confirmed award updates the normal XP state first, then publishes the returned authoritative total to cache.
+- Invalid token, network failure, or malformed response must not overwrite a cached total with zero.
+- Logout switches to the established guest XP flow and does not project account cache into the guest identity.
+
+## Chips strategy
+
+- Cache only the last server-confirmed balance used for display.
+- Hydrate it after authenticated identity resolution, then refresh through the existing chips client.
+- Never use the cached balance to approve a claim, poker buy-in, transfer, or adjustment.
+- Publish a new balance after every successful chips read and transaction response.
+- On transaction failure, retain the last confirmed value and let the existing error UI describe the failed operation.
+- Do not optimistically decrement or increment the shared cache unless the server response contains the resulting authoritative balance.
+
+## Auth transitions and invalidation
+
+### Logout
+
+1. Increment auth generation and cancel application of old in-flight results.
+2. Clear rendered profile, XP, and chips account state synchronously.
+3. Remove the departing user's cached slices as the conservative MVP policy.
+4. Continue with existing signed-out and guest rendering.
+
+### Account switch
+
+1. Apply logout invalidation for user A.
+2. Resolve user B from Supabase; never use a standalone "last user" pointer for hydration.
+3. Read only user B's keys and start new revalidation requests.
+
+### Profile, XP, and chips updates
+
+- Publish only after successful server confirmation.
+- Include `userId`, slice, normalized value, `confirmedAt`, and an event ID.
+- Ignore events for a different user or an older confirmation timestamp.
+
+## Multi-tab synchronization
+
+Use `BroadcastChannel("kcswh:user-ui:v1")` when available. Messages contain no tokens and carry only the same allowlisted cache record fields.
+
+Use the browser `storage` event as fallback because writes use `localStorage`. A receiving tab validates version, slice, `userId`, timestamp, and value schema before applying an update. It must ignore its own event ID and must not trigger an API mutation or award animation.
+
+Cross-device convergence remains request-based; this plan adds no realtime backend.
+
+## Race handling
+
+- Maintain a monotonically increasing auth generation in memory.
+- Capture `{ generation, userId }` for every hydration and request.
+- Check both values before DOM or cache writes.
+- Deduplicate concurrent reads per slice where existing clients already expose an in-flight promise.
+- Compare `confirmedAt` before applying cross-tab events so an older response cannot overwrite newer state.
+- Treat malformed cache, quota errors, disabled storage, and unavailable `BroadcastChannel` as recoverable network-only states.
+
+## Testing plan
+
+### Contract and unit coverage
+
+- Cache schema accepts only allowlisted fields and rejects wrong version/user ID.
+- Malformed, oversized, negative, or non-finite XP/chips values are ignored.
+- Logout and account switch invalidate pending results.
+- Hydration emits no XP award animation or chips transaction effect.
+- Storage failures fall back to loading plus network refresh.
+
+### Browser coverage
+
+- Uploaded avatar remains visible across full-page navigation without an initials flash after identity resolution.
+- Default avatar remains correct and removal clears the uploaded image.
+- XP and chips render cached confirmed values, then reconcile to changed server values.
+- Failed requests retain cached values and do not force zero.
+- Two accounts in one browser never see each other's topbar state.
+- Two tabs converge through `BroadcastChannel`; storage-event fallback is also exercised.
+- BFCache restore does not duplicate listeners, requests, or award animation.
+- Representative root, nested game, account, public-profile, poker, and legal pages use the same bootstrap order.
+
+### Manual smoke
+
+1. Sign in with an uploaded avatar and known XP/chips.
+2. Navigate repeatedly between root, a game, poker, account, and legal pages.
+3. Confirm no initials or zero-value flash after the session resolves locally.
+4. Change avatar and perform XP/chips-producing actions; confirm another tab updates.
+5. Sign out and sign in as a second account; confirm no first-account data appears.
+6. Simulate offline/network failure after one successful load; confirm cached display remains visibly stale rather than resetting.
+
+## Proposed implementation split
+
+### PR 1: Infrastructure and avatar
+
+- Add `user-ui-state.js`, cache schema, auth generation, and cross-tab transport.
+- Integrate profile publication and topbar avatar hydration.
+- Add the shared script to every topbar page using existing page-validation tooling.
+- Verify uploaded/default avatar, navigation, logout, account switch, and stale requests.
+
+### PR 2: XP hydration
+
+- Publish server-confirmed status and award totals from `XPClient`.
+- Hydrate badge without award animation.
+- Preserve guest/account separation, migration-notice rules, BFCache, and daily/session caps.
+
+### PR 3: Chips hydration
+
+- Publish server-confirmed balance reads and transaction results.
+- Hydrate display only; all operations continue to query the authoritative server.
+- Verify claims, profile history, poker transitions, account switch, and multi-tab updates.
+
+Each PR must be independently deployable and pass existing lifecycle, XP, chips, auth, profile, static-page, and Playwright checks.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Previous user's data flashes after account switch | Resolve Supabase user first; require key and embedded `userId` match; use auth generation. |
+| Cached value is stale | Always revalidate; bound hydration age; cache never authorizes operations. |
+| Old request overwrites new identity | Check generation and user ID before every apply/write. |
+| Cross-tab update loops | Event IDs, timestamp ordering, and no republish of received events. |
+| Cache corruption or storage denial | Strict parsing and network-only fallback. |
+| Hydration triggers XP animation | Separate hydration/status application from confirmed positive award effects. |
+| Chips display implies transactional authority | Cache display balance only; all mutations remain server-confirmed. |
+| Added script ordering differs between pages | Extend static page inventory guard and representative nested-page browser tests. |
+
+## Breaking impact
+
+No backend or data migration is planned. Frontend behavior changes from loading placeholders to last server-confirmed values after identity resolution. During a short revalidation window, XP or chips may be stale by design; product copy and accessibility state must not claim that cached values are freshly synchronized.
+
+The main compatibility risk is script ordering across many static pages. Implementation must preserve plain-script/IIFE and JSP compatibility, use root-absolute assets where rewritten routes require them, use `klog` for diagnostics, and update CSP hashes if any inline bootstrap changes.
+
+## Exit criteria
+
+- No authenticated identity slice is rendered before Supabase user resolution.
+- Full-page navigation hydrates valid cached avatar, XP, and chips without provisional initials or zeroes.
+- Profile, XP, and chips revalidate in parallel and remain server-authoritative.
+- Logout, account switch, stale requests, multi-tab updates, and BFCache are deterministic.
+- No cached field can authorize or mutate account state.
+- Existing account, XP, chips, bonuses, poker, public-profile, and game flows remain unaffected.

--- a/favorites.html
+++ b/favorites.html
@@ -30,6 +30,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -110,7 +111,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game.html
+++ b/game.html
@@ -28,6 +28,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -38,7 +39,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game_cats.html
+++ b/game_cats.html
@@ -17,6 +17,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host data-game-slug="cats" data-game-id="cats">
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game_trex.html
+++ b/game_trex.html
@@ -16,6 +16,7 @@
 <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -39,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host data-game-slug="t-rex" data-game-id="t-rex">
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="2048" data-game-id="2048">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/asteroids/index.html
+++ b/games-open/asteroids/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="asteroids" data-game-id="asteroids">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/breakout/index.html
+++ b/games-open/breakout/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="breakout" data-game-id="breakout">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/brick-breaker/index.html
+++ b/games-open/brick-breaker/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="brick-breaker" data-game-id="brick-breaker">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/connect-four/index.html
+++ b/games-open/connect-four/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="connect-four" data-game-id="connect-four">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/flappy/index.html
+++ b/games-open/flappy/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -28,7 +29,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="flappy" data-game-id="flappy">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/freedoom/index.html
+++ b/games-open/freedoom/index.html
@@ -17,6 +17,7 @@
     <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -28,7 +29,7 @@
     <script src="../../js/consent-services.js" defer></script>
   </head>
   <body data-game-host data-game-slug="freedoom" data-game-id="freedoom">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/frogger/index.html
+++ b/games-open/frogger/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="frogger" data-game-id="frogger">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/galaga/index.html
+++ b/games-open/galaga/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="galaga" data-game-id="galaga">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/hangman/index.html
+++ b/games-open/hangman/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="hangman" data-game-id="hangman">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/memory-match/index.html
+++ b/games-open/memory-match/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="memory-match" data-game-id="memory-match">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/minesweeper/index.html
+++ b/games-open/minesweeper/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="minesweeper" data-game-id="minesweeper">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/missile-command/index.html
+++ b/games-open/missile-command/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="missile-command" data-game-id="missile-command">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="pacman" data-game-id="pacman">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/pong/index.html
+++ b/games-open/pong/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="pong" data-game-id="pong">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/simon/index.html
+++ b/games-open/simon/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="simon" data-game-id="simon">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/snake/index.html
+++ b/games-open/snake/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="snake" data-game-id="snake">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/sokoban/index.html
+++ b/games-open/sokoban/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="sokoban" data-game-id="sokoban">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/solitaire/index.html
+++ b/games-open/solitaire/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="solitaire" data-game-id="solitaire">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/space-invaders/index.html
+++ b/games-open/space-invaders/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="space-invaders" data-game-id="space-invaders">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/sudoku/index.html
+++ b/games-open/sudoku/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="sudoku" data-game-id="sudoku">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="tetris" data-game-id="tetris">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/tic-tac-toe/index.html
+++ b/games-open/tic-tac-toe/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="tic-tac-toe" data-game-id="tic-tac-toe">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/whac-a-mole/index.html
+++ b/games-open/whac-a-mole/index.html
@@ -18,6 +18,7 @@
 <script src="/js/i18n.js" defer></script>
     <script src="/js/auth/supabase-config.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+    <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
@@ -29,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="whac-a-mole" data-game-id="whac-a-mole">
-    <div class="topbar">
+    <div class="topbar" data-user-ui-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
   <script src="/js/adsense-init.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/home-bonuses.js" defer></script>
@@ -43,7 +44,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/js/auth/supabaseClient.js
+++ b/js/auth/supabaseClient.js
@@ -256,6 +256,17 @@
     node.style.backgroundImage = uploaded ? 'url("' + avatar.url.replace(/["\\]/g, '') + '")' : '';
   }
 
+  function setUserUiState(value){
+    try {
+      var bars = doc.querySelectorAll('.topbar');
+      for (var i = 0; i < bars.length; i++) bars[i].setAttribute('data-user-ui-state', value);
+    } catch (_err){}
+  }
+
+  function userUiState(){
+    return window.UserUiState && typeof window.UserUiState.hydrate === 'function' ? window.UserUiState : null;
+  }
+
   function selectNodes(){
     nodes.shell = doc.getElementById('avatarShell');
     nodes.button = doc.getElementById('avatarButton');
@@ -305,7 +316,7 @@
     }
   }
 
-  function refreshProfile(user){
+  function refreshProfile(user, uiGeneration, hadCachedProfile){
     if (!user) return;
     var load = window.ProfileClient && typeof window.ProfileClient.getMe === 'function'
       ? window.ProfileClient.getMe()
@@ -317,10 +328,34 @@
         });
       });
     load.then(function(profile){
-      if (state.user && state.user.id === user.id) renderUser(user, profile);
+      var ui = userUiState();
+      if (!state.user || state.user.id !== user.id || (ui && !ui.isCurrent(user.id, uiGeneration))) return;
+      if (ui) ui.publish(user.id, 'profile', profile, Date.now());
+      else setUserUiState('ready');
+      renderUser(user, profile);
     }).catch(function(error){
+      var ui = userUiState();
+      if (ui) ui.markRefreshFailed(user.id, uiGeneration, !!hadCachedProfile);
+      else setUserUiState(hadCachedProfile ? 'stale' : 'loading');
       logDiag('profile:topbar_load_failed', { code: error && error.code ? error.code : 'request_failed' });
     });
+  }
+
+  function applyResolvedUser(user){
+    var previousUserId = state.user && state.user.id ? String(state.user.id) : null;
+    var ui = userUiState();
+    if (!user || !user.id){
+      if (ui && previousUserId) ui.clearUser(previousUserId);
+      if (ui) ui.setAnonymous(); else setUserUiState('anonymous');
+      renderUser(null, null);
+      return;
+    }
+    var userId = String(user.id);
+    if (ui && previousUserId && previousUserId !== userId) ui.clearUser(previousUserId);
+    var hydrated = ui ? ui.hydrate(userId) : { generation: 0, profile: null };
+    if (!ui) setUserUiState('loading');
+    renderUser(user, hydrated.profile || null);
+    refreshProfile(user, hydrated.generation, !!hydrated.profile);
   }
 
   function toggleMenu(force){
@@ -425,7 +460,19 @@
     if (nodes.menuAction){ nodes.menuAction.addEventListener('click', handleAction); }
     if (nodes.menuUser){ nodes.menuUser.addEventListener('click', handleMenuUserClick); }
     doc.addEventListener('langchange', function(){ renderUser(state.user, state.profile); });
-    doc.addEventListener('profile:updated', function(event){ if (state.user) renderUser(state.user, event && event.detail ? event.detail : state.profile); });
+    doc.addEventListener('profile:updated', function(event){
+      if (!state.user) return;
+      var profile = event && event.detail ? event.detail : state.profile;
+      var ui = userUiState();
+      if (ui && profile) ui.publish(String(state.user.id), 'profile', profile, Date.now());
+      renderUser(state.user, profile);
+    });
+    var ui = userUiState();
+    if (ui && typeof ui.onChange === 'function'){
+      ui.onChange(function(detail){
+        if (state.user && detail && detail.slice === 'profile' && detail.userId === String(state.user.id)) renderUser(state.user, detail.value);
+      });
+    }
 
     renderUser(state.user);
   }
@@ -434,14 +481,12 @@
     renderUser(null, null);
 
     getCurrentUser().then(function(user){
-      renderUser(user, null);
-      refreshProfile(user);
+      applyResolvedUser(user);
     });
 
     onAuthChange(function(_event, user){
       if (window.ProfileClient && typeof window.ProfileClient.clear === 'function') window.ProfileClient.clear();
-      renderUser(user, null);
-      refreshProfile(user);
+      applyResolvedUser(user);
     });
   }
 

--- a/js/user-ui-state.js
+++ b/js/user-ui-state.js
@@ -9,6 +9,7 @@
   var activeUserId = null;
   var generation = 0;
   var channel = null;
+  var appliedAt = { profile: 0, xp: 0, chips: 0 };
 
   function klog(kind, data){
     try { if (window.KLog && typeof window.KLog.log === 'function') window.KLog.log(kind, data || {}); } catch (_err){}
@@ -91,12 +92,18 @@
 
   function hydrate(userId){
     if (!validUserId(userId)) return { generation: generation, profile: null, xp: null, chips: null };
-    if (activeUserId !== userId) generation += 1;
+    if (activeUserId !== userId){
+      generation += 1;
+      appliedAt = { profile: 0, xp: 0, chips: 0 };
+    }
     activeUserId = userId;
     var result = { generation: generation, profile: null, xp: null, chips: null };
     ['profile', 'xp', 'chips'].forEach(function(slice){
       var record = read(slice, userId);
-      if (record) result[slice] = record.value;
+      if (record){
+        result[slice] = record.value;
+        appliedAt[slice] = record.confirmedAt;
+      }
     });
     setTopbarState(result.profile || result.xp || result.chips ? 'hydrated' : 'loading');
     return result;
@@ -121,6 +128,7 @@
     if (!Number.isSafeInteger(timestamp) || timestamp < 1) timestamp = Date.now();
     var record = { version: VERSION, userId: userId, slice: slice, confirmedAt: timestamp, value: normalized };
     writeRecord(record);
+    appliedAt[slice] = timestamp;
     setTopbarState('ready');
     emit(record);
     if (channel){ try { channel.postMessage(record); } catch (_err){} }
@@ -133,10 +141,10 @@
     if (store){
       ['profile', 'xp', 'chips'].forEach(function(slice){ try { store.removeItem(key(slice, userId)); } catch (_err){} });
     }
-    if (activeUserId === userId){ activeUserId = null; generation += 1; }
+    if (activeUserId === userId){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; }
   }
 
-  function setAnonymous(){ activeUserId = null; generation += 1; setTopbarState('anonymous'); }
+  function setAnonymous(){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; setTopbarState('anonymous'); }
 
   function markRefreshFailed(userId, expectedGeneration, hasCachedValue){
     if (!isCurrent(userId, expectedGeneration)) return;
@@ -154,10 +162,11 @@
     var normalized = normalize(record.slice, record.value);
     var confirmedAt = Number(record.confirmedAt);
     if (!normalized || !Number.isSafeInteger(confirmedAt) || confirmedAt < 1) return;
-    var current = read(record.slice, activeUserId);
-    if (current && current.confirmedAt >= confirmedAt) return;
+    if (appliedAt[record.slice] >= confirmedAt) return;
     var accepted = { version: VERSION, userId: activeUserId, slice: record.slice, confirmedAt: confirmedAt, value: normalized };
     writeRecord(accepted);
+    appliedAt[record.slice] = confirmedAt;
+    setTopbarState('ready');
     emit(accepted);
   }
 

--- a/js/user-ui-state.js
+++ b/js/user-ui-state.js
@@ -1,0 +1,184 @@
+(function(){
+  if (typeof window === 'undefined') return;
+
+  var VERSION = 1;
+  var PREFIX = 'kcswh:user-ui:';
+  var CHANNEL_NAME = 'kcswh:user-ui:v1';
+  var MAX_AGE = { profile: 7 * 24 * 60 * 60 * 1000, xp: 15 * 60 * 1000, chips: 5 * 60 * 1000 };
+  var listeners = [];
+  var activeUserId = null;
+  var generation = 0;
+  var channel = null;
+
+  function klog(kind, data){
+    try { if (window.KLog && typeof window.KLog.log === 'function') window.KLog.log(kind, data || {}); } catch (_err){}
+  }
+
+  function storage(){
+    try { return window.localStorage || null; } catch (_err){ return null; }
+  }
+
+  function key(slice, userId){ return PREFIX + slice + ':v' + VERSION + ':' + userId; }
+
+  function validUserId(value){ return typeof value === 'string' && value.length > 0 && value.length <= 128; }
+
+  function normalizeAvatar(value){
+    var avatar = value && typeof value === 'object' ? value : {};
+    var type = avatar.type === 'uploaded' ? 'uploaded' : 'default';
+    var variant = typeof avatar.variant === 'string' && /^[a-z0-9-]{1,40}$/.test(avatar.variant) ? avatar.variant : 'default';
+    var result = { type: type, variant: variant };
+    if (type === 'uploaded' && typeof avatar.url === 'string' && /^https:\/\/[^\s"\\]{1,2048}$/.test(avatar.url)) result.url = avatar.url;
+    if (type === 'uploaded' && !result.url) result.type = 'default';
+    return result;
+  }
+
+  function normalize(slice, value){
+    if (!value || typeof value !== 'object') return null;
+    if (slice === 'profile'){
+      var displayName = typeof value.displayName === 'string' ? value.displayName.trim() : '';
+      if (!displayName || displayName.length > 40) return null;
+      return { displayName: displayName, avatar: normalizeAvatar(value.avatar) };
+    }
+    if (slice === 'xp'){
+      var total = Number(value.totalLifetime);
+      var level = Number(value.level);
+      if (!Number.isSafeInteger(total) || total < 0 || !Number.isSafeInteger(level) || level < 1) return null;
+      return { totalLifetime: total, level: level };
+    }
+    if (slice === 'chips'){
+      var balance = Number(value.balance);
+      if (!Number.isSafeInteger(balance) || balance < 0) return null;
+      return { balance: balance };
+    }
+    return null;
+  }
+
+  function parseRecord(slice, userId, raw, now){
+    var record;
+    try { record = JSON.parse(raw); } catch (_err){ return null; }
+    if (!record || record.version !== VERSION || record.userId !== userId) return null;
+    var confirmedAt = Number(record.confirmedAt);
+    if (!Number.isSafeInteger(confirmedAt) || confirmedAt < 1 || now - confirmedAt > MAX_AGE[slice]) return null;
+    var value = normalize(slice, record.value);
+    return value ? { version: VERSION, userId: userId, confirmedAt: confirmedAt, value: value } : null;
+  }
+
+  function read(slice, userId){
+    var store = storage();
+    if (!store) return null;
+    var cacheKey = key(slice, userId);
+    var raw;
+    try { raw = store.getItem(cacheKey); } catch (_err){ return null; }
+    if (!raw) return null;
+    var record = parseRecord(slice, userId, raw, Date.now());
+    if (!record){ try { store.removeItem(cacheKey); } catch (_err){} }
+    return record;
+  }
+
+  function setTopbarState(value){
+    try {
+      var bars = document.querySelectorAll('.topbar');
+      for (var i = 0; i < bars.length; i++) bars[i].setAttribute('data-user-ui-state', value);
+    } catch (_err){}
+  }
+
+  function emit(detail){
+    for (var i = 0; i < listeners.length; i++){
+      try { listeners[i](detail); } catch (_err){}
+    }
+    try { document.dispatchEvent(new CustomEvent('user-ui:change', { detail: detail })); } catch (_err){}
+  }
+
+  function hydrate(userId){
+    if (!validUserId(userId)) return { generation: generation, profile: null, xp: null, chips: null };
+    if (activeUserId !== userId) generation += 1;
+    activeUserId = userId;
+    var result = { generation: generation, profile: null, xp: null, chips: null };
+    ['profile', 'xp', 'chips'].forEach(function(slice){
+      var record = read(slice, userId);
+      if (record) result[slice] = record.value;
+    });
+    setTopbarState(result.profile || result.xp || result.chips ? 'hydrated' : 'loading');
+    return result;
+  }
+
+  function isCurrent(userId, expectedGeneration){
+    return activeUserId === userId && generation === expectedGeneration;
+  }
+
+  function writeRecord(record){
+    var store = storage();
+    if (!store) return false;
+    try { store.setItem(key(record.slice, record.userId), JSON.stringify({ version: VERSION, userId: record.userId, confirmedAt: record.confirmedAt, value: record.value })); return true; }
+    catch (_err){ return false; }
+  }
+
+  function publish(userId, slice, value, confirmedAt){
+    if (!validUserId(userId) || activeUserId !== userId || !Object.prototype.hasOwnProperty.call(MAX_AGE, slice)) return null;
+    var normalized = normalize(slice, value);
+    if (!normalized) return null;
+    var timestamp = Number(confirmedAt);
+    if (!Number.isSafeInteger(timestamp) || timestamp < 1) timestamp = Date.now();
+    var record = { version: VERSION, userId: userId, slice: slice, confirmedAt: timestamp, value: normalized };
+    writeRecord(record);
+    setTopbarState('ready');
+    emit(record);
+    if (channel){ try { channel.postMessage(record); } catch (_err){} }
+    return normalized;
+  }
+
+  function clearUser(userId){
+    if (!validUserId(userId)) return;
+    var store = storage();
+    if (store){
+      ['profile', 'xp', 'chips'].forEach(function(slice){ try { store.removeItem(key(slice, userId)); } catch (_err){} });
+    }
+    if (activeUserId === userId){ activeUserId = null; generation += 1; }
+  }
+
+  function setAnonymous(){ activeUserId = null; generation += 1; setTopbarState('anonymous'); }
+
+  function markRefreshFailed(userId, expectedGeneration, hasCachedValue){
+    if (!isCurrent(userId, expectedGeneration)) return;
+    setTopbarState(hasCachedValue ? 'stale' : 'loading');
+  }
+
+  function onChange(listener){
+    if (typeof listener !== 'function') return function(){};
+    listeners.push(listener);
+    return function(){ listeners = listeners.filter(function(item){ return item !== listener; }); };
+  }
+
+  function acceptExternal(record){
+    if (!record || record.version !== VERSION || record.userId !== activeUserId || !Object.prototype.hasOwnProperty.call(MAX_AGE, record.slice)) return;
+    var normalized = normalize(record.slice, record.value);
+    var confirmedAt = Number(record.confirmedAt);
+    if (!normalized || !Number.isSafeInteger(confirmedAt) || confirmedAt < 1) return;
+    var current = read(record.slice, activeUserId);
+    if (current && current.confirmedAt >= confirmedAt) return;
+    var accepted = { version: VERSION, userId: activeUserId, slice: record.slice, confirmedAt: confirmedAt, value: normalized };
+    writeRecord(accepted);
+    emit(accepted);
+  }
+
+  try {
+    if (typeof window.BroadcastChannel === 'function'){
+      channel = new window.BroadcastChannel(CHANNEL_NAME);
+      channel.addEventListener('message', function(event){ acceptExternal(event && event.data); });
+    }
+  } catch (_err){ channel = null; }
+
+  window.addEventListener('storage', function(event){
+    if (!event || typeof event.key !== 'string' || event.key.indexOf(PREFIX) !== 0 || !event.newValue) return;
+    var parts = event.key.split(':');
+    var slice = parts[2];
+    var userId = parts.slice(4).join(':');
+    var parsed;
+    try { parsed = JSON.parse(event.newValue); } catch (_err){ return; }
+    if (parsed) parsed.slice = slice;
+    if (parsed && parsed.userId === userId) acceptExternal(parsed);
+  });
+
+  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markRefreshFailed: markRefreshFailed, onChange: onChange };
+  klog('user_ui_state_ready', { version: VERSION });
+})();

--- a/legal/cookies-notice.en.html
+++ b/legal/cookies-notice.en.html
@@ -15,6 +15,7 @@
   <script src="../js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="../js/topbar.js" defer></script>
   <script src="../js/xpClient.js" defer></script>
@@ -35,7 +36,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/cookies-notice.pl.html
+++ b/legal/cookies-notice.pl.html
@@ -15,6 +15,7 @@
   <script src="../js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="../js/topbar.js" defer></script>
   <script src="../js/xpClient.js" defer></script>
@@ -35,7 +36,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/privacy.en.html
+++ b/legal/privacy.en.html
@@ -15,6 +15,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -37,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/privacy.pl.html
+++ b/legal/privacy.pl.html
@@ -15,6 +15,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -37,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/terms.en.html
+++ b/legal/terms.en.html
@@ -15,6 +15,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -37,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/terms.pl.html
+++ b/legal/terms.pl.html
@@ -15,6 +15,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -37,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/play.html
+++ b/play.html
@@ -33,6 +33,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -54,7 +55,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/poker/index.html
+++ b/poker/index.html
@@ -16,6 +16,7 @@
   <script src="/js/adsense-init.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
   <script src="/js/core/number-format.js" defer></script>
@@ -36,7 +37,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/profile.html
+++ b/profile.html
@@ -13,6 +13,7 @@
   <script src="/js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="/js/profile-client.js" defer></script>
   <script src="/js/chips/client.js" defer></script>
@@ -27,7 +28,7 @@
   <script src="/js/public-profile-page.js" defer></script>
 </head>
 <body>
-  <header class="topbar">
+  <header class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <a href="/index.html" class="brand" aria-label="Arcade Hub home"><div class="logo" aria-hidden="true"></div><h1>Arcade Hub</h1></a>
     </div>

--- a/recently-played.html
+++ b/recently-played.html
@@ -30,6 +30,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -84,7 +85,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -100,6 +100,7 @@ run("node", ["tests/public-profiles.behavior.test.mjs"], "public-profiles-behavi
 run("node", ["tests/profile-avatar.behavior.test.mjs"], "profile-avatar-behavior");
 run("node", ["tests/public-profile-xp.e2e.test.mjs"], "public-profile-xp-e2e");
 run("node", ["tests/public-profile-ui.contract.test.mjs"], "public-profile-ui-contract");
+run("node", ["tests/user-ui-state.behavior.test.mjs"], "user-ui-state-behavior");
 run("node", ["tests/home-bonuses.contract.test.mjs"], "home-bonuses-contract");
 run("node", ["tests/account-auth.contract.test.mjs"], "account-auth-contract");
 run("node", ["tests/xp-ledger.behavior.test.mjs"], "xp-ledger-behavior");

--- a/tests/e2e/topbar-profile-avatar.spec.js
+++ b/tests/e2e/topbar-profile-avatar.spec.js
@@ -3,35 +3,50 @@ const { test, expect } = require('@playwright/test');
 const AVATAR_URL = 'https://stage-test.supabase.co/storage/v1/object/public/profile-avatars/smoke.webp';
 const PAGES = ['/', '/games-open/2048/'];
 
+async function mockAuthenticatedSession(page) {
+  await page.route('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js', (route) => route.fulfill({
+    contentType: 'application/javascript',
+    body: '',
+  }));
+  await page.route('**/js/auth/supabase-config.js', (route) => route.fulfill({
+    contentType: 'application/javascript',
+    body: `
+      window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
+      window.supabase = { createClient: function(){ return { auth: {
+        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: 'avatar-user', email: 'private@example.test' } } } }); },
+        onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
+        signOut: function(){ return Promise.resolve(); }
+      } }; } };
+    `,
+  }));
+}
+
+const profile = () => ({
+  handle: 'avatar-player',
+  displayName: 'Avatar Player',
+  bio: '',
+  avatar: { type: 'uploaded', variant: 'fox-blue', url: AVATAR_URL },
+  handleCanCustomize: false,
+});
+
 test.describe('authenticated topbar profile avatar', () => {
   for (const path of PAGES) {
     test(`renders uploaded avatar on ${path}`, async ({ page }) => {
-      await page.route('**/js/auth/supabase-config.js', (route) => route.fulfill({
-        contentType: 'application/javascript',
-        body: `
-          window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
-          window.supabase = { createClient: function(){ return { auth: {
-            getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: 'avatar-user', email: 'private@example.test' } } } }); },
-            onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
-            signOut: function(){ return Promise.resolve(); }
-          } }; } };
-        `,
-      }));
-      await page.route('**/.netlify/functions/profile-me', (route) => route.fulfill({
+      await mockAuthenticatedSession(page);
+      let profileRequests = 0;
+      await page.route('**/.netlify/functions/profile-me', (route) => {
+        profileRequests += 1;
+        return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          handle: 'avatar-player',
-          displayName: 'Avatar Player',
-          bio: '',
-          avatar: { type: 'uploaded', variant: 'fox-blue', url: AVATAR_URL },
-          handleCanCustomize: false,
-        }),
-      }));
+        body: JSON.stringify(profile()),
+        });
+      });
 
       await page.goto(path, { waitUntil: 'domcontentloaded' });
       const avatar = page.locator('#avatarInitials');
       const menuAvatar = page.locator('#avatarMenuInitials');
+      await expect.poll(() => profileRequests).toBeGreaterThan(0);
       await expect(avatar).toHaveClass(/profile-avatar--uploaded/);
       await expect(avatar).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
       await expect(avatar).toHaveText('');
@@ -39,4 +54,48 @@ test.describe('authenticated topbar profile avatar', () => {
       await expect(menuAvatar).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
     });
   }
+
+  test('hydrates the cached avatar before delayed revalidation without a visible initials frame', async ({ page }) => {
+    await mockAuthenticatedSession(page);
+    let requests = 0;
+    await page.route('**/.netlify/functions/profile-me', async (route) => {
+      requests += 1;
+      if (requests > 1) await new Promise((resolve) => setTimeout(resolve, 1200));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(profile()) });
+    });
+    await page.addInitScript(() => {
+      window.__avatarFrames = [];
+      function sample(){
+        const node = document.getElementById('avatarInitials');
+        const bar = document.querySelector('.topbar');
+        if (node && bar){
+          const style = getComputedStyle(node);
+          window.__avatarFrames.push({
+            state: bar.getAttribute('data-user-ui-state'),
+            text: node.textContent.trim(),
+            color: style.color,
+            uploaded: node.classList.contains('profile-avatar--uploaded'),
+          });
+        }
+        requestAnimationFrame(sample);
+      }
+      requestAnimationFrame(sample);
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#avatarInitials')).toHaveClass(/profile-avatar--uploaded/);
+    await page.goto('/games-open/2048/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-state', 'hydrated');
+    await expect(page.locator('#avatarInitials')).toHaveClass(/profile-avatar--uploaded/);
+    const frames = await page.evaluate(() => window.__avatarFrames);
+    assertNoVisibleInitials(frames);
+  });
 });
+
+function assertNoVisibleInitials(frames) {
+  expect(frames.length).toBeGreaterThan(0);
+  for (const frame of frames) {
+    const transparent = frame.color === 'rgba(0, 0, 0, 0)';
+    expect(frame.text && !transparent, JSON.stringify(frame)).toBeFalsy();
+  }
+}

--- a/tests/public-profile-ui.contract.test.mjs
+++ b/tests/public-profile-ui.contract.test.mjs
@@ -130,7 +130,7 @@ test("topbar derives its visible signed-in identity from the public profile", as
   const [source, accountSource] = await Promise.all([read("js/auth/supabaseClient.js"), read("js/account-page.js")]);
   assert.match(source, /name = profile && profile\.displayName \? profile\.displayName : t\('player'/);
   assert.match(source, /email = t\('profileAccountSynced'/);
-  assert.match(source, /refreshProfile\(user\)/);
+  assert.match(source, /refreshProfile\(user, hydrated\.generation/);
   assert.match(source, /avatar\.type === 'uploaded'/);
   assert.match(source, /classList\.toggle\('profile-avatar--uploaded', !!uploaded\)/);
   assert.match(source, /style\.backgroundImage = uploaded/);
@@ -145,9 +145,12 @@ test("every HTML page with a topbar loads the shared auth avatar bridge first", 
   assert.ok(files.length > 30, "expected the full topbar page inventory");
   for (const { file, source } of files){
     const authIndex = source.indexOf("/js/auth/supabaseClient.js");
+    const userUiIndex = source.indexOf("/js/user-ui-state.js");
     const topbarIndex = Math.max(source.indexOf("/js/topbar.js"), source.indexOf('src="js/topbar.js"'));
     assert.match(source, /(?:\/|\b)css\/portal\.css/, `${file} must load uploaded-avatar styles`);
-    assert.ok(authIndex >= 0, `${file} must load the shared auth avatar bridge`);
+    assert.match(source, /class="topbar"[^>]*data-user-ui-state="pending"/, `${file} must start pending before first paint`);
+    assert.ok(userUiIndex >= 0, `${file} must load user UI state`);
+    assert.ok(authIndex > userUiIndex, `${file} must load user UI state before auth`);
     assert.ok(topbarIndex > authIndex, `${file} must load auth before topbar`);
   }
 });

--- a/tests/user-ui-state.behavior.test.mjs
+++ b/tests/user-ui-state.behavior.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const source = await readFile(new URL('../js/user-ui-state.js', import.meta.url), 'utf8');
+
+function createContext(initial = {}){
+  const values = new Map(Object.entries(initial));
+  const topbar = { state: 'pending', setAttribute(name, value){ if (name === 'data-user-ui-state') this.state = value; } };
+  const listeners = {};
+  const window = {
+    localStorage: {
+      getItem(key){ return values.has(key) ? values.get(key) : null; },
+      setItem(key, value){ values.set(key, String(value)); },
+      removeItem(key){ values.delete(key); },
+    },
+    addEventListener(type, listener){ listeners[type] = listener; },
+    KLog: { log(){} },
+  };
+  const document = { querySelectorAll(){ return [topbar]; }, dispatchEvent(){} };
+  window.window = window;
+  vm.runInNewContext(source, { window, document, CustomEvent: class {}, Date, JSON });
+  return { api: window.UserUiState, values, topbar, listeners };
+}
+
+const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.stringify({
+  version: 1,
+  userId,
+  confirmedAt,
+  value: { displayName, avatar: { type: 'uploaded', variant: 'fox-blue', url: 'https://stage-test.supabase.co/avatar.webp' } },
+});
+
+{
+  const state = createContext({
+    'kcswh:user-ui:profile:v1:user-a': profileRecord('user-a', 'User A'),
+    'kcswh:user-ui:profile:v1:user-b': profileRecord('user-b', 'User B'),
+  });
+  const hydrated = state.api.hydrate('user-a');
+  const repeated = state.api.hydrate('user-a');
+  assert.equal(hydrated.profile.displayName, 'User A');
+  assert.equal(repeated.generation, hydrated.generation);
+  assert.equal(state.topbar.state, 'hydrated');
+  assert.equal(state.api.isCurrent('user-a', hydrated.generation), true);
+  assert.equal(state.api.publish('user-b', 'profile', { displayName: 'Wrong', avatar: {} }), null);
+}
+
+{
+  const cacheKey = 'kcswh:user-ui:profile:v1:user-a';
+  const state = createContext({ [cacheKey]: profileRecord('user-b', 'Wrong identity') });
+  const hydrated = state.api.hydrate('user-a');
+  assert.equal(hydrated.profile, null);
+  assert.equal(state.values.has(cacheKey), false);
+  assert.equal(state.topbar.state, 'loading');
+}
+
+{
+  const state = createContext();
+  const hydrated = state.api.hydrate('user-a');
+  const value = state.api.publish('user-a', 'profile', { displayName: 'Confirmed User', avatar: { type: 'default', variant: 'orbit-green' } }, Date.now());
+  assert.equal(value.displayName, 'Confirmed User');
+  assert.equal(state.topbar.state, 'ready');
+  assert.equal(state.values.has('kcswh:user-ui:profile:v1:user-a'), true);
+  state.api.clearUser('user-a');
+  assert.equal(state.values.has('kcswh:user-ui:profile:v1:user-a'), false);
+  assert.equal(state.api.isCurrent('user-a', hydrated.generation), false);
+  state.api.setAnonymous();
+  assert.equal(state.topbar.state, 'anonymous');
+}
+
+console.log('user UI state behavior tests passed');

--- a/tests/user-ui-state.behavior.test.mjs
+++ b/tests/user-ui-state.behavior.test.mjs
@@ -4,8 +4,8 @@ import vm from 'node:vm';
 
 const source = await readFile(new URL('../js/user-ui-state.js', import.meta.url), 'utf8');
 
-function createContext(initial = {}){
-  const values = new Map(Object.entries(initial));
+function createContext(initial = {}, options = {}){
+  const values = options.values || new Map(Object.entries(initial));
   const topbar = { state: 'pending', setAttribute(name, value){ if (name === 'data-user-ui-state') this.state = value; } };
   const listeners = {};
   const window = {
@@ -17,10 +17,24 @@ function createContext(initial = {}){
     addEventListener(type, listener){ listeners[type] = listener; },
     KLog: { log(){} },
   };
+  if (options.BroadcastChannel) window.BroadcastChannel = options.BroadcastChannel;
   const document = { querySelectorAll(){ return [topbar]; }, dispatchEvent(){} };
   window.window = window;
   vm.runInNewContext(source, { window, document, CustomEvent: class {}, Date, JSON });
   return { api: window.UserUiState, values, topbar, listeners };
+}
+
+function createChannelHub(){
+  const channels = [];
+  class BroadcastChannel {
+    constructor(){ this.listener = null; channels.push(this); }
+    addEventListener(type, listener){ if (type === 'message') this.listener = listener; }
+    postMessage(data){ channels.forEach((channel) => { if (channel !== this && channel.listener) channel.listener({ data }); }); }
+  }
+  return {
+    BroadcastChannel,
+    deliver(index, data){ if (channels[index] && channels[index].listener) channels[index].listener({ data }); },
+  };
 }
 
 const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.stringify({
@@ -42,6 +56,24 @@ const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.st
   assert.equal(state.topbar.state, 'hydrated');
   assert.equal(state.api.isCurrent('user-a', hydrated.generation), true);
   assert.equal(state.api.publish('user-b', 'profile', { displayName: 'Wrong', avatar: {} }), null);
+}
+
+{
+  const values = new Map();
+  const hub = createChannelHub();
+  const first = createContext({}, { values, BroadcastChannel: hub.BroadcastChannel });
+  const second = createContext({}, { values, BroadcastChannel: hub.BroadcastChannel });
+  const received = [];
+  first.api.hydrate('shared-user');
+  second.api.hydrate('shared-user');
+  second.api.onChange((event) => received.push(event));
+  const confirmedAt = Date.now();
+  first.api.publish('shared-user', 'profile', { displayName: 'Shared Avatar', avatar: { type: 'uploaded', variant: 'fox-blue', url: 'https://stage-test.supabase.co/new-avatar.webp' } }, confirmedAt);
+  assert.equal(received.length, 1);
+  assert.equal(received[0].value.avatar.url, 'https://stage-test.supabase.co/new-avatar.webp');
+  assert.equal(second.topbar.state, 'ready');
+  hub.deliver(1, received[0]);
+  assert.equal(received.length, 1);
 }
 
 {

--- a/xp.html
+++ b/xp.html
@@ -16,6 +16,7 @@
   <script src="js/i18n.js" defer></script>
   <script src="/js/auth/supabase-config.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
+  <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
   <script src="js/chips/client.js" defer></script>
   <script src="js/core/number-format.js" defer></script>
@@ -40,7 +41,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar">
+  <div class="topbar" data-user-ui-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>


### PR DESCRIPTION
## Summary
- retain the accepted User UI Hydration Plan v1.1
- implement PR 1: shared user-scoped UI cache infrastructure and auth generation guards
- hydrate cached profile identity/avatar across full-page navigation, then revalidate in the background
- add a source-markup pending state to every topbar page so initials and account values cannot flash before identity resolution
- synchronize profile cache updates across tabs with BroadcastChannel and storage-event fallback

## Scope
This implements infrastructure and avatar hydration only. XP and chips cache publication remain the planned follow-up PRs. No backend, database, migration, Redis, or environment changes.

## Verification
- `npm run check:all`
- `npm test`
- `node tests/public-profile-ui.contract.test.mjs`
- `node tests/user-ui-state.behavior.test.mjs`
- `PORT=4174 npx playwright test tests/e2e/topbar-profile-avatar.spec.js`
- `git diff --check`

## Breaking impact
- all pages with the shared topbar now load `/js/user-ui-state.js` before the auth bridge
- authenticated profile identity may be briefly stale while background revalidation runs
- logout/account switch clears identity-bound cache before rendering the next identity
- no API or persisted server-data contract changes