### PR TITLE
fix leaderboard ranks for visible profiles

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -78,7 +78,7 @@ GET /.netlify/functions/xp-leaderboard?period=today|week|all_time&page=1&limit=2
 GET /.netlify/functions/xp-leaderboard-me?period=today|week|all_time
 ```
 
-The first endpoint is public, returns only allowlisted profile identity, rank, period XP, lifetime-derived level, and profile URL, and uses `no-store`. Fresh reads prevent a recently re-enabled owner from appearing in authenticated `me` while an older public page still omits them. It never includes `me` and never returns UUIDs, emails, bio, chips, ledger/session data, Redis keys, or avatar storage keys. Missing profiles produce a shorter deterministic raw page; the endpoint does not borrow members from the next page. `page` is capped at 20 and `limit` at 50.
+The first endpoint is public, returns only allowlisted profile identity, rank, period XP, lifetime-derived level, and profile URL, and uses `no-store`. Fresh reads prevent a recently re-enabled owner from appearing in authenticated `me` while an older public page still omits them. It never includes `me` and never returns UUIDs, emails, bio, chips, ledger/session data, Redis keys, or avatar storage keys. Missing profiles produce a shorter deterministic raw page; the endpoint does not borrow members from the next page and does not count omitted members in visible competition ranks. `page` is capped at 20 and `limit` at 50, bounding the rank prefix to 1000 candidates.
 
 The second endpoint requires `Authorization: Bearer <Supabase access token>`, returns only the matching public-safe row or `me: null`, and always uses `private, no-store`. Public and private results must not be merged into one cacheable response.
 

--- a/docs/xp-leaderboard-implementation-plan.md
+++ b/docs/xp-leaderboard-implementation-plan.md
@@ -65,7 +65,7 @@ The API response includes the normalized period key and `nextResetAt` for period
 - A visible row requires a matching `public.user_profiles` record.
 - Every successfully created Supabase account receives a profile from the `auth.users` provisioning trigger. The bounded profile-coverage operation remains repair tooling; public leaderboard reads never create profiles.
 - The leaderboard writer uses the Redis hidden marker and does not add a database query to every XP award.
-- If an exceptional indexed account has no profile, the API omits it, returns a shorter page, and records a `klog` diagnostic without public identifiers. It must not pull candidates from the next raw Redis page to fill the gap. Reconciliation removes or repairs the invalid member outside the public request.
+- If an exceptional indexed account has no profile, the API omits it, returns a shorter page, and records a `klog` diagnostic without public identifiers. It must not pull candidates from the next raw Redis page to fill the gap. Public ranks exclude the omitted account; reconciliation removes or repairs the invalid member outside the public request.
 
 Owners may opt out through `user_profiles.leaderboard_visible`. SQL reads fail closed by filtering hidden profiles, while Redis projection synchronization removes hidden members and prevents award or conversion writers from re-adding them. The public profile remains available by handle.
 
@@ -194,7 +194,7 @@ GET /.netlify/functions/xp-leaderboard-me?period=today|week|all_time
 - The `me` endpoint accepts only `period`; it does not accept public page or limit parameters.
 - Apply the existing CORS conventions and a reusable public-IP rate limit.
 
-Offset/rank pagination matches Redis sorted-set access and is sufficient for the current product scale. The raw Redis range is always `offset = (page - 1) * limit` through `offset + limit - 1`. Public projection may omit an exceptional member without a profile, but it must not over-fetch into the next page. Rankings can move between requests as XP is awarded; the API documents this eventual movement rather than pretending to provide a stable snapshot cursor.
+Offset/rank pagination matches Redis sorted-set access and is sufficient for the current product scale. The requested raw page remains `offset = (page - 1) * limit` through `offset + limit - 1`. To calculate ranks among eligible profiles across pages, the API reads the bounded raw prefix from zero through that page boundary; the existing page and limit caps bound this to 1000 candidates. Public projection may omit an exceptional member without a profile, but it must not pull a member from the next raw page. Rankings can move between requests as XP is awarded; the API documents this eventual movement rather than pretending to provide a stable snapshot cursor.
 
 ### Response contract
 
@@ -261,8 +261,8 @@ Never return email, Supabase UUID, auth metadata, IP, chips, ledger data, poker 
 
 ### Profile join
 
-1. Read a bounded candidate range and scores from Redis.
-2. Batch-query `user_profiles` with the existing trusted SQL helper.
+1. Read the bounded candidate prefix through the requested raw page and its scores from Redis.
+2. Batch-query `user_profiles` for that prefix with the existing trusted SQL helper.
 3. Preserve Redis ordering while projecting profiles through shared avatar/public-profile helpers.
 4. Batch-read lifetime totals when period scores do not represent lifetime XP.
 5. If a candidate has no profile, omit it from that response, return a shorter page, and emit an aggregate diagnostic. Do not read beyond the page's raw Redis range.
@@ -270,7 +270,7 @@ Never return email, Supabase UUID, auth metadata, IP, chips, ledger data, poker 
 
 Do not serialize raw Redis members or database rows.
 
-This preserves deterministic page boundaries: a missing profile at raw position 10 cannot pull a position from page 2 into page 1. Until reconciliation removes the invalid member, public rank numbers may contain a gap, which is preferable to duplicate or skipped users across pages.
+This preserves deterministic page boundaries: a missing profile at raw position 10 cannot pull a position from page 2 into page 1. The rank calculation filters the same bounded prefix through the public profile allowlist, so omitted or hidden members do not consume visible positions and competition ranks remain consistent across pages.
 
 ### Cache policy
 
@@ -354,7 +354,7 @@ Do not load gameplay XP scoring modules merely to render rankings. Reuse only th
 - Clients cannot submit XP, rank, member IDs, or profile fields to the leaderboard.
 - Invalid Bearer tokens always return `401` on authenticated ranking requests.
 - Use explicit response projection and generic errors.
-- Apply bounded page/limit values, rate limiting, request timeouts, and fixed raw Redis page ranges.
+- Apply bounded page/limit values, rate limiting, request timeouts, and bounded raw Redis prefixes.
 - Do not provide handle prefix search, full export, arbitrary historical period keys, or unbounded page traversal.
 - Only current periods and `all_time` are public in MVP; callers cannot select an old Redis key.
 - Use `klog` for diagnostics and never log JWTs, emails, raw UUIDs, or full response rows.

--- a/netlify/functions/_shared/xp-leaderboard-read.mjs
+++ b/netlify/functions/_shared/xp-leaderboard-read.mjs
@@ -106,10 +106,21 @@ async function readLifetimeXp(store, namespace, candidates, period) {
   });
 }
 
-async function competitionRanks(store, key, scores) {
-  const distinct = [...new Set(scores)];
-  const entries = await Promise.all(distinct.map(async (score) => [score, 1 + await store.zcount(key, `(${score}`, "+inf")]));
-  return new Map(entries);
+function visibleCompetitionRanks(candidates, profiles) {
+  const ranks = new Map();
+  let visibleCount = 0;
+  let currentScore = null;
+  let currentRank = 0;
+  for (const candidate of candidates) {
+    if (!profiles.has(candidate.member)) continue;
+    if (currentScore === null || candidate.score !== currentScore) {
+      currentScore = candidate.score;
+      currentRank = visibleCount + 1;
+    }
+    ranks.set(candidate.member, currentRank);
+    visibleCount += 1;
+  }
+  return ranks;
 }
 
 async function readLeaderboardPage(options, deps = {}) {
@@ -121,24 +132,29 @@ async function readLeaderboardPage(options, deps = {}) {
   const periodState = resolveLeaderboardPeriod({ period, namespace, nowMs });
   const offset = (page - 1) * limit;
   const redisStartedAt = Date.now();
-  const [rawRows, total] = await Promise.all([
-    store.zrevrangeWithScores(periodState.key, offset, offset + limit - 1),
+  const [rawPrefix, total] = await Promise.all([
+    store.zrevrangeWithScores(periodState.key, 0, offset + limit - 1),
     store.zcard(periodState.key),
   ]);
-  const candidates = rawRows.map((row) => ({ member: String(row.member), score: normalizeScore(row.score) }));
+  const prefixCandidates = rawPrefix.map((row) => ({ member: String(row.member), score: normalizeScore(row.score) }));
+  const candidates = prefixCandidates.slice(offset, offset + limit);
+  const validPrefix = prefixCandidates.filter((candidate) => UUID_RE.test(candidate.member) && candidate.score > 0);
   const validCandidates = candidates.filter((candidate) => UUID_RE.test(candidate.member) && candidate.score > 0);
-  const ranks = await competitionRanks(store, periodState.key, candidates.map((row) => row.score));
-  const lifetimeValues = await readLifetimeXp(store, namespace, validCandidates, period);
-  const redisMs = Date.now() - redisStartedAt;
+  let redisMs = Date.now() - redisStartedAt;
   const profilesStartedAt = Date.now();
-  const profiles = await readProfiles(validCandidates.map((row) => row.member), deps.executeSql);
+  const profiles = await readProfiles(validPrefix.map((row) => row.member), deps.executeSql);
+  const profileMs = Date.now() - profilesStartedAt;
+  const ranks = visibleCompetitionRanks(validPrefix, profiles);
+  const visibleCandidates = validCandidates.filter((candidate) => profiles.has(candidate.member));
+  const lifetimeStartedAt = Date.now();
+  const lifetimeValues = await readLifetimeXp(store, namespace, visibleCandidates, period);
+  redisMs += Date.now() - lifetimeStartedAt;
   const rows = [];
-  for (let index = 0; index < validCandidates.length; index += 1) {
-    const candidate = validCandidates[index];
+  for (let index = 0; index < visibleCandidates.length; index += 1) {
+    const candidate = visibleCandidates[index];
     const profile = profiles.get(candidate.member);
-    if (!profile) continue;
     rows.push(projectLeaderboardProfile(profile, {
-      rank: ranks.get(candidate.score),
+      rank: ranks.get(candidate.member),
       xp: candidate.score,
       lifetimeXp: lifetimeValues[index],
     }));
@@ -160,7 +176,7 @@ async function readLeaderboardPage(options, deps = {}) {
       missingProfiles: validCandidates.length - rows.length,
       invalidMembers: candidates.length - validCandidates.length,
       redisMs,
-      profileMs: Date.now() - profilesStartedAt,
+      profileMs,
     },
   };
 }
@@ -176,14 +192,23 @@ async function readLeaderboardMe(options, userId, deps = {}) {
   let me = null;
   let missingProfiles = 0;
   if (score > 0) {
-    const [profiles, greaterCount, lifetimeXp] = await Promise.all([
-      readProfiles([userId], deps.executeSql),
-      store.zcount(periodState.key, `(${score}`, "+inf"),
-      readLifetimeXp(store, namespace, [{ member: userId, score }], options.period).then((values) => values[0]),
-    ]);
+    const greaterCount = await store.zcount(periodState.key, `(${score}`, "+inf");
+    const rawGreater = greaterCount > 0
+      ? await store.zrevrangeWithScores(periodState.key, 0, greaterCount - 1)
+      : [];
+    const greaterCandidates = rawGreater
+      .map((row) => ({ member: String(row.member), score: normalizeScore(row.score) }))
+      .filter((candidate) => UUID_RE.test(candidate.member) && candidate.score > score);
+    const profiles = await readProfiles([...greaterCandidates.map((candidate) => candidate.member), userId], deps.executeSql);
     const profile = profiles.get(userId);
-    if (profile) me = projectLeaderboardProfile(profile, { rank: greaterCount + 1, xp: score, lifetimeXp });
-    else missingProfiles = 1;
+    missingProfiles = greaterCandidates.filter((candidate) => !profiles.has(candidate.member)).length;
+    if (profile) {
+      const lifetimeXp = await readLifetimeXp(store, namespace, [{ member: userId, score }], options.period).then((values) => values[0]);
+      const visibleGreaterCount = greaterCandidates.filter((candidate) => profiles.has(candidate.member)).length;
+      me = projectLeaderboardProfile(profile, { rank: visibleGreaterCount + 1, xp: score, lifetimeXp });
+    } else {
+      missingProfiles += 1;
+    }
   }
   return {
     response: {

--- a/tests/xp-leaderboard-api.behavior.test.mjs
+++ b/tests/xp-leaderboard-api.behavior.test.mjs
@@ -103,6 +103,51 @@ test("public pages use competition ranks and never over-fetch a missing profile"
   }
 });
 
+test("public and authenticated ranks ignore stale members without an eligible profile", async () => {
+  const store = await seededStore();
+  const keys = createXpLeaderboardKeys({ namespace: NAMESPACE });
+  for (const [userId, score] of [[USER_D, 4000], [USER_A, 3699], [USER_B, 500], [USER_C, 96]]) {
+    await store.zadd(keys.allTime(), score, userId);
+    await store.set(`${NAMESPACE}:total:${userId}`, score);
+  }
+  const readOnlyVisibleProfiles = (userIds) => Promise.resolve(new Map(
+    userIds
+      .filter((userId) => userId === USER_A || userId === USER_C)
+      .map((userId) => [userId, PROFILE_MAP.get(userId)]),
+  ));
+
+  const complete = await readLeaderboardPage({ period: "all_time", page: 1, limit: 25 }, {
+    store, namespace: NAMESPACE, nowMs: NOW, readProfiles: readOnlyVisibleProfiles,
+  });
+  const first = await readLeaderboardPage({ period: "all_time", page: 1, limit: 2 }, {
+    store, namespace: NAMESPACE, nowMs: NOW, readProfiles: readOnlyVisibleProfiles,
+  });
+  const second = await readLeaderboardPage({ period: "all_time", page: 2, limit: 2 }, {
+    store, namespace: NAMESPACE, nowMs: NOW, readProfiles: readOnlyVisibleProfiles,
+  });
+  const own = await readLeaderboardMe({ period: "all_time" }, USER_A, {
+    store, namespace: NAMESPACE, nowMs: NOW, readProfiles: readOnlyVisibleProfiles,
+  });
+
+  assert.deepEqual(complete.response.rows.map(({ rank, handle }) => ({ rank, handle })), [
+    { rank: 1, handle: "alpha-ace-123456" },
+    { rank: 2, handle: "cosmic-comet-123456" },
+  ]);
+  assert.equal(complete.diagnostics.missingProfiles, 2);
+  assert.deepEqual(first.response.rows.map(({ rank, handle }) => ({ rank, handle })), [
+    { rank: 1, handle: "alpha-ace-123456" },
+  ]);
+  assert.deepEqual(second.response.rows.map(({ rank, handle }) => ({ rank, handle })), [
+    { rank: 2, handle: "cosmic-comet-123456" },
+  ]);
+  assert.equal(first.response.hasMore, true);
+  assert.equal(second.response.hasMore, false);
+  assert.equal(first.diagnostics.missingProfiles, 1);
+  assert.equal(second.diagnostics.missingProfiles, 1);
+  assert.equal(own.response.me.rank, 1);
+  assert.equal(own.diagnostics.missingProfiles, 1);
+});
+
 test("period XP uses the period index while level uses batched canonical lifetime XP", async () => {
   const store = await seededStore();
   const periods = getXpLeaderboardPeriods(NOW);


### PR DESCRIPTION
## What changed

- calculate public competition ranks only from profiles eligible for the leaderboard
- keep ranks correct across raw pagination boundaries by validating the bounded prefix through the requested page
- apply the same eligibility-aware rank calculation to the authenticated `me` endpoint
- document the corrected ranking contract

## Root cause

Redis `ZCOUNT` included stale, hidden, or missing-profile members before the SQL profile allowlist removed them from the response. Those invisible members consumed positions, so two rendered players could appear as `#2` and `#4`.

## User impact

Displayed positions now describe the visible leaderboard. In the reported four-member raw index with only two eligible profiles, the API returns `#1` and `#2`. Competition ties still use `1, 2, 2, 4`, and raw page boundaries remain deterministic.

## Validation

- `node --test tests/xp-leaderboard-api.behavior.test.mjs`
- `npm test`
- `npm run syntax`
- `git diff --check`

No database migration or environment change is required.