### PR TITLE
Fix poker hand continuity after reconnect

### DIFF
--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -246,35 +246,23 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn[hidden]{display:none;}
 
-.poker-preaction-panel{position:absolute; right:0; bottom:calc(100% + 8px); width:min(70vw, 240px); display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); grid-template-rows:repeat(2, minmax(38px, auto)); gap:7px; padding:8px; border-radius:16px; border:1px solid rgba(255,223,180,0.24); background:linear-gradient(180deg, rgba(9,12,20,0.96), rgba(2,4,8,0.98)); box-shadow:0 12px 22px rgba(0,0,0,0.48);}
-
-.poker-preaction-panel[hidden]{display:none;}
-
-.poker-action-toggle{display:block; min-width:0; cursor:pointer;}
+.poker-action-toggle{display:block; cursor:pointer;}
 
 .poker-action-toggle[hidden]{display:none;}
 
-.poker-action-toggle--slot-fold{grid-area:1 / 1;}
-
-.poker-action-toggle--slot-primary{grid-area:1 / 2;}
-
-.poker-action-toggle--slot-amount{grid-area:2 / 1;}
-
-.poker-action-toggle--slot-all-in{grid-area:2 / 2;}
-
 .poker-action-toggle input{position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;}
 
-.poker-action-toggle span{position:relative; display:flex; align-items:center; min-height:38px; padding:0 8px 0 32px; border-radius:12px; color:#f7f8fd; font-size:0.76rem; font-weight:700; line-height:1.15; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 6px 10px rgba(0,0,0,0.36);}
+.poker-action-toggle span{position:relative; display:flex; align-items:center; min-height:50px; padding:0 16px 0 50px; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
 
-.poker-action-toggle span::before{content:""; position:absolute; left:9px; top:50%; width:15px; height:15px; border-radius:5px; border:2px solid rgba(255,255,255,0.82); background:rgba(4,8,14,0.2); transform:translateY(-50%); box-shadow:inset 0 1px 1px rgba(255,255,255,0.12);}
+.poker-action-toggle span::before{content:""; position:absolute; left:16px; top:50%; width:21px; height:21px; border-radius:7px; border:2px solid rgba(255,255,255,0.82); background:rgba(4,8,14,0.2); transform:translateY(-50%); box-shadow:inset 0 1px 1px rgba(255,255,255,0.12);}
 
 .poker-action-toggle input:focus-visible + span{outline:2px solid #fff; outline-offset:2px;}
 
-.poker-action-toggle input:checked + span{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 8px 13px rgba(0,0,0,0.42);}
+.poker-action-toggle input:checked + span{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
 
 .poker-action-toggle input:checked + span::before{background:rgba(255,255,255,0.94); border-color:rgba(255,255,255,0.98);}
 
-.poker-action-toggle input:checked + span::after{content:""; position:absolute; left:14px; top:50%; width:5px; height:9px; border-right:2px solid #0b1320; border-bottom:2px solid #0b1320; transform:translateY(-58%) rotate(42deg);}
+.poker-action-toggle input:checked + span::after{content:""; position:absolute; left:23px; top:50%; width:6px; height:11px; border-right:3px solid #0b1320; border-bottom:3px solid #0b1320; transform:translateY(-58%) rotate(42deg);}
 
 .poker-action-toggle input:disabled + span{cursor:not-allowed; opacity:0.5;}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -246,11 +246,49 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn[hidden]{display:none;}
 
+.poker-preaction-panel{position:absolute; right:0; bottom:calc(100% + 8px); width:min(70vw, 240px); display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); grid-template-rows:repeat(2, minmax(38px, auto)); gap:7px; padding:8px; border-radius:16px; border:1px solid rgba(255,223,180,0.24); background:linear-gradient(180deg, rgba(9,12,20,0.96), rgba(2,4,8,0.98)); box-shadow:0 12px 22px rgba(0,0,0,0.48);}
+
+.poker-preaction-panel[hidden]{display:none;}
+
+.poker-action-toggle{display:block; min-width:0; cursor:pointer;}
+
+.poker-action-toggle[hidden]{display:none;}
+
+.poker-action-toggle--slot-fold{grid-area:1 / 1;}
+
+.poker-action-toggle--slot-primary{grid-area:1 / 2;}
+
+.poker-action-toggle--slot-amount{grid-area:2 / 1;}
+
+.poker-action-toggle--slot-all-in{grid-area:2 / 2;}
+
+.poker-action-toggle input{position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;}
+
+.poker-action-toggle span{position:relative; display:flex; align-items:center; min-height:38px; padding:0 8px 0 32px; border-radius:12px; color:#f7f8fd; font-size:0.76rem; font-weight:700; line-height:1.15; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 6px 10px rgba(0,0,0,0.36);}
+
+.poker-action-toggle span::before{content:""; position:absolute; left:9px; top:50%; width:15px; height:15px; border-radius:5px; border:2px solid rgba(255,255,255,0.82); background:rgba(4,8,14,0.2); transform:translateY(-50%); box-shadow:inset 0 1px 1px rgba(255,255,255,0.12);}
+
+.poker-action-toggle input:focus-visible + span{outline:2px solid #fff; outline-offset:2px;}
+
+.poker-action-toggle input:checked + span{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 8px 13px rgba(0,0,0,0.42);}
+
+.poker-action-toggle input:checked + span::before{background:rgba(255,255,255,0.94); border-color:rgba(255,255,255,0.98);}
+
+.poker-action-toggle input:checked + span::after{content:""; position:absolute; left:14px; top:50%; width:5px; height:9px; border-right:2px solid #0b1320; border-bottom:2px solid #0b1320; transform:translateY(-58%) rotate(42deg);}
+
+.poker-action-toggle input:disabled + span{cursor:not-allowed; opacity:0.5;}
+
 .poker-action-btn--fold{background:linear-gradient(180deg, #dc4e4e, #981c1c);}
 
 .poker-action-btn--call{background:linear-gradient(180deg, #2f79df, #1c4497);}
 
 .poker-action-btn--raise{background:linear-gradient(180deg, #33a95f, #1a7039);}
+
+.poker-action-toggle--fold span{background:linear-gradient(180deg, #dc4e4e, #981c1c);}
+
+.poker-action-toggle--call span{background:linear-gradient(180deg, #2f79df, #1c4497);}
+
+.poker-action-toggle--raise span{background:linear-gradient(180deg, #33a95f, #1a7039);}
 
 .poker-action-btn:active:not(:disabled){transform:translateY(1px) scale(0.99);}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -242,25 +242,9 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn{min-height:50px; border:none; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
 
+.poker-action-btn:disabled{cursor:not-allowed; opacity:0.42; filter:grayscale(0.72); box-shadow:inset 0 1px 1px rgba(255,255,255,0.1), 0 5px 10px rgba(0,0,0,0.28);}
+
 .poker-action-btn[hidden]{display:none;}
-
-.poker-action-toggle{display:block;}
-
-.poker-action-toggle[hidden]{display:none;}
-
-.poker-action-toggle input{position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;}
-
-.poker-action-toggle span{position:relative; display:flex; align-items:center; min-height:50px; padding:0 16px 0 50px; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
-
-.poker-action-toggle span::before{content:""; position:absolute; left:16px; top:50%; width:21px; height:21px; border-radius:7px; border:2px solid rgba(255,255,255,0.82); background:rgba(4,8,14,0.2); transform:translateY(-50%); box-shadow:inset 0 1px 1px rgba(255,255,255,0.12);}
-
-.poker-action-toggle input:checked + span{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
-
-.poker-action-toggle input:checked + span::before{background:rgba(255,255,255,0.94); border-color:rgba(255,255,255,0.98);}
-
-.poker-action-toggle input:checked + span::after{content:""; position:absolute; left:23px; top:50%; width:6px; height:11px; border-right:3px solid #0b1320; border-bottom:3px solid #0b1320; transform:translateY(-58%) rotate(42deg);}
-
-.poker-action-toggle input:disabled + span{opacity:0.5;}
 
 .poker-action-btn--fold{background:linear-gradient(180deg, #dc4e4e, #981c1c);}
 
@@ -268,13 +252,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn--raise{background:linear-gradient(180deg, #33a95f, #1a7039);}
 
-.poker-action-toggle--fold span{background:linear-gradient(180deg, #dc4e4e, #981c1c);}
-
-.poker-action-toggle--call span{background:linear-gradient(180deg, #2f79df, #1c4497);}
-
-.poker-action-toggle--raise span{background:linear-gradient(180deg, #33a95f, #1a7039);}
-
-.poker-action-btn:active{transform:translateY(1px) scale(0.99);}
+.poker-action-btn:active:not(:disabled){transform:translateY(1px) scale(0.99);}
 
 .poker-action-btn.is-selected{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1231,25 +1231,6 @@
     return Math.max(0, Math.trunc(Number(value)));
   }
 
-  function isContestableOpponentSeat(seat, currentUserId){
-    if (!seat || typeof seat.userId !== 'string' || !seat.userId) return false;
-    if (seat.userId === currentUserId) return false;
-    if (/FOLD/i.test(seat.status || '')) return false;
-    return true;
-  }
-
-  function resolveMaxContestableOpponentBehindAmount(currentUserId){
-    if (!currentUserId || !Array.isArray(state.seats)) return null;
-    var max = null;
-    state.seats.forEach(function(seat){
-      if (!isContestableOpponentSeat(seat, currentUserId)) return;
-      var amount = resolveStack(seat.userId);
-      if (!Number.isFinite(amount) || amount <= 0) return;
-      max = max == null ? amount : Math.max(max, amount);
-    });
-    return max;
-  }
-
   function getAllowedActions(){
     return Array.isArray(state.legalActions) ? state.legalActions.slice() : [];
   }
@@ -2248,28 +2229,23 @@
     if (!stackAmount || stackAmount < 1) return null;
     var constraints = state.actionConstraints || {};
     var toCall = Number.isFinite(constraints.toCall) ? Math.max(0, Math.trunc(constraints.toCall)) : null;
-    var contestableOpponentBehind = resolveMaxContestableOpponentBehindAmount(state.currentUserId);
-    var cappedTotalContribution = contestableOpponentBehind == null
-      ? stackAmount
-      : Math.max(0, Math.min(stackAmount, (toCall || 0) + Math.trunc(contestableOpponentBehind)));
     if (allowed.indexOf('CALL') !== -1 && toCall != null && toCall > 0 && stackAmount <= toCall){
       return { type: 'CALL', amount: null };
     }
     if (allowed.indexOf('RAISE') !== -1 && Number.isFinite(constraints.maxRaiseTo)){
       var maxRaiseTo = Math.max(1, Math.trunc(constraints.maxRaiseTo));
-      var minRaiseTo = Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
-      var currentUserBet = Math.max(0, maxRaiseTo - stackAmount);
-      var cappedRaiseTo = Math.min(maxRaiseTo, Math.max(currentUserBet + cappedTotalContribution, minRaiseTo));
-      if (toCall != null && toCall > 0 && cappedRaiseTo <= currentUserBet + toCall){
-        return { type: 'CALL', amount: null };
-      }
-      return { type: 'RAISE', amount: cappedRaiseTo };
+      return { type: 'RAISE', amount: maxRaiseTo };
     }
     if (allowed.indexOf('BET') !== -1){
       var maxBet = Number.isFinite(constraints.maxBetAmount) ? Math.max(1, Math.trunc(constraints.maxBetAmount)) : stackAmount;
-      return { type: 'BET', amount: Math.max(1, Math.min(maxBet, cappedTotalContribution || maxBet)) };
+      return { type: 'BET', amount: maxBet };
     }
     return null;
+  }
+
+  function canQueueAllInPreaction(){
+    var stackAmount = resolveStack(state.currentUserId);
+    return stackAmount == null || stackAmount > 0;
   }
 
   function resolveAmountBounds(amountAction, stackAmount){
@@ -2361,7 +2337,7 @@
       queuedPreaction.amount = queuedAmount;
       return;
     }
-    if (queuedPreaction.slot === 'allIn' && !preactionState.allInPlan) clearQueuedPreaction();
+    if (queuedPreaction.slot === 'allIn' && !preactionState.allInAvailable) clearQueuedPreaction();
   }
 
   function resolveQueuedPreactionExecution(liveState){
@@ -2402,7 +2378,7 @@
     var projectedAllowed = preactionMode ? resolveProjectedAllowedActions() : [];
     var preactionPrimary = resolvePrimaryAction(projectedAllowed);
     var preactionAmountAction = resolveAmountAction(projectedAllowed);
-    var preactionAllInPlan = resolveAllInPlan(projectedAllowed);
+    var preactionAllInAvailable = preactionMode && canQueueAllInPreaction();
     var preactionAmountBounds = resolveAmountBounds(preactionAmountAction, stackAmount);
     var displayPrimary = primary || preactionPrimary || 'CHECK';
     var displayAmountAction = amountAction || preactionAmountAction || 'BET';
@@ -2416,7 +2392,7 @@
         foldVisible: isFoldAvailable(),
         primaryAction: preactionPrimary,
         amountAction: preactionAmountAction,
-        allInPlan: preactionAllInPlan,
+        allInAvailable: preactionAllInAvailable,
         amountBounds: preactionAmountBounds
       });
     }
@@ -2505,7 +2481,7 @@
     if (els.allInPreactionWrap) els.allInPreactionWrap.hidden = !preactionMode;
     if (els.allInPreaction) {
       els.allInPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'allIn');
-      els.allInPreaction.disabled = !liveReady || controlsLocked || !preactionAllInPlan;
+      els.allInPreaction.disabled = !liveReady || controlsLocked || !preactionAllInAvailable;
       els.allInPreaction.dataset.slot = 'allIn';
     }
     if (els.amountInputWrap){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -159,6 +159,8 @@
   var reconnectSeatNo = null;
   var lastKnownCurrentSeatNo = null;
   var bootReady = false;
+  var queuedPreaction = null;
+  var queuedPreactionInFlight = false;
   var stickyWinnerReveal = {
     handId: null,
     visibleUntilMs: 0,
@@ -2299,24 +2301,124 @@
     return value;
   }
 
+  function clearQueuedPreaction(){
+    queuedPreaction = null;
+  }
+
+  function resetQueuedPreactionState(){
+    queuedPreaction = null;
+    queuedPreactionInFlight = false;
+  }
+
+  function getPreactionInput(slot){
+    if (slot === 'fold') return els.foldPreaction;
+    if (slot === 'primary') return els.primaryPreaction;
+    if (slot === 'amount') return els.amountPreaction;
+    if (slot === 'allIn') return els.allInPreaction;
+    return null;
+  }
+
+  function readQueuedAmount(){
+    var value = els.amountInput ? parseInt(els.amountInput.value, 10) : NaN;
+    return Number.isFinite(value) ? Math.trunc(value) : null;
+  }
+
+  function buildQueuedPreaction(slot){
+    if (slot === 'fold') return { slot: 'fold', action: 'FOLD', amount: null };
+    if (slot === 'primary'){
+      var primaryAction = els.primaryPreaction ? (els.primaryPreaction.dataset.action || '') : '';
+      return primaryAction ? { slot: 'primary', action: primaryAction, amount: null } : null;
+    }
+    if (slot === 'amount'){
+      var amountAction = els.amountPreaction ? (els.amountPreaction.dataset.action || '') : '';
+      var amount = readQueuedAmount();
+      return amountAction && Number.isFinite(amount) ? { slot: 'amount', action: amountAction, amount: amount } : null;
+    }
+    if (slot === 'allIn') return { slot: 'allIn', action: null, amount: null };
+    return null;
+  }
+
+  function syncQueuedPreactionWithPreactionState(preactionState){
+    if (!queuedPreaction || !preactionState) return;
+    if (queuedPreaction.slot === 'fold'){
+      if (!preactionState.foldVisible) clearQueuedPreaction();
+      return;
+    }
+    if (queuedPreaction.slot === 'primary'){
+      if (!preactionState.primaryAction || queuedPreaction.action !== preactionState.primaryAction) clearQueuedPreaction();
+      return;
+    }
+    if (queuedPreaction.slot === 'amount'){
+      if (!preactionState.amountAction || queuedPreaction.action !== preactionState.amountAction || !preactionState.amountBounds){
+        clearQueuedPreaction();
+        return;
+      }
+      var queuedAmount = readQueuedAmount();
+      if (!Number.isFinite(queuedAmount) || queuedAmount < preactionState.amountBounds.min || (preactionState.amountBounds.max != null && queuedAmount > preactionState.amountBounds.max)){
+        clearQueuedPreaction();
+        return;
+      }
+      queuedPreaction.amount = queuedAmount;
+      return;
+    }
+    if (queuedPreaction.slot === 'allIn' && !preactionState.allInPlan) clearQueuedPreaction();
+  }
+
+  function resolveQueuedPreactionExecution(liveState){
+    if (!queuedPreaction || !liveState) return null;
+    if (queuedPreaction.slot === 'fold') return liveState.foldVisible ? { action: 'FOLD', amount: null } : null;
+    if (queuedPreaction.slot === 'primary'){
+      return queuedPreaction.action && queuedPreaction.action === liveState.primaryAction
+        ? { action: queuedPreaction.action, amount: null }
+        : null;
+    }
+    if (queuedPreaction.slot === 'amount'){
+      if (!queuedPreaction.action || queuedPreaction.action !== liveState.amountAction || !liveState.amountBounds) return null;
+      if (!Number.isFinite(queuedPreaction.amount) || queuedPreaction.amount < liveState.amountBounds.min || (liveState.amountBounds.max != null && queuedPreaction.amount > liveState.amountBounds.max)) return null;
+      return { action: queuedPreaction.action, amount: queuedPreaction.amount };
+    }
+    if (queuedPreaction.slot === 'allIn'){
+      return liveState.allInPlan
+        ? { action: liveState.allInPlan.type, amount: liveState.allInPlan.amount == null ? null : liveState.allInPlan.amount }
+        : null;
+    }
+    return null;
+  }
+
   function renderControls(){
     var signedIn = isSignedIn();
     var seated = !!deriveCurrentSeat();
     var liveReady = isWsReady();
     var activeHand = hasActiveHand();
     var usersTurn = isUsersTurn();
+    var controlsLocked = queuedPreactionInFlight;
     var allowed = liveReady && usersTurn ? getAllowedActions() : [];
     var primary = resolvePrimaryAction(allowed);
     var amountAction = resolveAmountAction(allowed);
     var allInPlan = resolveAllInPlan(allowed);
     var stackAmount = resolveStack(state.currentUserId);
     var amountBounds = resolveAmountBounds(amountAction, stackAmount);
-    var projectedAllowed = signedIn && seated && activeHand && !isCurrentUserFolded() ? resolveProjectedAllowedActions() : [];
-    var displayPrimary = primary || resolvePrimaryAction(projectedAllowed) || 'CHECK';
-    var displayAmountAction = amountAction || resolveAmountAction(projectedAllowed) || 'BET';
+    var preactionMode = !!(signedIn && seated && liveReady && activeHand && !usersTurn && !isCurrentUserFolded());
+    var projectedAllowed = preactionMode ? resolveProjectedAllowedActions() : [];
+    var preactionPrimary = resolvePrimaryAction(projectedAllowed);
+    var preactionAmountAction = resolveAmountAction(projectedAllowed);
+    var preactionAllInPlan = resolveAllInPlan(projectedAllowed);
+    var preactionAmountBounds = resolveAmountBounds(preactionAmountAction, stackAmount);
+    var displayPrimary = primary || preactionPrimary || 'CHECK';
+    var displayAmountAction = amountAction || preactionAmountAction || 'BET';
     var showActionButtons = signedIn && seated;
-    var actionControlsLocked = !liveReady || !usersTurn;
+    var actionControlsLocked = !liveReady || !usersTurn || controlsLocked;
     var joinDisabled = !signedIn || seated || !state.tableId || !liveReady;
+    if (!seated || !activeHand || isCurrentUserFolded()) clearQueuedPreaction();
+    if (preactionMode) {
+      syncQueuedPreactionWithPreactionState({
+        foldVisible: isFoldAvailable(),
+        primaryAction: preactionPrimary,
+        amountAction: preactionAmountAction,
+        allInPlan: preactionAllInPlan,
+        amountBounds: preactionAmountBounds
+      });
+    }
 
     if (els.signInBtn) {
       els.signInBtn.hidden = signedIn && !isGuestMode;
@@ -2370,9 +2472,45 @@
       els.allInBtn.dataset.action = allInPlan ? allInPlan.type : '';
       els.allInBtn.disabled = actionControlsLocked || !allInPlan;
     }
+    if (els.preactionPanel) els.preactionPanel.hidden = !preactionMode;
+    if (els.foldPreactionWrap) els.foldPreactionWrap.hidden = !preactionMode || !isFoldAvailable();
+    if (els.foldPreaction) {
+      els.foldPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'fold');
+      els.foldPreaction.disabled = !liveReady || controlsLocked;
+      els.foldPreaction.dataset.slot = 'fold';
+    }
+    if (els.primaryPreactionWrap) els.primaryPreactionWrap.hidden = !preactionMode || !preactionPrimary;
+    if (els.primaryPreaction) {
+      els.primaryPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'primary');
+      els.primaryPreaction.disabled = !liveReady || controlsLocked || !preactionPrimary;
+      els.primaryPreaction.dataset.slot = 'primary';
+      els.primaryPreaction.dataset.action = preactionPrimary || '';
+    }
+    if (els.primaryPreactionText) {
+      var projectedToCall = Number.isFinite(state.actionConstraints && state.actionConstraints.toCall)
+        ? Math.max(0, Math.trunc(state.actionConstraints.toCall))
+        : null;
+      els.primaryPreactionText.textContent = preactionPrimary === 'CALL'
+        ? ('Call (' + formatCompactAmount(projectedToCall) + ')')
+        : 'Check';
+    }
+    if (els.amountPreactionWrap) els.amountPreactionWrap.hidden = !preactionMode || !preactionAmountAction;
+    if (els.amountPreaction) {
+      els.amountPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'amount');
+      els.amountPreaction.disabled = !liveReady || controlsLocked || !preactionAmountAction;
+      els.amountPreaction.dataset.slot = 'amount';
+      els.amountPreaction.dataset.action = preactionAmountAction || '';
+    }
+    if (els.amountPreactionText) els.amountPreactionText.textContent = preactionAmountAction === 'RAISE' ? 'Raise' : 'Bet';
+    if (els.allInPreactionWrap) els.allInPreactionWrap.hidden = !preactionMode || !preactionAllInPlan;
+    if (els.allInPreaction) {
+      els.allInPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'allIn');
+      els.allInPreaction.disabled = !liveReady || controlsLocked || !preactionAllInPlan;
+      els.allInPreaction.dataset.slot = 'allIn';
+    }
     if (els.amountInputWrap){
       els.amountInputWrap.hidden = false;
-      var activeAmountBounds = usersTurn ? amountBounds : null;
+      var activeAmountBounds = usersTurn ? amountBounds : preactionMode ? preactionAmountBounds : null;
       if (activeAmountBounds){
         var syncedAmount = syncAmountInput(activeAmountBounds);
         if (els.amountValue) els.amountValue.textContent = formatCompactAmount(Number.isFinite(syncedAmount) ? syncedAmount : activeAmountBounds.min);
@@ -2381,8 +2519,8 @@
         els.amountInputWrap.classList.add('is-disabled');
       }
     }
-    if (els.amountInput) els.amountInput.disabled = !liveReady || !usersTurn || !amountAction;
-    if (els.amountValue && (!usersTurn || !amountAction)) {
+    if (els.amountInput) els.amountInput.disabled = !liveReady || controlsLocked || !(usersTurn ? amountAction : preactionMode ? preactionAmountAction : null);
+    if (els.amountValue && !(usersTurn ? amountAction : preactionMode ? preactionAmountAction : null)) {
       els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput && els.amountInput.value ? els.amountInput.value : '20', 10) || 20);
     }
   }
@@ -2485,6 +2623,26 @@
     });
   }
 
+  function maybeExecuteQueuedPreaction(){
+    if (!queuedPreaction || queuedPreactionInFlight || !isUsersTurn()) return;
+    var allowed = getAllowedActions();
+    var liveState = {
+      foldVisible: isFoldAvailable(),
+      primaryAction: resolvePrimaryAction(allowed),
+      amountAction: resolveAmountAction(allowed),
+      allInPlan: resolveAllInPlan(allowed),
+      amountBounds: resolveAmountBounds(resolveAmountAction(allowed), resolveStack(state.currentUserId))
+    };
+    var nextAction = resolveQueuedPreactionExecution(liveState);
+    clearQueuedPreaction();
+    if (!nextAction || !nextAction.action) return;
+    queuedPreactionInFlight = true;
+    handleAction(nextAction.action, nextAction.amount == null ? undefined : nextAction.amount).then(function(){
+      queuedPreactionInFlight = false;
+      renderControls();
+    });
+  }
+
   function isSeatTakenError(error){
     var message = error && error.message ? String(error.message) : '';
     return /seat_taken/i.test(message);
@@ -2516,8 +2674,8 @@
 
   function rejoinSeatAfterReconnect(){
     if (!Number.isInteger(reconnectSeatNo) || reconnectSeatNo < 1) return false;
+    if (autoJoinAttempted) return true;
     var preferredSeatNo = reconnectSeatNo;
-    reconnectSeatNo = null;
     autoJoinAttempted = true;
     setError('');
     sendCommand('sendJoin', {
@@ -2528,11 +2686,13 @@
       var resolvedSeatNo = result && Number.isInteger(Number(result.seatNo))
         ? Number(result.seatNo)
         : preferredSeatNo;
+      reconnectSeatNo = null;
       lastKnownCurrentSeatNo = resolvedSeatNo;
       state.statusText = 'Reconnected to seat ' + resolvedSeatNo;
       renderInfoPanel();
     }).catch(function(err){
       autoJoinAttempted = false;
+      reconnectSeatNo = preferredSeatNo;
       setError(err && err.message ? err.message : 'Failed to reconnect seat');
     });
     return true;
@@ -2613,6 +2773,29 @@
   }
 
   function bindControls(){
+    function bindPreaction(slot){
+      var input = getPreactionInput(slot);
+      if (!input) return;
+      input.addEventListener('change', function(){
+        if (!input.checked){
+          if (queuedPreaction && queuedPreaction.slot === slot) clearQueuedPreaction();
+          renderControls();
+          return;
+        }
+        queuedPreaction = buildQueuedPreaction(slot);
+        if (!queuedPreaction) {
+          input.checked = false;
+          renderControls();
+          return;
+        }
+        ['fold', 'primary', 'amount', 'allIn'].forEach(function(otherSlot){
+          if (otherSlot === slot) return;
+          var otherInput = getPreactionInput(otherSlot);
+          if (otherInput) otherInput.checked = false;
+        });
+        renderControls();
+      });
+    }
     if (els.signInBtn) els.signInBtn.addEventListener('click', openSignIn);
     if (els.foldBtn) els.foldBtn.addEventListener('click', function(){
       handleAction('FOLD');
@@ -2656,6 +2839,10 @@
     });
     if (els.amountInput) els.amountInput.addEventListener('input', function(){
       if (els.amountValue) els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput.value, 10) || 0);
+      if (queuedPreaction && queuedPreaction.slot === 'amount'){
+        var queuedAmount = readQueuedAmount();
+        if (Number.isFinite(queuedAmount)) queuedPreaction.amount = queuedAmount;
+      }
     });
     if (els.joinSeat) els.joinSeat.addEventListener('input', function(){
       els.joinSeat.dataset.userEdited = '1';
@@ -2665,6 +2852,10 @@
       if (!plan) return;
       handleAction(plan.type, plan.amount == null ? undefined : plan.amount);
     });
+    bindPreaction('fold');
+    bindPreaction('primary');
+    bindPreaction('amount');
+    bindPreaction('allIn');
   }
 
   function selectElements(){
@@ -2704,9 +2895,22 @@
     els.closedTableCountdown = document.getElementById('pokerV2ClosedTableCountdown');
     els.startBtn = document.getElementById('pokerV2StartBtn');
     els.foldBtn = document.getElementById('pokerV2FoldBtn');
+    els.preactionPanel = document.getElementById('pokerV2PreactionPanel');
+    els.foldPreactionWrap = document.getElementById('pokerV2FoldPreactionWrap');
+    els.foldPreaction = document.getElementById('pokerV2FoldPreaction');
+    els.foldPreactionText = document.getElementById('pokerV2FoldPreactionText');
     els.primaryBtn = document.getElementById('pokerV2PrimaryBtn');
+    els.primaryPreactionWrap = document.getElementById('pokerV2PrimaryPreactionWrap');
+    els.primaryPreaction = document.getElementById('pokerV2PrimaryPreaction');
+    els.primaryPreactionText = document.getElementById('pokerV2PrimaryPreactionText');
     els.amountBtn = document.getElementById('pokerV2AmountBtn');
+    els.amountPreactionWrap = document.getElementById('pokerV2AmountPreactionWrap');
+    els.amountPreaction = document.getElementById('pokerV2AmountPreaction');
+    els.amountPreactionText = document.getElementById('pokerV2AmountPreactionText');
     els.allInBtn = document.getElementById('pokerV2AllInBtn');
+    els.allInPreactionWrap = document.getElementById('pokerV2AllInPreactionWrap');
+    els.allInPreaction = document.getElementById('pokerV2AllInPreaction');
+    els.allInPreactionText = document.getElementById('pokerV2AllInPreactionText');
     els.amountInput = document.getElementById('pokerV2AmountInput');
     els.amountValue = document.getElementById('pokerV2AmountValue');
     els.amountInputWrap = document.getElementById('pokerV2AmountInputWrap');
@@ -2714,6 +2918,7 @@
 
   function startDemoMode(){
     startTurnClock();
+    resetQueuedPreactionState();
     state = cloneState(demoState);
     state.wsReady = false;
     render();
@@ -2734,6 +2939,7 @@
 
   function applySignedOutState(){
     stopLiveMode();
+    resetQueuedPreactionState();
     state = createEmptyLiveState(tableId, null);
     state.statusText = LIVE_STATUS_COPY.auth;
     render();
@@ -2741,6 +2947,7 @@
 
   function applyAuthenticatedPendingState(user){
     stopLiveMode();
+    resetQueuedPreactionState();
     isGuestMode = false;
     currentGuestSession = null;
     state = createEmptyLiveState(tableId, user && user.id ? String(user.id) : null);
@@ -2829,6 +3036,7 @@
         }
         var previousVisual = captureVisualSnapshot();
         mergeSnapshot(payload);
+        maybeExecuteQueuedPreaction();
         render();
         var nextVisual = captureVisualSnapshot();
         animateChipDiff(previousVisual, nextVisual);

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -2407,6 +2407,7 @@
     var displayPrimary = primary || preactionPrimary || 'CHECK';
     var displayAmountAction = amountAction || preactionAmountAction || 'BET';
     var showActionButtons = signedIn && seated;
+    var showLiveActionButtons = showActionButtons && !preactionMode;
     var actionControlsLocked = !liveReady || !usersTurn || controlsLocked;
     var joinDisabled = !signedIn || seated || !state.tableId || !liveReady;
     if (!seated || !activeHand || isCurrentUserFolded()) clearQueuedPreaction();
@@ -2446,12 +2447,12 @@
     if (els.stackText) els.stackText.textContent = stackAmount == null ? '—' : formatNumber(stackAmount);
 
     if (els.foldBtn){
-      els.foldBtn.hidden = !showActionButtons;
+      els.foldBtn.hidden = !showLiveActionButtons;
       els.foldBtn.dataset.action = 'FOLD';
       els.foldBtn.disabled = actionControlsLocked || !isFoldAvailable();
     }
     if (els.primaryBtn){
-      els.primaryBtn.hidden = !showActionButtons;
+      els.primaryBtn.hidden = !showLiveActionButtons;
       var toCall = Number.isFinite(state.actionConstraints && state.actionConstraints.toCall)
         ? Math.max(0, Math.trunc(state.actionConstraints.toCall))
         : null;
@@ -2462,24 +2463,23 @@
       els.primaryBtn.disabled = actionControlsLocked || !primary;
     }
     if (els.amountBtn){
-      els.amountBtn.hidden = !showActionButtons;
+      els.amountBtn.hidden = !showLiveActionButtons;
       els.amountBtn.textContent = displayAmountAction === 'RAISE' ? 'Raise' : 'Bet';
       els.amountBtn.dataset.action = amountAction || '';
       els.amountBtn.disabled = actionControlsLocked || !amountAction;
     }
     if (els.allInBtn){
-      els.allInBtn.hidden = !showActionButtons;
+      els.allInBtn.hidden = !showLiveActionButtons;
       els.allInBtn.dataset.action = allInPlan ? allInPlan.type : '';
       els.allInBtn.disabled = actionControlsLocked || !allInPlan;
     }
-    if (els.preactionPanel) els.preactionPanel.hidden = !preactionMode;
-    if (els.foldPreactionWrap) els.foldPreactionWrap.hidden = !preactionMode || !isFoldAvailable();
+    if (els.foldPreactionWrap) els.foldPreactionWrap.hidden = !preactionMode;
     if (els.foldPreaction) {
       els.foldPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'fold');
-      els.foldPreaction.disabled = !liveReady || controlsLocked;
+      els.foldPreaction.disabled = !liveReady || controlsLocked || !isFoldAvailable();
       els.foldPreaction.dataset.slot = 'fold';
     }
-    if (els.primaryPreactionWrap) els.primaryPreactionWrap.hidden = !preactionMode || !preactionPrimary;
+    if (els.primaryPreactionWrap) els.primaryPreactionWrap.hidden = !preactionMode;
     if (els.primaryPreaction) {
       els.primaryPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'primary');
       els.primaryPreaction.disabled = !liveReady || controlsLocked || !preactionPrimary;
@@ -2494,7 +2494,7 @@
         ? ('Call (' + formatCompactAmount(projectedToCall) + ')')
         : 'Check';
     }
-    if (els.amountPreactionWrap) els.amountPreactionWrap.hidden = !preactionMode || !preactionAmountAction;
+    if (els.amountPreactionWrap) els.amountPreactionWrap.hidden = !preactionMode;
     if (els.amountPreaction) {
       els.amountPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'amount');
       els.amountPreaction.disabled = !liveReady || controlsLocked || !preactionAmountAction;
@@ -2502,7 +2502,7 @@
       els.amountPreaction.dataset.action = preactionAmountAction || '';
     }
     if (els.amountPreactionText) els.amountPreactionText.textContent = preactionAmountAction === 'RAISE' ? 'Raise' : 'Bet';
-    if (els.allInPreactionWrap) els.allInPreactionWrap.hidden = !preactionMode || !preactionAllInPlan;
+    if (els.allInPreactionWrap) els.allInPreactionWrap.hidden = !preactionMode;
     if (els.allInPreaction) {
       els.allInPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'allIn');
       els.allInPreaction.disabled = !liveReady || controlsLocked || !preactionAllInPlan;
@@ -2895,7 +2895,6 @@
     els.closedTableCountdown = document.getElementById('pokerV2ClosedTableCountdown');
     els.startBtn = document.getElementById('pokerV2StartBtn');
     els.foldBtn = document.getElementById('pokerV2FoldBtn');
-    els.preactionPanel = document.getElementById('pokerV2PreactionPanel');
     els.foldPreactionWrap = document.getElementById('pokerV2FoldPreactionWrap');
     els.foldPreaction = document.getElementById('pokerV2FoldPreaction');
     els.foldPreactionText = document.getElementById('pokerV2FoldPreactionText');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -55,6 +55,7 @@
   var CLOSED_TABLE_REDIRECT_SECONDS = 5;
   var WINNER_REVEAL_MS = 4_000;
   var CHIP_FLY_MS = 420;
+  var AUTO_JOIN_RETRY_DELAYS_MS = [250, 750, 1500, 3000];
   var CHIP_DENOMINATIONS = [
     { value: 1000, color: 'yellow' },
     { value: 500, color: 'purple' },
@@ -156,6 +157,9 @@
   var suggestedSeatNoParam = null;
   var shouldAutoJoin = false;
   var autoJoinAttempted = false;
+  var autoJoinRetryTimer = null;
+  var autoJoinRetryCount = 0;
+  var autoJoinErrorActive = false;
   var reconnectSeatNo = null;
   var lastKnownCurrentSeatNo = null;
   var bootReady = false;
@@ -1147,7 +1151,7 @@
     syncStickyWinnerReveal();
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
     state.statusText = LIVE_STATUS_COPY.live;
-    state.errorText = '';
+    if (!autoJoinErrorActive) state.errorText = '';
     if (pendingLeaveNavigation && !hasRenderableCurrentSeat()){
       pendingLeaveRetryAfterReconnect = false;
       pendingLeaveNavigation = false;
@@ -2619,22 +2623,73 @@
     });
   }
 
-  function isSeatTakenError(error){
-    var message = error && error.message ? String(error.message) : '';
-    return /seat_taken/i.test(message);
+  function autoJoinErrorCode(error){
+    var value = error && (error.code || error.message) ? String(error.code || error.message) : '';
+    return value.trim().toLowerCase();
+  }
+
+  function isRetryableAutoJoinError(error){
+    var code = autoJoinErrorCode(error);
+    if (!code) return false;
+    return /^(timeout|ws_unavailable|temporarily_unavailable|authoritative_join_failed|authoritative_state_invalid|state_missing|poker_state_missing|state_conflict|conflict|persist_failed|seat_taken|table_load_failed|table_bootstrap_failed)$/.test(code);
+  }
+
+  function clearAutoJoinRetry(){
+    if (autoJoinRetryTimer){
+      window.clearTimeout(autoJoinRetryTimer);
+      autoJoinRetryTimer = null;
+    }
+  }
+
+  function resetAutoJoinRetryState(){
+    clearAutoJoinRetry();
+    autoJoinRetryCount = 0;
+    autoJoinErrorActive = false;
+  }
+
+  function scheduleAutoJoinRetry(error){
+    if (!shouldAutoJoin || !isRetryableAutoJoinError(error) || autoJoinRetryTimer) return false;
+    if (autoJoinRetryCount >= AUTO_JOIN_RETRY_DELAYS_MS.length) return false;
+    var delayMs = AUTO_JOIN_RETRY_DELAYS_MS[autoJoinRetryCount];
+    autoJoinRetryCount += 1;
+    autoJoinRetryTimer = window.setTimeout(function(){
+      autoJoinRetryTimer = null;
+      autoJoinAttempted = false;
+      if (deriveCurrentSeat()){
+        resetAutoJoinRetryState();
+        return;
+      }
+      autoJoinSeat();
+    }, delayMs);
+    return true;
   }
 
   function autoJoinSeat(){
-    if (!shouldAutoJoin || autoJoinAttempted) return;
-    if (!isSignedIn() || !isWsReady() || deriveCurrentSeat()) return;
+    if (!shouldAutoJoin) return;
+    if (deriveCurrentSeat()){
+      autoJoinAttempted = false;
+      resetAutoJoinRetryState();
+      return;
+    }
+    if (autoJoinAttempted || autoJoinRetryTimer) return;
+    if (!isSignedIn() || !isWsReady()) return;
     autoJoinAttempted = true;
     if (suggestedSeatNoParam && els.joinSeat) els.joinSeat.value = String(suggestedSeatNoParam);
+    autoJoinErrorActive = false;
     setError('');
     sendCommand('sendJoin', buildJoinPayloadWithOptions({ autoSeat: true })).then(function(result){
+      resetAutoJoinRetryState();
       state.statusText = result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted';
       renderInfoPanel();
     }).catch(function(err){
-      if (isSeatTakenError(err)) autoJoinAttempted = false;
+      autoJoinAttempted = false;
+      autoJoinErrorActive = true;
+      var retryScheduled = scheduleAutoJoinRetry(err);
+      klog('poker_auto_join_failed', {
+        reason: autoJoinErrorCode(err) || 'unknown',
+        retryScheduled: retryScheduled,
+        retryCount: autoJoinRetryCount
+      });
       setError(err && err.message ? err.message : 'Failed to auto-join');
     });
   }
@@ -2904,6 +2959,8 @@
     stopTurnClock();
     clearWinnerRevealTimer();
     cancelClosedTableRedirect();
+    resetAutoJoinRetryState();
+    autoJoinAttempted = false;
     pendingPostRevealSnapshot = null;
     state.wsReady = false;
     if (wsClient && typeof wsClient.destroy === 'function'){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -156,9 +156,9 @@
   var suggestedSeatNoParam = null;
   var shouldAutoJoin = false;
   var autoJoinAttempted = false;
+  var reconnectSeatNo = null;
+  var lastKnownCurrentSeatNo = null;
   var bootReady = false;
-  var queuedPreaction = null;
-  var queuedPreactionInFlight = false;
   var stickyWinnerReveal = {
     handId: null,
     visibleUntilMs: 0,
@@ -1085,6 +1085,10 @@
     var nextSeats = normalizeSeatRows(payload, state.seats, state.tableId);
     if (nextSeats.length || Array.isArray(payload.seats) || Array.isArray(tableObj.members) || Array.isArray(payload.authoritativeMembers) || Array.isArray(publicObj.seats)) {
       state.seats = nextSeats;
+      var currentSeatAfterMerge = deriveCurrentSeat();
+      if (currentSeatAfterMerge && Number.isInteger(currentSeatAfterMerge.seatNo)) {
+        lastKnownCurrentSeatNo = currentSeatAfterMerge.seatNo;
+      }
     }
     seatCommittedByUserId = extractSeatCommittedByUserId(payload);
 
@@ -2295,120 +2299,24 @@
     return value;
   }
 
-  function clearQueuedPreaction(){
-    queuedPreaction = null;
-  }
-
-  function resetQueuedPreactionState(){
-    queuedPreaction = null;
-    queuedPreactionInFlight = false;
-  }
-
-  function getPreactionInput(slot){
-    if (slot === 'fold') return els.foldPreaction;
-    if (slot === 'primary') return els.primaryPreaction;
-    if (slot === 'amount') return els.amountPreaction;
-    if (slot === 'allIn') return els.allInPreaction;
-    return null;
-  }
-
-  function readQueuedAmount(){
-    var value = els.amountInput ? parseInt(els.amountInput.value, 10) : NaN;
-    return Number.isFinite(value) ? Math.trunc(value) : null;
-  }
-
-  function buildQueuedPreaction(slot){
-    if (slot === 'fold') return { slot: 'fold', action: 'FOLD', amount: null };
-    if (slot === 'primary'){
-      var primaryAction = els.primaryPreaction ? (els.primaryPreaction.dataset.action || '') : '';
-      return primaryAction ? { slot: 'primary', action: primaryAction, amount: null } : null;
-    }
-    if (slot === 'amount'){
-      var amountAction = els.amountPreaction ? (els.amountPreaction.dataset.action || '') : '';
-      var amount = readQueuedAmount();
-      return amountAction && Number.isFinite(amount) ? { slot: 'amount', action: amountAction, amount: amount } : null;
-    }
-    if (slot === 'allIn') return { slot: 'allIn', action: null, amount: null };
-    return null;
-  }
-
-  function syncQueuedPreactionWithPreactionState(preactionState){
-    if (!queuedPreaction || !preactionState) return;
-    if (queuedPreaction.slot === 'fold'){
-      if (!preactionState.foldVisible) clearQueuedPreaction();
-      return;
-    }
-    if (queuedPreaction.slot === 'primary'){
-      if (!preactionState.primaryAction || queuedPreaction.action !== preactionState.primaryAction) clearQueuedPreaction();
-      return;
-    }
-    if (queuedPreaction.slot === 'amount'){
-      if (!preactionState.amountAction || queuedPreaction.action !== preactionState.amountAction || !preactionState.amountBounds){
-        clearQueuedPreaction();
-        return;
-      }
-      var queuedAmount = readQueuedAmount();
-      if (!Number.isFinite(queuedAmount) || queuedAmount < preactionState.amountBounds.min || (preactionState.amountBounds.max != null && queuedAmount > preactionState.amountBounds.max)){
-        clearQueuedPreaction();
-        return;
-      }
-      queuedPreaction.amount = queuedAmount;
-      return;
-    }
-    if (queuedPreaction.slot === 'allIn' && !preactionState.allInPlan) clearQueuedPreaction();
-  }
-
-  function resolveQueuedPreactionExecution(liveState){
-    if (!queuedPreaction || !liveState) return null;
-    if (queuedPreaction.slot === 'fold') return liveState.foldVisible ? { action: 'FOLD', amount: null } : null;
-    if (queuedPreaction.slot === 'primary'){
-      return queuedPreaction.action && queuedPreaction.action === liveState.primaryAction
-        ? { action: queuedPreaction.action, amount: null }
-        : null;
-    }
-    if (queuedPreaction.slot === 'amount'){
-      if (!queuedPreaction.action || queuedPreaction.action !== liveState.amountAction || !liveState.amountBounds) return null;
-      if (!Number.isFinite(queuedPreaction.amount) || queuedPreaction.amount < liveState.amountBounds.min || (liveState.amountBounds.max != null && queuedPreaction.amount > liveState.amountBounds.max)) return null;
-      return { action: queuedPreaction.action, amount: queuedPreaction.amount };
-    }
-    if (queuedPreaction.slot === 'allIn'){
-      return liveState.allInPlan
-        ? { action: liveState.allInPlan.type, amount: liveState.allInPlan.amount == null ? null : liveState.allInPlan.amount }
-        : null;
-    }
-    return null;
-  }
-
   function renderControls(){
     var signedIn = isSignedIn();
     var seated = !!deriveCurrentSeat();
     var liveReady = isWsReady();
     var activeHand = hasActiveHand();
     var usersTurn = isUsersTurn();
-    var controlsLocked = queuedPreactionInFlight;
     var allowed = liveReady && usersTurn ? getAllowedActions() : [];
     var primary = resolvePrimaryAction(allowed);
     var amountAction = resolveAmountAction(allowed);
     var allInPlan = resolveAllInPlan(allowed);
     var stackAmount = resolveStack(state.currentUserId);
     var amountBounds = resolveAmountBounds(amountAction, stackAmount);
-    var preactionMode = !!(signedIn && seated && liveReady && activeHand && !usersTurn && !isCurrentUserFolded());
-    var projectedAllowed = preactionMode ? resolveProjectedAllowedActions() : [];
-    var preactionPrimary = resolvePrimaryAction(projectedAllowed);
-    var preactionAmountAction = resolveAmountAction(projectedAllowed);
-    var preactionAllInPlan = resolveAllInPlan(projectedAllowed);
-    var preactionAmountBounds = resolveAmountBounds(preactionAmountAction, stackAmount);
+    var projectedAllowed = signedIn && seated && activeHand && !isCurrentUserFolded() ? resolveProjectedAllowedActions() : [];
+    var displayPrimary = primary || resolvePrimaryAction(projectedAllowed) || 'CHECK';
+    var displayAmountAction = amountAction || resolveAmountAction(projectedAllowed) || 'BET';
+    var showActionButtons = signedIn && seated;
+    var actionControlsLocked = !liveReady || !usersTurn;
     var joinDisabled = !signedIn || seated || !state.tableId || !liveReady;
-    if (!seated || !activeHand || isCurrentUserFolded()) clearQueuedPreaction();
-    if (preactionMode) {
-      syncQueuedPreactionWithPreactionState({
-        foldVisible: isFoldAvailable(),
-        primaryAction: preactionPrimary,
-        amountAction: preactionAmountAction,
-        allInPlan: preactionAllInPlan,
-        amountBounds: preactionAmountBounds
-      });
-    }
 
     if (els.signInBtn) {
       els.signInBtn.hidden = signedIn && !isGuestMode;
@@ -2436,70 +2344,35 @@
     if (els.stackText) els.stackText.textContent = stackAmount == null ? '—' : formatNumber(stackAmount);
 
     if (els.foldBtn){
-      els.foldBtn.hidden = !usersTurn || !isFoldAvailable();
+      els.foldBtn.hidden = !showActionButtons;
       els.foldBtn.dataset.action = 'FOLD';
-      els.foldBtn.disabled = !liveReady || controlsLocked;
+      els.foldBtn.disabled = actionControlsLocked || !isFoldAvailable();
     }
     if (els.primaryBtn){
-      els.primaryBtn.hidden = !usersTurn || !primary;
+      els.primaryBtn.hidden = !showActionButtons;
       var toCall = Number.isFinite(state.actionConstraints && state.actionConstraints.toCall)
         ? Math.max(0, Math.trunc(state.actionConstraints.toCall))
         : null;
-      els.primaryBtn.textContent = primary === 'CHECK'
+      els.primaryBtn.textContent = displayPrimary === 'CHECK'
         ? 'Check'
         : ('Call (' + formatCompactAmount(toCall) + ')');
       els.primaryBtn.dataset.action = primary || '';
-      els.primaryBtn.disabled = !liveReady || controlsLocked;
+      els.primaryBtn.disabled = actionControlsLocked || !primary;
     }
     if (els.amountBtn){
-      els.amountBtn.hidden = !usersTurn || !amountAction;
-      els.amountBtn.textContent = amountAction === 'RAISE' ? 'Raise' : 'Bet';
+      els.amountBtn.hidden = !showActionButtons;
+      els.amountBtn.textContent = displayAmountAction === 'RAISE' ? 'Raise' : 'Bet';
       els.amountBtn.dataset.action = amountAction || '';
-      els.amountBtn.disabled = !liveReady || controlsLocked;
+      els.amountBtn.disabled = actionControlsLocked || !amountAction;
     }
     if (els.allInBtn){
-      els.allInBtn.hidden = !usersTurn || !allInPlan;
+      els.allInBtn.hidden = !showActionButtons;
       els.allInBtn.dataset.action = allInPlan ? allInPlan.type : '';
-      els.allInBtn.disabled = !liveReady || controlsLocked;
-    }
-    if (els.foldPreactionWrap) els.foldPreactionWrap.hidden = !preactionMode || !isFoldAvailable();
-    if (els.foldPreaction) {
-      els.foldPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'fold');
-      els.foldPreaction.disabled = !liveReady;
-      els.foldPreaction.dataset.slot = 'fold';
-    }
-    if (els.primaryPreactionWrap) els.primaryPreactionWrap.hidden = !preactionMode || !preactionPrimary;
-    if (els.primaryPreaction) {
-      els.primaryPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'primary');
-      els.primaryPreaction.disabled = !liveReady || !preactionPrimary;
-      els.primaryPreaction.dataset.slot = 'primary';
-      els.primaryPreaction.dataset.action = preactionPrimary || '';
-    }
-    if (els.primaryPreactionText) {
-      var projectedToCall = Number.isFinite(state.actionConstraints && state.actionConstraints.toCall)
-        ? Math.max(0, Math.trunc(state.actionConstraints.toCall))
-        : null;
-      els.primaryPreactionText.textContent = preactionPrimary === 'CALL'
-        ? ('Call (' + formatCompactAmount(projectedToCall) + ')')
-        : 'Check';
-    }
-    if (els.amountPreactionWrap) els.amountPreactionWrap.hidden = !preactionMode || !preactionAmountAction;
-    if (els.amountPreaction) {
-      els.amountPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'amount');
-      els.amountPreaction.disabled = !liveReady || !preactionAmountAction;
-      els.amountPreaction.dataset.slot = 'amount';
-      els.amountPreaction.dataset.action = preactionAmountAction || '';
-    }
-    if (els.amountPreactionText) els.amountPreactionText.textContent = preactionAmountAction === 'RAISE' ? 'Raise' : 'Bet';
-    if (els.allInPreactionWrap) els.allInPreactionWrap.hidden = !preactionMode || !preactionAllInPlan;
-    if (els.allInPreaction) {
-      els.allInPreaction.checked = !!(queuedPreaction && queuedPreaction.slot === 'allIn');
-      els.allInPreaction.disabled = !liveReady || !preactionAllInPlan;
-      els.allInPreaction.dataset.slot = 'allIn';
+      els.allInBtn.disabled = actionControlsLocked || !allInPlan;
     }
     if (els.amountInputWrap){
       els.amountInputWrap.hidden = false;
-      var activeAmountBounds = usersTurn ? amountBounds : preactionMode ? preactionAmountBounds : null;
+      var activeAmountBounds = usersTurn ? amountBounds : null;
       if (activeAmountBounds){
         var syncedAmount = syncAmountInput(activeAmountBounds);
         if (els.amountValue) els.amountValue.textContent = formatCompactAmount(Number.isFinite(syncedAmount) ? syncedAmount : activeAmountBounds.min);
@@ -2508,8 +2381,8 @@
         els.amountInputWrap.classList.add('is-disabled');
       }
     }
-    if (els.amountInput) els.amountInput.disabled = !liveReady || controlsLocked || !(usersTurn ? amountAction : preactionMode ? preactionAmountAction : null);
-    if (els.amountValue && !(usersTurn ? amountAction : preactionMode ? preactionAmountAction : null)) {
+    if (els.amountInput) els.amountInput.disabled = !liveReady || !usersTurn || !amountAction;
+    if (els.amountValue && (!usersTurn || !amountAction)) {
       els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput && els.amountInput.value ? els.amountInput.value : '20', 10) || 20);
     }
   }
@@ -2612,26 +2485,6 @@
     });
   }
 
-  function maybeExecuteQueuedPreaction(){
-    if (!queuedPreaction || queuedPreactionInFlight || !isUsersTurn()) return;
-    var allowed = getAllowedActions();
-    var liveState = {
-      foldVisible: isFoldAvailable(),
-      primaryAction: resolvePrimaryAction(allowed),
-      amountAction: resolveAmountAction(allowed),
-      allInPlan: resolveAllInPlan(allowed),
-      amountBounds: resolveAmountBounds(resolveAmountAction(allowed), resolveStack(state.currentUserId))
-    };
-    var nextAction = resolveQueuedPreactionExecution(liveState);
-    clearQueuedPreaction();
-    if (!nextAction || !nextAction.action) return;
-    queuedPreactionInFlight = true;
-    handleAction(nextAction.action, nextAction.amount == null ? undefined : nextAction.amount).then(function(){
-      queuedPreactionInFlight = false;
-      renderControls();
-    });
-  }
-
   function isSeatTakenError(error){
     var message = error && error.message ? String(error.message) : '';
     return /seat_taken/i.test(message);
@@ -2650,6 +2503,39 @@
       if (isSeatTakenError(err)) autoJoinAttempted = false;
       setError(err && err.message ? err.message : 'Failed to auto-join');
     });
+  }
+
+  function rememberSeatForReconnect(){
+    var currentSeat = deriveCurrentSeat();
+    var seatNo = currentSeat && Number.isInteger(currentSeat.seatNo)
+      ? currentSeat.seatNo
+      : lastKnownCurrentSeatNo;
+    reconnectSeatNo = Number.isInteger(seatNo) && seatNo > 0 ? seatNo : null;
+    autoJoinAttempted = false;
+  }
+
+  function rejoinSeatAfterReconnect(){
+    if (!Number.isInteger(reconnectSeatNo) || reconnectSeatNo < 1) return false;
+    var preferredSeatNo = reconnectSeatNo;
+    reconnectSeatNo = null;
+    autoJoinAttempted = true;
+    setError('');
+    sendCommand('sendJoin', {
+      tableId: state.tableId,
+      autoSeat: true,
+      preferredSeatNo: preferredSeatNo
+    }).then(function(result){
+      var resolvedSeatNo = result && Number.isInteger(Number(result.seatNo))
+        ? Number(result.seatNo)
+        : preferredSeatNo;
+      lastKnownCurrentSeatNo = resolvedSeatNo;
+      state.statusText = 'Reconnected to seat ' + resolvedSeatNo;
+      renderInfoPanel();
+    }).catch(function(err){
+      autoJoinAttempted = false;
+      setError(err && err.message ? err.message : 'Failed to reconnect seat');
+    });
+    return true;
   }
 
   function closeMenu(){
@@ -2727,29 +2613,6 @@
   }
 
   function bindControls(){
-    function bindPreaction(slot){
-      var input = getPreactionInput(slot);
-      if (!input) return;
-      input.addEventListener('change', function(){
-        if (!input.checked){
-          if (queuedPreaction && queuedPreaction.slot === slot) clearQueuedPreaction();
-          renderControls();
-          return;
-        }
-        queuedPreaction = buildQueuedPreaction(slot);
-        if (!queuedPreaction) {
-          input.checked = false;
-          renderControls();
-          return;
-        }
-        ['fold', 'primary', 'amount', 'allIn'].forEach(function(otherSlot){
-          if (otherSlot === slot) return;
-          var otherInput = getPreactionInput(otherSlot);
-          if (otherInput) otherInput.checked = false;
-        });
-        renderControls();
-      });
-    }
     if (els.signInBtn) els.signInBtn.addEventListener('click', openSignIn);
     if (els.foldBtn) els.foldBtn.addEventListener('click', function(){
       handleAction('FOLD');
@@ -2793,10 +2656,6 @@
     });
     if (els.amountInput) els.amountInput.addEventListener('input', function(){
       if (els.amountValue) els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput.value, 10) || 0);
-      if (queuedPreaction && queuedPreaction.slot === 'amount'){
-        var queuedAmount = readQueuedAmount();
-        if (Number.isFinite(queuedAmount)) queuedPreaction.amount = queuedAmount;
-      }
     });
     if (els.joinSeat) els.joinSeat.addEventListener('input', function(){
       els.joinSeat.dataset.userEdited = '1';
@@ -2806,10 +2665,6 @@
       if (!plan) return;
       handleAction(plan.type, plan.amount == null ? undefined : plan.amount);
     });
-    bindPreaction('fold');
-    bindPreaction('primary');
-    bindPreaction('amount');
-    bindPreaction('allIn');
   }
 
   function selectElements(){
@@ -2849,21 +2704,9 @@
     els.closedTableCountdown = document.getElementById('pokerV2ClosedTableCountdown');
     els.startBtn = document.getElementById('pokerV2StartBtn');
     els.foldBtn = document.getElementById('pokerV2FoldBtn');
-    els.foldPreactionWrap = document.getElementById('pokerV2FoldPreactionWrap');
-    els.foldPreaction = document.getElementById('pokerV2FoldPreaction');
-    els.foldPreactionText = document.getElementById('pokerV2FoldPreactionText');
     els.primaryBtn = document.getElementById('pokerV2PrimaryBtn');
-    els.primaryPreactionWrap = document.getElementById('pokerV2PrimaryPreactionWrap');
-    els.primaryPreaction = document.getElementById('pokerV2PrimaryPreaction');
-    els.primaryPreactionText = document.getElementById('pokerV2PrimaryPreactionText');
     els.amountBtn = document.getElementById('pokerV2AmountBtn');
-    els.amountPreactionWrap = document.getElementById('pokerV2AmountPreactionWrap');
-    els.amountPreaction = document.getElementById('pokerV2AmountPreaction');
-    els.amountPreactionText = document.getElementById('pokerV2AmountPreactionText');
     els.allInBtn = document.getElementById('pokerV2AllInBtn');
-    els.allInPreactionWrap = document.getElementById('pokerV2AllInPreactionWrap');
-    els.allInPreaction = document.getElementById('pokerV2AllInPreaction');
-    els.allInPreactionText = document.getElementById('pokerV2AllInPreactionText');
     els.amountInput = document.getElementById('pokerV2AmountInput');
     els.amountValue = document.getElementById('pokerV2AmountValue');
     els.amountInputWrap = document.getElementById('pokerV2AmountInputWrap');
@@ -2871,7 +2714,6 @@
 
   function startDemoMode(){
     startTurnClock();
-    resetQueuedPreactionState();
     state = cloneState(demoState);
     state.wsReady = false;
     render();
@@ -2892,7 +2734,6 @@
 
   function applySignedOutState(){
     stopLiveMode();
-    resetQueuedPreactionState();
     state = createEmptyLiveState(tableId, null);
     state.statusText = LIVE_STATUS_COPY.auth;
     render();
@@ -2900,7 +2741,6 @@
 
   function applyAuthenticatedPendingState(user){
     stopLiveMode();
-    resetQueuedPreactionState();
     isGuestMode = false;
     currentGuestSession = null;
     state = createEmptyLiveState(tableId, user && user.id ? String(user.id) : null);
@@ -2955,7 +2795,13 @@
             leaveAndReturnToLobby();
             return;
           }
-          autoJoinSeat();
+          if (!rejoinSeatAfterReconnect()) autoJoinSeat();
+        } else if (status === 'reconnecting'){
+          rememberSeatForReconnect();
+          state.wsReady = false;
+          state.statusText = LIVE_STATUS_COPY.connecting;
+          renderInfoPanel();
+          renderControls();
         } else if (status === 'command_result') {
           syncClosedTableRedirectFromSignal(info && info.reason ? info.reason : null);
         } else if (status === 'failed'){
@@ -2983,7 +2829,6 @@
         }
         var previousVisual = captureVisualSnapshot();
         mergeSnapshot(payload);
-        maybeExecuteQueuedPreaction();
         render();
         var nextVisual = captureVisualSnapshot();
         animateChipDiff(previousVisual, nextVisual);

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -311,10 +311,17 @@
       }
       if (frame.type === 'error') {
         var rid = frame.requestId || (frame.payload && frame.payload.requestId) || null;
+        var commandErrorHandled = false;
         if (rid && pending.has(rid)) {
           var entry = pending.get(rid); pending.delete(rid); clearTimeout(entry.timer); entry.reject(createError(frame.payload && frame.payload.code ? frame.payload.code : 'ws_error'));
+          commandErrorHandled = true;
         }
-        var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error'; emitStatus('error', { code: code }); emitProtocolError(code, frame.payload && frame.payload.message ? frame.payload.message : null);
+        var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error';
+        if (commandErrorHandled) {
+          emitStatus('command_error', { code: code, requestId: rid });
+          return;
+        }
+        emitStatus('error', { code: code }); emitProtocolError(code, frame.payload && frame.payload.message ? frame.payload.message : null);
         return;
       }
       if (frame.type === 'pong') return;

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -105,25 +105,9 @@
       </div>
       <div class="poker-action-buttons">
         <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2FoldBtn" hidden>Fold</button>
-        <label class="poker-action-toggle poker-action-toggle--fold" id="pokerV2FoldPreactionWrap" hidden>
-          <input type="checkbox" id="pokerV2FoldPreaction" aria-label="Queue fold">
-          <span id="pokerV2FoldPreactionText">Fold</span>
-        </label>
         <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2PrimaryBtn" hidden>Check</button>
-        <label class="poker-action-toggle poker-action-toggle--fold" id="pokerV2PrimaryPreactionWrap" hidden>
-          <input type="checkbox" id="pokerV2PrimaryPreaction" aria-label="Queue primary action">
-          <span id="pokerV2PrimaryPreactionText">Check</span>
-        </label>
         <button type="button" class="poker-action-btn poker-action-btn--call" id="pokerV2AmountBtn" hidden>Bet</button>
-        <label class="poker-action-toggle poker-action-toggle--call" id="pokerV2AmountPreactionWrap" hidden>
-          <input type="checkbox" id="pokerV2AmountPreaction" aria-label="Queue amount action">
-          <span id="pokerV2AmountPreactionText">Bet</span>
-        </label>
         <button type="button" class="poker-action-btn poker-action-btn--raise" id="pokerV2AllInBtn" hidden>All in</button>
-        <label class="poker-action-toggle poker-action-toggle--raise" id="pokerV2AllInPreactionWrap" hidden>
-          <input type="checkbox" id="pokerV2AllInPreaction" aria-label="Queue all in">
-          <span id="pokerV2AllInPreactionText">All in</span>
-        </label>
       </div>
     </div>
 

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -105,24 +105,22 @@
       </div>
       <div class="poker-action-buttons">
         <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2FoldBtn" hidden>Fold</button>
-        <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2PrimaryBtn" hidden>Check</button>
-        <button type="button" class="poker-action-btn poker-action-btn--call" id="pokerV2AmountBtn" hidden>Bet</button>
-        <button type="button" class="poker-action-btn poker-action-btn--raise" id="pokerV2AllInBtn" hidden>All in</button>
-      </div>
-      <div class="poker-preaction-panel" id="pokerV2PreactionPanel" aria-label="Pre-actions" hidden>
-        <label class="poker-action-toggle poker-action-toggle--fold poker-action-toggle--slot-fold" id="pokerV2FoldPreactionWrap" hidden>
+        <label class="poker-action-toggle poker-action-toggle--fold" id="pokerV2FoldPreactionWrap" hidden>
           <input type="checkbox" id="pokerV2FoldPreaction" aria-label="Queue fold">
           <span id="pokerV2FoldPreactionText">Fold</span>
         </label>
-        <label class="poker-action-toggle poker-action-toggle--fold poker-action-toggle--slot-primary" id="pokerV2PrimaryPreactionWrap" hidden>
+        <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2PrimaryBtn" hidden>Check</button>
+        <label class="poker-action-toggle poker-action-toggle--fold" id="pokerV2PrimaryPreactionWrap" hidden>
           <input type="checkbox" id="pokerV2PrimaryPreaction" aria-label="Queue primary action">
           <span id="pokerV2PrimaryPreactionText">Check</span>
         </label>
-        <label class="poker-action-toggle poker-action-toggle--call poker-action-toggle--slot-amount" id="pokerV2AmountPreactionWrap" hidden>
+        <button type="button" class="poker-action-btn poker-action-btn--call" id="pokerV2AmountBtn" hidden>Bet</button>
+        <label class="poker-action-toggle poker-action-toggle--call" id="pokerV2AmountPreactionWrap" hidden>
           <input type="checkbox" id="pokerV2AmountPreaction" aria-label="Queue amount action">
           <span id="pokerV2AmountPreactionText">Bet</span>
         </label>
-        <label class="poker-action-toggle poker-action-toggle--raise poker-action-toggle--slot-all-in" id="pokerV2AllInPreactionWrap" hidden>
+        <button type="button" class="poker-action-btn poker-action-btn--raise" id="pokerV2AllInBtn" hidden>All in</button>
+        <label class="poker-action-toggle poker-action-toggle--raise" id="pokerV2AllInPreactionWrap" hidden>
           <input type="checkbox" id="pokerV2AllInPreaction" aria-label="Queue all in">
           <span id="pokerV2AllInPreactionText">All in</span>
         </label>

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -109,6 +109,24 @@
         <button type="button" class="poker-action-btn poker-action-btn--call" id="pokerV2AmountBtn" hidden>Bet</button>
         <button type="button" class="poker-action-btn poker-action-btn--raise" id="pokerV2AllInBtn" hidden>All in</button>
       </div>
+      <div class="poker-preaction-panel" id="pokerV2PreactionPanel" aria-label="Pre-actions" hidden>
+        <label class="poker-action-toggle poker-action-toggle--fold poker-action-toggle--slot-fold" id="pokerV2FoldPreactionWrap" hidden>
+          <input type="checkbox" id="pokerV2FoldPreaction" aria-label="Queue fold">
+          <span id="pokerV2FoldPreactionText">Fold</span>
+        </label>
+        <label class="poker-action-toggle poker-action-toggle--fold poker-action-toggle--slot-primary" id="pokerV2PrimaryPreactionWrap" hidden>
+          <input type="checkbox" id="pokerV2PrimaryPreaction" aria-label="Queue primary action">
+          <span id="pokerV2PrimaryPreactionText">Check</span>
+        </label>
+        <label class="poker-action-toggle poker-action-toggle--call poker-action-toggle--slot-amount" id="pokerV2AmountPreactionWrap" hidden>
+          <input type="checkbox" id="pokerV2AmountPreaction" aria-label="Queue amount action">
+          <span id="pokerV2AmountPreactionText">Bet</span>
+        </label>
+        <label class="poker-action-toggle poker-action-toggle--raise poker-action-toggle--slot-all-in" id="pokerV2AllInPreactionWrap" hidden>
+          <input type="checkbox" id="pokerV2AllInPreaction" aria-label="Queue all in">
+          <span id="pokerV2AllInPreactionText">All in</span>
+        </label>
+      </div>
     </div>
 
     <div class="poker-confirm-modal" id="pokerV2LeaveConfirmModal" role="dialog" aria-modal="true" aria-labelledby="pokerV2LeaveConfirmTitle" hidden>

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -1362,6 +1362,54 @@ test('poker v2 auto-joins from query params after live auth', async () => {
   assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 100, autoSeat: true, preferredSeatNo: 4 }));
 });
 
+test('poker v2 retries Play now auto-join after a transient authoritative join failure', async () => {
+  const harness = createHarness({
+    search: '?tableId=table-1&seatNo=4&autoJoin=1',
+    sendJoin(payload, context){
+      if (context.attempt === 1) {
+        const error = new Error('authoritative_join_rehydrate_failed');
+        error.code = 'TABLE_BOOTSTRAP_FAILED';
+        return Promise.reject(error);
+      }
+      return Promise.resolve({ ok: true, seatNo: payload.preferredSeatNo });
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  await waitFor(() => harness.joinPayloads.length === 1);
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 0,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [] },
+      public: {
+        hand: { handId: null, status: 'INIT', dealerSeatNo: null },
+        turn: { userId: null, deadlineAt: null },
+        pot: { total: 0, sidePots: [] },
+        legalActions: { seat: null, actions: [] },
+        actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        stacks: {}
+      },
+      you: { seat: null }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(harness.joinPayloads.length, 1);
+  assert.equal(harness.elements.pokerV2ErrorText.textContent, 'authoritative_join_rehydrate_failed');
+  assert.equal(harness.elements.pokerV2ErrorText.hidden, false);
+
+  harness.advanceTime(250);
+  await harness.flush();
+
+  assert.equal(harness.joinPayloads.length, 2);
+  assert.equal(JSON.stringify(harness.joinPayloads[1]), JSON.stringify({ tableId: 'table-1', buyIn: 100, autoSeat: true, preferredSeatNo: 4 }));
+  assert.equal(harness.logs.some((entry) => entry.kind === 'poker_auto_join_failed' && entry.data.retryScheduled === true), true);
+});
+
 test('poker v2 safely rejoins the same authoritative seat after a socket reconnect', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -117,7 +117,7 @@ function createHarness(options = {}){
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
-    'pokerV2AllInBtn', 'pokerV2PreactionPanel', 'pokerV2FoldPreactionWrap', 'pokerV2FoldPreaction', 'pokerV2FoldPreactionText',
+    'pokerV2AllInBtn', 'pokerV2FoldPreactionWrap', 'pokerV2FoldPreaction', 'pokerV2FoldPreactionText',
     'pokerV2PrimaryPreactionWrap', 'pokerV2PrimaryPreaction', 'pokerV2PrimaryPreactionText',
     'pokerV2AmountPreactionWrap', 'pokerV2AmountPreaction', 'pokerV2AmountPreactionText',
     'pokerV2AllInPreactionWrap', 'pokerV2AllInPreaction', 'pokerV2AllInPreactionText',
@@ -975,17 +975,18 @@ test('poker v2 keeps action buttons stable while exposing single-select preactio
     harness.elements.pokerV2AllInBtn
   ];
   buttons.forEach((button) => {
-    assert.equal(button.hidden, false);
+    assert.equal(button.hidden, true);
     assert.equal(button.disabled, true);
   });
   assert.equal(harness.elements.pokerV2PrimaryBtn.textContent, 'Call (6)');
   assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Raise');
-  assert.equal(harness.elements.pokerV2PreactionPanel.hidden, false);
   assert.equal(harness.elements.pokerV2FoldPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2PrimaryPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2AmountPreactionWrap.hidden, false);
+  assert.equal(harness.elements.pokerV2AllInPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2PrimaryPreactionText.textContent, 'Call (6)');
   assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise');
+  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, true);
 
   harness.elements.pokerV2PrimaryPreaction.click();
   await harness.flush();
@@ -1063,7 +1064,10 @@ test('poker v2 auto-executes a queued preaction without moving the live action b
   await harness.flush();
 
   assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-preaction-call', action: 'CALL' }));
-  assert.equal(harness.elements.pokerV2PreactionPanel.hidden, true);
+  assert.equal(harness.elements.pokerV2FoldPreactionWrap.hidden, true);
+  assert.equal(harness.elements.pokerV2PrimaryPreactionWrap.hidden, true);
+  assert.equal(harness.elements.pokerV2AmountPreactionWrap.hidden, true);
+  assert.equal(harness.elements.pokerV2AllInPreactionWrap.hidden, true);
   assert.equal(harness.elements.pokerV2FoldBtn.hidden, false);
   assert.equal(harness.elements.pokerV2PrimaryBtn.hidden, false);
   assert.equal(harness.elements.pokerV2AmountBtn.hidden, false);
@@ -1110,8 +1114,16 @@ test('poker v2 enables only legal actions without removing or moving the other b
     harness.elements.pokerV2AllInBtn
   ];
   buttonsBeforeTurn.forEach((button) => {
-    assert.equal(button.hidden, false);
+    assert.equal(button.hidden, true);
     assert.equal(button.disabled, true);
+  });
+  [
+    harness.elements.pokerV2FoldPreactionWrap,
+    harness.elements.pokerV2PrimaryPreactionWrap,
+    harness.elements.pokerV2AmountPreactionWrap,
+    harness.elements.pokerV2AllInPreactionWrap
+  ].forEach((preaction) => {
+    assert.equal(preaction.hidden, false);
   });
 
   ws.onSnapshot({

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -986,7 +986,7 @@ test('poker v2 keeps action buttons stable while exposing single-select preactio
   assert.equal(harness.elements.pokerV2AllInPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2PrimaryPreactionText.textContent, 'Call (6)');
   assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise');
-  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, true);
+  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, false);
 
   harness.elements.pokerV2PrimaryPreaction.click();
   await harness.flush();
@@ -1072,6 +1072,148 @@ test('poker v2 auto-executes a queued preaction without moving the live action b
   assert.equal(harness.elements.pokerV2PrimaryBtn.hidden, false);
   assert.equal(harness.elements.pokerV2AmountBtn.hidden, false);
   assert.equal(harness.elements.pokerV2AllInBtn.hidden, false);
+});
+
+test('poker v2 queues all-in intent without pre-turn raise limits and resolves it from live turn constraints', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 34,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-all-in', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 18, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD'] },
+        actionConstraints: { toCall: 6, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        stacks: { 'user-1': 100, 'villain-1': 80 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, false);
+  harness.elements.pokerV2AllInPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, true);
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 35,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-all-in', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 24, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
+        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 100, maxBetAmount: null },
+        stacks: { 'user-1': 100, 'villain-1': 80 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-preaction-all-in', action: 'RAISE', amount: 100 }));
+});
+
+test('poker v2 clears queued all-in intent when the live turn has no legal all-in realization', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 36,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-all-in-invalid', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 18, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD'] },
+        actionConstraints: { toCall: 6, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        stacks: { 'user-1': 100, 'villain-1': 80 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  harness.elements.pokerV2AllInPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, true);
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 37,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-all-in-invalid', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 18, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CHECK'] },
+        actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        stacks: { 'user-1': 100, 'villain-1': 80 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0);
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, false);
+  assert.equal(harness.elements.pokerV2AllInBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2AllInBtn.disabled, true);
 });
 
 test('poker v2 enables only legal actions without removing or moving the other buttons', async () => {
@@ -1165,7 +1307,7 @@ test('poker v2 enables only legal actions without removing or moving the other b
   assert.equal(harness.actPayloads.length, 0);
 });
 
-test('poker v2 caps raise all-in to call plus the biggest active opponent stack behind', async () => {
+test('poker v2 sends authoritative maxRaiseTo for all-in even when the active opponent stack is smaller', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -1208,7 +1350,7 @@ test('poker v2 caps raise all-in to call plus the biggest active opponent stack 
   harness.elements.pokerV2AllInBtn.click();
   await harness.flush();
 
-  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-all-in', action: 'RAISE', amount: 45 }));
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-all-in', action: 'RAISE', amount: 100 }));
 });
 
 test('poker v2 auto-joins from query params after live auth', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -117,10 +117,7 @@ function createHarness(options = {}){
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
-    'pokerV2AllInBtn', 'pokerV2FoldPreactionWrap', 'pokerV2FoldPreaction', 'pokerV2FoldPreactionText',
-    'pokerV2PrimaryPreactionWrap', 'pokerV2PrimaryPreaction', 'pokerV2PrimaryPreactionText',
-    'pokerV2AmountPreactionWrap', 'pokerV2AmountPreaction', 'pokerV2AmountPreactionText',
-    'pokerV2AllInPreactionWrap', 'pokerV2AllInPreaction', 'pokerV2AllInPreactionText',
+    'pokerV2AllInBtn',
     'pokerV2AmountInput', 'pokerV2AmountInputWrap', 'pokerV2AmountValue',
     'pokerTableScreen', 'pokerBootSplash'
   ].forEach((id) => {
@@ -131,10 +128,6 @@ function createHarness(options = {}){
   elements.pokerV2SeatNo.value = '1';
   elements.pokerV2BuyIn.value = '100';
   elements.pokerV2AmountInput.value = '20';
-  elements.pokerV2FoldPreaction.type = 'checkbox';
-  elements.pokerV2PrimaryPreaction.type = 'checkbox';
-  elements.pokerV2AmountPreaction.type = 'checkbox';
-  elements.pokerV2AllInPreaction.type = 'checkbox';
   elements.pokerV2LeaveConfirmModal.hidden = true;
   elements.pokerV2ClosedTableModal.hidden = true;
   elements.pokerMenuPanel.setAttribute('hidden', 'hidden');
@@ -931,7 +924,7 @@ test('poker v2 keeps fold available even when live legalActions omit fold', asyn
   assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-fold-always', action: 'FOLD' }));
 });
 
-test('poker v2 swaps action buttons for single-select preaction checkboxes during other players turns', async () => {
+test('poker v2 keeps every action button visible and disabled during another player turn', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -952,7 +945,7 @@ test('poker v2 swaps action buttons for single-select preaction checkboxes durin
         ]
       },
       public: {
-        hand: { handId: 'hand-preaction-checkbox', status: 'TURN', dealerSeatNo: 2 },
+        hand: { handId: 'hand-stable-controls-off-turn', status: 'TURN', dealerSeatNo: 2 },
         turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 18, sidePots: [] },
         legalActions: { seat: 1, actions: [] },
@@ -964,27 +957,22 @@ test('poker v2 swaps action buttons for single-select preaction checkboxes durin
   });
   await harness.flush();
 
-  assert.equal(harness.elements.pokerV2FoldBtn.hidden, true);
-  assert.equal(harness.elements.pokerV2PrimaryBtn.hidden, true);
-  assert.equal(harness.elements.pokerV2AmountBtn.hidden, true);
-  assert.equal(harness.elements.pokerV2FoldPreactionWrap.hidden, false);
-  assert.equal(harness.elements.pokerV2PrimaryPreactionWrap.hidden, false);
-  assert.equal(harness.elements.pokerV2AmountPreactionWrap.hidden, false);
-  assert.equal(harness.elements.pokerV2PrimaryPreactionText.textContent, 'Call (6)');
-  assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise');
-
-  harness.elements.pokerV2PrimaryPreaction.click();
-  await harness.flush();
-  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, true);
-  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false);
-
-  harness.elements.pokerV2AmountPreaction.click();
-  await harness.flush();
-  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, false);
-  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true);
+  const buttons = [
+    harness.elements.pokerV2FoldBtn,
+    harness.elements.pokerV2PrimaryBtn,
+    harness.elements.pokerV2AmountBtn,
+    harness.elements.pokerV2AllInBtn
+  ];
+  buttons.forEach((button) => {
+    assert.equal(button.hidden, false);
+    assert.equal(button.disabled, true);
+  });
+  assert.equal(harness.elements.pokerV2PrimaryBtn.textContent, 'Call (6)');
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Raise');
+  assert.equal(harness.actPayloads.length, 0);
 });
 
-test('poker v2 auto-executes a queued primary preaction when the player turn starts', async () => {
+test('poker v2 enables only legal actions without removing or moving the other buttons', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -1005,11 +993,11 @@ test('poker v2 auto-executes a queued primary preaction when the player turn sta
         ]
       },
       public: {
-        hand: { handId: 'hand-preaction-call', status: 'TURN', dealerSeatNo: 2 },
+        hand: { handId: 'hand-stable-controls-transition', status: 'TURN', dealerSeatNo: 2 },
         turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 18, sidePots: [] },
         legalActions: { seat: 1, actions: [] },
-        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 120 }
+        actionConstraints: { toCall: 0, maxBetAmount: 120 }
       },
       private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
       you: { seat: 1 }
@@ -1017,8 +1005,16 @@ test('poker v2 auto-executes a queued primary preaction when the player turn sta
   });
   await harness.flush();
 
-  harness.elements.pokerV2PrimaryPreaction.click();
-  await harness.flush();
+  const buttonsBeforeTurn = [
+    harness.elements.pokerV2FoldBtn,
+    harness.elements.pokerV2PrimaryBtn,
+    harness.elements.pokerV2AmountBtn,
+    harness.elements.pokerV2AllInBtn
+  ];
+  buttonsBeforeTurn.forEach((button) => {
+    assert.equal(button.hidden, false);
+    assert.equal(button.disabled, true);
+  });
 
   ws.onSnapshot({
     kind: 'stateSnapshot',
@@ -1035,11 +1031,11 @@ test('poker v2 auto-executes a queued primary preaction when the player turn sta
         ]
       },
       public: {
-        hand: { handId: 'hand-preaction-call', status: 'TURN', dealerSeatNo: 2 },
+        hand: { handId: 'hand-stable-controls-transition', status: 'TURN', dealerSeatNo: 2 },
         turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 24, sidePots: [] },
-        legalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
-        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 120 }
+        legalActions: { seat: 1, actions: ['CHECK'] },
+        actionConstraints: { toCall: 0 }
       },
       private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
       you: { seat: 1 }
@@ -1047,152 +1043,16 @@ test('poker v2 auto-executes a queued primary preaction when the player turn sta
   });
   await harness.flush();
 
-  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-preaction-call', action: 'CALL' }));
-  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, false);
-});
-
-test('poker v2 clears an invalid queued preaction and falls back to live buttons on turn start', async () => {
-  const harness = createHarness();
-  harness.fireDomContentLoaded();
-  await harness.flush();
-
-  const ws = harness.getCreateOptions();
-  ws.onSnapshot({
-    kind: 'stateSnapshot',
-    payload: {
-      tableId: 'table-1',
-      stateVersion: 34,
-      table: {
-        tableId: 'table-1',
-        status: 'OPEN',
-        maxSeats: 6,
-        members: [
-          { userId: 'user-1', seat: 1, displayName: 'Hero' },
-          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
-        ]
-      },
-      public: {
-        hand: { handId: 'hand-preaction-invalid', status: 'TURN', dealerSeatNo: 2 },
-        turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
-        pot: { total: 18, sidePots: [] },
-        legalActions: { seat: 1, actions: [] },
-        actionConstraints: { toCall: 0, maxBetAmount: 120 }
-      },
-      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
-      you: { seat: 1 }
-    }
-  });
-  await harness.flush();
-
-  harness.elements.pokerV2PrimaryPreaction.click();
-  await harness.flush();
-  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, true);
-
-  ws.onSnapshot({
-    kind: 'stateSnapshot',
-    payload: {
-      tableId: 'table-1',
-      stateVersion: 35,
-      table: {
-        tableId: 'table-1',
-        status: 'OPEN',
-        maxSeats: 6,
-        members: [
-          { userId: 'user-1', seat: 1, displayName: 'Hero' },
-          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
-        ]
-      },
-      public: {
-        hand: { handId: 'hand-preaction-invalid', status: 'TURN', dealerSeatNo: 2 },
-        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
-        pot: { total: 24, sidePots: [] },
-        legalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
-        actionConstraints: { toCall: 8, minRaiseTo: 24, maxRaiseTo: 120 }
-      },
-      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
-      you: { seat: 1 }
-    }
-  });
-  await harness.flush();
-
-  assert.equal(harness.actPayloads.length, 0);
-  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, false);
+  assert.equal(harness.elements.pokerV2FoldBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2FoldBtn.disabled, false);
   assert.equal(harness.elements.pokerV2PrimaryBtn.hidden, false);
-  assert.equal(harness.elements.pokerV2PrimaryBtn.textContent, 'Call (8)');
-});
-
-test('poker v2 uses the current amount slider value for queued amount preactions', async () => {
-  const harness = createHarness();
-  harness.fireDomContentLoaded();
-  await harness.flush();
-
-  const ws = harness.getCreateOptions();
-  ws.onSnapshot({
-    kind: 'stateSnapshot',
-    payload: {
-      tableId: 'table-1',
-      stateVersion: 36,
-      table: {
-        tableId: 'table-1',
-        status: 'OPEN',
-        maxSeats: 6,
-        members: [
-          { userId: 'user-1', seat: 1, displayName: 'Hero' },
-          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
-        ]
-      },
-      public: {
-        hand: { handId: 'hand-preaction-bet', status: 'TURN', dealerSeatNo: 2 },
-        turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
-        pot: { total: 18, sidePots: [] },
-        legalActions: { seat: 1, actions: [] },
-        actionConstraints: { toCall: 0, maxBetAmount: 120 }
-      },
-      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
-      you: { seat: 1 }
-    }
-  });
-  await harness.flush();
-
-  harness.elements.pokerV2AmountInput.value = '77';
-  harness.elements.pokerV2AmountInput.click();
-  harness.elements.pokerV2AmountInput.click();
-  harness.elements.pokerV2AmountInput._listeners.input.forEach((fn) => fn({ target: harness.elements.pokerV2AmountInput }));
-  harness.elements.pokerV2AmountPreaction.click();
-  await harness.flush();
-
-  harness.elements.pokerV2AmountInput.value = '99';
-  harness.elements.pokerV2AmountInput._listeners.input.forEach((fn) => fn({ target: harness.elements.pokerV2AmountInput }));
-  await harness.flush();
-
-  ws.onSnapshot({
-    kind: 'stateSnapshot',
-    payload: {
-      tableId: 'table-1',
-      stateVersion: 37,
-      table: {
-        tableId: 'table-1',
-        status: 'OPEN',
-        maxSeats: 6,
-        members: [
-          { userId: 'user-1', seat: 1, displayName: 'Hero' },
-          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
-        ]
-      },
-      public: {
-        hand: { handId: 'hand-preaction-bet', status: 'TURN', dealerSeatNo: 2 },
-        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
-        pot: { total: 24, sidePots: [] },
-        legalActions: { seat: 1, actions: ['FOLD', 'CHECK', 'BET'] },
-        actionConstraints: { toCall: 0, maxBetAmount: 120 }
-      },
-      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
-      you: { seat: 1 }
-    }
-  });
-  await harness.flush();
-
-  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-preaction-bet', action: 'BET', amount: 99 }));
+  assert.equal(harness.elements.pokerV2PrimaryBtn.disabled, false);
+  assert.equal(harness.elements.pokerV2PrimaryBtn.textContent, 'Check');
+  assert.equal(harness.elements.pokerV2AmountBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2AmountBtn.disabled, true);
+  assert.equal(harness.elements.pokerV2AllInBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2AllInBtn.disabled, true);
+  assert.equal(harness.actPayloads.length, 0);
 });
 
 test('poker v2 caps raise all-in to call plus the biggest active opponent stack behind', async () => {
@@ -1248,6 +1108,52 @@ test('poker v2 auto-joins from query params after live auth', async () => {
   await waitFor(() => harness.joinPayloads.length === 1);
 
   assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 100, autoSeat: true, preferredSeatNo: 4 }));
+});
+
+test('poker v2 safely rejoins the same authoritative seat after a socket reconnect', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 40,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true },
+          { userId: 'user-1', seat: 4, displayName: 'Hero' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-before-reconnect', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  ws.onStatus('reconnecting', { attempt: 1 });
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+
+  assert.equal(harness.joinPayloads.length, 1);
+  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({
+    tableId: 'table-1',
+    autoSeat: true,
+    preferredSeatNo: 4
+  }));
+  assert.equal(Object.prototype.hasOwnProperty.call(harness.joinPayloads[0], 'buyIn'), false);
 });
 
 test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -117,7 +117,10 @@ function createHarness(options = {}){
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
-    'pokerV2AllInBtn',
+    'pokerV2AllInBtn', 'pokerV2PreactionPanel', 'pokerV2FoldPreactionWrap', 'pokerV2FoldPreaction', 'pokerV2FoldPreactionText',
+    'pokerV2PrimaryPreactionWrap', 'pokerV2PrimaryPreaction', 'pokerV2PrimaryPreactionText',
+    'pokerV2AmountPreactionWrap', 'pokerV2AmountPreaction', 'pokerV2AmountPreactionText',
+    'pokerV2AllInPreactionWrap', 'pokerV2AllInPreaction', 'pokerV2AllInPreactionText',
     'pokerV2AmountInput', 'pokerV2AmountInputWrap', 'pokerV2AmountValue',
     'pokerTableScreen', 'pokerBootSplash'
   ].forEach((id) => {
@@ -128,6 +131,10 @@ function createHarness(options = {}){
   elements.pokerV2SeatNo.value = '1';
   elements.pokerV2BuyIn.value = '100';
   elements.pokerV2AmountInput.value = '20';
+  elements.pokerV2FoldPreaction.type = 'checkbox';
+  elements.pokerV2PrimaryPreaction.type = 'checkbox';
+  elements.pokerV2AmountPreaction.type = 'checkbox';
+  elements.pokerV2AllInPreaction.type = 'checkbox';
   elements.pokerV2LeaveConfirmModal.hidden = true;
   elements.pokerV2ClosedTableModal.hidden = true;
   elements.pokerMenuPanel.setAttribute('hidden', 'hidden');
@@ -155,7 +162,11 @@ function createHarness(options = {}){
     },
     destroy(){ this._ready = false; },
     isReady(){ return this._ready; },
-    sendJoin(payload){ joinPayloads.push(payload); return Promise.resolve({ ok: true, seatNo: payload.seatNo || payload.preferredSeatNo || 1 }); },
+    sendJoin(payload){
+      joinPayloads.push(payload);
+      if (typeof options.sendJoin === 'function') return options.sendJoin(payload, { attempt: joinPayloads.length });
+      return Promise.resolve({ ok: true, seatNo: payload.seatNo || payload.preferredSeatNo || 1 });
+    },
     sendAct(payload){ actPayloads.push(payload); return Promise.resolve({ ok: true }); },
     sendStartHand(payload){ startPayloads.push(payload); return Promise.resolve({ ok: true }); },
     sendLeave(payload){
@@ -924,7 +935,7 @@ test('poker v2 keeps fold available even when live legalActions omit fold', asyn
   assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-fold-always', action: 'FOLD' }));
 });
 
-test('poker v2 keeps every action button visible and disabled during another player turn', async () => {
+test('poker v2 keeps action buttons stable while exposing single-select preactions off-turn', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -969,7 +980,94 @@ test('poker v2 keeps every action button visible and disabled during another pla
   });
   assert.equal(harness.elements.pokerV2PrimaryBtn.textContent, 'Call (6)');
   assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Raise');
+  assert.equal(harness.elements.pokerV2PreactionPanel.hidden, false);
+  assert.equal(harness.elements.pokerV2FoldPreactionWrap.hidden, false);
+  assert.equal(harness.elements.pokerV2PrimaryPreactionWrap.hidden, false);
+  assert.equal(harness.elements.pokerV2AmountPreactionWrap.hidden, false);
+  assert.equal(harness.elements.pokerV2PrimaryPreactionText.textContent, 'Call (6)');
+  assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise');
+
+  harness.elements.pokerV2PrimaryPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, true);
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false);
+
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2PrimaryPreaction.checked, false);
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true);
   assert.equal(harness.actPayloads.length, 0);
+});
+
+test('poker v2 auto-executes a queued preaction without moving the live action buttons', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 32,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-call', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 18, sidePots: [] },
+        legalActions: { seat: 1, actions: [] },
+        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 120 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  harness.elements.pokerV2PrimaryPreaction.click();
+  await harness.flush();
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 33,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'user-1', seat: 1, displayName: 'Hero' },
+          { userId: 'villain-1', seat: 2, displayName: 'Villain 1' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-preaction-call', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 24, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
+        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 120 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-preaction-call', action: 'CALL' }));
+  assert.equal(harness.elements.pokerV2PreactionPanel.hidden, true);
+  assert.equal(harness.elements.pokerV2FoldBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2PrimaryBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2AmountBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2AllInBtn.hidden, false);
 });
 
 test('poker v2 enables only legal actions without removing or moving the other buttons', async () => {
@@ -1154,6 +1252,62 @@ test('poker v2 safely rejoins the same authoritative seat after a socket reconne
     preferredSeatNo: 4
   }));
   assert.equal(Object.prototype.hasOwnProperty.call(harness.joinPayloads[0], 'buyIn'), false);
+});
+
+test('poker v2 retries the same reconnect seat after a transient join failure', async () => {
+  const harness = createHarness({
+    sendJoin(payload, context){
+      if (context.attempt === 1) return Promise.reject(new Error('timeout'));
+      return Promise.resolve({ ok: true, seatNo: payload.preferredSeatNo });
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 40,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true },
+          { userId: 'user-1', seat: 4, displayName: 'Hero' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-reconnect-retry', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  ws.onStatus('reconnecting', { attempt: 1 });
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+  assert.equal(harness.joinPayloads.length, 1);
+
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+
+  assert.equal(harness.joinPayloads.length, 2);
+  harness.joinPayloads.forEach((payload) => {
+    assert.equal(JSON.stringify(payload), JSON.stringify({
+      tableId: 'table-1',
+      autoSeat: true,
+      preferredSeatNo: 4
+    }));
+  });
 });
 
 test('poker v2 aligns the right rail seats and keeps the chip on the dealer seat', async () => {

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -178,6 +178,33 @@ test('poker ws client sendJoin/sendLeave/sendStartHand/sendAct resolve and rejec
   await assert.rejects(actPromise, (err) => err && err.code === 'hand_not_live');
 });
 
+test('poker ws client keeps the socket ready after a command-scoped error frame', async () => {
+  const h = loadClientHarness();
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const joinPromise = h.client.sendJoin({ tableId: 'table_test_1' }, 'join_bootstrap_retry');
+  ws.message({
+    type: 'error',
+    requestId: 'join_bootstrap_retry',
+    payload: {
+      requestId: 'join_bootstrap_retry',
+      code: 'TABLE_BOOTSTRAP_FAILED',
+      message: 'authoritative_join_rehydrate_failed'
+    }
+  });
+
+  await assert.rejects(joinPromise, (err) => err && err.code === 'TABLE_BOOTSTRAP_FAILED');
+  assert.equal(h.client.isReady(), true);
+  assert.equal(h.statuses.some((entry) => entry.status === 'command_error' && entry.data.code === 'TABLE_BOOTSTRAP_FAILED'), true);
+  assert.equal(h.statuses.some((entry) => entry.status === 'error'), false);
+  assert.equal(h.protocolErrors.length, 0);
+});
+
 test('poker ws client can queue leave without waiting for commandResult', async () => {
   const h = loadClientHarness();
   h.client.start();

--- a/ws-server/poker/reconnect/resync.behavior.test.mjs
+++ b/ws-server/poker/reconnect/resync.behavior.test.mjs
@@ -341,6 +341,62 @@ test("resync restores presence and seat without duplicates", async () => {
   }
 });
 
+test("authenticated table subscription reattaches an existing seat after socket reconnect", async () => {
+  const secret = "table-subscription-reattach-secret";
+  const token = makeHs256Jwt({ secret, sub: "reattach_user" });
+  const tableId = "table_subscription_reattach";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PRESENCE_TTL_MS: "10000"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+
+    const firstSocket = await connectClient(port);
+    await hello(firstSocket, "hello-subscription-reattach-1");
+    await auth(firstSocket, token, "auth-subscription-reattach-1");
+    sendFrame(firstSocket, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "join-subscription-reattach-1",
+      ts: "2026-07-13T12:00:00Z",
+      payload: { tableId }
+    });
+    await nextMessageOfType(firstSocket, "commandResult", { skipTypes: ["stateSnapshot", "statePatch"] });
+    const joined = await nextMessageOfType(firstSocket, "table_state", { skipTypes: ["stateSnapshot", "statePatch"] });
+    const seat = joined.payload.members[0].seat;
+
+    const firstSocketClosed = waitSocketClose(firstSocket);
+    firstSocket.close();
+    await firstSocketClosed;
+
+    const reconnectedSocket = await connectClient(port);
+    await hello(reconnectedSocket, "hello-subscription-reattach-2");
+    await auth(reconnectedSocket, token, "auth-subscription-reattach-2");
+    const reattached = await subscribeTableState(
+      reconnectedSocket,
+      tableId,
+      "subscription-reattach-2",
+      "2026-07-13T12:00:01Z",
+      "subscription reattach"
+    );
+
+    assert.equal(reattached.type, "table_state");
+    assert.deepEqual(reattached.payload.members, [{ userId: "reattach_user", seat }]);
+
+    const noDuplicateFrames = await attemptMessage(reconnectedSocket);
+    assert.equal(noDuplicateFrames, null);
+    reconnectedSocket.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 
 
 test("resync join flow is command-first for actor-visible frames", async () => {

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -202,6 +202,83 @@ test("rolloverSettledHand delays next-hand bootstrap until explicitly invoked", 
   assert.equal(nextState.turnDeadlineAt > nextState.turnStartedAt, true);
 });
 
+test("authenticated resubscribe restores seated human presence so a fold settlement rolls into the next hand", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const tableId = "table_resubscribe_after_fold";
+  const humanUserId = "human_folded";
+  const botUserId = "bot_after_fold";
+  const restored = tableManager.restoreTableFromPersisted(tableId, {
+    coreState: {
+      version: 12,
+      roomId: tableId,
+      maxSeats: 6,
+      appliedRequestIds: [],
+      members: [
+        { userId: humanUserId, seat: 1 },
+        { userId: botUserId, seat: 2 }
+      ],
+      seats: { [humanUserId]: 1, [botUserId]: 2 },
+      publicStacks: { [humanUserId]: 99, [botUserId]: 101 },
+      seatDetailsByUserId: {
+        [humanUserId]: { isBot: false, botProfile: null, leaveAfterHand: false },
+        [botUserId]: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false }
+      },
+      pokerState: {
+        tableId,
+        handId: "hand_folded_before_background_reconnect",
+        phase: "SETTLED",
+        dealerSeatNo: 1,
+        seats: [
+          { userId: humanUserId, seatNo: 1, status: "FOLDED" },
+          { userId: botUserId, seatNo: 2, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { [humanUserId]: 99, [botUserId]: 101 },
+        foldedByUserId: { [humanUserId]: true, [botUserId]: false },
+        showdown: {
+          handId: "hand_folded_before_background_reconnect",
+          winners: [botUserId],
+          potsAwarded: [{ amount: 3, winners: [botUserId] }],
+          potAwardedTotal: 3,
+          reason: "all_folded"
+        },
+        handSettlement: {
+          handId: "hand_folded_before_background_reconnect",
+          settledAt: "2026-07-13T12:00:00.000Z",
+          payouts: { [botUserId]: 3 }
+        },
+        holeCardsByUserId: { [humanUserId]: ["AS", "KD"], [botUserId]: ["2C", "2D"] }
+      }
+    },
+    presenceByUserId: new Map([
+      [humanUserId, { userId: humanUserId, seat: 1, connected: false, lastSeenAt: 1, expiresAt: 2 }]
+    ])
+  });
+  assert.equal(restored.ok, true);
+
+  const reconnectedWs = fakeWs("ws-resubscribe-after-fold");
+  const subscribed = tableManager.subscribe({
+    ws: reconnectedWs,
+    tableId,
+    userId: humanUserId,
+    nowTs: 10_000
+  });
+
+  assert.equal(subscribed.ok, true);
+  assert.equal(subscribed.reattached, true);
+  assert.equal(tableManager.hasConnectedHumanPresence(tableId), true);
+  assert.deepEqual(memberPairs(tableManager.tableState(tableId).members), [[humanUserId, 1]]);
+
+  const rollover = tableManager.rolloverSettledHand({ tableId, nowMs: 10_001 });
+  assert.equal(rollover.ok, true);
+  assert.equal(rollover.changed, true);
+
+  const nextState = tableManager.persistedPokerState(tableId);
+  assert.equal(nextState.phase, "PREFLOP");
+  assert.deepEqual(nextState.seats.map((seat) => seat.userId), [humanUserId, botUserId]);
+  assert.equal(nextState.foldedByUserId[humanUserId], false);
+  assert.equal(nextState.holeCardsByUserId[humanUserId].length, 2);
+});
+
 test("bootstrapHand excludes disconnected human ghost seats from the next hand", () => {
   const tableManager = createTableManager({ maxSeats: 6 });
   const tableId = "table_bootstrap_connected_human_only";

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -1595,7 +1595,7 @@ export function createTableManager({
     };
   }
 
-  function subscribe({ ws, tableId }) {
+  function subscribe({ ws, tableId, userId = null, nowTs = Date.now() }) {
     const conn = ensureConn(ws);
     if (conn.subscribedTableId && conn.subscribedTableId !== tableId) {
       return { ok: false, code: "one_table_per_connection", message: "Connection is already subscribed to a different table" };
@@ -1604,9 +1604,32 @@ export function createTableManager({
     const table = ensureTable(tableId);
     table.subscribers.add(ws);
     conn.subscribedTableId = tableId;
+    const normalizedUserId = typeof userId === "string" ? userId.trim() : "";
+    const member = normalizedUserId
+      ? table.coreState.members.find((entry) => entry?.userId === normalizedUserId) ?? null
+      : null;
+    if (member) {
+      const seat = Number.isInteger(member.seat) ? member.seat : table.coreState.seats?.[normalizedUserId];
+      const existingPresence = table.presenceByUserId.get(normalizedUserId);
+      if (existingPresence) {
+        existingPresence.seat = seat;
+        markConnected(existingPresence, nowTs);
+      } else {
+        table.presenceByUserId.set(normalizedUserId, {
+          userId: normalizedUserId,
+          seat,
+          connected: true,
+          lastSeenAt: nowTs,
+          expiresAt: null
+        });
+      }
+      conn.joinedTableId = tableId;
+      touchTableActivity(table, nowTs);
+    }
 
     return {
       ok: true,
+      reattached: Boolean(member),
       tableState: tableState(tableId)
     };
   }

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -4874,10 +4874,11 @@ test("WS act persists state to file-backed optimistic store", async () => {
     const baseline = await nextMessageForRequest(ws, { type: "stateSnapshot", requestId: "snap-persist" });
     const handId = baseline.payload.public.hand.handId;
 
+    const resultPromise = nextCommandResultForRequest(ws, "act-persist");
+    const stateUpdatePromise = nextStateUpdate(ws, { baseline: baseline.payload, timeoutMs: 4000 });
     sendFrame(ws, { version: "1.0", type: "act", requestId: "act-persist", ts: "2026-02-28T02:00:02Z", payload: { tableId, handId, action: "fold" } });
-    const result = await nextCommandResultForRequest(ws, "act-persist");
+    const [result] = await Promise.all([resultPromise, stateUpdatePromise]);
     assert.equal(result.payload.status, "accepted");
-    await nextStateUpdate(ws, { baseline: baseline.payload, timeoutMs: 4000 });
     await new Promise((resolve) => setTimeout(resolve, 150));
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-persist-after", ts: "2026-02-28T02:00:03Z", payload: { tableId, view: "snapshot" } });
     const afterPersist = await nextMessageForRequest(ws, { type: "stateSnapshot", requestId: "snap-persist-after" });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2865,7 +2865,12 @@ wss.on("connection", (ws) => {
         return;
       }
 
-      const subscribed = tableManager.subscribe({ ws, tableId });
+      const subscribed = tableManager.subscribe({
+        ws,
+        tableId,
+        userId: connState.session.userId,
+        nowTs: Date.now()
+      });
       if (!subscribed.ok) {
         sendError(ws, connState, {
           code: "INVALID_COMMAND",


### PR DESCRIPTION
## Summary

- restore seated runtime presence after authenticated WebSocket reconnect
- safely rejoin the previously confirmed seat and preserve it across transient failures
- keep Fold, Check/Call, Bet/Raise, and All in in four fixed positions; unavailable actions stay visible but disabled
- preserve pre-actions in those same four slots
- resolve queued All in from fresh live constraints as CALL, maximum BET, or maximum RAISE
- recover Play now auto-join from transient authoritative/bootstrap failures without requiring refresh
- keep a command-scoped WS error local to that command instead of marking the whole socket unavailable

## Root cause

Reconnect subscriptions previously restored only observer presence, so bots could finish a hand while the next hand could not start without eligible human runtime presence.

The Play now path had a second one-shot failure mode. A transient first join failure left autoJoinAttempted set, while the following INIT snapshot cleared the visible error. A correlated TABLE_BOOTSTRAP_FAILED frame was also treated as a global socket failure. The page therefore displayed Live table connected with an empty INIT table, but no retry was possible. Refresh reset the client flags and made the next join succeed.

Off-turn snapshots intentionally omit complete raise and bet limits. All in is therefore stored as intent and resolved only when authoritative turn constraints arrive.

## Verification

- npm test
- npm run check:all
- npm run ci:guards
- focused poker WS client and poker-v2 suites
- syntax and diff checks

Regression coverage confirms reconnect continuity, Fold rollover, fixed action slots, same-slot pre-actions, semantic All in resolution, command-scoped WS errors preserving socket readiness, and bounded Play now auto-join retry after a transient bootstrap failure.

## Deployment impact

- WS server and static poker client changed earlier in this PR; deploy-preview must use the matching WS preview build
- latest Play now correction changes only the static poker client and tests
- no database migrations
- no new environment variables or secrets
- no CSP changes
- no WebSocket payload schema change