### PR TITLE
feat: add XP leaderboard backfill tooling

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,51 @@ This document preserves the operational and rollout details that were previously
 - Once unlocked, the recorder auto-starts (`window.KLog.start(1)`) and the About page surfaces a **Dump diagnostics** button. Clicking it opens a new tab populated with the recent buffer (up to 1000 lines) and falls back to downloading `kcswh-diagnostic-<timestamp>.txt` when the popup is blocked.
 - The buffer captures the XP lifecycle breadcrumbs (`xp_init`, `xp_start`, `xp_stop`, `block_no_host`, `block_hard_idle`, `award`) so you can confirm that accrual only happens on game hosts and is suppressed on idle or non-host pages. Check `window.KLog.status()` for the active level and line count.
 
+## XP leaderboard maintenance
+
+`/.netlify/functions/admin-xp-leaderboard-maintenance` is an admin-only, bounded maintenance endpoint. It does not expose rankings publicly. Requests default to dry-run, accept at most 50 accounts, use the configured `XP_KEY_NS`, and refuse unknown Supabase targets. Apply requests require the exact confirmation returned by the detected target: `apply:<stage|production>:<project-ref>`.
+
+Prerequisites are existing runtime configuration only: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, Upstash REST credentials, `XP_KEY_NS`, and `SUPABASE_STAGE_PROJECT_REF` on deploy previews. No database migration or new persistent environment variable is required.
+
+Use an admin Supabase access token and the matching deploy URL. Start every operation without `apply`:
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer <admin access token>" \
+  -H "Content-Type: application/json" \
+  https://<deploy>/.netlify/functions/admin-xp-leaderboard-maintenance \
+  -d '{"operation":"profile_coverage","page":1,"limit":25}'
+```
+
+Run pages until `hasMore` is false. Then repeat each page with `"apply":true` and the exact target confirmation, for example on stage:
+
+```json
+{
+  "operation": "profile_coverage",
+  "page": 1,
+  "limit": 25,
+  "apply": true,
+  "confirmation": "apply:stage:<stage-project-ref>"
+}
+```
+
+After profile coverage completes, run `backfill` with the same dry-run-first and paged apply sequence. It reads canonical lifetime/current-day/current-week counters, sets non-zero sorted-set scores, removes stale zero scores, and refreshes bounded day/week TTLs. Re-running every page must converge to `updated: 0`, `removed: 0`, and only `unchanged` results.
+
+Finally run `prune` separately for `all_time`, `today`, and `week`. It removes index members without a public profile. Prune uses `offset`, not `page`; when an apply removes rows it returns the same `nextOffset` so shifted members are not skipped:
+
+```json
+{
+  "operation": "prune",
+  "period": "all_time",
+  "offset": 0,
+  "limit": 25,
+  "apply": true,
+  "confirmation": "apply:stage:<stage-project-ref>"
+}
+```
+
+Stop on any non-zero `failed` count. The endpoint logs aggregate counts only and never logs user IDs or emails. Do not run production apply until the public API PR is deployed dark and stage backfill has been rerun successfully. Rollback consists of removing the derived `<XP_KEY_NS>:leaderboard:v1:*` sorted sets; never modify canonical `total` or `daily` XP keys.
+
 ## Stage DB identity check
 - Netlify deploy previews must point at the stage Supabase project before DB migration automation is enabled.
 - Configure these variables in Netlify for the `deploy-preview` context with stage values:
@@ -37,6 +82,8 @@ This document preserves the operational and rollout details that were previously
 - The admin-only endpoint `/.netlify/functions/admin-stage-identity` returns sanitized environment identity:
   - `environmentContext`
   - `supabaseProjectRef`
+  - separate `supabaseUrlProjectRef` and `databaseProjectRef`
+  - `databaseMatchesSupabaseProjectRef`
   - `expectedStageProjectRef`
   - `databaseTarget`
   - `chipsEnabled`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,7 +24,7 @@ This document preserves the operational and rollout details that were previously
 
 ## XP leaderboard maintenance
 
-`/.netlify/functions/admin-xp-leaderboard-maintenance` is an admin-only, bounded maintenance endpoint. It does not expose rankings publicly. Requests default to dry-run, accept at most 50 accounts, use the configured `XP_KEY_NS`, and refuse unknown Supabase targets. A successful dry-run returns a signed `applyToken` valid for five minutes. The token is bound to the admin, target project, operation, page, offset, limit, and period; it cannot authorize a different request.
+`/.netlify/functions/admin-xp-leaderboard-maintenance` is an admin-only, bounded maintenance endpoint. It does not expose rankings publicly. Requests default to dry-run, accept at most 50 accounts, use the configured `XP_KEY_NS`, and refuse unknown Supabase targets. A successful dry-run returns a signed `applyToken` valid for five minutes. The token is bound to the admin, Netlify deploy, target project, operation, page, offset, limit, and period; it cannot authorize a different request.
 
 Prerequisites are existing runtime configuration only: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, Upstash REST credentials, `XP_KEY_NS`, and `SUPABASE_STAGE_PROJECT_REF` on deploy previews. No database migration or new persistent environment variable is required.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,7 +24,7 @@ This document preserves the operational and rollout details that were previously
 
 ## XP leaderboard maintenance
 
-`/.netlify/functions/admin-xp-leaderboard-maintenance` is an admin-only, bounded maintenance endpoint. It does not expose rankings publicly. Requests default to dry-run, accept at most 50 accounts, use the configured `XP_KEY_NS`, and refuse unknown Supabase targets. Apply requests require the exact confirmation returned by the detected target: `apply:<stage|production>:<project-ref>`.
+`/.netlify/functions/admin-xp-leaderboard-maintenance` is an admin-only, bounded maintenance endpoint. It does not expose rankings publicly. Requests default to dry-run, accept at most 50 accounts, use the configured `XP_KEY_NS`, and refuse unknown Supabase targets. A successful dry-run returns a signed `applyToken` valid for five minutes. The token is bound to the admin, target project, operation, page, offset, limit, and period; it cannot authorize a different request.
 
 Prerequisites are existing runtime configuration only: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, Upstash REST credentials, `XP_KEY_NS`, and `SUPABASE_STAGE_PROJECT_REF` on deploy previews. No database migration or new persistent environment variable is required.
 
@@ -38,7 +38,7 @@ curl -sS -X POST \
   -d '{"operation":"profile_coverage","page":1,"limit":25}'
 ```
 
-Run pages until `hasMore` is false. Then repeat each page with `"apply":true` and the exact target confirmation, for example on stage:
+For each page, inspect the dry-run response and stop if `failed` is non-zero. Apply that exact page immediately with the returned token:
 
 ```json
 {
@@ -46,11 +46,11 @@ Run pages until `hasMore` is false. Then repeat each page with `"apply":true` an
   "page": 1,
   "limit": 25,
   "apply": true,
-  "confirmation": "apply:stage:<stage-project-ref>"
+  "applyToken": "<token returned by this exact dry-run>"
 }
 ```
 
-After profile coverage completes, run `backfill` with the same dry-run-first and paged apply sequence. It reads canonical lifetime/current-day/current-week counters, sets non-zero sorted-set scores, removes stale zero scores, and refreshes bounded day/week TTLs. Re-running every page must converge to `updated: 0`, `removed: 0`, and only `unchanged` results.
+Expired tokens, changed parameters, another admin, and another stage/production target return `409` before maintenance runs. After profile coverage completes, run `backfill` with the same dry-run-first and paged apply sequence. It reads canonical lifetime/current-day/current-week counters, sets non-zero sorted-set scores, removes stale zero scores, and refreshes bounded day/week TTLs. Re-running every page must converge to `updated: 0`, `removed: 0`, and only `unchanged` results.
 
 Finally run `prune` separately for `all_time`, `today`, and `week`. It removes index members without a public profile. Prune uses `offset`, not `page`; when an apply removes rows it returns the same `nextOffset` so shifted members are not skipped:
 
@@ -61,7 +61,7 @@ Finally run `prune` separately for `all_time`, `today`, and `week`. It removes i
   "offset": 0,
   "limit": 25,
   "apply": true,
-  "confirmation": "apply:stage:<stage-project-ref>"
+  "applyToken": "<token returned by this exact prune dry-run>"
 }
 ```
 

--- a/docs/xp-leaderboard-implementation-plan.md
+++ b/docs/xp-leaderboard-implementation-plan.md
@@ -375,6 +375,8 @@ Implementation status: complete in PR #690. The shared 03:00 Warsaw/ISO period h
 
 ### PR 2: Backfill and reconciliation
 
+Implementation status: implemented on branch `feat/xp-leaderboard-backfill`; stage dry-run/apply verification remains required before merge. The maintenance endpoint is admin-only, bounded, dry-run by default, and does not expose leaderboard data publicly.
+
 - Add the guarded idempotent backfill/reconciliation tool.
 - Add and run the separate trusted profile-coverage preflight; verify retained daily keys on stage.
 - Remove exceptional missing-profile members from projections rather than changing public page boundaries.

--- a/netlify/functions/_shared/store-upstash.mjs
+++ b/netlify/functions/_shared/store-upstash.mjs
@@ -112,7 +112,7 @@ function createMemoryStore() {
     async expire(key, seconds) {
       const entry = sweep(key);
       if (!entry) return 0;
-      setValue(key, entry.value, seconds * 1000);
+      memory.set(key, { ...entry, expiry: Date.now() + seconds * 1000 });
       return 1;
     },
     async ttl(key) {

--- a/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
+++ b/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
@@ -80,6 +80,11 @@ function actorFingerprint(userId, secret) {
   return createHmac("sha256", secret).update(`actor:${String(userId || "")}`).digest("base64url").slice(0, 22);
 }
 
+function deploymentFingerprint(env, secret) {
+  const deployment = env.DEPLOY_ID || env.COMMIT_REF || env.DEPLOY_PRIME_URL || env.URL || env.CONTEXT || "local";
+  return createHmac("sha256", secret).update(`deploy:${deployment}`).digest("base64url").slice(0, 22);
+}
+
 function issueMaintenanceApplyToken({ request, target, adminUserId, env = process.env, nowMs = Date.now() }) {
   if (!request?.dryRun) throw maintenanceError("apply_token_requires_dry_run", 409);
   const secret = resolveApplyTokenSecret(env);
@@ -90,6 +95,7 @@ function issueMaintenanceApplyToken({ request, target, adminUserId, env = proces
     projectRef: target.projectRef,
     scope: maintenanceRequestScope(request),
     actor: actorFingerprint(adminUserId, secret),
+    deployment: deploymentFingerprint(env, secret),
     iat: issuedAt,
     exp: issuedAt + APPLY_TOKEN_TTL_SEC,
   };
@@ -125,6 +131,7 @@ function verifyMaintenanceApplyToken({ token, request, target, adminUserId, env 
     throw maintenanceError("apply_token_target_mismatch", 409);
   }
   if (payload.actor !== actorFingerprint(adminUserId, secret)) throw maintenanceError("apply_token_actor_mismatch", 409);
+  if (payload.deployment !== deploymentFingerprint(env, secret)) throw maintenanceError("apply_token_deploy_mismatch", 409);
   if (JSON.stringify(payload.scope) !== JSON.stringify(maintenanceRequestScope(request))) {
     throw maintenanceError("apply_token_scope_mismatch", 409);
   }

--- a/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
+++ b/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { executeSql, klog } from "./supabase-admin.mjs";
 import { store as defaultStore } from "./store-upstash.mjs";
 import { ensureUserProfile } from "./user-profile.mjs";
@@ -5,6 +6,8 @@ import { createXpLeaderboardKeys, getXpLeaderboardPeriods, getXpLeaderboardWeekD
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 50;
+const APPLY_TOKEN_TTL_SEC = 5 * 60;
+const APPLY_TOKEN_VERSION = 1;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function maintenanceError(code, status = 400) {
@@ -37,11 +40,11 @@ function parseMaintenanceRequest(payload = {}) {
     offset: Math.max(0, Math.floor(Number(payload.offset) || 0)),
     limit: normalizePositiveInt(payload.limit, DEFAULT_LIMIT, MAX_LIMIT),
     dryRun: payload.apply !== true,
-    confirmation: typeof payload.confirmation === "string" ? payload.confirmation.trim() : "",
+    applyToken: typeof payload.applyToken === "string" ? payload.applyToken.trim() : "",
   };
 }
 
-function validateMaintenanceTarget({ identity, request }) {
+function validateMaintenanceTarget({ identity }) {
   const target = identity?.databaseTarget;
   const projectRef = identity?.supabaseProjectRef;
   if (!projectRef || (target !== "stage" && target !== "production")) throw maintenanceError("unsafe_target", 409);
@@ -50,11 +53,82 @@ function validateMaintenanceTarget({ identity, request }) {
     throw maintenanceError("supabase_resource_mismatch", 409);
   }
   if (identity.serviceRoleProjectRef && identity.serviceRoleProjectRef !== projectRef) throw maintenanceError("service_role_project_mismatch", 409);
-  if (!request.dryRun) {
-    const expected = `apply:${target}:${projectRef}`;
-    if (request.confirmation !== expected) throw maintenanceError("confirmation_required", 409);
-  }
   return { databaseTarget: target, projectRef, environmentContext: identity.environmentContext || "unknown" };
+}
+
+function maintenanceRequestScope(request) {
+  return {
+    operation: request.operation,
+    page: request.page,
+    offset: request.offset,
+    limit: request.limit,
+    period: request.period,
+  };
+}
+
+function resolveApplyTokenSecret(env = process.env) {
+  const secret = String(env.SUPABASE_SERVICE_ROLE_KEY || "");
+  if (!secret) throw maintenanceError("apply_token_unavailable", 503);
+  return createHmac("sha256", secret).update("xp-leaderboard-maintenance:v1").digest();
+}
+
+function signApplyTokenPayload(encodedPayload, secret) {
+  return createHmac("sha256", secret).update(encodedPayload).digest("base64url");
+}
+
+function actorFingerprint(userId, secret) {
+  return createHmac("sha256", secret).update(`actor:${String(userId || "")}`).digest("base64url").slice(0, 22);
+}
+
+function issueMaintenanceApplyToken({ request, target, adminUserId, env = process.env, nowMs = Date.now() }) {
+  if (!request?.dryRun) throw maintenanceError("apply_token_requires_dry_run", 409);
+  const secret = resolveApplyTokenSecret(env);
+  const issuedAt = Math.floor(nowMs / 1000);
+  const payload = {
+    v: APPLY_TOKEN_VERSION,
+    target: target.databaseTarget,
+    projectRef: target.projectRef,
+    scope: maintenanceRequestScope(request),
+    actor: actorFingerprint(adminUserId, secret),
+    iat: issuedAt,
+    exp: issuedAt + APPLY_TOKEN_TTL_SEC,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return {
+    token: `${encodedPayload}.${signApplyTokenPayload(encodedPayload, secret)}`,
+    expiresAt: payload.exp * 1000,
+  };
+}
+
+function verifyMaintenanceApplyToken({ token, request, target, adminUserId, env = process.env, nowMs = Date.now() }) {
+  if (!token) throw maintenanceError("apply_token_required", 409);
+  const secret = resolveApplyTokenSecret(env);
+  const parts = token.split(".");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) throw maintenanceError("invalid_apply_token", 409);
+  const expectedSignature = Buffer.from(signApplyTokenPayload(parts[0], secret));
+  const suppliedSignature = Buffer.from(parts[1]);
+  if (expectedSignature.length !== suppliedSignature.length || !timingSafeEqual(expectedSignature, suppliedSignature)) {
+    throw maintenanceError("invalid_apply_token", 409);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+  } catch {
+    throw maintenanceError("invalid_apply_token", 409);
+  }
+  const nowSec = Math.floor(nowMs / 1000);
+  if (payload?.v !== APPLY_TOKEN_VERSION || !Number.isInteger(payload.exp) || !Number.isInteger(payload.iat)) {
+    throw maintenanceError("invalid_apply_token", 409);
+  }
+  if (payload.exp <= nowSec || payload.iat > nowSec + 30) throw maintenanceError("apply_token_expired", 409);
+  if (payload.target !== target.databaseTarget || payload.projectRef !== target.projectRef) {
+    throw maintenanceError("apply_token_target_mismatch", 409);
+  }
+  if (payload.actor !== actorFingerprint(adminUserId, secret)) throw maintenanceError("apply_token_actor_mismatch", 409);
+  if (JSON.stringify(payload.scope) !== JSON.stringify(maintenanceRequestScope(request))) {
+    throw maintenanceError("apply_token_scope_mismatch", 409);
+  }
+  return payload;
 }
 
 async function listAuthUsersPage({ page, limit, env = process.env, fetchFn = fetch }) {
@@ -247,8 +321,10 @@ async function runLeaderboardMaintenance(request, deps = {}) {
 }
 
 export {
+  issueMaintenanceApplyToken,
   listAuthUsersPage,
   listProfilesPage,
+  maintenanceRequestScope,
   maintenanceError,
   parseMaintenanceRequest,
   readCanonicalProjection,
@@ -258,4 +334,5 @@ export {
   runProfileCoverage,
   runPrune,
   validateMaintenanceTarget,
+  verifyMaintenanceApplyToken,
 };

--- a/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
+++ b/netlify/functions/_shared/xp-leaderboard-maintenance.mjs
@@ -1,0 +1,261 @@
+import { executeSql, klog } from "./supabase-admin.mjs";
+import { store as defaultStore } from "./store-upstash.mjs";
+import { ensureUserProfile } from "./user-profile.mjs";
+import { createXpLeaderboardKeys, getXpLeaderboardPeriods, getXpLeaderboardWeekDayKeys } from "./xp-leaderboard.mjs";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 50;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function maintenanceError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function normalizePositiveInt(value, fallback, max = Number.MAX_SAFE_INTEGER) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, max);
+}
+
+function normalizeCounter(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
+}
+
+function parseMaintenanceRequest(payload = {}) {
+  const operation = typeof payload.operation === "string" ? payload.operation.trim() : "";
+  if (!['profile_coverage', 'backfill', 'prune'].includes(operation)) throw maintenanceError("invalid_operation");
+  const period = typeof payload.period === "string" ? payload.period.trim() : "all_time";
+  if (operation === "prune" && !['today', 'week', 'all_time'].includes(period)) throw maintenanceError("invalid_period");
+  return {
+    operation,
+    period,
+    page: normalizePositiveInt(payload.page, 1),
+    offset: Math.max(0, Math.floor(Number(payload.offset) || 0)),
+    limit: normalizePositiveInt(payload.limit, DEFAULT_LIMIT, MAX_LIMIT),
+    dryRun: payload.apply !== true,
+    confirmation: typeof payload.confirmation === "string" ? payload.confirmation.trim() : "",
+  };
+}
+
+function validateMaintenanceTarget({ identity, request }) {
+  const target = identity?.databaseTarget;
+  const projectRef = identity?.supabaseProjectRef;
+  if (!projectRef || (target !== "stage" && target !== "production")) throw maintenanceError("unsafe_target", 409);
+  if (target === "stage" && identity.stageProjectRefMatches !== true) throw maintenanceError("stage_ref_mismatch", 409);
+  if (identity.supabaseUrlProjectRef !== projectRef || identity.databaseProjectRef !== projectRef || identity.databaseMatchesSupabaseProjectRef !== true) {
+    throw maintenanceError("supabase_resource_mismatch", 409);
+  }
+  if (identity.serviceRoleProjectRef && identity.serviceRoleProjectRef !== projectRef) throw maintenanceError("service_role_project_mismatch", 409);
+  if (!request.dryRun) {
+    const expected = `apply:${target}:${projectRef}`;
+    if (request.confirmation !== expected) throw maintenanceError("confirmation_required", 409);
+  }
+  return { databaseTarget: target, projectRef, environmentContext: identity.environmentContext || "unknown" };
+}
+
+async function listAuthUsersPage({ page, limit, env = process.env, fetchFn = fetch }) {
+  const baseUrl = String(env.SUPABASE_URL || env.SUPABASE_URL_V2 || "").replace(/\/$/, "");
+  const serviceRoleKey = String(env.SUPABASE_SERVICE_ROLE_KEY || "");
+  if (!/^https:\/\/[^/]+\.supabase\.co$/i.test(baseUrl) || !serviceRoleKey) throw maintenanceError("supabase_admin_unconfigured", 503);
+  const response = await fetchFn(`${baseUrl}/auth/v1/admin/users?page=${page}&per_page=${limit}`, {
+    headers: { apikey: serviceRoleKey, authorization: `Bearer ${serviceRoleKey}` },
+    cache: "no-store",
+  });
+  if (!response?.ok) throw maintenanceError("supabase_admin_failed", 503);
+  const payload = await response.json();
+  const users = Array.isArray(payload) ? payload : payload?.users;
+  if (!Array.isArray(users)) throw maintenanceError("supabase_admin_invalid_response", 503);
+  return users.map((user) => user?.id).filter((id) => typeof id === "string" && id.length > 0);
+}
+
+async function readExistingProfileIds(userIds, runSql = executeSql) {
+  const validIds = userIds.filter((userId) => UUID_RE.test(userId));
+  if (!validIds.length) return new Set();
+  const rows = await runSql(
+    `select user_id::text from public.user_profiles where user_id = any($1::uuid[]);`,
+    [validIds],
+  );
+  return new Set((rows || []).map((row) => row.user_id));
+}
+
+async function runProfileCoverage(request, deps = {}) {
+  const listUsers = deps.listAuthUsersPage || listAuthUsersPage;
+  const readExisting = deps.readExistingProfileIds || readExistingProfileIds;
+  const ensureProfile = deps.ensureUserProfile || ensureUserProfile;
+  const userIds = await listUsers({ page: request.page, limit: request.limit, env: deps.env, fetchFn: deps.fetchFn });
+  const existing = await readExisting(userIds, deps.executeSql);
+  const missing = userIds.filter((userId) => !existing.has(userId));
+  let created = 0;
+  let failed = 0;
+  if (!request.dryRun) {
+    for (const userId of missing) {
+      try {
+        await ensureProfile(userId);
+        created += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+  }
+  return {
+    operation: request.operation,
+    dryRun: request.dryRun,
+    page: request.page,
+    limit: request.limit,
+    processed: userIds.length,
+    existing: existing.size,
+    missing: missing.length,
+    created,
+    failed,
+    hasMore: userIds.length === request.limit,
+    nextPage: userIds.length === request.limit ? request.page + 1 : null,
+  };
+}
+
+async function listProfilesPage({ page, limit, runSql = executeSql }) {
+  const rows = await runSql(
+    `select user_id::text
+     from public.user_profiles
+     order by user_id
+     offset $1 limit $2;`,
+    [(page - 1) * limit, limit],
+  );
+  return (rows || []).map((row) => row.user_id).filter(Boolean);
+}
+
+async function readCanonicalProjection({ store, namespace, userId, periods, weekDayKeys }) {
+  const totalKey = `${namespace}:total:${userId}`;
+  const dayKey = `${namespace}:daily:${userId}:${periods.dayKey}`;
+  const weekKeys = weekDayKeys.map((key) => `${namespace}:daily:${userId}:${key}`);
+  const values = await Promise.all([store.get(totalKey), store.get(dayKey), ...weekKeys.map((key) => store.get(key))]);
+  return {
+    allTime: normalizeCounter(values[0]),
+    today: normalizeCounter(values[1]),
+    week: values.slice(2).reduce((sum, value) => sum + normalizeCounter(value), 0),
+  };
+}
+
+async function setProjectionScore({ store, key, member, score, dryRun }) {
+  const current = normalizeCounter(await store.zscore(key, member));
+  if (current === score) return "unchanged";
+  if (!dryRun) {
+    if (score > 0) await store.zadd(key, score, member);
+    else await store.zrem(key, member);
+  }
+  return score > 0 ? "updated" : "removed";
+}
+
+async function runBackfill(request, deps = {}) {
+  const store = deps.store || defaultStore;
+  const namespace = deps.namespace || process.env.XP_KEY_NS || "kcswh:xp:v2";
+  const now = Number.isFinite(deps.now) ? deps.now : Date.now();
+  const periods = getXpLeaderboardPeriods(now);
+  const weekDayKeys = getXpLeaderboardWeekDayKeys(now);
+  const leaderboardKeys = createXpLeaderboardKeys({ namespace });
+  const profileIds = await (deps.listProfilesPage || listProfilesPage)({ page: request.page, limit: request.limit, runSql: deps.executeSql });
+  const counts = { processed: 0, updated: 0, removed: 0, unchanged: 0, failed: 0 };
+  for (const userId of profileIds) {
+    try {
+      const canonical = await readCanonicalProjection({ store, namespace, userId, periods, weekDayKeys });
+      const results = await Promise.all([
+        setProjectionScore({ store, key: leaderboardKeys.allTime(), member: userId, score: canonical.allTime, dryRun: request.dryRun }),
+        setProjectionScore({ store, key: leaderboardKeys.day(periods.dayKey), member: userId, score: canonical.today, dryRun: request.dryRun }),
+        setProjectionScore({ store, key: leaderboardKeys.week(periods.weekKey), member: userId, score: canonical.week, dryRun: request.dryRun }),
+      ]);
+      counts.processed += 1;
+      for (const result of results) counts[result] += 1;
+    } catch {
+      counts.failed += 1;
+    }
+  }
+  if (!request.dryRun && counts.processed > 0) {
+    await Promise.all([
+      store.expire(leaderboardKeys.day(periods.dayKey), Math.max(1, periods.dayExpiresAtSec - Math.floor(now / 1000))),
+      store.expire(leaderboardKeys.week(periods.weekKey), Math.max(1, periods.weekExpiresAtSec - Math.floor(now / 1000))),
+    ]);
+  }
+  return {
+    operation: request.operation,
+    dryRun: request.dryRun,
+    page: request.page,
+    limit: request.limit,
+    periodKeys: { today: periods.dayKey, week: periods.weekKey },
+    ...counts,
+    hasMore: profileIds.length === request.limit,
+    nextPage: profileIds.length === request.limit ? request.page + 1 : null,
+  };
+}
+
+function selectLeaderboardKey({ period, namespace, now }) {
+  const periods = getXpLeaderboardPeriods(now);
+  const keys = createXpLeaderboardKeys({ namespace });
+  if (period === "today") return keys.day(periods.dayKey);
+  if (period === "week") return keys.week(periods.weekKey);
+  return keys.allTime();
+}
+
+async function runPrune(request, deps = {}) {
+  const store = deps.store || defaultStore;
+  const namespace = deps.namespace || process.env.XP_KEY_NS || "kcswh:xp:v2";
+  const now = Number.isFinite(deps.now) ? deps.now : Date.now();
+  const key = selectLeaderboardKey({ period: request.period, namespace, now });
+  const candidates = await store.zrevrangeWithScores(key, request.offset, request.offset + request.limit - 1);
+  const readExisting = deps.readExistingProfileIds || readExistingProfileIds;
+  const existing = await readExisting(candidates.map((row) => row.member), deps.executeSql);
+  const missing = candidates.filter((row) => !existing.has(row.member));
+  if (!request.dryRun) {
+    for (const row of missing) await store.zrem(key, row.member);
+  }
+  const nextOffset = candidates.length === request.limit
+    ? (request.dryRun || missing.length === 0 ? request.offset + request.limit : request.offset)
+    : null;
+  return {
+    operation: request.operation,
+    period: request.period,
+    dryRun: request.dryRun,
+    offset: request.offset,
+    limit: request.limit,
+    processed: candidates.length,
+    missing: missing.length,
+    removed: request.dryRun ? 0 : missing.length,
+    hasMore: nextOffset !== null,
+    nextOffset,
+  };
+}
+
+async function runLeaderboardMaintenance(request, deps = {}) {
+  let result;
+  if (request.operation === "profile_coverage") result = await runProfileCoverage(request, deps);
+  else if (request.operation === "backfill") result = await runBackfill(request, deps);
+  else result = await runPrune(request, deps);
+  klog("xp_leaderboard_maintenance", {
+    operation: result.operation,
+    period: result.period || null,
+    dryRun: result.dryRun,
+    processed: result.processed,
+    missing: result.missing || 0,
+    updated: result.updated || 0,
+    removed: result.removed || 0,
+    failed: result.failed || 0,
+    hasMore: result.hasMore,
+  });
+  return result;
+}
+
+export {
+  listAuthUsersPage,
+  listProfilesPage,
+  maintenanceError,
+  parseMaintenanceRequest,
+  readCanonicalProjection,
+  readExistingProfileIds,
+  runBackfill,
+  runLeaderboardMaintenance,
+  runProfileCoverage,
+  runPrune,
+  validateMaintenanceTarget,
+};

--- a/netlify/functions/_shared/xp-leaderboard.mjs
+++ b/netlify/functions/_shared/xp-leaderboard.mjs
@@ -31,6 +31,10 @@ function addUtcDays(dayKey, days) {
   };
 }
 
+function formatUtcDay({ year, month, day }) {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
 export function getXpLeaderboardPeriods(nowMs = Date.now()) {
   const dayKey = warsawDayKey(nowMs);
   const { isoYear, week, isoDay } = isoWeekForDay(dayKey);
@@ -45,6 +49,16 @@ export function getXpLeaderboardPeriods(nowMs = Date.now()) {
     dayExpiresAtSec: Math.floor((nextDayResetAt + DAY_RETENTION_MS) / 1000),
     weekExpiresAtSec: Math.floor((nextWeekResetAt + WEEK_RETENTION_MS) / 1000),
   });
+}
+
+export function getXpLeaderboardWeekDayKeys(nowMs = Date.now()) {
+  const currentDayKey = warsawDayKey(nowMs);
+  const { isoDay } = isoWeekForDay(currentDayKey);
+  const keys = [];
+  for (let offset = isoDay - 1; offset >= 0; offset -= 1) {
+    keys.push(formatUtcDay(addUtcDays(currentDayKey, -offset)));
+  }
+  return Object.freeze(keys);
 }
 
 export function createXpLeaderboardKeys({ namespace = "kcswh:xp:v2" } = {}) {

--- a/netlify/functions/admin-stage-identity.mjs
+++ b/netlify/functions/admin-stage-identity.mjs
@@ -76,7 +76,9 @@ function resolveDatabaseTarget({ environmentContext, projectRef, expectedStagePr
 
 function buildStageIdentity(env = process.env) {
   const environmentContext = resolveEnvironmentContext(env);
-  const supabaseProjectRef = resolveConfiguredProjectRef(env);
+  const supabaseUrlProjectRef = parseProjectRefFromSupabaseUrl(env.SUPABASE_URL || env.SUPABASE_URL_V2);
+  const databaseProjectRef = parseProjectRefFromDbUrl(env.SUPABASE_DB_URL);
+  const supabaseProjectRef = supabaseUrlProjectRef || databaseProjectRef || resolveConfiguredProjectRef(env);
   const expectedStageProjectRef = resolveExpectedStageProjectRef(env);
   const serviceRoleProjectRef = parseProjectRefFromSupabaseJwt(env.SUPABASE_SERVICE_ROLE_KEY);
   const stageProjectRefMatches = !!expectedStageProjectRef && !!supabaseProjectRef && expectedStageProjectRef === supabaseProjectRef;
@@ -89,6 +91,9 @@ function buildStageIdentity(env = process.env) {
   return {
     environmentContext,
     supabaseProjectRef: supabaseProjectRef || null,
+    supabaseUrlProjectRef: supabaseUrlProjectRef || null,
+    databaseProjectRef: databaseProjectRef || null,
+    databaseMatchesSupabaseProjectRef: !!supabaseUrlProjectRef && !!databaseProjectRef && supabaseUrlProjectRef === databaseProjectRef,
     expectedStageProjectRef,
     databaseTarget,
     chipsEnabled: env.CHIPS_ENABLED === "1",

--- a/netlify/functions/admin-xp-leaderboard-maintenance.mjs
+++ b/netlify/functions/admin-xp-leaderboard-maintenance.mjs
@@ -2,9 +2,11 @@ import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.m
 import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
 import { buildStageIdentity } from "./admin-stage-identity.mjs";
 import {
+  issueMaintenanceApplyToken,
   parseMaintenanceRequest,
   runLeaderboardMaintenance,
   validateMaintenanceTarget,
+  verifyMaintenanceApplyToken,
 } from "./_shared/xp-leaderboard-maintenance.mjs";
 
 function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
@@ -12,6 +14,7 @@ function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
   const requireAdmin = deps.requireAdminUser || requireAdminUser;
   const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
   const runMaintenance = deps.runLeaderboardMaintenance || runLeaderboardMaintenance;
+  const now = deps.now || (() => Date.now());
 
   return async function handler(event) {
     const origin = event.headers?.origin || event.headers?.Origin;
@@ -21,7 +24,7 @@ function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
     if (event.httpMethod !== "POST") return { statusCode: 405, headers: cors, body: JSON.stringify({ error: "method_not_allowed" }) };
 
     try {
-      await requireAdmin(event, env);
+      const admin = await requireAdmin(event, env);
       let payload;
       try {
         payload = event.body ? JSON.parse(event.body) : {};
@@ -29,8 +32,22 @@ function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
         return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "bad_json" }) };
       }
       const request = parseMaintenanceRequest(payload);
-      const target = validateMaintenanceTarget({ identity: buildIdentity(), request });
+      const target = validateMaintenanceTarget({ identity: buildIdentity() });
+      const nowMs = now();
+      if (!request.dryRun) {
+        verifyMaintenanceApplyToken({
+          token: request.applyToken,
+          request,
+          target,
+          adminUserId: admin.userId,
+          env,
+          nowMs,
+        });
+      }
       const result = await runMaintenance(request, { env });
+      const apply = request.dryRun && Number(result.failed || 0) === 0
+        ? issueMaintenanceApplyToken({ request, target, adminUserId: admin.userId, env, nowMs })
+        : null;
       return {
         statusCode: 200,
         headers: cors,
@@ -39,9 +56,9 @@ function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
             databaseTarget: target.databaseTarget,
             environmentContext: target.environmentContext,
             projectRef: target.projectRef,
-            applyConfirmation: `apply:${target.databaseTarget}:${target.projectRef}`,
           },
           result,
+          ...(apply ? { applyToken: apply.token, applyTokenExpiresAt: apply.expiresAt } : {}),
         }),
       };
     } catch (error) {

--- a/netlify/functions/admin-xp-leaderboard-maintenance.mjs
+++ b/netlify/functions/admin-xp-leaderboard-maintenance.mjs
@@ -1,0 +1,59 @@
+import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.mjs";
+import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
+import { buildStageIdentity } from "./admin-stage-identity.mjs";
+import {
+  parseMaintenanceRequest,
+  runLeaderboardMaintenance,
+  validateMaintenanceTarget,
+} from "./_shared/xp-leaderboard-maintenance.mjs";
+
+function createAdminXpLeaderboardMaintenanceHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const requireAdmin = deps.requireAdminUser || requireAdminUser;
+  const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
+  const runMaintenance = deps.runLeaderboardMaintenance || runLeaderboardMaintenance;
+
+  return async function handler(event) {
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) return { statusCode: 403, headers: baseHeaders(), body: JSON.stringify({ error: "forbidden_origin" }) };
+    if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: cors, body: "" };
+    if (event.httpMethod !== "POST") return { statusCode: 405, headers: cors, body: JSON.stringify({ error: "method_not_allowed" }) };
+
+    try {
+      await requireAdmin(event, env);
+      let payload;
+      try {
+        payload = event.body ? JSON.parse(event.body) : {};
+      } catch {
+        return { statusCode: 400, headers: cors, body: JSON.stringify({ error: "bad_json" }) };
+      }
+      const request = parseMaintenanceRequest(payload);
+      const target = validateMaintenanceTarget({ identity: buildIdentity(), request });
+      const result = await runMaintenance(request, { env });
+      return {
+        statusCode: 200,
+        headers: cors,
+        body: JSON.stringify({
+          target: {
+            databaseTarget: target.databaseTarget,
+            environmentContext: target.environmentContext,
+            projectRef: target.projectRef,
+            applyConfirmation: `apply:${target.databaseTarget}:${target.projectRef}`,
+          },
+          result,
+        }),
+      };
+    } catch (error) {
+      if (error?.status === 401 || error?.status === 403) return adminAuthErrorResponse(error, cors);
+      const status = Number(error?.status) || 500;
+      const code = status < 500 ? (error?.code || "invalid_request") : "server_error";
+      klog("xp_leaderboard_maintenance_failed", { code: error?.code || "server_error", status });
+      return { statusCode: status, headers: cors, body: JSON.stringify({ error: code }) };
+    }
+  };
+}
+
+const handler = createAdminXpLeaderboardMaintenanceHandler();
+
+export { createAdminXpLeaderboardMaintenanceHandler, handler };

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -106,6 +106,7 @@ run("node", ["tests/home-bonuses.contract.test.mjs"], "home-bonuses-contract");
 run("node", ["tests/account-auth.contract.test.mjs"], "account-auth-contract");
 run("node", ["tests/xp-ledger.behavior.test.mjs"], "xp-ledger-behavior");
 run("node", ["tests/xp-leaderboard-foundation.behavior.test.mjs"], "xp-leaderboard-foundation-behavior");
+run("node", ["tests/xp-leaderboard-maintenance.behavior.test.mjs"], "xp-leaderboard-maintenance-behavior");
 run("node", ["tests/sidebar-admin-visibility.behavior.test.mjs"], "sidebar-admin-visibility-behavior");
 run("node", ["tests/i18n.behavior.test.mjs"], "i18n-behavior");
 run("node", ["tests/static-html.behavior.test.mjs"], "static-html-behavior");

--- a/tests/admin-stage-identity.behavior.test.mjs
+++ b/tests/admin-stage-identity.behavior.test.mjs
@@ -38,6 +38,9 @@ test("admin-stage-identity derives stage target without exposing secrets", async
 
   assert.equal(identity.environmentContext, "deploy-preview");
   assert.equal(identity.supabaseProjectRef, "stageabc");
+  assert.equal(identity.supabaseUrlProjectRef, "stageabc");
+  assert.equal(identity.databaseProjectRef, "stageabc");
+  assert.equal(identity.databaseMatchesSupabaseProjectRef, true);
   assert.equal(identity.expectedStageProjectRef, "stageabc");
   assert.equal(identity.databaseTarget, "stage");
   assert.equal(identity.stageProjectRefMatches, true);
@@ -81,6 +84,19 @@ test("admin-stage-identity detects service role project mismatch", () => {
   assert.equal(identity.stageProjectRefMatches, true);
   assert.equal(identity.serviceRoleProjectRef, "prodabc");
   assert.equal(identity.serviceRoleStageProjectRefMatches, false);
+});
+
+test("admin-stage-identity exposes a sanitized URL and DB project mismatch", () => {
+  const identity = buildStageIdentity({
+    CONTEXT: "deploy-preview",
+    SUPABASE_URL: "https://stageabc.supabase.co",
+    SUPABASE_DB_URL: "postgresql://postgres.prodabc:pw@aws-0-us.pooler.supabase.com:6543/postgres",
+    SUPABASE_STAGE_PROJECT_REF: "stageabc",
+  });
+  assert.equal(identity.supabaseUrlProjectRef, "stageabc");
+  assert.equal(identity.databaseProjectRef, "prodabc");
+  assert.equal(identity.databaseMatchesSupabaseProjectRef, false);
+  assert.equal(JSON.stringify(identity).includes("postgresql://"), false);
 });
 
 test("admin-stage-identity rejects postgres project-ref usernames on non-Supabase hosts", () => {

--- a/tests/xp-leaderboard-maintenance.behavior.test.mjs
+++ b/tests/xp-leaderboard-maintenance.behavior.test.mjs
@@ -3,48 +3,113 @@ import test from "node:test";
 import { __createMemoryStoreForTests } from "../netlify/functions/_shared/store-upstash.mjs";
 import { createAdminXpLeaderboardMaintenanceHandler } from "../netlify/functions/admin-xp-leaderboard-maintenance.mjs";
 import {
+  issueMaintenanceApplyToken,
   listAuthUsersPage,
   parseMaintenanceRequest,
   runBackfill,
   runProfileCoverage,
   runPrune,
   validateMaintenanceTarget,
+  verifyMaintenanceApplyToken,
 } from "../netlify/functions/_shared/xp-leaderboard-maintenance.mjs";
 import { createXpLeaderboardKeys, getXpLeaderboardPeriods, getXpLeaderboardWeekDayKeys } from "../netlify/functions/_shared/xp-leaderboard.mjs";
 
 const USER_1 = "00000000-0000-4000-8000-000000000001";
 const USER_2 = "00000000-0000-4000-8000-000000000002";
 const NAMESPACE = "test:xp:maintenance";
+const NOW = Date.UTC(2026, 6, 13, 5, 0, 0);
+const TOKEN_ENV = { SUPABASE_SERVICE_ROLE_KEY: "test-service-role-secret-at-least-32-chars" };
+const STAGE_TARGET = { databaseTarget: "stage", projectRef: "stage-ref", environmentContext: "deploy-preview" };
+const STAGE_IDENTITY = {
+  databaseTarget: "stage",
+  supabaseProjectRef: "stage-ref",
+  supabaseUrlProjectRef: "stage-ref",
+  databaseProjectRef: "stage-ref",
+  databaseMatchesSupabaseProjectRef: true,
+  stageProjectRefMatches: true,
+  serviceRoleProjectRef: "stage-ref",
+  environmentContext: "deploy-preview",
+};
 
 test("maintenance requests default to bounded dry-run and reject unsafe operations", () => {
   assert.deepEqual(parseMaintenanceRequest({ operation: "backfill", limit: 500 }), {
-    operation: "backfill", period: "all_time", page: 1, offset: 0, limit: 50, dryRun: true, confirmation: "",
+    operation: "backfill", period: "all_time", page: 1, offset: 0, limit: 50, dryRun: true, applyToken: "",
   });
   assert.throws(() => parseMaintenanceRequest({ operation: "unknown" }), /invalid_operation/);
   assert.throws(() => parseMaintenanceRequest({ operation: "prune", period: "old-week" }), /invalid_period/);
 });
 
-test("apply requires an exact detected target confirmation", () => {
-  const identity = {
-    databaseTarget: "stage",
-    supabaseProjectRef: "stage-ref",
-    supabaseUrlProjectRef: "stage-ref",
-    databaseProjectRef: "stage-ref",
-    databaseMatchesSupabaseProjectRef: true,
-    stageProjectRefMatches: true,
-    serviceRoleProjectRef: "stage-ref",
-    environmentContext: "deploy-preview",
-  };
-  assert.equal(validateMaintenanceTarget({ identity, request: { dryRun: true } }).databaseTarget, "stage");
-  assert.throws(() => validateMaintenanceTarget({ identity, request: { dryRun: false, confirmation: "" } }), /confirmation_required/);
-  assert.equal(validateMaintenanceTarget({
-    identity,
-    request: { dryRun: false, confirmation: "apply:stage:stage-ref" },
-  }).projectRef, "stage-ref");
+test("maintenance target validation rejects inconsistent server resources", () => {
+  assert.equal(validateMaintenanceTarget({ identity: STAGE_IDENTITY }).databaseTarget, "stage");
   assert.throws(() => validateMaintenanceTarget({
-    identity: { ...identity, serviceRoleProjectRef: "other-ref" },
-    request: { dryRun: true },
+    identity: { ...STAGE_IDENTITY, serviceRoleProjectRef: "other-ref" },
   }), /service_role_project_mismatch/);
+});
+
+test("signed apply token is bound to operation, page, target, actor, and expiry", () => {
+  const dryRun = parseMaintenanceRequest({ operation: "profile_coverage", page: 1, limit: 25 });
+  const issued = issueMaintenanceApplyToken({
+    request: dryRun, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW,
+  });
+  const matchingApply = parseMaintenanceRequest({
+    operation: "profile_coverage", page: 1, limit: 25, apply: true, applyToken: issued.token,
+  });
+  assert.equal(verifyMaintenanceApplyToken({
+    token: issued.token, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW,
+  }).scope.page, 1);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token,
+    request: parseMaintenanceRequest({ operation: "backfill", page: 1, limit: 25, apply: true }),
+    target: STAGE_TARGET,
+    adminUserId: USER_1,
+    env: TOKEN_ENV,
+    nowMs: NOW,
+  }), /apply_token_scope_mismatch/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token,
+    request: parseMaintenanceRequest({ operation: "profile_coverage", page: 2, limit: 25, apply: true }),
+    target: STAGE_TARGET,
+    adminUserId: USER_1,
+    env: TOKEN_ENV,
+    nowMs: NOW,
+  }), /apply_token_scope_mismatch/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token,
+    request: matchingApply,
+    target: { databaseTarget: "production", projectRef: "prod-ref" },
+    adminUserId: USER_1,
+    env: TOKEN_ENV,
+    nowMs: NOW,
+  }), /apply_token_target_mismatch/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_2, env: TOKEN_ENV, nowMs: NOW,
+  }), /apply_token_actor_mismatch/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW + (5 * 60 * 1000),
+  }), /apply_token_expired/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: `${issued.token.slice(0, -1)}x`, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW,
+  }), /invalid_apply_token/);
+});
+
+test("prune apply token is bound to period and raw offset", () => {
+  const dryRun = parseMaintenanceRequest({ operation: "prune", period: "all_time", offset: 0, limit: 25 });
+  const issued = issueMaintenanceApplyToken({
+    request: dryRun, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW,
+  });
+  for (const mismatch of [
+    { operation: "prune", period: "week", offset: 0, limit: 25, apply: true },
+    { operation: "prune", period: "all_time", offset: 25, limit: 25, apply: true },
+  ]) {
+    assert.throws(() => verifyMaintenanceApplyToken({
+      token: issued.token,
+      request: parseMaintenanceRequest(mismatch),
+      target: STAGE_TARGET,
+      adminUserId: USER_1,
+      env: TOKEN_ENV,
+      nowMs: NOW,
+    }), /apply_token_scope_mismatch/);
+  }
 });
 
 test("profile coverage discovery uses bounded Supabase Admin pagination and keeps only IDs", async () => {
@@ -76,7 +141,7 @@ test("profile coverage is read-only in dry-run and creates only missing profiles
     { processed: 2, existing: 1, missing: 1, created: 0 });
   assert.deepEqual(created, []);
   const apply = await runProfileCoverage(parseMaintenanceRequest({
-    operation: "profile_coverage", apply: true, confirmation: "unused-by-service",
+    operation: "profile_coverage", apply: true,
   }), deps);
   assert.equal(apply.created, 1);
   assert.deepEqual(created, [USER_2]);
@@ -141,33 +206,32 @@ test("prune removes missing profiles without skipping the shifted raw offset", a
 
 test("admin endpoint is authenticated and keeps target validation ahead of maintenance", async () => {
   let maintenanceCalls = 0;
-  const identity = {
-    databaseTarget: "stage",
-    supabaseProjectRef: "stage-ref",
-    supabaseUrlProjectRef: "stage-ref",
-    databaseProjectRef: "stage-ref",
-    databaseMatchesSupabaseProjectRef: true,
-    stageProjectRefMatches: true,
-    serviceRoleProjectRef: "stage-ref",
-    environmentContext: "deploy-preview",
-  };
   const handler = createAdminXpLeaderboardMaintenanceHandler({
-    env: {},
+    env: TOKEN_ENV,
     requireAdminUser: async () => ({ userId: USER_1 }),
-    buildStageIdentity: () => identity,
+    buildStageIdentity: () => STAGE_IDENTITY,
     runLeaderboardMaintenance: async (request) => { maintenanceCalls += 1; return { operation: request.operation, dryRun: request.dryRun }; },
+    now: () => NOW,
   });
   const rejected = await handler({
     httpMethod: "POST", headers: {}, body: JSON.stringify({ operation: "backfill", apply: true }),
   });
   assert.equal(rejected.statusCode, 409);
-  assert.equal(JSON.parse(rejected.body).error, "confirmation_required");
+  assert.equal(JSON.parse(rejected.body).error, "apply_token_required");
   assert.equal(maintenanceCalls, 0);
+  const dryRun = await handler({
+    httpMethod: "POST", headers: {}, body: JSON.stringify({ operation: "backfill", page: 2, limit: 25 }),
+  });
+  assert.equal(dryRun.statusCode, 200);
+  const dryRunPayload = JSON.parse(dryRun.body);
+  assert.equal(typeof dryRunPayload.applyToken, "string");
+  assert.equal(dryRunPayload.applyTokenExpiresAt, NOW + (5 * 60 * 1000));
+  assert.equal(maintenanceCalls, 1);
   const accepted = await handler({
     httpMethod: "POST",
     headers: {},
-    body: JSON.stringify({ operation: "backfill", apply: true, confirmation: "apply:stage:stage-ref" }),
+    body: JSON.stringify({ operation: "backfill", page: 2, limit: 25, apply: true, applyToken: dryRunPayload.applyToken }),
   });
   assert.equal(accepted.statusCode, 200);
-  assert.equal(maintenanceCalls, 1);
+  assert.equal(maintenanceCalls, 2);
 });

--- a/tests/xp-leaderboard-maintenance.behavior.test.mjs
+++ b/tests/xp-leaderboard-maintenance.behavior.test.mjs
@@ -18,7 +18,7 @@ const USER_1 = "00000000-0000-4000-8000-000000000001";
 const USER_2 = "00000000-0000-4000-8000-000000000002";
 const NAMESPACE = "test:xp:maintenance";
 const NOW = Date.UTC(2026, 6, 13, 5, 0, 0);
-const TOKEN_ENV = { SUPABASE_SERVICE_ROLE_KEY: "test-service-role-secret-at-least-32-chars" };
+const TOKEN_ENV = { SUPABASE_SERVICE_ROLE_KEY: "test-service-role-secret-at-least-32-chars", DEPLOY_ID: "deploy-stage-a" };
 const STAGE_TARGET = { databaseTarget: "stage", projectRef: "stage-ref", environmentContext: "deploy-preview" };
 const STAGE_IDENTITY = {
   databaseTarget: "stage",
@@ -84,6 +84,14 @@ test("signed apply token is bound to operation, page, target, actor, and expiry"
   assert.throws(() => verifyMaintenanceApplyToken({
     token: issued.token, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_2, env: TOKEN_ENV, nowMs: NOW,
   }), /apply_token_actor_mismatch/);
+  assert.throws(() => verifyMaintenanceApplyToken({
+    token: issued.token,
+    request: matchingApply,
+    target: STAGE_TARGET,
+    adminUserId: USER_1,
+    env: { ...TOKEN_ENV, DEPLOY_ID: "deploy-stage-b" },
+    nowMs: NOW,
+  }), /apply_token_deploy_mismatch/);
   assert.throws(() => verifyMaintenanceApplyToken({
     token: issued.token, request: matchingApply, target: STAGE_TARGET, adminUserId: USER_1, env: TOKEN_ENV, nowMs: NOW + (5 * 60 * 1000),
   }), /apply_token_expired/);

--- a/tests/xp-leaderboard-maintenance.behavior.test.mjs
+++ b/tests/xp-leaderboard-maintenance.behavior.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __createMemoryStoreForTests } from "../netlify/functions/_shared/store-upstash.mjs";
+import { createAdminXpLeaderboardMaintenanceHandler } from "../netlify/functions/admin-xp-leaderboard-maintenance.mjs";
+import {
+  listAuthUsersPage,
+  parseMaintenanceRequest,
+  runBackfill,
+  runProfileCoverage,
+  runPrune,
+  validateMaintenanceTarget,
+} from "../netlify/functions/_shared/xp-leaderboard-maintenance.mjs";
+import { createXpLeaderboardKeys, getXpLeaderboardPeriods, getXpLeaderboardWeekDayKeys } from "../netlify/functions/_shared/xp-leaderboard.mjs";
+
+const USER_1 = "00000000-0000-4000-8000-000000000001";
+const USER_2 = "00000000-0000-4000-8000-000000000002";
+const NAMESPACE = "test:xp:maintenance";
+
+test("maintenance requests default to bounded dry-run and reject unsafe operations", () => {
+  assert.deepEqual(parseMaintenanceRequest({ operation: "backfill", limit: 500 }), {
+    operation: "backfill", period: "all_time", page: 1, offset: 0, limit: 50, dryRun: true, confirmation: "",
+  });
+  assert.throws(() => parseMaintenanceRequest({ operation: "unknown" }), /invalid_operation/);
+  assert.throws(() => parseMaintenanceRequest({ operation: "prune", period: "old-week" }), /invalid_period/);
+});
+
+test("apply requires an exact detected target confirmation", () => {
+  const identity = {
+    databaseTarget: "stage",
+    supabaseProjectRef: "stage-ref",
+    supabaseUrlProjectRef: "stage-ref",
+    databaseProjectRef: "stage-ref",
+    databaseMatchesSupabaseProjectRef: true,
+    stageProjectRefMatches: true,
+    serviceRoleProjectRef: "stage-ref",
+    environmentContext: "deploy-preview",
+  };
+  assert.equal(validateMaintenanceTarget({ identity, request: { dryRun: true } }).databaseTarget, "stage");
+  assert.throws(() => validateMaintenanceTarget({ identity, request: { dryRun: false, confirmation: "" } }), /confirmation_required/);
+  assert.equal(validateMaintenanceTarget({
+    identity,
+    request: { dryRun: false, confirmation: "apply:stage:stage-ref" },
+  }).projectRef, "stage-ref");
+  assert.throws(() => validateMaintenanceTarget({
+    identity: { ...identity, serviceRoleProjectRef: "other-ref" },
+    request: { dryRun: true },
+  }), /service_role_project_mismatch/);
+});
+
+test("profile coverage discovery uses bounded Supabase Admin pagination and keeps only IDs", async () => {
+  let request = null;
+  const ids = await listAuthUsersPage({
+    page: 2,
+    limit: 25,
+    env: { SUPABASE_URL: "https://stage-ref.supabase.co", SUPABASE_SERVICE_ROLE_KEY: "service-secret" },
+    fetchFn: async (url, options) => {
+      request = { url, options };
+      return { ok: true, json: async () => ({ users: [{ id: USER_1, email: "private@example.com" }] }) };
+    },
+  });
+  assert.deepEqual(ids, [USER_1]);
+  assert.equal(request.url, "https://stage-ref.supabase.co/auth/v1/admin/users?page=2&per_page=25");
+  assert.equal(request.options.headers.apikey, "service-secret");
+  assert.equal(JSON.stringify(ids).includes("private@example.com"), false);
+});
+
+test("profile coverage is read-only in dry-run and creates only missing profiles on apply", async () => {
+  const created = [];
+  const deps = {
+    listAuthUsersPage: async () => [USER_1, USER_2],
+    readExistingProfileIds: async () => new Set([USER_1]),
+    ensureUserProfile: async (userId) => { created.push(userId); },
+  };
+  const dryRun = await runProfileCoverage(parseMaintenanceRequest({ operation: "profile_coverage" }), deps);
+  assert.deepEqual({ processed: dryRun.processed, existing: dryRun.existing, missing: dryRun.missing, created: dryRun.created },
+    { processed: 2, existing: 1, missing: 1, created: 0 });
+  assert.deepEqual(created, []);
+  const apply = await runProfileCoverage(parseMaintenanceRequest({
+    operation: "profile_coverage", apply: true, confirmation: "unused-by-service",
+  }), deps);
+  assert.equal(apply.created, 1);
+  assert.deepEqual(created, [USER_2]);
+});
+
+test("backfill converges canonical totals and removes stale zero projections", async () => {
+  const store = __createMemoryStoreForTests();
+  const now = Date.now();
+  const periods = getXpLeaderboardPeriods(now);
+  const weekDays = getXpLeaderboardWeekDayKeys(now);
+  const keys = createXpLeaderboardKeys({ namespace: NAMESPACE });
+  await store.set(`${NAMESPACE}:total:${USER_1}`, "120");
+  await store.set(`${NAMESPACE}:daily:${USER_1}:${periods.dayKey}`, "20");
+  for (const dayKey of weekDays) await store.set(`${NAMESPACE}:daily:${USER_1}:${dayKey}`, "5");
+  await store.zadd(keys.allTime(), 10, USER_1);
+  await store.zadd(keys.allTime(), 99, USER_2);
+  await store.zadd(keys.day(periods.dayKey), 99, USER_2);
+  await store.zadd(keys.week(periods.weekKey), 99, USER_2);
+  const deps = { store, namespace: NAMESPACE, now, listProfilesPage: async () => [USER_1, USER_2] };
+
+  const dryRun = await runBackfill(parseMaintenanceRequest({ operation: "backfill" }), deps);
+  assert.equal(dryRun.updated > 0, true);
+  assert.equal(await store.zscore(keys.allTime(), USER_1), 10);
+
+  const applied = await runBackfill(parseMaintenanceRequest({ operation: "backfill", apply: true }), deps);
+  assert.equal(applied.failed, 0);
+  assert.equal(await store.zscore(keys.allTime(), USER_1), 120);
+  assert.equal(await store.zscore(keys.day(periods.dayKey), USER_1), 5);
+  assert.equal(await store.zscore(keys.week(periods.weekKey), USER_1), weekDays.length * 5);
+  assert.equal(await store.zscore(keys.allTime(), USER_2), null);
+  assert.equal(await store.zscore(keys.day(periods.dayKey), USER_2), null);
+  assert.equal(await store.zscore(keys.week(periods.weekKey), USER_2), null);
+
+  const rerun = await runBackfill(parseMaintenanceRequest({ operation: "backfill", apply: true }), deps);
+  assert.equal(rerun.updated, 0);
+  assert.equal(rerun.removed, 0);
+  assert.equal(rerun.unchanged, 6);
+});
+
+test("prune removes missing profiles without skipping the shifted raw offset", async () => {
+  const store = __createMemoryStoreForTests();
+  const keys = createXpLeaderboardKeys({ namespace: NAMESPACE });
+  await store.zadd(keys.allTime(), 20, USER_1);
+  await store.zadd(keys.allTime(), 10, USER_2);
+  const request = parseMaintenanceRequest({ operation: "prune", period: "all_time", apply: true, limit: 2 });
+  const first = await runPrune(request, {
+    store,
+    namespace: NAMESPACE,
+    readExistingProfileIds: async () => new Set([USER_1]),
+  });
+  assert.equal(first.removed, 1);
+  assert.equal(first.nextOffset, 0);
+  assert.equal(await store.zscore(keys.allTime(), USER_2), null);
+  const second = await runPrune({ ...request, offset: first.nextOffset }, {
+    store,
+    namespace: NAMESPACE,
+    readExistingProfileIds: async () => new Set([USER_1]),
+  });
+  assert.equal(second.removed, 0);
+  assert.equal(second.hasMore, false);
+});
+
+test("admin endpoint is authenticated and keeps target validation ahead of maintenance", async () => {
+  let maintenanceCalls = 0;
+  const identity = {
+    databaseTarget: "stage",
+    supabaseProjectRef: "stage-ref",
+    supabaseUrlProjectRef: "stage-ref",
+    databaseProjectRef: "stage-ref",
+    databaseMatchesSupabaseProjectRef: true,
+    stageProjectRefMatches: true,
+    serviceRoleProjectRef: "stage-ref",
+    environmentContext: "deploy-preview",
+  };
+  const handler = createAdminXpLeaderboardMaintenanceHandler({
+    env: {},
+    requireAdminUser: async () => ({ userId: USER_1 }),
+    buildStageIdentity: () => identity,
+    runLeaderboardMaintenance: async (request) => { maintenanceCalls += 1; return { operation: request.operation, dryRun: request.dryRun }; },
+  });
+  const rejected = await handler({
+    httpMethod: "POST", headers: {}, body: JSON.stringify({ operation: "backfill", apply: true }),
+  });
+  assert.equal(rejected.statusCode, 409);
+  assert.equal(JSON.parse(rejected.body).error, "confirmation_required");
+  assert.equal(maintenanceCalls, 0);
+  const accepted = await handler({
+    httpMethod: "POST",
+    headers: {},
+    body: JSON.stringify({ operation: "backfill", apply: true, confirmation: "apply:stage:stage-ref" }),
+  });
+  assert.equal(accepted.statusCode, 200);
+  assert.equal(maintenanceCalls, 1);
+});


### PR DESCRIPTION
## Summary
- add an admin-only, bounded XP leaderboard maintenance endpoint
- add profile coverage, canonical XP backfill, and missing-profile prune operations
- require a successful dry-run before each apply through a five-minute signed token
- bind each token to the admin, target, project, operation, page, offset, limit, and period
- document the stage rollout and rollback procedure

## Scope
This is leaderboard implementation Phase 2 only. It does not add the public leaderboard API or UI.

## Verification
- `npm test`
- `npm run check:all`
- `node scripts/syntax-check.mjs`
- `node tests/xp-leaderboard-maintenance.behavior.test.mjs`
- `node tests/admin-stage-identity.behavior.test.mjs`
- `git diff --check`

Token coverage includes operation/page/period/offset/target/admin mismatches, expiry, tampering, and a successful matching dry-run/apply pair.

## Deployment
- no database migration
- no new environment variables
- stage dry-run/apply smoke remains required on the Deploy Preview before merge
- production apply must wait for a successful stage run and the later dark public API rollout

## Breaking impact
No public runtime contract changes. The only write path added is the authenticated admin maintenance endpoint. Apply is rejected unless the same admin first completes an identical dry-run against the same target and uses its short-lived signed token.