### PR TITLE
Fix production WS artifact layout

### DIFF
--- a/.github/workflows/ws-server-deploy.yml
+++ b/.github/workflows/ws-server-deploy.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - "ws-server/**"
+      - "shared/**"
+      - "netlify/functions/_shared/chips-ledger.mjs"
+      - "netlify/functions/_shared/poker-*.mjs"
+      - "netlify/functions/_shared/supabase-admin.mjs"
       - "ws-tests/**"
       - ".github/workflows/ws-server-deploy.yml"
   push:
@@ -11,6 +15,10 @@ on:
       - "main"
     paths:
       - "ws-server/**"
+      - "shared/**"
+      - "netlify/functions/_shared/chips-ledger.mjs"
+      - "netlify/functions/_shared/poker-*.mjs"
+      - "netlify/functions/_shared/supabase-admin.mjs"
       - ".github/workflows/ws-server-deploy.yml"
   workflow_dispatch:
 
@@ -69,11 +77,12 @@ jobs:
         run: |
           set -euo pipefail
           ARTIFACT_DIR="$GITHUB_WORKSPACE/.artifacts/ws-server"
-          STAGE_DIR="$ARTIFACT_DIR/stage"
+          STAGE_ROOT="$ARTIFACT_DIR/stage"
+          STAGE_WS_DIR="$STAGE_ROOT/ws-server"
           ARTIFACT_FILE="$ARTIFACT_DIR/ws-server-dist.tgz"
 
           rm -rf "$ARTIFACT_DIR"
-          mkdir -p "$STAGE_DIR"
+          mkdir -p "$STAGE_WS_DIR"
 
           npm ci --prefix ws-server
           npm run --prefix ws-server build --if-present
@@ -81,33 +90,47 @@ jobs:
           rm -rf ws-server/node_modules
           npm ci --prefix ws-server --omit=dev
 
-          cp ws-server/package.json "$STAGE_DIR"/
-          cp ws-server/package-lock.json "$STAGE_DIR"/
-          cp -R ws-server/node_modules "$STAGE_DIR"/node_modules
+          cp ws-server/package.json "$STAGE_WS_DIR"/
+          cp ws-server/package-lock.json "$STAGE_WS_DIR"/
+          cp -R ws-server/node_modules "$STAGE_WS_DIR"/node_modules
+          ln -s ws-server/node_modules "$STAGE_ROOT/node_modules"
 
           if [ -d ws-server/dist ]; then
-            cp -R ws-server/dist "$STAGE_DIR"/dist
+            cp -R ws-server/dist "$STAGE_WS_DIR"/dist
           fi
 
           if [ -f ws-server/server.mjs ]; then
-            cp ws-server/server.mjs "$STAGE_DIR"/
+            cp ws-server/server.mjs "$STAGE_WS_DIR"/
           fi
 
           if [ -d ws-server/poker ]; then
-            cp -R ws-server/poker "$STAGE_DIR"/poker
+            cp -R ws-server/poker "$STAGE_WS_DIR"/poker
           fi
 
-          if [ -d shared/poker-domain ]; then
-            mkdir -p "$STAGE_DIR"/shared
-            cp -R shared/poker-domain "$STAGE_DIR"/shared/poker-domain
+          if [ -d ws-server/shared ]; then
+            cp -R ws-server/shared "$STAGE_WS_DIR"/shared
+          fi
+
+          if [ -d shared ]; then
+            cp -R shared "$STAGE_ROOT"/shared
           fi
 
           if [ -d netlify/functions/_shared ]; then
-            mkdir -p "$STAGE_DIR"/netlify/functions/_shared
-            cp netlify/functions/_shared/chips-ledger.mjs "$STAGE_DIR"/netlify/functions/_shared/
-            cp netlify/functions/_shared/poker-*.mjs "$STAGE_DIR"/netlify/functions/_shared/
-            cp netlify/functions/_shared/supabase-admin.mjs "$STAGE_DIR"/netlify/functions/_shared/
+            mkdir -p "$STAGE_ROOT"/netlify/functions/_shared
+            cp netlify/functions/_shared/chips-ledger.mjs "$STAGE_ROOT"/netlify/functions/_shared/
+            cp netlify/functions/_shared/poker-*.mjs "$STAGE_ROOT"/netlify/functions/_shared/
+            cp netlify/functions/_shared/supabase-admin.mjs "$STAGE_ROOT"/netlify/functions/_shared/
           fi
+
+          test -f "$STAGE_WS_DIR/server.mjs"
+          test -f "$STAGE_ROOT/shared/profile-avatar-projection.mjs"
+          test -f "$STAGE_ROOT/netlify/functions/_shared/chips-ledger.mjs"
+          test -d "$STAGE_ROOT/node_modules/postgres"
+          (
+            cd "$STAGE_ROOT"
+            node --input-type=module -e "await import('./ws-server/poker/read-model/public-poker-identity.mjs')"
+            node --input-type=module -e "await import('./ws-server/shared/poker-domain/inactive-cleanup-deps.mjs')"
+          )
 
           tar \
             --sort=name \
@@ -116,7 +139,7 @@ jobs:
             --group=0 \
             --numeric-owner \
             -czf "$ARTIFACT_FILE" \
-            -C "$STAGE_DIR" \
+            -C "$STAGE_ROOT" \
             .
 
       - name: Upload ws-server artifact to VPS
@@ -155,6 +178,7 @@ jobs:
             TMP_ARCHIVE="/tmp/arcadeplatform-ws/.artifacts/ws-server/ws-server-dist.tgz"
             RELEASE_ID="$RELEASE_SHA"
             NEW_RELEASE_DIR="$RELEASES_DIR/$RELEASE_ID"
+            NEW_RELEASE_APP_DIR="$NEW_RELEASE_DIR/ws-server"
             PREVIOUS_TARGET=""
             HAVE_SWITCHED=0
             HEALTH_RETRIES=30
@@ -206,8 +230,12 @@ jobs:
             sudo -n rm -rf "$NEW_RELEASE_DIR"
             sudo -n mkdir -p "$NEW_RELEASE_DIR"
             sudo -n tar -xzf "$TMP_ARCHIVE" -C "$NEW_RELEASE_DIR"
+            sudo -n test -f "$NEW_RELEASE_APP_DIR/server.mjs"
+            sudo -n test -f "$NEW_RELEASE_DIR/shared/profile-avatar-projection.mjs"
+            sudo -n test -f "$NEW_RELEASE_DIR/netlify/functions/_shared/chips-ledger.mjs"
+            sudo -n test -d "$NEW_RELEASE_DIR/node_modules/postgres"
 
-            sudo -n ln -sfn "$NEW_RELEASE_DIR" "$CURRENT_LINK.tmp"
+            sudo -n ln -sfn "$NEW_RELEASE_APP_DIR" "$CURRENT_LINK.tmp"
             sudo -n mv -Tf "$CURRENT_LINK.tmp" "$CURRENT_LINK"
             HAVE_SWITCHED=1
 

--- a/ws-tests/ws-server-deploy-rollout.test.mjs
+++ b/ws-tests/ws-server-deploy-rollout.test.mjs
@@ -9,6 +9,7 @@ function rollout({ baseDir, releaseSha, archivePath }) {
   const releasesDir = path.join(baseDir, "releases");
   const currentLink = path.join(baseDir, "current");
   const newReleaseDir = path.join(releasesDir, releaseSha);
+  const newReleaseAppDir = path.join(newReleaseDir, "ws-server");
 
   fs.rmSync(newReleaseDir, { recursive: true, force: true });
   fs.mkdirSync(newReleaseDir, { recursive: true });
@@ -17,14 +18,8 @@ function rollout({ baseDir, releaseSha, archivePath }) {
 
   const tmpLink = `${currentLink}.tmp`;
   fs.rmSync(tmpLink, { force: true });
-  fs.symlinkSync(newReleaseDir, tmpLink);
+  fs.symlinkSync(newReleaseAppDir, tmpLink);
   fs.renameSync(tmpLink, currentLink);
-}
-
-function createArchive({ archivePath, fileName, fileContent }) {
-  const staging = fs.mkdtempSync(path.join(os.tmpdir(), "ws-rollout-stage-"));
-  fs.writeFileSync(path.join(staging, fileName), fileContent);
-  execFileSync("tar", ["-czf", archivePath, "-C", staging, "."]);
 }
 
 test("rollout script is atomic: current symlink switches only after extract success", async () => {
@@ -44,9 +39,12 @@ test("rollout script is atomic: current symlink switches only after extract succ
   assert.equal(afterFail, oldRelease);
 
   const goodArchive = path.join(baseDir, "good.tgz");
-  createArchive({ archivePath: goodArchive, fileName: "server.mjs", fileContent: "export {}\n" });
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), "ws-rollout-layout-"));
+  fs.mkdirSync(path.join(staging, "ws-server"), { recursive: true });
+  fs.writeFileSync(path.join(staging, "ws-server", "server.mjs"), "export {}\n");
+  execFileSync("tar", ["-czf", goodArchive, "-C", staging, "."]);
 
   rollout({ baseDir, releaseSha: "new-success", archivePath: goodArchive });
   const afterSuccess = await fs.promises.realpath(currentLink);
-  assert.equal(afterSuccess, path.join(releasesDir, "new-success"));
+  assert.equal(afterSuccess, path.join(releasesDir, "new-success", "ws-server"));
 });

--- a/ws-tests/ws-server-deploy.artifact-path.guard.test.mjs
+++ b/ws-tests/ws-server-deploy.artifact-path.guard.test.mjs
@@ -11,8 +11,17 @@ test("ws-server deploy artifact is produced in workspace and uploaded from works
 
   assert.doesNotMatch(text, /source:\s*\/tmp\//);
   assert.match(text, /ARTIFACT_DIR="\$GITHUB_WORKSPACE\/\.artifacts\/ws-server"/);
+  assert.match(text, /STAGE_ROOT="\$ARTIFACT_DIR\/stage"/);
+  assert.match(text, /STAGE_WS_DIR="\$STAGE_ROOT\/ws-server"/);
   assert.match(text, /ARTIFACT_FILE="\$ARTIFACT_DIR\/ws-server-dist\.tgz"/);
+  assert.match(text, /ln -s ws-server\/node_modules "\$STAGE_ROOT\/node_modules"/);
+  assert.match(text, /cp -R ws-server\/shared "\$STAGE_WS_DIR"\/shared/);
+  assert.match(text, /cp -R shared "\$STAGE_ROOT"\/shared/);
+  assert.match(text, /test -f "\$STAGE_ROOT\/shared\/profile-avatar-projection\.mjs"/);
+  assert.match(text, /await import\('\.\/ws-server\/poker\/read-model\/public-poker-identity\.mjs'\)/);
+  assert.match(text, /await import\('\.\/ws-server\/shared\/poker-domain\/inactive-cleanup-deps\.mjs'\)/);
   assert.match(text, /-czf "\$ARTIFACT_FILE"/);
+  assert.match(text, /-C "\$STAGE_ROOT"/);
   assert.match(text, /source: \.artifacts\/ws-server\/ws-server-dist\.tgz/);
   assert.doesNotMatch(text, /strip_components:\s*3/);
   assert.match(text, /TMP_ARCHIVE="\/tmp\/arcadeplatform-ws\/\.artifacts\/ws-server\/ws-server-dist\.tgz"/);

--- a/ws-tests/ws-server-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-server-deploy.workflow.guard.test.mjs
@@ -10,6 +10,10 @@ test("ws-server deploy workflow has guarded triggers, secrets and concurrency", 
   const text = workflowText();
 
   assert.match(text, /"ws-server\/\*\*"/);
+  assert.match(text, /"shared\/\*\*"/);
+  assert.match(text, /"netlify\/functions\/_shared\/chips-ledger\.mjs"/);
+  assert.match(text, /"netlify\/functions\/_shared\/poker-\*\.mjs"/);
+  assert.match(text, /"netlify\/functions\/_shared\/supabase-admin\.mjs"/);
   assert.match(text, /concurrency:\n\s+group: ws-server-\$\{\{ github\.ref \}\}/);
   assert.match(text, /permissions:\n\s+contents: read/);
 
@@ -33,6 +37,7 @@ test("workflow includes rollback discipline and atomic current switch markers", 
 
   assert.match(text, /trap 'on_error' ERR/);
   assert.match(text, /rollback\(\)/);
-  assert.match(text, /ln -sfn "\$NEW_RELEASE_DIR" "\$CURRENT_LINK\.tmp"/);
+  assert.match(text, /NEW_RELEASE_APP_DIR="\$NEW_RELEASE_DIR\/ws-server"/);
+  assert.match(text, /ln -sfn "\$NEW_RELEASE_APP_DIR" "\$CURRENT_LINK\.tmp"/);
   assert.match(text, /mv -Tf "\$CURRENT_LINK\.tmp" "\$CURRENT_LINK"/);
 });

--- a/ws-tests/ws-ws-dependency.guard.test.mjs
+++ b/ws-tests/ws-ws-dependency.guard.test.mjs
@@ -167,11 +167,15 @@ test("ws authoritative leave adapter imports with ws-server dependency graph", (
 
 test("ws deploy artifact contract includes authoritative leave runtime files", () => {
   const deployWorkflow = fs.readFileSync(".github/workflows/ws-server-deploy.yml", "utf8");
-  assert.match(deployWorkflow, /cp -R shared\/poker-domain "\$STAGE_DIR"\/shared\/poker-domain/);
-  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/chips-ledger\.mjs "\$STAGE_DIR"\/netlify\/functions\/_shared\//);
-  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/poker-\*\.mjs "\$STAGE_DIR"\/netlify\/functions\/_shared\//);
-  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/supabase-admin\.mjs "\$STAGE_DIR"\/netlify\/functions\/_shared\//);
-  assert.doesNotMatch(deployWorkflow, /cp -R netlify\/functions\/_shared "\$STAGE_DIR"\/netlify\/functions\/_shared/);
+  assert.match(deployWorkflow, /STAGE_ROOT="\$ARTIFACT_DIR\/stage"/);
+  assert.match(deployWorkflow, /STAGE_WS_DIR="\$STAGE_ROOT\/ws-server"/);
+  assert.match(deployWorkflow, /cp -R ws-server\/poker "\$STAGE_WS_DIR"\/poker/);
+  assert.match(deployWorkflow, /cp -R ws-server\/shared "\$STAGE_WS_DIR"\/shared/);
+  assert.match(deployWorkflow, /cp -R shared "\$STAGE_ROOT"\/shared/);
+  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/chips-ledger\.mjs "\$STAGE_ROOT"\/netlify\/functions\/_shared\//);
+  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/poker-\*\.mjs "\$STAGE_ROOT"\/netlify\/functions\/_shared\//);
+  assert.match(deployWorkflow, /cp netlify\/functions\/_shared\/supabase-admin\.mjs "\$STAGE_ROOT"\/netlify\/functions\/_shared\//);
+  assert.doesNotMatch(deployWorkflow, /cp -R netlify\/functions\/_shared "\$STAGE_ROOT"\/netlify\/functions\/_shared/);
 });
 
 test("ws authoritative leave executor non-override path resolves real module loader contract", async () => {


### PR DESCRIPTION
## Root cause

Post-merge run [29271964627](https://github.com/krzysztofcal/arcadePlatform/actions/runs/29271964627) passed validation and artifact upload, but `ws-server.service` never reached local `/healthz` after the release switch.

PR #700 added a static import from `ws-server/poker/read-model/public-poker-identity.mjs` to `../../../shared/profile-avatar-projection.mjs`. Docker and WS preview deployments preserve the repository-level `ws-server/` + `shared/` layout, but the production workflow flattened `ws-server/` into the release root and copied only `shared/poker-domain`. The deployed Node process therefore terminated during module loading with `ERR_MODULE_NOT_FOUND` before starting the health endpoint.

The workflow switched the symlink back, but its rollback restart also reported a systemd failure. A follow-up external probe returned `502` from `https://ws.kcswh.pl/healthz` three times, so production WS recovery still requires either merging this fix (which triggers the corrected push deploy) or an explicitly authorized emergency deployment of the last known-good revision.

## What changed

- package production releases with the repository-relative layout:
  - `ws-server/`
  - `shared/`
  - `netlify/functions/_shared/`
- point `/opt/ws-server/current` at the release's nested `ws-server/` directory while preserving atomic switch and rollback behavior
- add a relative root `node_modules` symlink so repository-root Netlify helpers can resolve the same production dependencies
- verify required files on the runner and VPS before switching the service
- import the avatar projector and inactive-cleanup dependency graph from the staged artifact before upload
- trigger the production workflow when WS runtime dependencies under `shared/**` or the selected Netlify shared modules change
- update rollout/artifact/trigger guards for the new contract

## Impact

No poker behavior, database schema, ENV, secret, CSP, or browser contract changes.

The PR workflow validates only; it does not deploy on `pull_request`. After merge, the normal `push` workflow will build this corrected artifact and retry the production WS deployment with the existing atomic rollback and health gates.

## Validation

- reproduced the old flattened layout failure locally as `ERR_MODULE_NOT_FOUND` for `profile-avatar-projection.mjs`
- constructed the corrected artifact locally and successfully imported both affected dependency paths
- full `npm test`
- `npm run syntax`
- all 16 `WS Server Deploy` workflow guards
- `git diff --check`
- PR `WS Server Deploy / validate` passed; deploy was correctly skipped for the pull-request event
