### PR TITLE
feat: hydrate cached chips in topbar

### DIFF
--- a/js/chips/client.js
+++ b/js/chips/client.js
@@ -8,7 +8,14 @@
   var BONUS_CAMPAIGNS_URL = '/.netlify/functions/bonus-campaigns';
   var AUTH_CACHE_MS = 60000;
 
-  var state = { token: null, checkedAt: 0, tokenPromise: null };
+  var state = { token: null, checkedAt: 0, tokenPromise: null, authGeneration: 0 };
+
+  function clearAuthCache(){
+    state.authGeneration += 1;
+    state.token = null;
+    state.checkedAt = 0;
+    state.tokenPromise = null;
+  }
 
   function toNumber(value){
     var num = Number(value);
@@ -107,7 +114,8 @@
       return state.tokenPromise;
     }
 
-    state.tokenPromise = (async function(){
+    var authGeneration = state.authGeneration;
+    var tokenPromise = (async function(){
       try {
         var token = null;
         var bridge = getAuthBridge();
@@ -127,17 +135,21 @@
           }
         }
 
+        if (authGeneration !== state.authGeneration) return null;
         state.token = token || null;
         state.checkedAt = Date.now();
         return state.token;
       } catch (_err){
+        if (authGeneration !== state.authGeneration) return null;
         state.token = null;
         state.checkedAt = Date.now();
         return null;
-      } finally {
-        state.tokenPromise = null;
       }
     })();
+    state.tokenPromise = tokenPromise;
+    tokenPromise.then(function(){
+      if (authGeneration === state.authGeneration && state.tokenPromise === tokenPromise) state.tokenPromise = null;
+    });
 
     return state.tokenPromise;
   }
@@ -320,6 +332,7 @@
     fetchBonusCampaigns: fetchBonusCampaigns,
     claimBonusCampaign: claimBonusCampaign,
     fetchState: fetchState,
+    clearAuthCache: clearAuthCache,
     refreshAuth: function(){ return fetchAuthToken(true); }
   };
 })();

--- a/js/chips/client.js
+++ b/js/chips/client.js
@@ -191,10 +191,17 @@
   }
 
   async function fetchBalance(){
+    var ui = window.UserUiState;
+    var uiContext = ui && typeof ui.getActiveContext === 'function' ? ui.getActiveContext() : null;
     var payload = await authedFetchWithRetry(BALANCE_URL, { method: 'GET' });
     if (payload && payload.data){
       var parsed = toNumber(payload.data.balance);
       if (parsed != null){ payload.data.balance = parsed; }
+    }
+    if (payload && payload.data && Number.isSafeInteger(payload.data.balance) && payload.data.balance >= 0){
+      if (uiContext && ui && typeof ui.isCurrent === 'function' && ui.isCurrent(uiContext.userId, uiContext.generation)){
+        ui.publish(uiContext.userId, 'chips', { balance: payload.data.balance }, Date.now());
+      }
     }
     emit('chips:balance', payload.data);
     return payload.data;

--- a/js/chips/client.js
+++ b/js/chips/client.js
@@ -210,8 +210,13 @@
       var parsed = toNumber(payload.data.balance);
       if (parsed != null){ payload.data.balance = parsed; }
     }
+    var contextIsCurrent = !uiContext
+      || !ui
+      || typeof ui.isCurrent !== 'function'
+      || ui.isCurrent(uiContext.userId, uiContext.generation);
+    if (!contextIsCurrent) return null;
     if (payload && payload.data && Number.isSafeInteger(payload.data.balance) && payload.data.balance >= 0){
-      if (uiContext && ui && typeof ui.isCurrent === 'function' && ui.isCurrent(uiContext.userId, uiContext.generation)){
+      if (uiContext && ui && typeof ui.publish === 'function'){
         ui.publish(uiContext.userId, 'chips', { balance: payload.data.balance }, Date.now());
       }
     }

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -294,10 +294,10 @@
     return true;
   }
 
-  function prepareChipIdentity(){
+  function prepareChipIdentity(expectedUserId){
     const ui = window.UserUiState;
     const context = ui && typeof ui.getActiveContext === 'function' ? ui.getActiveContext() : null;
-    const userId = context && context.userId ? context.userId : null;
+    const userId = expectedUserId || (context && context.userId ? context.userId : null);
     if (userId && userId === chipIdentityUserId){
       if (!chipHasHydratedValue) hydrateChipBadge();
       return;
@@ -306,7 +306,8 @@
     chipInFlight = null;
     chipHasHydratedValue = false;
     chipIdentityUserId = userId;
-    if (!hydrateChipBadge()) setChipBadge('', { loading: true });
+    const contextMatches = !expectedUserId || (context && context.userId === expectedUserId);
+    if (!contextMatches || !hydrateChipBadge()) setChipBadge('', { loading: true });
   }
 
   function setAuthState(next){
@@ -344,7 +345,7 @@
         hideChipBadge();
         return;
       }
-      prepareChipIdentity();
+      prepareChipIdentity(user && user.id ? String(user.id) : null);
       refreshXpBadge();
       refreshChipBadge();
       refreshWelcomeBonusBadge();
@@ -466,13 +467,14 @@
       hideWelcomeBonusBadge();
       return;
     }
-    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION'){
+    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION' || event === 'USER_UPDATED'){
       setAuthState(hasUser ? AuthState.SIGNED_IN : AuthState.SIGNED_OUT);
       if (!isAuthed()){
         hideChipBadge();
         hideWelcomeBonusBadge();
         return;
       }
+      prepareChipIdentity(user && user.id ? String(user.id) : (session && session.user && session.user.id ? String(session.user.id) : null));
       refreshXpBadge();
       refreshChipBadge();
       refreshWelcomeBonusBadge();

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -6,6 +6,9 @@
   win.__topbarBooted = true;
   const chipNodes = { badge: null, amount: null, bonus: null, ready: false };
   let chipInFlight = null;
+  let chipHasHydratedValue = false;
+  let chipRequestGeneration = 0;
+  let chipIdentityUserId = null;
   let welcomeBonusInFlight = null;
   let chipsClientWaitTries = 0;
   let welcomeBonusClientWaitTries = 0;
@@ -260,16 +263,50 @@
     chipNodes.bonus.hidden = false;
   }
 
-  function renderChipBadgeBalance(amount){
+  function renderChipBadgeBalance(amount, uiState){
     const formatKey = 'format' + 'CompactNumber';
     const formatter = window && window.ArcadeFormat && typeof window.ArcadeFormat[formatKey] === 'function'
       ? window.ArcadeFormat[formatKey]
       : null;
     const text = amount == null ? '—' : formatter ? formatter(amount) : String(Math.round(amount));
     setChipBadge(text, { loading: false });
+    chipHasHydratedValue = amount != null;
     if (window.UserUiState && typeof window.UserUiState.markActiveSliceApplied === 'function'){
-      window.UserUiState.markActiveSliceApplied('chips', 'ready');
+      window.UserUiState.markActiveSliceApplied('chips', uiState || 'ready');
     }
+  }
+
+  function hydrateChipBadge(){
+    const ui = window.UserUiState;
+    if (!ui || typeof ui.readActiveSlice !== 'function') return false;
+    const cached = ui.readActiveSlice('chips');
+    const balance = cached && Number.isSafeInteger(cached.balance) && cached.balance >= 0 ? cached.balance : null;
+    if (balance == null) return false;
+    renderChipBadgeBalance(balance, 'hydrated');
+    return true;
+  }
+
+  function retainCachedChipBadge(){
+    if (!chipHasHydratedValue) return false;
+    if (window.UserUiState && typeof window.UserUiState.markActiveSliceApplied === 'function'){
+      window.UserUiState.markActiveSliceApplied('chips', 'stale');
+    }
+    return true;
+  }
+
+  function prepareChipIdentity(){
+    const ui = window.UserUiState;
+    const context = ui && typeof ui.getActiveContext === 'function' ? ui.getActiveContext() : null;
+    const userId = context && context.userId ? context.userId : null;
+    if (userId && userId === chipIdentityUserId){
+      if (!chipHasHydratedValue) hydrateChipBadge();
+      return;
+    }
+    chipRequestGeneration += 1;
+    chipInFlight = null;
+    chipHasHydratedValue = false;
+    chipIdentityUserId = userId;
+    if (!hydrateChipBadge()) setChipBadge('', { loading: true });
   }
 
   function setAuthState(next){
@@ -285,12 +322,16 @@
     }
     if (amount){ amount.textContent = ''; }
     if (!isAuthed()){
+      chipRequestGeneration += 1;
+      chipInFlight = null;
+      chipIdentityUserId = null;
+      chipHasHydratedValue = false;
       hideChipBadge();
       hideWelcomeBonusBadge();
       return;
     }
     if (badge){ badge.hidden = false; }
-    setChipBadge('', { loading: true });
+    prepareChipIdentity();
     refreshChipBadge();
     refreshWelcomeBonusBadge();
   }
@@ -303,6 +344,7 @@
         hideChipBadge();
         return;
       }
+      prepareChipIdentity();
       refreshXpBadge();
       refreshChipBadge();
       refreshWelcomeBonusBadge();
@@ -371,7 +413,10 @@
     }
     chipsClientWaitTries = 0;
     if (chipInFlight){ return chipInFlight; }
-    setChipBadge('', { loading: true });
+    if (!chipHasHydratedValue) setChipBadge('', { loading: true });
+    const requestGeneration = chipRequestGeneration;
+    const ui = window.UserUiState;
+    const uiContext = ui && typeof ui.getActiveContext === 'function' ? ui.getActiveContext() : null;
     chipInFlight = (async function(){
       let timeoutId = null;
       try {
@@ -384,12 +429,14 @@
           }, timeoutMs);
         });
         const balance = await Promise.race([window.ChipsClient.fetchBalance(), timeoutPromise]);
+        if (requestGeneration !== chipRequestGeneration) return;
+        if (uiContext && ui && typeof ui.isCurrent === 'function' && !ui.isCurrent(uiContext.userId, uiContext.generation)) return;
         const raw = balance && balance.balance != null ? Number(balance.balance) : null;
         const value = Number.isFinite(raw) ? raw : null;
         renderChipBadgeBalance(value);
       } catch (err){
         if (err && err.code === 'timeout'){
-          hideChipBadge();
+          if (!retainCachedChipBadge()) hideChipBadge();
           return;
         }
         if (err && (err.status === 404 || err.code === 'not_found')){
@@ -401,10 +448,10 @@
           hideChipBadge();
           return;
         }
-        hideChipBadge();
+        if (!retainCachedChipBadge()) hideChipBadge();
       } finally {
         if (timeoutId){ clearTimeout(timeoutId); }
-        chipInFlight = null;
+        if (requestGeneration === chipRequestGeneration) chipInFlight = null;
       }
     })();
 
@@ -447,6 +494,11 @@
       refreshChipBadge();
       refreshWelcomeBonusBadge();
     });
+    if (window.UserUiState && typeof window.UserUiState.onChange === 'function'){
+      window.UserUiState.onChange(function(detail){
+        if (detail && detail.slice === 'chips' && detail.value) renderChipBadgeBalance(detail.value.balance, 'ready');
+      });
+    }
   }
 
   function tryWireAuthBridge(){

--- a/js/topbar.js
+++ b/js/topbar.js
@@ -461,6 +461,7 @@
 
   function handleAuthChange(event, user, session){
     const hasUser = !!(user || (session && session.user));
+    if (window.ChipsClient && typeof window.ChipsClient.clearAuthCache === 'function') window.ChipsClient.clearAuthCache();
     if (event === 'SIGNED_OUT'){
       setAuthState(AuthState.SIGNED_OUT);
       hideChipBadge();

--- a/js/user-ui-state.js
+++ b/js/user-ui-state.js
@@ -129,6 +129,10 @@
     return activeUserId === userId && generation === expectedGeneration;
   }
 
+  function getActiveContext(){
+    return activeUserId ? { userId: activeUserId, generation: generation } : null;
+  }
+
   function writeRecord(record){
     var store = storage();
     if (!store) return false;
@@ -149,6 +153,12 @@
     emit(record);
     if (channel){ try { channel.postMessage(record); } catch (_err){} }
     return normalized;
+  }
+
+  function readActiveSlice(slice){
+    if (!activeUserId || !Object.prototype.hasOwnProperty.call(MAX_AGE, slice)) return null;
+    var record = read(slice, activeUserId);
+    return record ? record.value : null;
   }
 
   function clearUser(userId){
@@ -214,6 +224,6 @@
     if (parsed && parsed.userId === userId) acceptExternal(parsed);
   });
 
-  window.UserUiState = { hydrate: hydrate, publish: publish, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markSliceApplied: markSliceApplied, markActiveSliceApplied: markActiveSliceApplied, markRefreshFailed: markRefreshFailed, onChange: onChange };
+  window.UserUiState = { hydrate: hydrate, publish: publish, readActiveSlice: readActiveSlice, getActiveContext: getActiveContext, clearUser: clearUser, setAnonymous: setAnonymous, isCurrent: isCurrent, markSliceApplied: markSliceApplied, markActiveSliceApplied: markActiveSliceApplied, markRefreshFailed: markRefreshFailed, onChange: onChange };
   klog('user_ui_state_ready', { version: VERSION });
 })();

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -101,6 +101,7 @@ run("node", ["tests/profile-avatar.behavior.test.mjs"], "profile-avatar-behavior
 run("node", ["tests/public-profile-xp.e2e.test.mjs"], "public-profile-xp-e2e");
 run("node", ["tests/public-profile-ui.contract.test.mjs"], "public-profile-ui-contract");
 run("node", ["tests/user-ui-state.behavior.test.mjs"], "user-ui-state-behavior");
+run("node", ["tests/chips-client-cache.behavior.test.mjs"], "chips-client-cache-behavior");
 run("node", ["tests/home-bonuses.contract.test.mjs"], "home-bonuses-contract");
 run("node", ["tests/account-auth.contract.test.mjs"], "account-auth-contract");
 run("node", ["tests/xp-ledger.behavior.test.mjs"], "xp-ledger-behavior");

--- a/tests/chips-client-cache.behavior.test.mjs
+++ b/tests/chips-client-cache.behavior.test.mjs
@@ -11,8 +11,9 @@ function response(balance){
 function createClient(fetchImpl){
   const published = [];
   let context = { userId: 'chips-user', generation: 1 };
+  let token = 'token-a';
   const window = {
-    SupabaseAuthBridge: { getAccessToken: async () => 'token' },
+    SupabaseAuthBridge: { getAccessToken: async () => token },
     UserUiState: {
       getActiveContext(){ return context; },
       isCurrent(userId, generation){ return context.userId === userId && context.generation === generation; },
@@ -22,7 +23,21 @@ function createClient(fetchImpl){
   };
   window.window = window;
   vm.runInNewContext(source, { window, document: { dispatchEvent(){} }, CustomEvent: class {}, fetch: fetchImpl, Date, JSON, Number });
-  return { client: window.ChipsClient, published, setContext(value){ context = value; } };
+  return { client: window.ChipsClient, published, setContext(value){ context = value; }, setToken(value){ token = value; } };
+}
+
+{
+  const authorization = [];
+  const state = createClient(async (_url, options) => {
+    authorization.push(options.headers.Authorization);
+    return response(authorization.length === 1 ? 896 : 950);
+  });
+  await state.client.fetchBalance();
+  state.setToken('token-b');
+  state.setContext({ userId: 'chips-user-b', generation: 2 });
+  state.client.clearAuthCache();
+  await state.client.fetchBalance();
+  assert.deepEqual(authorization, ['Bearer token-a', 'Bearer token-b']);
 }
 
 {

--- a/tests/chips-client-cache.behavior.test.mjs
+++ b/tests/chips-client-cache.behavior.test.mjs
@@ -10,6 +10,7 @@ function response(balance){
 
 function createClient(fetchImpl){
   const published = [];
+  const events = [];
   let context = { userId: 'chips-user', generation: 1 };
   let token = 'token-a';
   const window = {
@@ -22,8 +23,11 @@ function createClient(fetchImpl){
     KLog: { log(){} },
   };
   window.window = window;
-  vm.runInNewContext(source, { window, document: { dispatchEvent(){} }, CustomEvent: class {}, fetch: fetchImpl, Date, JSON, Number });
-  return { client: window.ChipsClient, published, setContext(value){ context = value; }, setToken(value){ token = value; } };
+  class CustomEvent {
+    constructor(type, options){ this.type = type; this.detail = options && options.detail; }
+  }
+  vm.runInNewContext(source, { window, document: { dispatchEvent(event){ events.push(event); } }, CustomEvent, fetch: fetchImpl, Date, JSON, Number });
+  return { client: window.ChipsClient, events, published, setContext(value){ context = value; }, setToken(value){ token = value; } };
 }
 
 {
@@ -55,8 +59,10 @@ function createClient(fetchImpl){
   await Promise.resolve();
   state.setContext({ userId: 'other-user', generation: 2 });
   release();
-  await pending;
+  const result = await pending;
+  assert.equal(result, null);
   assert.equal(state.published.length, 0);
+  assert.equal(state.events.filter((event) => event.type === 'chips:balance').length, 0);
 }
 
 console.log('chips client cache behavior tests passed');

--- a/tests/chips-client-cache.behavior.test.mjs
+++ b/tests/chips-client-cache.behavior.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const source = await readFile(new URL('../js/chips/client.js', import.meta.url), 'utf8');
+
+function response(balance){
+  return { status: 200, ok: true, async json(){ return { balance }; } };
+}
+
+function createClient(fetchImpl){
+  const published = [];
+  let context = { userId: 'chips-user', generation: 1 };
+  const window = {
+    SupabaseAuthBridge: { getAccessToken: async () => 'token' },
+    UserUiState: {
+      getActiveContext(){ return context; },
+      isCurrent(userId, generation){ return context.userId === userId && context.generation === generation; },
+      publish(userId, slice, value){ published.push({ userId, slice, value }); return value; },
+    },
+    KLog: { log(){} },
+  };
+  window.window = window;
+  vm.runInNewContext(source, { window, document: { dispatchEvent(){} }, CustomEvent: class {}, fetch: fetchImpl, Date, JSON, Number });
+  return { client: window.ChipsClient, published, setContext(value){ context = value; } };
+}
+
+{
+  const state = createClient(async () => response(896));
+  const result = await state.client.fetchBalance();
+  assert.equal(result.balance, 896);
+  assert.equal(JSON.stringify(state.published), JSON.stringify([{ userId: 'chips-user', slice: 'chips', value: { balance: 896 } }]));
+}
+
+{
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const state = createClient(async () => { await gate; return response(900); });
+  const pending = state.client.fetchBalance();
+  await Promise.resolve();
+  state.setContext({ userId: 'other-user', generation: 2 });
+  release();
+  await pending;
+  assert.equal(state.published.length, 0);
+}
+
+console.log('chips client cache behavior tests passed');

--- a/tests/e2e/topbar-chips-hydration.spec.js
+++ b/tests/e2e/topbar-chips-hydration.spec.js
@@ -115,7 +115,6 @@ test('hides account A chips during a direct signed-in switch to account B', asyn
   await page.waitForTimeout(100);
   await expect(amount).toHaveCSS('visibility', 'hidden');
   expect(await page.evaluate(() => localStorage.getItem('kcswh:user-ui:chips:v1:chips-user-b'))).toBeNull();
-  expect(await page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.balance, CACHE_KEY)).toBe(896);
 
   releaseB();
   await expect(amount).toHaveText('950');

--- a/tests/e2e/topbar-chips-hydration.spec.js
+++ b/tests/e2e/topbar-chips-hydration.spec.js
@@ -10,13 +10,15 @@ async function mockAuthenticatedSession(page) {
     body: `
       window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
       var currentAuthUser = { id: '${USER_ID}', email: 'private@example.test' };
+      var currentAccessToken = 'token-a';
       var authStateCallback = null;
       window.__switchAuthUser = function(userId){
         currentAuthUser = { id: userId, email: 'private@example.test' };
-        if (authStateCallback) authStateCallback('SIGNED_IN', { access_token: 'test-token', user: currentAuthUser });
+        currentAccessToken = 'token-b';
+        if (authStateCallback) authStateCallback('SIGNED_IN', { access_token: currentAccessToken, user: currentAuthUser });
       };
       window.supabase = { createClient: function(){ return { auth: {
-        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: currentAuthUser } } }); },
+        getSession: function(){ return Promise.resolve({ data: { session: { access_token: currentAccessToken, user: currentAuthUser } } }); },
         onAuthStateChange: function(callback){ authStateCallback = callback; return { data: { subscription: { unsubscribe: function(){} } } }; },
         signOut: function(){ return Promise.resolve(); }
       } }; } };
@@ -91,8 +93,10 @@ test('hides account A chips during a direct signed-in switch to account B', asyn
   const lateAGate = new Promise((resolve) => { releaseLateA = resolve; });
   const bGate = new Promise((resolve) => { releaseB = resolve; });
   let requests = 0;
+  const authorization = [];
   await page.route('**/.netlify/functions/chips-balance', async (route) => {
     const requestNo = ++requests;
+    authorization.push(route.request().headers().authorization);
     if (requestNo === 2) await lateAGate;
     if (requestNo === 3) await bGate;
     const balance = requestNo === 1 ? 896 : (requestNo === 2 ? 777 : 950);
@@ -107,6 +111,7 @@ test('hides account A chips during a direct signed-in switch to account B', asyn
 
   await page.evaluate(() => window.__switchAuthUser('chips-user-b'));
   await expect.poll(() => requests).toBe(3);
+  expect(authorization[2]).toBe('Bearer token-b');
   await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'loading');
   await expect(amount).toHaveCSS('visibility', 'hidden');
   await expect(amount).not.toHaveText('896');

--- a/tests/e2e/topbar-chips-hydration.spec.js
+++ b/tests/e2e/topbar-chips-hydration.spec.js
@@ -9,9 +9,15 @@ async function mockAuthenticatedSession(page) {
     contentType: 'application/javascript',
     body: `
       window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
+      var currentAuthUser = { id: '${USER_ID}', email: 'private@example.test' };
+      var authStateCallback = null;
+      window.__switchAuthUser = function(userId){
+        currentAuthUser = { id: userId, email: 'private@example.test' };
+        if (authStateCallback) authStateCallback('SIGNED_IN', { access_token: 'test-token', user: currentAuthUser });
+      };
       window.supabase = { createClient: function(){ return { auth: {
-        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: '${USER_ID}', email: 'private@example.test' } } } }); },
-        onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
+        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: currentAuthUser } } }); },
+        onAuthStateChange: function(callback){ authStateCallback = callback; return { data: { subscription: { unsubscribe: function(){} } } }; },
         signOut: function(){ return Promise.resolve(); }
       } }; } };
     `,
@@ -75,4 +81,44 @@ test('retains cached chips when balance revalidation fails', async ({ page }) =>
   await expect(page.locator('#chipBadgeAmount')).toHaveText('896');
   await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'stale');
   await expect(page.locator('#chipBadgeAmount')).toHaveCSS('visibility', 'visible');
+});
+
+test('hides account A chips during a direct signed-in switch to account B', async ({ page }) => {
+  await mockAuthenticatedSession(page);
+  await seedCachedBalance(page, 896);
+  let releaseLateA;
+  let releaseB;
+  const lateAGate = new Promise((resolve) => { releaseLateA = resolve; });
+  const bGate = new Promise((resolve) => { releaseB = resolve; });
+  let requests = 0;
+  await page.route('**/.netlify/functions/chips-balance', async (route) => {
+    const requestNo = ++requests;
+    if (requestNo === 2) await lateAGate;
+    if (requestNo === 3) await bGate;
+    const balance = requestNo === 1 ? 896 : (requestNo === 2 ? 777 : 950);
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ balance }) });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  const amount = page.locator('#chipBadgeAmount');
+  await expect(amount).toHaveText('896');
+  await page.evaluate(() => document.dispatchEvent(new CustomEvent('chips:tx-complete', { detail: { ok: true } })));
+  await expect.poll(() => requests).toBe(2);
+
+  await page.evaluate(() => window.__switchAuthUser('chips-user-b'));
+  await expect.poll(() => requests).toBe(3);
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'loading');
+  await expect(amount).toHaveCSS('visibility', 'hidden');
+  await expect(amount).not.toHaveText('896');
+
+  releaseLateA();
+  await page.waitForTimeout(100);
+  await expect(amount).toHaveCSS('visibility', 'hidden');
+  expect(await page.evaluate(() => localStorage.getItem('kcswh:user-ui:chips:v1:chips-user-b'))).toBeNull();
+  expect(await page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.balance, CACHE_KEY)).toBe(896);
+
+  releaseB();
+  await expect(amount).toHaveText('950');
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'ready');
+  await expect.poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('kcswh:user-ui:chips:v1:chips-user-b')).value.balance)).toBe(950);
 });

--- a/tests/e2e/topbar-chips-hydration.spec.js
+++ b/tests/e2e/topbar-chips-hydration.spec.js
@@ -106,6 +106,10 @@ test('hides account A chips during a direct signed-in switch to account B', asyn
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   const amount = page.locator('#chipBadgeAmount');
   await expect(amount).toHaveText('896');
+  await page.evaluate(() => {
+    window.__chipBalanceEvents = [];
+    document.addEventListener('chips:balance', (event) => window.__chipBalanceEvents.push(event.detail && event.detail.balance));
+  });
   await page.evaluate(() => document.dispatchEvent(new CustomEvent('chips:tx-complete', { detail: { ok: true } })));
   await expect.poll(() => requests).toBe(2);
 
@@ -120,9 +124,11 @@ test('hides account A chips during a direct signed-in switch to account B', asyn
   await page.waitForTimeout(100);
   await expect(amount).toHaveCSS('visibility', 'hidden');
   expect(await page.evaluate(() => localStorage.getItem('kcswh:user-ui:chips:v1:chips-user-b'))).toBeNull();
+  expect(await page.evaluate(() => window.__chipBalanceEvents.includes(777))).toBe(false);
 
   releaseB();
   await expect(amount).toHaveText('950');
+  await expect.poll(() => page.evaluate(() => window.__chipBalanceEvents.includes(950))).toBe(true);
   await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'ready');
   await expect.poll(() => page.evaluate(() => JSON.parse(localStorage.getItem('kcswh:user-ui:chips:v1:chips-user-b')).value.balance)).toBe(950);
 });

--- a/tests/e2e/topbar-chips-hydration.spec.js
+++ b/tests/e2e/topbar-chips-hydration.spec.js
@@ -1,0 +1,78 @@
+const { test, expect } = require('@playwright/test');
+
+const USER_ID = 'chips-hydration-user';
+const CACHE_KEY = `kcswh:user-ui:chips:v1:${USER_ID}`;
+
+async function mockAuthenticatedSession(page) {
+  await page.route('https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js', (route) => route.fulfill({ contentType: 'application/javascript', body: '' }));
+  await page.route('**/js/auth/supabase-config.js', (route) => route.fulfill({
+    contentType: 'application/javascript',
+    body: `
+      window.SUPABASE_CONFIG = { SUPABASE_URL: 'https://stage-test.supabase.co', SUPABASE_ANON_KEY: 'test-key' };
+      window.supabase = { createClient: function(){ return { auth: {
+        getSession: function(){ return Promise.resolve({ data: { session: { access_token: 'test-token', user: { id: '${USER_ID}', email: 'private@example.test' } } } }); },
+        onAuthStateChange: function(){ return { data: { subscription: { unsubscribe: function(){} } } }; },
+        signOut: function(){ return Promise.resolve(); }
+      } }; } };
+    `,
+  }));
+  await page.route('**/.netlify/functions/profile-me', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ displayName: 'Chips Player', avatar: { type: 'default', variant: 'orbit-green' } }) }));
+  await page.route('**/.netlify/functions/welcome-bonus', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ eligible: false, alreadyClaimed: true }) }));
+}
+
+async function seedCachedBalance(page, balance) {
+  await page.addInitScript(({ key, userId, value }) => {
+    localStorage.setItem(key, JSON.stringify({ version: 1, userId, confirmedAt: Date.now(), value: { balance: value } }));
+    window.__chipFrames = [];
+    function sample(){
+      const amount = document.getElementById('chipBadgeAmount');
+      if (amount) window.__chipFrames.push({ text: amount.textContent.trim(), visibility: getComputedStyle(amount).visibility });
+      requestAnimationFrame(sample);
+    }
+    requestAnimationFrame(sample);
+  }, { key: CACHE_KEY, userId: USER_ID, value: balance });
+}
+
+test('hydrates chips before revalidation and refreshes after a transaction event', async ({ page }) => {
+  await mockAuthenticatedSession(page);
+  await seedCachedBalance(page, 896);
+  let releaseBalance;
+  let serverBalance = 950;
+  let requests = 0;
+  const balanceGate = new Promise((resolve) => { releaseBalance = resolve; });
+  await page.route('**/.netlify/functions/chips-balance', async (route) => {
+    requests += 1;
+    if (requests === 1) await balanceGate;
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ balance: serverBalance }) });
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  const amount = page.locator('#chipBadgeAmount');
+  await expect.poll(() => requests).toBe(1);
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'hydrated');
+  await expect(amount).toHaveText('896');
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const visible = await page.evaluate(() => window.__chipFrames.filter((frame) => frame.visibility === 'visible').map((frame) => frame.text));
+  expect(visible[0]).toBe('896');
+  expect(visible.includes('')).toBe(false);
+
+  releaseBalance();
+  await expect(amount).toHaveText('950');
+  await expect.poll(() => page.evaluate((key) => JSON.parse(localStorage.getItem(key)).value.balance, CACHE_KEY)).toBe(950);
+
+  serverBalance = 1000;
+  await page.evaluate(() => document.dispatchEvent(new CustomEvent('chips:tx-complete', { detail: { ok: true } })));
+  await expect(amount).toHaveText('1k');
+  await expect.poll(() => requests).toBe(2);
+});
+
+test('retains cached chips when balance revalidation fails', async ({ page }) => {
+  await mockAuthenticatedSession(page);
+  await seedCachedBalance(page, 896);
+  await page.route('**/.netlify/functions/chips-balance', (route) => route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'server_error' }) }));
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#chipBadgeAmount')).toHaveText('896');
+  await expect(page.locator('.topbar')).toHaveAttribute('data-user-ui-chips-state', 'stale');
+  await expect(page.locator('#chipBadgeAmount')).toHaveCSS('visibility', 'visible');
+});

--- a/tests/user-ui-state.behavior.test.mjs
+++ b/tests/user-ui-state.behavior.test.mjs
@@ -59,6 +59,7 @@ const profileRecord = (userId, displayName, confirmedAt = Date.now()) => JSON.st
   assert.equal(state.topbar.state, 'hydrated');
   assert.equal(state.topbar.attributes['data-user-ui-xp-state'], 'loading');
   assert.equal(state.api.isCurrent('user-a', hydrated.generation), true);
+  assert.equal(JSON.stringify(state.api.getActiveContext()), JSON.stringify({ userId: 'user-a', generation: hydrated.generation }));
   assert.equal(state.api.publish('user-b', 'profile', { displayName: 'Wrong', avatar: {} }), null);
 }
 


### PR DESCRIPTION
## Summary
- implement phase 3 of User UI Hydration Plan v1.1
- hydrate chips from the active user's last server-confirmed balance
- keep cached chips visible as stale when background revalidation fails
- publish successful `chips-balance` reads to the shared user-scoped cache
- refresh and republish balance after existing transaction-complete events
- synchronize chips across tabs through the existing UserUiState transport
- reject stale balance responses after logout or account switch

## Verification
- `npm run check:all`
- `npm test`
- `node tests/chips-client-cache.behavior.test.mjs`
- `node tests/user-ui-state.behavior.test.mjs`
- `PORT=4174 npx playwright test tests/e2e/topbar-profile-avatar.spec.js tests/e2e/topbar-xp-hydration.spec.js tests/e2e/topbar-chips-hydration.spec.js`
- `git diff --check`

## Breaking impact
- chips may briefly show the last server-confirmed balance for up to 5 minutes while revalidation is pending
- cached chips are display-only and never authorize claims, poker actions, transfers, or ledger mutations
- no backend, database, migration, CSP, or environment changes