### PR TITLE
fix: expose production maintenance target

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,6 +28,8 @@ This document preserves the operational and rollout details that were previously
 
 Prerequisites are existing runtime configuration only: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, Upstash REST credentials, `XP_KEY_NS`, and `SUPABASE_STAGE_PROJECT_REF` on deploy previews. No database migration or new persistent environment variable is required.
 
+Production deploys receive `ARCADE_DEPLOY_TARGET=production` from `netlify.toml`. This source-controlled, non-secret marker is required because Netlify does not guarantee that its build-only `CONTEXT` value is present in the Functions runtime. The maintenance target still requires matching Supabase URL, database, and service-role project references; the marker alone cannot authorize a mismatched target.
+
 Use an admin Supabase access token and the matching deploy URL. Start every operation without `apply`:
 
 ```bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -83,6 +83,7 @@
 # Production context - secure defaults
 # NOTE: These are baseline values. Override in Netlify UI for sensitive settings.
 [context.production.environment]
+  ARCADE_DEPLOY_TARGET = "production"
   XP_DEBUG = "0"
   XP_RATE_LIMIT_ENABLED = "1"
   XP_SESSION_RATE_LIMIT_ENABLED = "1"

--- a/netlify/functions/admin-stage-identity.mjs
+++ b/netlify/functions/admin-stage-identity.mjs
@@ -51,6 +51,10 @@ function parseProjectRefFromSupabaseJwt(value) {
 }
 
 function resolveEnvironmentContext(env = process.env) {
+  const configuredTarget = normalizeString(env.ARCADE_DEPLOY_TARGET);
+  if (["production", "deploy-preview", "branch-deploy", "development"].includes(configuredTarget)) {
+    return configuredTarget;
+  }
   return normalizeString(env.CONTEXT || env.NETLIFY_CONTEXT || env.NODE_ENV) || "unknown";
 }
 

--- a/tests/admin-stage-identity.behavior.test.mjs
+++ b/tests/admin-stage-identity.behavior.test.mjs
@@ -65,6 +65,20 @@ test("admin-stage-identity marks production context as production when stage ref
   assert.equal(identity.stageProjectRefMatches, false);
 });
 
+test("admin-stage-identity uses the source-controlled production target when Netlify omits runtime context", () => {
+  const identity = buildStageIdentity({
+    ARCADE_DEPLOY_TARGET: "production",
+    SUPABASE_URL: "https://prodabc.supabase.co",
+    SUPABASE_DB_URL: "postgresql://postgres.prodabc:secret@aws-0-eu.pooler.supabase.com:6543/postgres",
+    SUPABASE_SERVICE_ROLE_KEY: makeUnsignedSupabaseJwt("prodabc"),
+  });
+
+  assert.equal(identity.environmentContext, "production");
+  assert.equal(identity.databaseTarget, "production");
+  assert.equal(identity.databaseMatchesSupabaseProjectRef, true);
+  assert.equal(identity.serviceRoleProjectRef, "prodabc");
+});
+
 test("admin-stage-identity parses project refs from supported Supabase URLs", () => {
   assert.equal(parseProjectRefFromSupabaseUrl("https://stageabc.supabase.co"), "stageabc");
   assert.equal(parseProjectRefFromDbUrl("postgresql://postgres.stageabc:pw@aws-0-us.pooler.supabase.com:6543/postgres"), "stageabc");


### PR DESCRIPTION
## Summary

- provide a source-controlled, non-secret production target marker to Netlify Functions
- make the admin identity guard use that marker when Netlify omits its build-only `CONTEXT` value at runtime
- preserve the existing Supabase URL, database, service-role, admin-auth, dry-run, and signed apply-token checks
- document why the explicit marker is required

## Root cause

The production leaderboard maintenance endpoint returned `409 unsafe_target`. Its Supabase URL, database project ref, and service-role project ref all matched production, but the Functions runtime reported no `CONTEXT`, `NETLIFY_CONTEXT`, or `NODE_ENV`. The guard therefore classified the target as `unknown` and correctly refused backfill.

## Verification

- `node --test tests/admin-stage-identity.behavior.test.mjs tests/xp-leaderboard-maintenance.behavior.test.mjs` (18 passed)
- `npm run -s check:all`
- `npm test`
- `git diff --check`

## Rollout

After merge and production deploy:

1. verify `admin-stage-identity` reports `environmentContext=production` and `databaseTarget=production`
2. run production `profile_coverage`, `backfill`, and all three `prune` operations through dry-run plus signed apply token
3. rerun backfill and confirm convergence
4. verify public leaderboard rows against canonical XP

No migration and no secret environment variable are required.

## Breaking impact

None expected for normal application traffic. The new marker only enables the already admin-protected maintenance guard to recognize the production deploy; resource matching remains mandatory.