### PR TITLE
feat: hydrate cached XP in topbar

### DIFF
--- a/about.en.html
+++ b/about.en.html
@@ -40,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/about.pl.html
+++ b/about.pl.html
@@ -40,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/about/licenses.html
+++ b/about/licenses.html
@@ -51,7 +51,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/account.html
+++ b/account.html
@@ -105,7 +105,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body class="page-account">
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/admin.html
+++ b/admin.html
@@ -37,7 +37,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body class="page-admin">
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/css/portal.css
+++ b/css/portal.css
@@ -178,9 +178,10 @@ html[data-auth="out"] #chipBadge{ display:none !important; }
 .avatar-circle[data-avatar-variant="orbit-green"],.avatar-menu__initials[data-avatar-variant="orbit-green"]{ background:linear-gradient(145deg,#19755d,#74d9a0); }
 .avatar-circle[data-avatar-variant="default"],.avatar-menu__initials[data-avatar-variant="default"]{ background:linear-gradient(145deg,#355070,#6ee7e7); }
 .avatar-circle.profile-avatar--uploaded,.avatar-menu__initials.profile-avatar--uploaded{ background-position:center; background-size:cover; }
-.topbar[data-user-ui-state="pending"] .avatar-circle,.topbar[data-user-ui-state="loading"] .avatar-circle{ color:transparent; background-image:linear-gradient(110deg,rgba(110,231,231,.12) 25%,rgba(167,139,250,.28) 45%,rgba(110,231,231,.12) 65%); background-size:220% 100%; animation:user-ui-placeholder 1.2s linear infinite; }
-.topbar[data-user-ui-state="pending"] .avatar-label,.topbar[data-user-ui-state="loading"] .avatar-label{ visibility:hidden; }
-.topbar[data-user-ui-state="pending"] #xpBadge .xp-badge__label,.topbar[data-user-ui-state="loading"] #xpBadge .xp-badge__label,.topbar[data-user-ui-state="pending"] #chipBadgeAmount,.topbar[data-user-ui-state="loading"] #chipBadgeAmount{ visibility:hidden; }
+.topbar[data-user-ui-profile-state="pending"] .avatar-circle,.topbar[data-user-ui-profile-state="loading"] .avatar-circle{ color:transparent; background-image:linear-gradient(110deg,rgba(110,231,231,.12) 25%,rgba(167,139,250,.28) 45%,rgba(110,231,231,.12) 65%); background-size:220% 100%; animation:user-ui-placeholder 1.2s linear infinite; }
+.topbar[data-user-ui-profile-state="pending"] .avatar-label,.topbar[data-user-ui-profile-state="loading"] .avatar-label{ visibility:hidden; }
+.topbar[data-user-ui-xp-state="pending"] #xpBadge .xp-badge__label,.topbar[data-user-ui-xp-state="loading"] #xpBadge .xp-badge__label{ visibility:hidden; }
+.topbar[data-user-ui-chips-state="pending"] #chipBadgeAmount,.topbar[data-user-ui-chips-state="loading"] #chipBadgeAmount{ visibility:hidden; }
 @keyframes user-ui-placeholder{ 0%{background-position:100% 0;} 100%{background-position:-100% 0;} }
 .category-bar{display:flex; flex-wrap:wrap; gap:10px; margin:0 0 16px; padding:4px 0;}
 .category-bar .category-button{appearance:none; -webkit-appearance:none; border:1px solid var(--border); background:var(--card-2); color:#cdd6ff; font:600 13px Poppins, sans-serif; padding:8px 14px; border-radius:999px; cursor:pointer; transition:background .18s ease, border-color .18s ease, color .18s ease;}

--- a/docs/user-ui-hydration-plan-v1.1.md
+++ b/docs/user-ui-hydration-plan-v1.1.md
@@ -122,13 +122,13 @@ Non-game pages must not start an XP award session. Game pages preserve their cur
 
 Stale-while-revalidate alone does not prevent a flash if identity-bound HTML is visible before JavaScript resolves the local session. The initial document must therefore enforce this contract before the first observable paint:
 
-- Every topbar starts with `data-user-ui-state="pending"` in its HTML markup. JavaScript must not add the pending state after load.
+- Every topbar starts with `data-user-ui-profile-state="pending"`, `data-user-ui-xp-state="pending"`, and `data-user-ui-chips-state="pending"` in its HTML markup. JavaScript must not add the pending states after load. The legacy summary `data-user-ui-state` may remain for compatibility, but it must not control another slice's visibility.
 - While `pending`, avatar initials, display name, XP numbers, and chips numbers are not visible. Neutral skeletons reserve the final avatar and badge dimensions to prevent layout shift.
 - The pending UI contains no cached or hardcoded account values, including provisional `0 XP`, `CH: 0`, or user initials.
 - Shared `portal.css` selectors own the pending presentation across all pages. Individual pages must not define competing identity-loading behavior.
 - Initials may be rendered only after identity is known and the matching profile is confirmed to have no uploaded or cached uploaded avatar.
 
-After local session resolution, the state machine is:
+After local session resolution, each slice advances independently through the state machine:
 
 ```text
 pending -> hydrated    matching valid cache was applied
@@ -139,7 +139,7 @@ hydrated/loading -> stale   refresh failed; keep only matching cached values, ot
 any authenticated state -> pending/anonymous   logout or account switch clears rendered identity first
 ```
 
-The state attribute may live on the topbar or document root, but there must be one canonical owner and one shared selector contract. Hydration may occur only after Supabase returns the current `userId`; synchronous access to cache after that point should be applied in the same task before scheduling network revalidation.
+The slice state attributes may live on the topbar or document root, but there must be one canonical owner and one shared selector contract. Profile completion must not reveal XP or chips, and XP completion must not reveal profile or chips. Hydration may occur only after Supabase returns the current `userId`; a cached slice becomes `hydrated` only after its consumer applies the value to the DOM, not merely when storage is read.
 
 This design does not promise cached account data before identity resolution. It promises that from first paint until resolution the user sees a neutral, dimensionally stable placeholder, never incorrect initials or numeric account values.
 

--- a/favorites.html
+++ b/favorites.html
@@ -111,7 +111,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game.html
+++ b/game.html
@@ -39,7 +39,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game_cats.html
+++ b/game_cats.html
@@ -30,7 +30,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host data-game-slug="cats" data-game-id="cats">
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/game_trex.html
+++ b/game_trex.html
@@ -40,7 +40,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host data-game-slug="t-rex" data-game-id="t-rex">
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/2048/index.html
+++ b/games-open/2048/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="2048" data-game-id="2048">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/asteroids/index.html
+++ b/games-open/asteroids/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/asteroids/index.html
+++ b/games-open/asteroids/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="asteroids" data-game-id="asteroids">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/breakout/index.html
+++ b/games-open/breakout/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="breakout" data-game-id="breakout">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/breakout/index.html
+++ b/games-open/breakout/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/brick-breaker/index.html
+++ b/games-open/brick-breaker/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/brick-breaker/index.html
+++ b/games-open/brick-breaker/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="brick-breaker" data-game-id="brick-breaker">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/connect-four/index.html
+++ b/games-open/connect-four/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/connect-four/index.html
+++ b/games-open/connect-four/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="connect-four" data-game-id="connect-four">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/flappy/index.html
+++ b/games-open/flappy/index.html
@@ -29,7 +29,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="flappy" data-game-id="flappy">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/flappy/index.html
+++ b/games-open/flappy/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/freedoom/index.html
+++ b/games-open/freedoom/index.html
@@ -29,7 +29,7 @@
     <script src="../../js/consent-services.js" defer></script>
   </head>
   <body data-game-host data-game-slug="freedoom" data-game-id="freedoom">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/freedoom/index.html
+++ b/games-open/freedoom/index.html
@@ -19,6 +19,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/frogger/index.html
+++ b/games-open/frogger/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="frogger" data-game-id="frogger">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/frogger/index.html
+++ b/games-open/frogger/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/galaga/index.html
+++ b/games-open/galaga/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="galaga" data-game-id="galaga">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/galaga/index.html
+++ b/games-open/galaga/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/hangman/index.html
+++ b/games-open/hangman/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/hangman/index.html
+++ b/games-open/hangman/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="hangman" data-game-id="hangman">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/memory-match/index.html
+++ b/games-open/memory-match/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="memory-match" data-game-id="memory-match">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/memory-match/index.html
+++ b/games-open/memory-match/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/minesweeper/index.html
+++ b/games-open/minesweeper/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="minesweeper" data-game-id="minesweeper">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/minesweeper/index.html
+++ b/games-open/minesweeper/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/missile-command/index.html
+++ b/games-open/missile-command/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="missile-command" data-game-id="missile-command">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/missile-command/index.html
+++ b/games-open/missile-command/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="pacman" data-game-id="pacman">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/pacman/index.html
+++ b/games-open/pacman/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/pong/index.html
+++ b/games-open/pong/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="pong" data-game-id="pong">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/pong/index.html
+++ b/games-open/pong/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/simon/index.html
+++ b/games-open/simon/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/simon/index.html
+++ b/games-open/simon/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="simon" data-game-id="simon">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/snake/index.html
+++ b/games-open/snake/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/snake/index.html
+++ b/games-open/snake/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="snake" data-game-id="snake">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/sokoban/index.html
+++ b/games-open/sokoban/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/sokoban/index.html
+++ b/games-open/sokoban/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="sokoban" data-game-id="sokoban">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/solitaire/index.html
+++ b/games-open/solitaire/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/solitaire/index.html
+++ b/games-open/solitaire/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="solitaire" data-game-id="solitaire">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/space-invaders/index.html
+++ b/games-open/space-invaders/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="space-invaders" data-game-id="space-invaders">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/space-invaders/index.html
+++ b/games-open/space-invaders/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/sudoku/index.html
+++ b/games-open/sudoku/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="sudoku" data-game-id="sudoku">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/sudoku/index.html
+++ b/games-open/sudoku/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="tetris" data-game-id="tetris">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/tetris/index.html
+++ b/games-open/tetris/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/tic-tac-toe/index.html
+++ b/games-open/tic-tac-toe/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="tic-tac-toe" data-game-id="tic-tac-toe">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/games-open/tic-tac-toe/index.html
+++ b/games-open/tic-tac-toe/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/whac-a-mole/index.html
+++ b/games-open/whac-a-mole/index.html
@@ -20,6 +20,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
     <script src="/js/user-ui-state.js" defer></script>
     <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
     <script src="/js/topbar.js" defer></script>
     <script src="/js/xpClient.js" defer></script>
     <script src="/js/ui/xp-overlay.js" defer></script>

--- a/games-open/whac-a-mole/index.html
+++ b/games-open/whac-a-mole/index.html
@@ -30,7 +30,7 @@
   <script src="../../js/consent-services.js" defer></script>
 </head>
   <body data-game-host data-game-slug="whac-a-mole" data-game-id="whac-a-mole">
-    <div class="topbar" data-user-ui-state="pending">
+    <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
       <div class="topbar-left">
         <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
           <span></span><span></span><span></span>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/js/auth/supabaseClient.js
+++ b/js/auth/supabaseClient.js
@@ -355,6 +355,7 @@
     var hydrated = ui ? ui.hydrate(userId) : { generation: 0, profile: null };
     if (!ui) setUserUiState('loading');
     renderUser(user, hydrated.profile || null);
+    if (ui && hydrated.profile) ui.markSliceApplied(userId, 'profile', 'hydrated');
     refreshProfile(user, hydrated.generation, !!hydrated.profile);
   }
 

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -146,7 +146,7 @@
     } else if (badge.getAttribute('href') !== CHIP_BADGE_HREF){
       badge.setAttribute('href', CHIP_BADGE_HREF);
     }
-    let amount = doc.getElementById('chipBadgeAmount');
+    let amount = badge.querySelector('#chipBadgeAmount') || doc.getElementById('chipBadgeAmount');
     if (!amount){
       const label = badge.querySelector('.chip-badge__label');
       amount = doc.createElement('span');
@@ -166,7 +166,7 @@
         badge.appendChild(wrap);
       }
     }
-    let bonus = doc.getElementById('welcomeBonusTopbarBadge');
+    let bonus = badge.querySelector('#welcomeBonusTopbarBadge') || doc.getElementById('welcomeBonusTopbarBadge');
     if (!bonus){
       const label = badge.querySelector('.chip-badge__label');
       bonus = doc.createElement('span');
@@ -267,6 +267,9 @@
       : null;
     const text = amount == null ? '—' : formatter ? formatter(amount) : String(Math.round(amount));
     setChipBadge(text, { loading: false });
+    if (window.UserUiState && typeof window.UserUiState.markActiveSliceApplied === 'function'){
+      window.UserUiState.markActiveSliceApplied('chips', 'ready');
+    }
   }
 
   function setAuthState(next){

--- a/js/user-ui-state.js
+++ b/js/user-ui-state.js
@@ -10,6 +10,7 @@
   var generation = 0;
   var channel = null;
   var appliedAt = { profile: 0, xp: 0, chips: 0 };
+  var sliceStates = { profile: 'pending', xp: 'pending', chips: 'pending' };
 
   function klog(kind, data){
     try { if (window.KLog && typeof window.KLog.log === 'function') window.KLog.log(kind, data || {}); } catch (_err){}
@@ -83,6 +84,21 @@
     } catch (_err){}
   }
 
+  function setSliceState(slice, value){
+    if (!Object.prototype.hasOwnProperty.call(MAX_AGE, slice)) return false;
+    sliceStates[slice] = value;
+    try {
+      var bars = document.querySelectorAll('.topbar');
+      for (var i = 0; i < bars.length; i++) bars[i].setAttribute('data-user-ui-' + slice + '-state', value);
+    } catch (_err){}
+    if (slice === 'profile') setTopbarState(value);
+    return true;
+  }
+
+  function setAllSliceStates(value){
+    ['profile', 'xp', 'chips'].forEach(function(slice){ setSliceState(slice, value); });
+  }
+
   function emit(detail){
     for (var i = 0; i < listeners.length; i++){
       try { listeners[i](detail); } catch (_err){}
@@ -95,6 +111,7 @@
     if (activeUserId !== userId){
       generation += 1;
       appliedAt = { profile: 0, xp: 0, chips: 0 };
+      setAllSliceStates('loading');
     }
     activeUserId = userId;
     var result = { generation: generation, profile: null, xp: null, chips: null };
@@ -105,7 +122,6 @@
         appliedAt[slice] = record.confirmedAt;
       }
     });
-    setTopbarState(result.profile || result.xp || result.chips ? 'hydrated' : 'loading');
     return result;
   }
 
@@ -129,7 +145,7 @@
     var record = { version: VERSION, userId: userId, slice: slice, confirmedAt: timestamp, value: normalized };
     writeRecord(record);
     appliedAt[slice] = timestamp;
-    setTopbarState('ready');
+    setSliceState(slice, 'ready');
     emit(record);
     if (channel){ try { channel.postMessage(record); } catch (_err){} }
     return normalized;
@@ -141,14 +157,19 @@
     if (store){
       ['profile', 'xp', 'chips'].forEach(function(slice){ try { store.removeItem(key(slice, userId)); } catch (_err){} });
     }
-    if (activeUserId === userId){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; }
+    if (activeUserId === userId){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; setAllSliceStates('pending'); }
   }
 
-  function setAnonymous(){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; setTopbarState('anonymous'); }
+  function setAnonymous(){ activeUserId = null; appliedAt = { profile: 0, xp: 0, chips: 0 }; generation += 1; setAllSliceStates('anonymous'); }
+
+  function markSliceApplied(userId, slice, value){
+    if (activeUserId !== userId) return false;
+    return setSliceState(slice, value);
+  }
 
   function markRefreshFailed(userId, expectedGeneration, hasCachedValue){
     if (!isCurrent(userId, expectedGeneration)) return;
-    setTopbarState(hasCachedValue ? 'stale' : 'loading');
+    setSliceState('profile', hasCachedValue ? 'stale' : 'loading');
   }
 
   function onChange(listener){
@@ -166,7 +187,7 @@
     var accepted = { version: VERSION, userId: activeUserId, slice: record.slice, confirmedAt: confirmedAt, value: normalized };
     writeRecord(accepted);
     appliedAt[record.slice] = confirmedAt;
-    setTopbarState('ready');
+    setSliceState(record.slice, 'ready');
     emit(accepted);
   }
 
@@ -188,6 +209,6 @@
     if (parsed && parsed.userId === userId) acceptExternal(parsed);
   });
 
-  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markRefreshFailed: markRefreshFailed, onChange: onChange };
+  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markSliceApplied: markSliceApplied, markRefreshFailed: markRefreshFailed, onChange: onChange };
   klog('user_ui_state_ready', { version: VERSION });
 })();

--- a/js/user-ui-state.js
+++ b/js/user-ui-state.js
@@ -167,6 +167,11 @@
     return setSliceState(slice, value);
   }
 
+  function markActiveSliceApplied(slice, value){
+    if (!activeUserId) return false;
+    return setSliceState(slice, value);
+  }
+
   function markRefreshFailed(userId, expectedGeneration, hasCachedValue){
     if (!isCurrent(userId, expectedGeneration)) return;
     setSliceState('profile', hasCachedValue ? 'stale' : 'loading');
@@ -209,6 +214,6 @@
     if (parsed && parsed.userId === userId) acceptExternal(parsed);
   });
 
-  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markSliceApplied: markSliceApplied, markRefreshFailed: markRefreshFailed, onChange: onChange };
+  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markSliceApplied: markSliceApplied, markActiveSliceApplied: markActiveSliceApplied, markRefreshFailed: markRefreshFailed, onChange: onChange };
   klog('user_ui_state_ready', { version: VERSION });
 })();

--- a/js/xp/core.js
+++ b/js/xp/core.js
@@ -1182,6 +1182,14 @@ function bootXpCore(window, document) {
     return true;
   }
 
+  function publishConfirmedXp(data) {
+    try {
+      if (window.XPClient && typeof window.XPClient.publishConfirmedXp === "function") {
+        window.XPClient.publishConfirmedXp(data).catch(() => {});
+      }
+    } catch (_) {}
+  }
+
   function attachBadge() {
     if (state.badge) return;
     if (document && typeof document.querySelector === "function") {
@@ -1211,6 +1219,7 @@ function bootXpCore(window, document) {
   function handleResponse(data, meta) {
     const mergedMeta = Object.assign({}, meta);
     applyServerDelta(data, mergedMeta);
+    publishConfirmedXp(data);
     emitConfirmedAward(data, mergedMeta);
     setBadgeLoading(false);
     return data;
@@ -1272,7 +1281,7 @@ function bootXpCore(window, document) {
     const clientThinksAuthenticated = isAuthenticatedUser && typeof isAuthenticatedUser === "function"
       ? isAuthenticatedUser()
       : false;
-    const authenticated = serverThinksAuthenticated || clientThinksAuthenticated;
+    const authenticated = meta?.authenticated === true || serverThinksAuthenticated || clientThinksAuthenticated;
     const isExplicitReset =
       reason === "reset"
       || reason === "daily_reset"
@@ -2251,6 +2260,7 @@ function bootXpCore(window, document) {
     return window.XPClient.fetchStatus()
       .then((data) => {
         applyServerDelta(data, { source: "reconcile" });
+        publishConfirmedXp(data);
         try {
           logDebug("badge_reconcile", {
             badgeShownXp: Number(state.badgeShownXp) || 0,

--- a/js/xpClient.js
+++ b/js/xpClient.js
@@ -447,6 +447,71 @@
     try { window.localStorage.setItem(migrationMarkerKey(identity), "1"); } catch (_) {}
   }
 
+  function getUserUiState() {
+    return window.UserUiState && typeof window.UserUiState.hydrate === "function"
+      ? window.UserUiState
+      : null;
+  }
+
+  function validConfirmedTotal(payload) {
+    if (!payload || typeof payload !== "object" || payload.ok !== true) return null;
+    const total = Number(payload.totalLifetime);
+    return Number.isSafeInteger(total) && total >= 0 ? total : null;
+  }
+
+  function applyHydratedXp(value, attempt) {
+    const total = Number(value && value.totalLifetime);
+    const level = Number(value && value.level);
+    if (!Number.isSafeInteger(total) || total < 0 || !Number.isSafeInteger(level) || level < 1) return false;
+    if (!window.XP || typeof window.XP.refreshFromServerStatus !== "function") {
+      if ((attempt || 0) < 10) schedule(() => applyHydratedXp(value, (attempt || 0) + 1), 50);
+      return false;
+    }
+    try {
+      const snapshot = typeof window.XP.getSnapshot === "function" ? window.XP.getSnapshot() : null;
+      if (snapshot && snapshot.totalXp === total && snapshot.level === level) return true;
+      window.XP.refreshFromServerStatus({ ok: true, status: "statusOnly", totalLifetime: total }, {
+        source: "user-ui-cache",
+        allowServerRegression: true,
+        authenticated: true,
+        hydration: true,
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  async function hydrateCachedXp() {
+    const ui = getUserUiState();
+    if (!ui) return null;
+    const userId = await getAuthenticatedUserId();
+    if (!userId) return null;
+    const hydrated = ui.hydrate(userId);
+    if (!hydrated || !hydrated.xp) return null;
+    applyHydratedXp(hydrated.xp, 0);
+    return hydrated.xp;
+  }
+
+  async function publishConfirmedXp(payload) {
+    const total = validConfirmedTotal(payload);
+    const ui = getUserUiState();
+    if (total == null || !ui || !window.XP || typeof window.XP.getSnapshot !== "function") return null;
+    const snapshot = window.XP.getSnapshot();
+    if (!snapshot || snapshot.totalXp !== total || !Number.isSafeInteger(snapshot.level) || snapshot.level < 1) return null;
+    const userId = await getAuthenticatedUserId();
+    if (!userId) return null;
+    return ui.publish(userId, "xp", { totalLifetime: total, level: snapshot.level }, Date.now());
+  }
+
+  function bindUserUiXp() {
+    const ui = getUserUiState();
+    if (!ui || typeof ui.onChange !== "function") return;
+    ui.onChange((detail) => {
+      if (detail && detail.slice === "xp") applyHydratedXp(detail.value, 0);
+    });
+  }
+
   function schedule(callback, delay) {
     const timer = typeof window.setTimeout === "function"
       ? window.setTimeout.bind(window)
@@ -473,9 +538,10 @@
       preserveBadge: !!migrationLegacy,
     });
     klog("xp_auth_changed", { event: eventName });
-    schedule(() => migrationLegacy
-      ? refreshInitialStatus(migrationLegacy)
-      : refreshBadgeFromServer(), 0);
+    schedule(() => {
+      hydrateCachedXp().catch(() => {});
+      return migrationLegacy ? refreshInitialStatus(migrationLegacy) : refreshBadgeFromServer();
+    }, 0);
   }
 
   function bindAuthChanges(attempt) {
@@ -732,6 +798,7 @@
           });
         } catch (_) {}
       }
+      await publishConfirmedXp(payload);
       return payload;
     } catch (err) {
       klog("xp_refresh_error", { message: err && err.message ? String(err.message) : "error" });
@@ -886,8 +953,12 @@
     getSessionStatus,
     isInitialStatusPending,
     isAuthenticated,
+    hydrateCachedXp,
+    publishConfirmedXp,
   };
 
+  bindUserUiXp();
   bindAuthChanges();
+  schedule(() => hydrateCachedXp().catch(() => {}), 0);
   scheduleInitialStatusRefresh();
 })();

--- a/js/xpClient.js
+++ b/js/xpClient.js
@@ -36,6 +36,7 @@
     migrationNoticeClose: null,
     migrationNoticeLangBound: false,
     awardSessionId: null,
+    xpCacheHydrated: false,
   };
 
   function isDiagEnabled() {
@@ -459,23 +460,31 @@
     return Number.isSafeInteger(total) && total >= 0 ? total : null;
   }
 
-  function applyHydratedXp(value, attempt) {
+  function applyHydratedXp(value, attempt, userId, appliedState) {
     const total = Number(value && value.totalLifetime);
     const level = Number(value && value.level);
     if (!Number.isSafeInteger(total) || total < 0 || !Number.isSafeInteger(level) || level < 1) return false;
     if (!window.XP || typeof window.XP.refreshFromServerStatus !== "function") {
-      if ((attempt || 0) < 10) schedule(() => applyHydratedXp(value, (attempt || 0) + 1), 50);
+      if ((attempt || 0) < 10) schedule(() => applyHydratedXp(value, (attempt || 0) + 1, userId, appliedState), 50);
       return false;
     }
     try {
       const snapshot = typeof window.XP.getSnapshot === "function" ? window.XP.getSnapshot() : null;
-      if (snapshot && snapshot.totalXp === total && snapshot.level === level) return true;
+      if (snapshot && snapshot.totalXp === total && snapshot.level === level) {
+        const ui = getUserUiState();
+        if (ui && userId && typeof ui.markSliceApplied === "function") ui.markSliceApplied(userId, "xp", appliedState || "hydrated");
+        state.xpCacheHydrated = true;
+        return true;
+      }
       window.XP.refreshFromServerStatus({ ok: true, status: "statusOnly", totalLifetime: total }, {
         source: "user-ui-cache",
         allowServerRegression: true,
         authenticated: true,
         hydration: true,
       });
+      const ui = getUserUiState();
+      if (ui && userId && typeof ui.markSliceApplied === "function") ui.markSliceApplied(userId, "xp", appliedState || "hydrated");
+      state.xpCacheHydrated = true;
       return true;
     } catch (_) {
       return false;
@@ -489,7 +498,7 @@
     if (!userId) return null;
     const hydrated = ui.hydrate(userId);
     if (!hydrated || !hydrated.xp) return null;
-    applyHydratedXp(hydrated.xp, 0);
+    applyHydratedXp(hydrated.xp, 0, userId, "hydrated");
     return hydrated.xp;
   }
 
@@ -501,14 +510,16 @@
     if (!snapshot || snapshot.totalXp !== total || !Number.isSafeInteger(snapshot.level) || snapshot.level < 1) return null;
     const userId = await getAuthenticatedUserId();
     if (!userId) return null;
-    return ui.publish(userId, "xp", { totalLifetime: total, level: snapshot.level }, Date.now());
+    const published = ui.publish(userId, "xp", { totalLifetime: total, level: snapshot.level }, Date.now());
+    if (published) state.xpCacheHydrated = true;
+    return published;
   }
 
   function bindUserUiXp() {
     const ui = getUserUiState();
     if (!ui || typeof ui.onChange !== "function") return;
     ui.onChange((detail) => {
-      if (detail && detail.slice === "xp") applyHydratedXp(detail.value, 0);
+      if (detail && detail.slice === "xp") applyHydratedXp(detail.value, 0, detail.userId, "ready");
     });
   }
 
@@ -532,6 +543,7 @@
     state.statusBootstrapped = false;
     state.statusPromise = null;
     state.awardSessionId = randomId();
+    state.xpCacheHydrated = false;
     clearServerSession();
     clearIdentityBoundXpCache({
       preserveLegacy: !!migrationLegacy,
@@ -801,6 +813,10 @@
       await publishConfirmedXp(payload);
       return payload;
     } catch (err) {
+      getAuthenticatedUserId().then((userId) => {
+        const ui = getUserUiState();
+        if (userId && ui && typeof ui.markSliceApplied === "function") ui.markSliceApplied(userId, "xp", state.xpCacheHydrated ? "stale" : "loading");
+      }).catch(() => {});
       klog("xp_refresh_error", { message: err && err.message ? String(err.message) : "error" });
       return null;
     }

--- a/legal/cookies-notice.en.html
+++ b/legal/cookies-notice.en.html
@@ -17,6 +17,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
   <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
   <script src="../js/topbar.js" defer></script>
   <script src="../js/xpClient.js" defer></script>
   <script src="/js/ui/xp-overlay.js" defer></script>

--- a/legal/cookies-notice.en.html
+++ b/legal/cookies-notice.en.html
@@ -36,7 +36,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/cookies-notice.pl.html
+++ b/legal/cookies-notice.pl.html
@@ -17,6 +17,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js" defer></script>
   <script src="/js/user-ui-state.js" defer></script>
   <script src="/js/auth/supabaseClient.js" defer></script>
+  <script src="/js/chips/client.js" defer></script>
   <script src="../js/topbar.js" defer></script>
   <script src="../js/xpClient.js" defer></script>
   <script src="/js/ui/xp-overlay.js" defer></script>

--- a/legal/cookies-notice.pl.html
+++ b/legal/cookies-notice.pl.html
@@ -36,7 +36,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/privacy.en.html
+++ b/legal/privacy.en.html
@@ -38,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/privacy.pl.html
+++ b/legal/privacy.pl.html
@@ -38,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/terms.en.html
+++ b/legal/terms.en.html
@@ -38,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/legal/terms.pl.html
+++ b/legal/terms.pl.html
@@ -38,7 +38,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/play.html
+++ b/play.html
@@ -55,7 +55,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body data-game-host>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/poker/index.html
+++ b/poker/index.html
@@ -37,7 +37,7 @@
   <script src="../js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/profile.html
+++ b/profile.html
@@ -28,7 +28,7 @@
   <script src="/js/public-profile-page.js" defer></script>
 </head>
 <body>
-  <header class="topbar" data-user-ui-state="pending">
+  <header class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <a href="/index.html" class="brand" aria-label="Arcade Hub home"><div class="logo" aria-hidden="true"></div><h1>Arcade Hub</h1></a>
     </div>

--- a/recently-played.html
+++ b/recently-played.html
@@ -85,7 +85,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>

--- a/tests/e2e/topbar-profile-avatar.spec.js
+++ b/tests/e2e/topbar-profile-avatar.spec.js
@@ -19,6 +19,11 @@ async function mockAuthenticatedSession(page) {
       } }; } };
     `,
   }));
+  await page.route('**/.netlify/functions/chips-balance', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ balance: 896 }),
+  }));
 }
 
 const profile = () => ({
@@ -52,6 +57,8 @@ test.describe('authenticated topbar profile avatar', () => {
       await expect(avatar).toHaveText('');
       await expect(menuAvatar).toHaveClass(/profile-avatar--uploaded/);
       await expect(menuAvatar).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
+      await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'ready');
+      await expect(page.locator('#chipBadgeAmount')).toHaveText('896');
     });
   }
 

--- a/tests/e2e/topbar-profile-avatar.spec.js
+++ b/tests/e2e/topbar-profile-avatar.spec.js
@@ -58,9 +58,11 @@ test.describe('authenticated topbar profile avatar', () => {
   test('hydrates the cached avatar before delayed revalidation without a visible initials frame', async ({ page }) => {
     await mockAuthenticatedSession(page);
     let requests = 0;
+    let releaseProfile;
+    const profileGate = new Promise((resolve) => { releaseProfile = resolve; });
     await page.route('**/.netlify/functions/profile-me', async (route) => {
       requests += 1;
-      if (requests > 1) await new Promise((resolve) => setTimeout(resolve, 1200));
+      if (requests > 1) await profileGate;
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(profile()) });
     });
     await page.addInitScript(() => {
@@ -85,10 +87,15 @@ test.describe('authenticated topbar profile avatar', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#avatarInitials')).toHaveClass(/profile-avatar--uploaded/);
     await page.goto('/games-open/2048/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-state', 'hydrated');
+    await expect.poll(() => requests).toBe(2);
+    await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-profile-state', 'hydrated');
     await expect(page.locator('#avatarInitials')).toHaveClass(/profile-avatar--uploaded/);
+    await expect(page.locator('#avatarInitials')).toHaveCSS('background-image', `url("${AVATAR_URL}")`);
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
     const frames = await page.evaluate(() => window.__avatarFrames);
     assertNoVisibleInitials(frames);
+    releaseProfile();
+    await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-profile-state', 'ready');
   });
 });
 

--- a/tests/e2e/topbar-xp-hydration.spec.js
+++ b/tests/e2e/topbar-xp-hydration.spec.js
@@ -1,0 +1,84 @@
+const { test, expect } = require('@playwright/test');
+
+const USER_ID = 'xp-hydration-user';
+const CACHE_KEY = `kcswh:user-ui:xp:v1:${USER_ID}`;
+
+async function mockAuthenticatedSession(page) {
+  await page.route('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js', (route) => route.fulfill({ contentType: 'application/javascript', body: '' }));
+  await page.route('**/js/auth/supabase-config.js', (route) => route.fulfill({
+    contentType: 'application/javascript',
+    body: `
+      window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
+      window.supabase = { createClient: function(){ return { auth: {
+        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: '${USER_ID}', email: 'private@example.test' } } } }); },
+        onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
+        signOut: function(){ return Promise.resolve(); }
+      } }; } };
+    `,
+  }));
+  await page.route('**/.netlify/functions/profile-me', (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ displayName: 'XP Player', avatar: { type: 'default', variant: 'fox-blue' } }),
+  }));
+}
+
+test('hydrates confirmed XP without an award animation and revalidates in the background', async ({ page }) => {
+  await mockAuthenticatedSession(page);
+  await page.addInitScript(({ key, userId }) => {
+    localStorage.setItem(key, JSON.stringify({
+      version: 1,
+      userId,
+      confirmedAt: Date.now(),
+      value: { totalLifetime: 300, level: 3 },
+    }));
+    window.__confirmedAwards = 0;
+    window.addEventListener('xp:award-confirmed', () => { window.__confirmedAwards += 1; });
+  }, { key: CACHE_KEY, userId: USER_ID });
+
+  let releaseStatus;
+  const statusGate = new Promise((resolve) => { releaseStatus = resolve; });
+  await page.route('**/.netlify/functions/calculate-xp', async (route) => {
+    const body = route.request().postDataJSON();
+    if (body.operation === 'status') {
+      await statusGate;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true, status: 'statusOnly', totalLifetime: 450, cap: 3000 }) });
+    }
+    return route.fulfill({ status: 400, contentType: 'application/json', body: JSON.stringify({ error: 'unexpected_award' }) });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  const badge = page.locator('#xpBadge');
+  await expect(badge.locator('.xp-badge__label')).toHaveText('Lvl 3, 300 XP');
+  await expect(badge).not.toHaveClass(/xp-badge--bump/);
+  expect(await page.evaluate(() => window.__confirmedAwards)).toBe(0);
+
+  releaseStatus();
+  await expect(badge.locator('.xp-badge__label')).toHaveText('Lvl 4, 450 XP');
+  await expect.poll(() => page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.totalLifetime, CACHE_KEY)).toBe(450);
+  await expect(badge).not.toHaveClass(/xp-badge--bump/);
+  expect(await page.evaluate(() => window.__confirmedAwards)).toBe(0);
+});
+
+test('keeps cached XP visible when status revalidation fails', async ({ page }) => {
+  await mockAuthenticatedSession(page);
+  await page.addInitScript(({ key, userId }) => {
+    localStorage.setItem(key, JSON.stringify({
+      version: 1,
+      userId,
+      confirmedAt: Date.now(),
+      value: { totalLifetime: 300, level: 3 },
+    }));
+  }, { key: CACHE_KEY, userId: USER_ID });
+  await page.route('**/.netlify/functions/calculate-xp', (route) => route.fulfill({
+    status: 500,
+    contentType: 'application/json',
+    body: JSON.stringify({ error: 'server_error' }),
+  }));
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#xpBadge .xp-badge__label')).toHaveText('Lvl 3, 300 XP');
+  await page.waitForTimeout(250);
+  await expect(page.locator('#xpBadge .xp-badge__label')).toHaveText('Lvl 3, 300 XP');
+  expect(await page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.totalLifetime, CACHE_KEY)).toBe(300);
+});

--- a/tests/e2e/topbar-xp-hydration.spec.js
+++ b/tests/e2e/topbar-xp-hydration.spec.js
@@ -2,6 +2,11 @@ const { test, expect } = require('@playwright/test');
 
 const USER_ID = 'xp-hydration-user';
 const CACHE_KEY = `kcswh:user-ui:xp:v1:${USER_ID}`;
+const PROFILE_CACHE_KEY = `kcswh:user-ui:profile:v1:${USER_ID}`;
+
+function cachedProfile() {
+  return { version: 1, userId: USER_ID, confirmedAt: Date.now(), value: { displayName: 'XP Player', avatar: { type: 'default', variant: 'fox-blue' } } };
+}
 
 async function mockAuthenticatedSession(page) {
   await page.route('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js', (route) => route.fulfill({ contentType: 'application/javascript', body: '' }));
@@ -32,9 +37,21 @@ test('hydrates confirmed XP without an award animation and revalidates in the ba
       confirmedAt: Date.now(),
       value: { totalLifetime: 300, level: 3 },
     }));
+    localStorage.setItem(`kcswh:user-ui:profile:v1:${userId}`, JSON.stringify({ version: 1, userId, confirmedAt: Date.now(), value: { displayName: 'XP Player', avatar: { type: 'default', variant: 'fox-blue' } } }));
     window.__confirmedAwards = 0;
+    window.__xpFrames = [];
     window.addEventListener('xp:award-confirmed', () => { window.__confirmedAwards += 1; });
+    function sample(){
+      const label = document.querySelector('#xpBadge .xp-badge__label');
+      if (label) window.__xpFrames.push({ text: label.textContent.trim(), visibility: getComputedStyle(label).visibility });
+      requestAnimationFrame(sample);
+    }
+    requestAnimationFrame(sample);
   }, { key: CACHE_KEY, userId: USER_ID });
+  await page.route('**/js/xp/core.js', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    await route.continue();
+  });
 
   let releaseStatus;
   const statusGate = new Promise((resolve) => { releaseStatus = resolve; });
@@ -50,6 +67,10 @@ test('hydrates confirmed XP without an award animation and revalidates in the ba
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   const badge = page.locator('#xpBadge');
   await expect(badge.locator('.xp-badge__label')).toHaveText('Lvl 3, 300 XP');
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const visibleBeforeStatus = await page.evaluate(() => window.__xpFrames.filter((frame) => frame.visibility === 'visible').map((frame) => frame.text));
+  expect(visibleBeforeStatus[0]).toBe('Lvl 3, 300 XP');
+  expect(visibleBeforeStatus.some((text) => /Lvl 1, 0 XP/.test(text))).toBe(false);
   await expect(badge).not.toHaveClass(/xp-badge--bump/);
   expect(await page.evaluate(() => window.__confirmedAwards)).toBe(0);
 
@@ -60,16 +81,9 @@ test('hydrates confirmed XP without an award animation and revalidates in the ba
   expect(await page.evaluate(() => window.__confirmedAwards)).toBe(0);
 });
 
-test('keeps cached XP visible when status revalidation fails', async ({ page }) => {
+test('keeps XP neutral when profile resolves and status fails without an XP cache', async ({ page }) => {
   await mockAuthenticatedSession(page);
-  await page.addInitScript(({ key, userId }) => {
-    localStorage.setItem(key, JSON.stringify({
-      version: 1,
-      userId,
-      confirmedAt: Date.now(),
-      value: { totalLifetime: 300, level: 3 },
-    }));
-  }, { key: CACHE_KEY, userId: USER_ID });
+  await page.addInitScript(({ key, profile }) => { localStorage.setItem(key, JSON.stringify(profile)); }, { key: PROFILE_CACHE_KEY, profile: cachedProfile() });
   await page.route('**/.netlify/functions/calculate-xp', (route) => route.fulfill({
     status: 500,
     contentType: 'application/json',
@@ -77,8 +91,9 @@ test('keeps cached XP visible when status revalidation fails', async ({ page }) 
   }));
 
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await expect(page.locator('#xpBadge .xp-badge__label')).toHaveText('Lvl 3, 300 XP');
   await page.waitForTimeout(250);
-  await expect(page.locator('#xpBadge .xp-badge__label')).toHaveText('Lvl 3, 300 XP');
-  expect(await page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.totalLifetime, CACHE_KEY)).toBe(300);
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-profile-state', /hydrated|ready/);
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-xp-state', 'loading');
+  await expect(page.locator('#xpBadge .xp-badge__label')).toHaveCSS('visibility', 'hidden');
+  await expect(page.locator('#xpBadge .xp-badge__label')).not.toHaveText('Lvl 1, 0 XP');
 });

--- a/tests/public-profile-ui.contract.test.mjs
+++ b/tests/public-profile-ui.contract.test.mjs
@@ -146,12 +146,14 @@ test("every HTML page with a topbar loads the shared auth avatar bridge first", 
   for (const { file, source } of files){
     const authIndex = source.indexOf("/js/auth/supabaseClient.js");
     const userUiIndex = source.indexOf("/js/user-ui-state.js");
+    const chipsIndex = Math.max(source.indexOf("/js/chips/client.js"), source.indexOf('src="js/chips/client.js"'));
     const topbarIndex = Math.max(source.indexOf("/js/topbar.js"), source.indexOf('src="js/topbar.js"'));
     assert.match(source, /(?:\/|\b)css\/portal\.css/, `${file} must load uploaded-avatar styles`);
     assert.match(source, /class="topbar"[^>]*data-user-ui-state="pending"/, `${file} must start pending before first paint`);
     assert.match(source, /class="topbar"[^>]*data-user-ui-profile-state="pending"[^>]*data-user-ui-xp-state="pending"[^>]*data-user-ui-chips-state="pending"/, `${file} must start every user UI slice pending`);
     assert.ok(userUiIndex >= 0, `${file} must load user UI state`);
     assert.ok(authIndex > userUiIndex, `${file} must load user UI state before auth`);
-    assert.ok(topbarIndex > authIndex, `${file} must load auth before topbar`);
+    assert.ok(chipsIndex > authIndex, `${file} must load the chips client after auth`);
+    assert.ok(topbarIndex > chipsIndex, `${file} must load the chips client before topbar`);
   }
 });

--- a/tests/public-profile-ui.contract.test.mjs
+++ b/tests/public-profile-ui.contract.test.mjs
@@ -149,6 +149,7 @@ test("every HTML page with a topbar loads the shared auth avatar bridge first", 
     const topbarIndex = Math.max(source.indexOf("/js/topbar.js"), source.indexOf('src="js/topbar.js"'));
     assert.match(source, /(?:\/|\b)css\/portal\.css/, `${file} must load uploaded-avatar styles`);
     assert.match(source, /class="topbar"[^>]*data-user-ui-state="pending"/, `${file} must start pending before first paint`);
+    assert.match(source, /class="topbar"[^>]*data-user-ui-profile-state="pending"[^>]*data-user-ui-xp-state="pending"[^>]*data-user-ui-chips-state="pending"/, `${file} must start every user UI slice pending`);
     assert.ok(userUiIndex >= 0, `${file} must load user UI state`);
     assert.ok(authIndex > userUiIndex, `${file} must load user UI state before auth`);
     assert.ok(topbarIndex > authIndex, `${file} must load auth before topbar`);

--- a/tests/user-ui-state.behavior.test.mjs
+++ b/tests/user-ui-state.behavior.test.mjs
@@ -96,6 +96,8 @@ const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.st
   assert.equal(value.displayName, 'Confirmed User');
   assert.equal(state.topbar.state, 'ready');
   assert.equal(state.values.has('kcswh:user-ui:profile:v1:user-a'), true);
+  assert.equal(state.api.markActiveSliceApplied('chips', 'ready'), true);
+  assert.equal(state.topbar.attributes['data-user-ui-chips-state'], 'ready');
   state.api.clearUser('user-a');
   assert.equal(state.values.has('kcswh:user-ui:profile:v1:user-a'), false);
   assert.equal(state.api.isCurrent('user-a', hydrated.generation), false);

--- a/tests/user-ui-state.behavior.test.mjs
+++ b/tests/user-ui-state.behavior.test.mjs
@@ -6,7 +6,7 @@ const source = await readFile(new URL('../js/user-ui-state.js', import.meta.url)
 
 function createContext(initial = {}, options = {}){
   const values = options.values || new Map(Object.entries(initial));
-  const topbar = { state: 'pending', setAttribute(name, value){ if (name === 'data-user-ui-state') this.state = value; } };
+  const topbar = { state: 'pending', attributes: {}, setAttribute(name, value){ this.attributes[name] = value; if (name === 'data-user-ui-state') this.state = value; } };
   const listeners = {};
   const window = {
     localStorage: {
@@ -53,7 +53,11 @@ const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.st
   const repeated = state.api.hydrate('user-a');
   assert.equal(hydrated.profile.displayName, 'User A');
   assert.equal(repeated.generation, hydrated.generation);
+  assert.equal(state.topbar.state, 'loading');
+  assert.equal(state.topbar.attributes['data-user-ui-xp-state'], 'loading');
+  state.api.markSliceApplied('user-a', 'profile', 'hydrated');
   assert.equal(state.topbar.state, 'hydrated');
+  assert.equal(state.topbar.attributes['data-user-ui-xp-state'], 'loading');
   assert.equal(state.api.isCurrent('user-a', hydrated.generation), true);
   assert.equal(state.api.publish('user-b', 'profile', { displayName: 'Wrong', avatar: {} }), null);
 }

--- a/tests/xp-client-contract.test.mjs
+++ b/tests/xp-client-contract.test.mjs
@@ -113,6 +113,45 @@ async function loadClientWithFetch(fetchImpl, options = {}) {
     assert.equal(applied.meta.bump, undefined);
   }
 
+  // Authenticated XP cache hydrates without award animation and publishes only confirmed snapshots.
+  {
+    let applied = null;
+    let userUiListener = null;
+    const published = [];
+    const cached = { totalLifetime: 300, level: 3 };
+    const XPClient = await loadClientWithFetch(async () => response(200, { ok: true, status: 'statusOnly', totalLifetime: 300 }), {
+      window: {
+        SupabaseAuthBridge: {
+          getAccessToken: async () => 'token',
+          getCurrentUserId: async () => 'xp-user',
+        },
+        UserUiState: {
+          hydrate(userId){ assert.equal(userId, 'xp-user'); return { xp: cached }; },
+          publish(userId, slice, value){ published.push({ userId, slice, value }); return value; },
+          onChange(listener){ userUiListener = listener; },
+        },
+        XP: {
+          refreshFromServerStatus(payload, meta){ applied = { payload, meta }; },
+          getSnapshot(){ return { totalXp: applied ? applied.payload.totalLifetime : 0, level: applied && applied.payload.totalLifetime === 450 ? 4 : (applied ? 3 : 1) }; },
+        },
+      },
+    });
+    const hydrated = await XPClient.hydrateCachedXp();
+    assert.deepEqual(hydrated, cached);
+    assert.equal(applied.payload.totalLifetime, 300);
+    assert.equal(applied.meta.source, 'user-ui-cache');
+    assert.equal(applied.meta.authenticated, true);
+    assert.equal(applied.meta.hydration, true);
+    assert.equal(applied.meta.bump, undefined);
+    await XPClient.publishConfirmedXp({ ok: true, totalLifetime: 300 });
+    assert.equal(JSON.stringify(published), JSON.stringify([{ userId: 'xp-user', slice: 'xp', value: cached }]));
+    await XPClient.publishConfirmedXp({ ok: false, totalLifetime: 900 });
+    assert.equal(published.length, 1);
+    userUiListener({ slice: 'xp', value: { totalLifetime: 450, level: 4 } });
+    assert.equal(applied.payload.totalLifetime, 450);
+    assert.equal(applied.meta.hydration, true);
+  }
+
   // Reaching the server-side session cap rotates the next award session.
   {
     const awardCalls = [];

--- a/xp.html
+++ b/xp.html
@@ -41,7 +41,7 @@
   <script src="js/consent-services.js" defer></script>
 </head>
 <body>
-  <div class="topbar" data-user-ui-state="pending">
+  <div class="topbar" data-user-ui-state="pending" data-user-ui-profile-state="pending" data-user-ui-xp-state="pending" data-user-ui-chips-state="pending">
     <div class="topbar-left">
       <button class="hamburger" id="sbToggle" aria-label="Toggle navigation" aria-expanded="false">
         <span></span><span></span><span></span>


### PR DESCRIPTION
## Summary
- implement phase 2 of User UI Hydration Plan v1.1
- track profile, XP, and chips readiness independently from the first HTML paint
- hydrate authenticated XP badge from a user-scoped, server-confirmed cache
- reveal cached XP only after the XP consumer has applied it
- revalidate through `calculate-xp operation=status` in the background
- publish successful status, reconciliation, and award totals back to the shared cache
- apply cached and cross-tab XP updates without award animation
- keep XP neutral when no safe cache exists and status refresh fails
- load the existing chips client on every topbar page and reveal CH only after a confirmed balance read
- prevent duplicate detached chip amount/bonus nodes

## Verification
- `npm run check:all`
- `npm test`
- `node tests/xp-client-contract.test.mjs`
- `node tests/user-ui-state.behavior.test.mjs`
- `node tests/public-profile-ui.contract.test.mjs`
- `PORT=4174 npx playwright test tests/e2e/topbar-profile-avatar.spec.js tests/e2e/topbar-xp-hydration.spec.js`
- `git diff --check`

## Breaking impact
- every topbar now carries independent profile, XP, and chips readiness attributes
- all 45 topbar pages now load the existing `/js/chips/client.js`
- the badge may show the last server-confirmed XP for up to 15 minutes while revalidation is pending
- cached values are presentation-only and never award XP or authorize gameplay
- no backend, Redis, database, migration, CSP, or environment changes