### PR TITLE
fix: fund poker bot replacements through escrow

### DIFF
--- a/.github/workflows/ws-deploy.yml
+++ b/.github/workflows/ws-deploy.yml
@@ -87,6 +87,10 @@ jobs:
 
       - name: Run ws table manager behavior test
         run: node --test ws-server/poker/table/table-manager.behavior.test.mjs
+
+      - name: Run persisted state writer behavior test
+        run: node --test ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+
       - name: Run authoritative leave adapter behavior test
         run: node --test ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
 

--- a/.github/workflows/ws-pr-checks.yml
+++ b/.github/workflows/ws-pr-checks.yml
@@ -89,6 +89,10 @@ jobs:
 
       - name: Run ws table manager behavior test
         run: node --test ws-server/poker/table/table-manager.behavior.test.mjs
+
+      - name: Run persisted state writer behavior test
+        run: node --test ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+
       - name: Run authoritative leave adapter behavior test
         run: node --test ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
 

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -1,6 +1,6 @@
 # Poker bot replacement escrow funding
 
-Status: planning only for GitHub issue #705. No implementation, production data change, automatic reconciliation, terminal bot cash-out, or new test is part of this plan.
+Status: planning only for GitHub issue #705. No implementation, production data change, automatic reconciliation, or terminal bot cash-out is part of this plan. The implementation must add only the small automated accounting test set defined below.
 
 ## Goal
 
@@ -62,7 +62,7 @@ This is limited to replacement funding. Issue #706 owns terminal bot cash-out an
 For each replacement:
 
 ```text
-oldStack       = integer current settled stack, allowed range 0..1
+oldStack       = integer current settled stack, valid funding range 0..99
 targetStack    = BOT_REPLACEMENT_STACK, currently 100
 fundingDelta   = targetStack - oldStack
 ledger entries = SYSTEM(TREASURY, -fundingDelta)
@@ -71,7 +71,9 @@ ledger entries = SYSTEM(TREASURY, -fundingDelta)
 
 The old residual remains backed by the escrow already present. The new ledger transfer backs exactly the additional claim. After the next hand posts blinds, the same value is represented by replacement stack plus pot; no further ledger transaction is needed.
 
-Invalid, fractional, negative, non-finite, or unexpectedly large old stacks fail closed. The engine must not replace such a bot or calculate a guessed delta.
+Add a pure synchronous `calculateReplacementFundingDelta({ oldStack, targetStack })` helper in `poker-engine.mjs`. It accepts integer values satisfying `targetStack > 0` and `0 <= oldStack < targetStack`, and returns the exact positive integer delta. Negative, fractional, non-finite, `NaN`, `oldStack >= targetStack`, or invalid target values fail closed with a controlled result; the engine must not calculate a guessed delta.
+
+The current replacement eligibility rule remains unchanged: `replaceBrokeBotsForNextHand()` only invokes funding for bots below `MIN_STACK_TO_JOIN_HAND`, so normal production descriptors currently contain old stacks 0 or 1. The pure helper deliberately supports the full range below the target, including `oldStack=99 -> 1`, so the accounting invariant remains correct if the replacement threshold changes in a future refactor.
 
 ## Prepared rollover contract
 
@@ -228,6 +230,7 @@ On WS process bootstrap or authoritative table restore, an active table restored
 
 - `ws-server/poker/engine/poker-engine.mjs`
   - keep `BOT_REPLACEMENT_STACK` at 100;
+  - add pure `calculateReplacementFundingDelta({ oldStack, targetStack })` validation and calculation;
   - extend `replaceBrokeBotsForNextHand()` with validated delta calculation and `replacementFundings` evidence;
   - preserve deterministic replacement identity and seat ordering.
 - `ws-server/poker/table/table-manager.mjs`
@@ -260,6 +263,27 @@ On WS process bootstrap or authoritative table restore, an active table restored
 - `docs/poker-bots.md`
   - document the replacement delta invariant, continued use of the current `TREASURY` source, and that terminal return remains owned by #706.
 
+### Focused automated tests
+
+- `ws-server/poker/engine/engine-rollover.behavior.test.mjs`
+  - add table-driven unit cases for exact deltas `0 -> 100`, `1 -> 99`, and `99 -> 1` with target 100;
+  - add fail-closed cases for `-1`, `NaN`, `Infinity`, fractional values, `oldStack === targetStack`, `oldStack > targetStack`, and invalid targets;
+  - keep these tests pure: no SQL, timers, sockets, or environment.
+- `ws-server/poker/table/table-manager.behavior.test.mjs`
+  - verify a prepared replacement does not mutate runtime;
+  - verify commit without a matching successful persistence/funding receipt is rejected and leaves the settled runtime unchanged;
+  - verify the same candidate commits only after a matching receipt and cannot be committed twice.
+- `ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs`
+  - add a small transaction-aware harness through the existing `beginSql` injection and exercise the real writer/ledger call boundary;
+  - verify successful CAS plus funding commits state and exactly one balanced ledger transaction;
+  - verify a funding exception rolls back both pending state and ledger effects;
+  - verify a CAS/version conflict makes zero ledger calls;
+  - verify replay of the same table/version/seat is already applied or rejected without a second funding transaction;
+  - recreate writer/manager instances over the same committed harness state to simulate process restart, then verify restored advanced state prevents replacement retry from funding again.
+- `scripts/test-all.mjs`, `.github/workflows/ws-pr-checks.yml`, and `.github/workflows/ws-deploy.yml`
+  - register the existing persisted-state-writer suite alongside the already registered rollover and table-manager suites so these invariants run locally, on PRs, and before WS deployment;
+  - do not add a database service, Playwright scenario, broad poker suite, or new test framework.
+
 ### Explicitly unchanged
 
 - `shared/poker-domain/inactive-cleanup.mjs` and `netlify/functions/_shared/poker-bot-cashout.mjs`: #706 scope; terminal behavior is not changed here.
@@ -286,9 +310,11 @@ GitHub issue #710 owns the optional future evaluation of a dedicated poker bot b
 
 ### Phase 2 — pure replacement funding evidence
 
+- add the pure delta helper and its table-driven unit tests;
 - extend the engine result with validated per-seat delta descriptors;
 - split table-manager rollover into prepare and receipt-guarded commit;
 - restrict the compatibility wrapper to existing in-memory mode, explicitly confirmed guest mode, or candidates without funding intents;
+- add the focused table-manager unit tests for preparation and receipt-gated runtime commit;
 - keep all calculations synchronous and side-effect-free until commit.
 
 ### Phase 3 — atomic ledger plus persistence
@@ -297,17 +323,43 @@ GitHub issue #710 owns the optional future evaluation of a dedicated poker bot b
 - execute state CAS and all `TABLE_BUY_IN` posts in the same `beginSqlWs()` transaction;
 - update `server.mjs` to commit runtime state only after database success;
 - add fast restore/backoff followed by persistent slow recovery and existing-style `klog` events;
-- ensure bootstrap and authoritative restore reschedule an active settled generation.
+- ensure bootstrap and authoritative restore reschedule an active settled generation;
+- add the focused persisted-state/ledger integration cases for commit, rollback, CAS conflict, replay idempotency, and restart retry.
 
 ### Phase 4 — staged verification and rollout
 
-- run the existing repository checks unchanged; do not add or modify tests;
+- register and run the three focused automated suites in local, WS PR, and WS deployment checks;
 - manually verify the cases below against WS preview and the stage ledger;
 - deploy production only after the stage invariant and retry behavior are confirmed.
 
+## Automated test contract
+
+### Deterministic unit tests
+
+Unit tests cover only pure or in-memory business contracts:
+
+1. `calculateReplacementFundingDelta()` returns 100 for old stack 0, 99 for old stack 1, and 1 for old stack 99 when target is 100.
+2. Invalid numeric inputs fail closed and never produce a funding descriptor.
+3. Prepare leaves `table.coreState` unchanged.
+4. Runtime commit requires a matching successful persistence/funding receipt and remains idempotent after the first commit.
+
+These cases use `node:test` and the existing engine/table-manager suites. They must not use a database, network, timers, or broad gameplay scenarios.
+
+### Transactional integration tests
+
+Integration tests cover the smallest writer-ledger-state boundary using the existing injectable `beginSql` contract and a transaction-aware deterministic harness:
+
+1. successful state CAS and one replacement funding commit together;
+2. ledger failure rolls back both state and ledger effects and produces no receipt usable by runtime commit;
+3. failed CAS performs no ledger funding;
+4. replay of the deterministic idempotency key cannot fund twice;
+5. a fresh writer/manager instance restoring the committed state does not fund the same replacement generation again.
+
+The harness must stage state and ledger changes and publish them only when the `beginSql` callback resolves, so the rollback assertion tests transaction behavior rather than only call order. Use the real replacement payload shape and existing `TABLE_BUY_IN` contract. Do not add an external database service, production/stage writes, WebSocket end-to-end scenario, Playwright coverage, or generalized transaction-testing framework.
+
 ## Manual verification
 
-No new automated test or test framework is planned.
+Manual verification complements the required automated invariants; it does not replace them.
 
 1. Confirm an initial bot seed continues to debit the existing `TREASURY` account and credit table escrow; #705 must not change that transaction.
 2. Settle a hand with one bot at stack 1. Confirm one replacement `TABLE_BUY_IN` for 99 and a target replacement claim of 100 before blind posting.
@@ -355,13 +407,13 @@ No new automated test or test framework is planned.
 | Database | No migration, new account, schema change, or production-data mutation. |
 | ENV/secrets | No new or changed value. The implementation consumes the current bot funding parser and existing system actor configuration. |
 | WS/browser contract | None. No snapshot field, message type, JSP, JavaScript browser compatibility, HTML, CSS, or CSP change. |
-| Tests | No new or modified tests. Existing checks are run unchanged, followed by the manual stage verification above. |
+| Tests | Adds only focused `node:test` cases in three existing suites and registers the persisted-state-writer suite in local/WS CI. No browser, broad gameplay, or external-DB test expansion. |
 
 The most important breaking risk is the intentional fail-closed gameplay behavior: if the existing `TREASURY` ledger transfer is unavailable, replacement rollover remains in `SETTLED` and retries instead of inventing chips. There is no new account-provisioning, funding, or ENV release gate.
 
 ## Acceptance criteria
 
-- Every replacement descriptor uses an integer old stack of 0 or 1, target 100, and exact positive delta `target - old`.
+- The pure delta helper accepts integer `0 <= oldStack < targetStack`, returns exact `target - old`, and fails closed for invalid values; current replacement eligibility still normally emits descriptors only for old stacks 0 or 1.
 - The existing `TREASURY` source is debited by exactly the sum of replacement deltas and table escrow is credited by the same amount.
 - State CAS and all replacement ledger posts commit or roll back together.
 - The live runtime, snapshots, and bot autoplay do not observe the replacement state before database success.
@@ -374,7 +426,7 @@ The most important breaking risk is the intentional fail-closed gameplay behavio
 - Initial bot funding remains unchanged and continues to use the current `TREASURY` source.
 - Guest tables remain outside the chips economy.
 - Inactive cleanup, terminal cash-out, and reconciliation remain unchanged and explicitly deferred to #706/#707.
-- Existing checks pass without adding or changing tests.
+- The focused unit and transactional integration tests pass in local, WS PR, and WS deployment checks.
 - WS preview manual verification passes before production rollout.
 
 ## Definition of Done
@@ -384,6 +436,7 @@ The most important breaking risk is the intentional fail-closed gameplay behavio
 - Persistent rollover follows prepare → atomic persist/fund → runtime commit.
 - Existing `TABLE_BUY_IN` validation and transaction helpers are reused; no new framework or generic ledger abstraction is introduced.
 - Failure is fail-closed, logged with `klog`, restored, retried quickly with bounded backoff, then retried at a bounded slow frequency until a terminal lifecycle condition.
+- The automated suite proves exact delta boundaries, invalid-input rejection, idempotency, transaction rollback, CAS-before-ledger ordering, receipt-gated runtime commit, and restart retry without duplicate funding.
 - The implementation contains no #706 cash-out behavior, #707 inventory, automatic remediation, frontend, CSS, JSP, or CSP work.
 
 ## Plan verdict

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -131,7 +131,6 @@ nextStateOverride
 privateStateForHoleCardsOverride
 replacementFundings
 botFundingSystemKey
-systemActorUserId
 deferRuntimeVersionUpdate
 ```
 
@@ -147,9 +146,11 @@ For a guest table, retain the current economy-free in-memory rollover and do not
 
 Extend `writeMutation()` and `writeViaDb()` with the optional, closed `replacementFundings` input. Reuse `postTransaction()` from `ws-server/poker/persistence/chips-ledger.mjs`; do not create a new ledger client or transaction framework.
 
+Replacement funding is an automatic internal `SYSTEM -> ESCROW` operation, so its ledger row uses `createdBy: null` and the closed metadata `actor: BOT`, `reason: BOT_REPLACEMENT_BUY_IN`. This matches the nullable `chips_transactions.created_by` schema and does not invent a human accounting actor. It also avoids adding or depending on an environment variable for #705; the separate legacy bot cash-out paths retain their existing actor requirements until #706.
+
 Within the existing `beginSqlWs()` callback, use this order:
 
-1. validate the prepared funding descriptors, bankroll key, system actor UUID, and target escrow key;
+1. validate the prepared funding descriptors, bankroll key, and target escrow key;
 2. execute the current optimistic `poker_state` update for `expectedVersion`;
 3. if the CAS did not update a row, return conflict/equal-state handling without posting any ledger entry;
 4. if the CAS succeeded, post every replacement `TABLE_BUY_IN` using the same `tx`;
@@ -184,13 +185,13 @@ This deliberately satisfies the issue requirement that the amount be bound to id
 
 The replacement UUID is deterministically derived from table, seat, and version, so it is redundant in the key. The old bot UUID and settled hand ID are useful audit evidence but are not required for uniqueness. Include both identities, `settledHandId`, from/to versions, old/target stack, delta, source `SYSTEM` key, and reason `BOT_REPLACEMENT_BUY_IN` in transaction metadata and reference.
 
-Use the existing `POKER_SYSTEM_ACTOR_USER_ID` as `createdBy`. Missing or invalid system actor configuration fails closed before the state CAS. Do not choose a connected human as the accounting actor.
+Use `createdBy: null` for this server-internal `SYSTEM -> ESCROW` transaction. Do not choose a connected human or require `POKER_SYSTEM_ACTOR_USER_ID` for replacement funding.
 
 ## Failure, retry, and restore behavior
 
 ### Before database commit
 
-For missing/inactive bankroll, insufficient bankroll balance, invalid delta, invalid actor, account mismatch, ledger validation failure, or state CAS conflict:
+For missing/inactive bankroll, insufficient bankroll balance, invalid delta, account mismatch, ledger validation failure, or state CAS conflict:
 
 - the database transaction rolls back;
 - no replacement state, ledger transaction, account delta, broadcast, or autoplay is committed;
@@ -240,7 +241,7 @@ On WS process bootstrap or authoritative table restore, an active table restored
   - expose the two new methods from the manager object;
   - do not add persisted or table-level pending-funding properties.
 - `ws-server/server.mjs`
-  - resolve the existing bot funding source through the unchanged shared `getBotConfig(process.env)` parser and resolve the existing system actor once at startup;
+  - resolve the existing bot funding source through the unchanged shared `getBotConfig(process.env)` parser without adding another runtime configuration dependency;
   - change `maybeScheduleSettledRollover()` to prepare, atomically persist/fund, commit runtime, then broadcast/autoplay;
   - extend `persistMutatedState()` only with optional prepared-state/funding inputs;
   - add the fixed fast/slow delay constants and extend each `settledRolloverTimerByTableId` record with `mode`, `attempt`, `generationKey`, `dueAt`, and `timer` rather than adding a parallel scheduler;

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -1,0 +1,379 @@
+# Poker bot replacement escrow funding
+
+Status: planning only for GitHub issue #705. No implementation, production data change, automatic reconciliation, terminal bot cash-out, or new test is part of this plan.
+
+## Goal
+
+Stop bot rollover from creating an authoritative replacement stack that is not backed by the table escrow account. Preserve the current poker rules and replacement target while funding only the increase in the table claim through the existing chips ledger.
+
+The smallest safe implementation is:
+
+1. prepare the next-hand state without mutating the live table;
+2. use the existing persisted-state database transaction to CAS the poker state and post every required replacement `TABLE_BUY_IN`;
+3. allow that transaction to commit only when both state persistence and ledger funding succeed;
+4. install and broadcast the prepared runtime state only after the database transaction commits.
+
+This is limited to replacement funding. Issue #706 owns terminal bot cash-out and issue #707 owns reconciliation inventory.
+
+## Confirmed current flow
+
+### Engine and table manager
+
+- `ws-server/poker/engine/poker-engine.mjs` defines `BOT_REPLACEMENT_STACK = 100` and `MIN_STACK_TO_JOIN_HAND = 2`.
+- `replaceBrokeBotsForNextHand()` iterates ordered bot members after a hand reaches `SETTLED`.
+- A bot with a stack below 2 receives a deterministic replacement UUID derived from table ID, seat number, and the next state version.
+- The old member, seat map entry, seat details, and stack key are replaced in memory. The new stack and optional `publicStacks` value are set directly to 100.
+- No ledger intent or funding evidence is returned.
+- `table-manager.mjs::rolloverSettledHand()` calls that helper, builds the next hand, immediately assigns the resulting `table.coreState`, and returns the new state version.
+
+### WS orchestration
+
+- `ws-server/server.mjs::maybeScheduleSettledRollover()` schedules a deduplicated `settled_rollover` command.
+- `createTableCommandQueue()` serializes commands per table and deduplicates the pending rollover command, but it is an in-process serialization boundary, not a database transaction.
+- The command currently mutates `table.coreState` through `rolloverSettledHand()`, then calls `persistMutatedState()`, then broadcasts and starts bot autoplay.
+- On persistence failure, `recoverFromPersistConflict()` reloads the persisted table. Until that recovery completes, the runtime has already held the uncommitted candidate state.
+
+### Authoritative persistence and database boundaries
+
+- `server.mjs::persistMutatedState()` currently reads the already-mutated state from `tableManager.persistedPokerState()` and calls `persistedStateWriter.writeMutation()`.
+- `ws-server/poker/persistence/persisted-state-writer.mjs::writeViaDb()` opens one `beginSqlWs()` transaction.
+- Inside that transaction, it performs an optimistic `poker_state.version` compare-and-swap, updates table activity, and writes optional hole-card/action/settlement audit data.
+- A version conflict returns without changing the persisted state. The equal-state path is treated as an already-applied replay.
+- `WS_PERSISTED_STATE_FILE` is a separate non-ledger file-store path and cannot provide atomic chips funding.
+
+### Existing ledger pattern
+
+- `shared/poker-domain/bots.mjs::seedBotsForJoin()` already posts bot funding as strict `TABLE_BUY_IN` entries:
+  - configured `SYSTEM` bankroll: negative amount;
+  - `ESCROW` account `POKER_TABLE:<tableId>`: equal positive amount.
+- `ws-server/poker/persistence/chips-ledger.mjs::postTransaction()` accepts an existing `tx` property. When supplied, it reuses that transaction instead of opening another one.
+- The helper already enforces the exact two-entry `SYSTEM(-) + ESCROW(+)` shape, balanced amounts, active accounts, non-negative balances, payload hashing, and the ledger idempotency constraint.
+- The persisted-state writer and WS ledger both use PostgreSQL transaction objects exposing `tx.unsafe()`, so the helper can run within the existing `beginSqlWs()` transaction.
+
+## Accounting decision and invariant
+
+- All bot funding created after rollout uses the configured dedicated `POKER_BOT_BANKROLL` `SYSTEM` account.
+- `POKER_BOT_BANKROLL_SYSTEM_KEY` remains the existing configuration property, but its default and deployed value become `POKER_BOT_BANKROLL`.
+- A replacement transfers the old bot's remaining claim to the deterministic new bot identity and funds only the increase to the existing target of 100.
+- No replacement cash-out is performed in this issue.
+- No direct `chips_accounts.balance` patch is permitted.
+
+For each replacement:
+
+```text
+oldStack       = integer current settled stack, allowed range 0..1
+targetStack    = BOT_REPLACEMENT_STACK, currently 100
+fundingDelta   = targetStack - oldStack
+ledger entries = SYSTEM(POKER_BOT_BANKROLL, -fundingDelta)
+                 ESCROW(POKER_TABLE:<tableId>, +fundingDelta)
+```
+
+The old residual remains backed by the escrow already present. The new ledger transfer backs exactly the additional claim. After the next hand posts blinds, the same value is represented by replacement stack plus pot; no further ledger transaction is needed.
+
+Invalid, fractional, negative, non-finite, or unexpectedly large old stacks fail closed. The engine must not replace such a bot or calculate a guessed delta.
+
+## Prepared rollover contract
+
+The persistent WS path must stop mutating `table.coreState` before database success.
+
+### Engine result
+
+Extend `replaceBrokeBotsForNextHand()` with an additive `replacementFundings` array. Each entry contains only deterministic domain evidence:
+
+```text
+seatNo
+oldBotUserId
+replacementBotUserId
+oldStack
+targetStack
+fundingDelta
+settledHandId
+fromStateVersion
+toStateVersion
+```
+
+The engine does not read environment variables, open SQL, select a bankroll account, or post ledger transactions. It continues to produce the replacement state and now also explains the exact increase that requires funding.
+
+Multiple broke bots produce one entry per seat, sorted by `seatNo`. A validation error returns an unchanged candidate plus a controlled failure reason; partial replacement plans are forbidden.
+
+### Table-manager methods
+
+Add two focused methods to `createTableManager()`:
+
+- `prepareSettledHandRollover({ tableId, nowMs })`
+  - performs the current eligibility, replacement, next-dealer, next-hand, hole-card, blind, and deadline calculations;
+  - returns `expectedVersion`, `stateVersion`, `nextCoreState`, `handId`, and `replacementFundings`;
+  - does not assign `table.coreState`, touch activity, broadcast, or schedule autoplay.
+- `commitSettledHandRollover({ tableId, expectedVersion, nextCoreState, persistedVersion, nowMs })`
+  - rechecks that the current runtime table is still on the expected settled version;
+  - requires `nextCoreState.version === expectedVersion + 1` and `persistedVersion` to match;
+  - installs the prepared state and touches activity only after the database result is successful.
+
+Retain `rolloverSettledHand()` as a compatibility wrapper around prepare plus commit for existing in-memory/guest behavior and current callers outside the persistent production path. `server.mjs` must use the explicit prepare/persist/commit path for non-guest tables so production funding cannot be bypassed.
+
+Do not store a pending plan on the table object. The prepared object remains local to the already serialized table command.
+
+## Atomic persistence design
+
+### `server.mjs::persistMutatedState()`
+
+Extend the existing optional argument contract with:
+
+```text
+nextStateOverride
+privateStateForHoleCardsOverride
+replacementFundings
+botBankrollSystemKey
+systemActorUserId
+deferRuntimeVersionUpdate
+```
+
+Ordinary action, timeout, join, and start-hand callers omit these properties and keep their current behavior. Settled rollover passes the prepared poker state and private hole-card state because the live table has not yet been mutated.
+
+For this prepared path, `deferRuntimeVersionUpdate` prevents `persistMutatedState()` from changing `table.persistedStateVersion` before the prepared `coreState` is installed. After `commitSettledHandRollover()` succeeds, `server.mjs` applies the returned persisted version. If the runtime commit validation unexpectedly fails after the database commit, the server immediately restores the now-funded, now-advanced state from persistence instead of retrying the old rollover.
+
+For a guest table, retain the current economy-free in-memory rollover and do not create a funding intent. For a non-guest table, non-empty replacement funding is mandatory before commit.
+
+### `persisted-state-writer.mjs`
+
+Extend `writeMutation()` and `writeViaDb()` with the optional, closed `replacementFundings` input. Reuse `postTransaction()` from `ws-server/poker/persistence/chips-ledger.mjs`; do not create a new ledger client or transaction framework.
+
+Within the existing `beginSqlWs()` callback, use this order:
+
+1. validate the prepared funding descriptors, bankroll key, system actor UUID, and target escrow key;
+2. execute the current optimistic `poker_state` update for `expectedVersion`;
+3. if the CAS did not update a row, return conflict/equal-state handling without posting any ledger entry;
+4. if the CAS succeeded, post every replacement `TABLE_BUY_IN` using the same `tx`;
+5. only after all mandatory funding calls succeed, continue the existing activity and best-effort audit writes;
+6. return from the callback and allow `beginSqlWs()` to commit.
+
+Although the state `UPDATE` statement executes before the ledger calls, the state is not committed or externally visible until the enclosing transaction commits. A funding exception must escape the mandatory section so PostgreSQL rolls back the state CAS and every funding entry together. It must not be handled like the existing best-effort hole-card or audit writes.
+
+If several bots are replaced in one rollover, all per-seat ledger transactions and the state CAS share the same database transaction. One failure rolls back the entire rollover; partial funded replacement sets are forbidden.
+
+The file-store branch must reject non-empty replacement funding with `ledger_unavailable` before writing the candidate state. Guest tables remain the explicit no-ledger exception.
+
+## Ledger payload and idempotency
+
+Use one `TABLE_BUY_IN` transaction per replacement seat. Reuse the bot seed entry shape and add replacement-specific metadata.
+
+Deterministic idempotency key:
+
+```text
+poker:bot-replacement-buyin:v1:<tableId>:<toStateVersion>:<seatNo>
+```
+
+Required key components:
+
+- `tableId`: scopes the logical table;
+- `toStateVersion`: identifies the single authoritative rollover generation;
+- `seatNo`: distinguishes multiple replacements in the same rollover.
+
+Do not include the funding amount in the key. The existing payload hash must reject reuse of the same logical key with a different amount or account.
+
+The replacement UUID is deterministically derived from table, seat, and version, so it is redundant in the key. The old bot UUID and settled hand ID are useful audit evidence but are not required for uniqueness. Include both identities, `settledHandId`, from/to versions, old/target stack, delta, source `SYSTEM` key, and reason `BOT_REPLACEMENT_BUY_IN` in transaction metadata and reference.
+
+Use the existing `POKER_SYSTEM_ACTOR_USER_ID` as `createdBy`. Missing or invalid system actor configuration fails closed before the state CAS. Do not choose a connected human as the accounting actor.
+
+## Failure, retry, and restore behavior
+
+### Before database commit
+
+For missing/inactive bankroll, insufficient bankroll balance, invalid delta, invalid actor, account mismatch, ledger validation failure, or state CAS conflict:
+
+- the database transaction rolls back;
+- no replacement state, ledger transaction, account delta, broadcast, or autoplay is committed;
+- the runtime keeps or restores the prior `SETTLED` state;
+- `recoverFromPersistConflict()` reloads authoritative persistence before any further snapshot;
+- `klog` records a controlled reason, replacement count, total requested delta, and state version. Do not log cards, emails, tokens, or raw SQL errors; do not use `console.log`.
+
+### Retry
+
+Add a small settled-rollover retry counter beside the existing rollover timer map in `server.mjs`. Reuse the existing timer and table command queue with a bounded exponential delay. Clear the counter on successful commit, table eviction, or a restored state that is no longer `SETTLED`.
+
+The retry recomputes the plan from the restored state. The same table, version, and seat produce the same replacement identity and idempotency key.
+
+- If the previous transaction rolled back, no ledger key exists and the retry may post normally.
+- If PostgreSQL committed but the WS process stopped before runtime commit, restart/restore loads the already-advanced poker state, so the old rollover is not planned again.
+- If stale runtime state encounters an existing key, treat the duplicate as a restore signal. Do not post another funding entry and do not accept a mismatched payload.
+- A persist conflict occurs before ledger posting, so it cannot create a funded-but-uncommitted replacement.
+
+Do not catch a PostgreSQL idempotency violation inside the same aborted transaction and then attempt to continue that transaction. Let the writer return failure, restore authoritative state outside the transaction, and rely on the atomic state-plus-ledger commit to distinguish an already-committed rollover from a rolled-back attempt.
+
+Cap retry frequency to avoid a hot loop when the bankroll is empty or misconfigured. Persistent failures remain visible through `klog` and leave the hand safely settled instead of inventing chips.
+
+## Exact affected files
+
+### Runtime and persistence
+
+- `ws-server/poker/engine/poker-engine.mjs`
+  - keep `BOT_REPLACEMENT_STACK` at 100;
+  - extend `replaceBrokeBotsForNextHand()` with validated delta calculation and `replacementFundings` evidence;
+  - preserve deterministic replacement identity and seat ordering.
+- `ws-server/poker/table/table-manager.mjs`
+  - add `prepareSettledHandRollover()` and `commitSettledHandRollover()`;
+  - retain `rolloverSettledHand()` as the compatibility wrapper;
+  - expose the two new methods from the manager object;
+  - do not add persisted or table-level pending-funding properties.
+- `ws-server/server.mjs`
+  - resolve the configured bankroll and existing system actor once at startup;
+  - change `maybeScheduleSettledRollover()` to prepare, atomically persist/fund, commit runtime, then broadcast/autoplay;
+  - extend `persistMutatedState()` only with optional prepared-state/funding inputs;
+  - add bounded retry state using the existing settled-rollover timer lifecycle;
+  - clear retries on success and eviction.
+- `ws-server/poker/persistence/persisted-state-writer.mjs`
+  - accept and validate optional replacement funding descriptors;
+  - call the existing WS ledger helper inside the current DB transaction after a successful state CAS;
+  - make funding failure transaction-fatal;
+  - reject replacement funding on the file-store path.
+- `ws-server/poker/persistence/chips-ledger.mjs`
+  - reuse unchanged if repository verification during implementation confirms its `tx` path and strict `TABLE_BUY_IN` contract remain as analyzed;
+  - do not broaden it to cash-out, reconciliation, or a generic transaction framework.
+
+### Configuration and account provisioning
+
+- `shared/poker-domain/bots.mjs::getBotConfig()`
+  - change the fallback `bankrollSystemKey` from `TREASURY` to `POKER_BOT_BANKROLL` so initial bot seed and replacement funding share the approved future source.
+- `netlify/functions/_shared/poker-bots.mjs::getBotConfig()`
+  - keep the duplicate compatibility config aligned with the same fallback; do not change autoplay policy.
+- `ws-server/shared/poker-domain/bots.mjs`
+  - re-export `getBotConfig` so `server.mjs` uses the shared parser rather than duplicating environment parsing.
+- `supabase/migrations/20260714113000_poker_bot_bankroll_system_account.sql`
+  - idempotently create active `SYSTEM` account `POKER_BOT_BANKROLL`;
+  - allocate an owner-approved initial amount from `TREASURY` with a balanced, idempotent ledger transaction and locked-account/non-negative guards;
+  - use the existing `ADMIN_ADJUST` transaction type with a dedicated key such as `seed:poker-bot-bankroll:v1`; do not add another enum or directly seed a non-zero balance without ledger entries.
+- `docs/poker-deployment.md`
+  - document the new default, required account, existing environment variable, system actor requirement, stage/prod scoping, WS preview deployment, monitoring, and rollback order.
+- `docs/poker-bots.md`
+  - document the replacement delta invariant and state that terminal return remains owned by #706.
+
+### Explicitly unchanged
+
+- `shared/poker-domain/inactive-cleanup.mjs` and `netlify/functions/_shared/poker-bot-cashout.mjs`: #706 scope; terminal behavior is not changed here.
+- Reconciliation modules or admin mutation endpoints: #707 and future remediation scope.
+- `poker_seats` schema and rows: replacement identity continues to be represented in persisted poker state and restored through the existing seat-number mapping.
+- Poker action reducer, payout rules, snapshots, WS protocol, bot policy/autoplay decision logic, browser/JSP/HTML/CSS, and CSP.
+- No script is added, so no CSP SHA is required. No CSS is changed; the one-selector-per-line rule is unaffected.
+
+## Implementation phases
+
+### Phase 0 — owner and deployment prerequisites
+
+Owner-controlled decisions and tasks:
+
+- approve the initial chips allocation moved from `TREASURY` to `POKER_BOT_BANKROLL`;
+- confirm `POKER_SYSTEM_ACTOR_USER_ID` is a valid operational UUID in WS preview and production;
+- configure `POKER_BOT_BANKROLL_SYSTEM_KEY=POKER_BOT_BANKROLL` separately for WS preview and production;
+- plan a normal drain/close of pre-rollout poker tables before switching the bankroll, avoiding mixed funding provenance within one live table.
+
+Exit criteria: the migration amount is approved, environment scopes are known, and no active legacy-funded table will cross the bankroll cutover unless it is intentionally flagged for later manual review.
+
+### Phase 1 — additive bankroll provisioning and configuration
+
+- add and apply the idempotent system-account allocation migration;
+- align both existing bot config parsers and the WS re-export;
+- update deployment documentation;
+- verify the account is active and funded before enabling the new default.
+
+### Phase 2 — pure replacement funding evidence
+
+- extend the engine result with validated per-seat delta descriptors;
+- split table-manager rollover into prepare and commit while preserving the compatibility wrapper;
+- keep all calculations synchronous and side-effect-free until commit.
+
+### Phase 3 — atomic ledger plus persistence
+
+- extend the existing writer input with the prepared state and funding descriptors;
+- execute state CAS and all `TABLE_BUY_IN` posts in the same `beginSqlWs()` transaction;
+- update `server.mjs` to commit runtime state only after database success;
+- add controlled restore/backoff behavior and existing-style `klog` events.
+
+### Phase 4 — staged verification and rollout
+
+- run the existing repository checks unchanged; do not add or modify tests;
+- manually verify the cases below against WS preview and the stage ledger;
+- deploy production only after the stage invariant and retry behavior are confirmed.
+
+## Manual verification
+
+No new automated test or test framework is planned.
+
+1. Confirm an initial bot seed debits `POKER_BOT_BANKROLL`, not `TREASURY`, and credits the table escrow.
+2. Settle a hand with one bot at stack 1. Confirm one replacement `TABLE_BUY_IN` for 99 and a target replacement claim of 100 before blind posting.
+3. Repeat with stack 0 and confirm a delta of 100.
+4. Settle a hand with two broke bots and confirm two per-seat transactions plus one state transition commit atomically.
+5. Verify the idempotency keys use the same table/version/seat on retry and no duplicate ledger entry appears.
+6. Temporarily make the stage bankroll insufficient or inactive. Confirm the state remains `SETTLED`, escrow is unchanged, no candidate snapshot/autoplay is emitted, a bounded retry occurs, and recovery succeeds after the account is restored.
+7. Force a state-version conflict. Confirm the CAS fails before ledger posting and the persisted state is restored.
+8. Restart the WS service immediately after a successful replacement commit. Confirm bootstrap restores the new hand and does not fund the replacement again.
+9. Verify a table with no broke bot performs no ledger operation and follows the current rollover behavior.
+10. Verify a guest table remains economy-free and continues in memory.
+11. Verify inactive cleanup behavior is unchanged and any terminal bot residual remains for #706 rather than being moved by this implementation.
+12. Inspect `klog` output for controlled status/reason/count/delta fields and absence of cards, auth data, and raw sensitive errors.
+
+## Deployment and rollback
+
+### Deployment
+
+1. Apply the additive migration to stage and verify the dedicated account and balanced allocation transaction.
+2. Set the WS-preview-scoped bankroll and system actor configuration.
+3. Run a **WS Preview Deploy** because `ws-server` runtime and persistence code change; an ordinary Netlify deploy preview alone is insufficient.
+4. Complete the manual stage scenarios, including failure, retry, restart, and ledger inspection.
+5. Drain or normally close legacy-funded production tables.
+6. Apply the production migration and production-scoped environment value.
+7. Deploy the WS service, then monitor replacement success/failure, retry counts, bankroll balance, escrow deltas, persistence conflicts, and settled-hand age.
+
+### Rollback
+
+- The system account and valid ledger allocation are additive and remain auditable; do not delete the account or reverse committed replacement buy-ins during an application rollback.
+- Reverting to the old WS code reintroduces the P0 unfunded-replacement defect. Before any code rollback, stop new bot tables and drain/close active bot tables or temporarily disable poker traffic.
+- Do not switch an active table from `POKER_BOT_BANKROLL` back to `TREASURY` mid-lifecycle.
+- If the new path fails, the safe runtime state is the prior settled hand. Restore service after fixing configuration/bankroll capacity instead of manually advancing state or patching balances.
+
+## Breaking and operational impact
+
+| Area | Impact |
+| --- | --- |
+| Poker gameplay | Intentional fail-closed change: a next hand with a replacement bot no longer starts when funding is unavailable. The table stays settled and retries instead of inventing chips. |
+| Bot replacement | Replacement identity, seat, target stack, dealer progression, cards, and autoplay policy remain the same after a successful commit. |
+| Initial bot funding | Operationally breaking default changes from `TREASURY` to `POKER_BOT_BANKROLL`; the account, allocation, and scoped environment value must exist before rollout. |
+| Runtime API | New prepare/commit methods are additive. The existing `rolloverSettledHand()` wrapper remains for compatibility, while the persistent production caller switches to the safe path. |
+| Persistence | `writeMutation()` receives optional additive inputs. Normal action/start/timeout callers remain unchanged. Mandatory replacement funding now participates in the state transaction. |
+| Ledger | Adds one `TABLE_BUY_IN` transaction per replacement seat. No transaction enum, balance semantics, or cash-out behavior changes. |
+| Restore/retry | A failed replacement may keep a table in `SETTLED` longer. Bounded retries and operational monitoring are required. |
+| Inactive cleanup | No code change. More correctly backed bot value may remain in escrow until #706 implements terminal return. |
+| Reconciliation | No implementation. Replacement ledger metadata creates cleaner future evidence for #707. |
+| Database | Additive data migration creates and funds one `SYSTEM` account; no table/column/schema contract changes. |
+| ENV/secrets | No new variable, but existing `POKER_BOT_BANKROLL_SYSTEM_KEY` and `POKER_SYSTEM_ACTOR_USER_ID` become deployment-critical for replacement funding. |
+| WS/browser contract | None. No snapshot field, message type, JSP, JavaScript browser compatibility, HTML, CSS, or CSP change. |
+| Tests | No new or modified tests. Existing checks are run unchanged, followed by the manual stage verification above. |
+
+The most important breaking risk is operational: deploying the code before provisioning and funding `POKER_BOT_BANKROLL` would intentionally stop replacement rollover at `SETTLED`. That failure mode is safe for accounting but visible to players, so migration and environment ordering are release gates.
+
+## Acceptance criteria
+
+- Every replacement descriptor uses an integer old stack of 0 or 1, target 100, and exact positive delta `target - old`.
+- The configured dedicated bankroll is debited by exactly the sum of replacement deltas and table escrow is credited by the same amount.
+- State CAS and all replacement ledger posts commit or roll back together.
+- The live runtime, snapshots, and bot autoplay do not observe the replacement state before database success.
+- Multiple replacements in one rollover are atomic and independently auditable by deterministic per-seat keys.
+- State conflicts create no ledger entry; ledger failures create no state transition.
+- Retry and restart cannot fund the same table/version/seat twice.
+- Initial bot funding after rollout also uses `POKER_BOT_BANKROLL`.
+- Guest tables remain outside the chips economy.
+- Inactive cleanup, terminal cash-out, and reconciliation remain unchanged and explicitly deferred to #706/#707.
+- Existing checks pass without adding or changing tests.
+- WS preview manual verification passes before production rollout.
+
+## Definition of Done
+
+- The owner-approved bankroll allocation and deployment configuration are complete in stage and production scopes.
+- Engine replacement returns closed, validated funding evidence without performing I/O.
+- Persistent rollover follows prepare → atomic persist/fund → runtime commit.
+- Existing `TABLE_BUY_IN` validation and transaction helpers are reused; no new framework or generic ledger abstraction is introduced.
+- Failure is fail-closed, logged with `klog`, restored, and retried with bounded delay.
+- The implementation contains no #706 cash-out behavior, #707 inventory, automatic remediation, frontend, CSS, JSP, or CSP work.
+
+## Plan verdict
+
+The smallest safe implementation is an additive prepared-rollover contract plus one mandatory funding step inside the existing persisted-state transaction. It keeps calculation in the engine, transaction authority in persistence, and broadcasts/autoplay in the current server orchestration. It avoids a new service or framework, reuses the established bot `TABLE_BUY_IN` shape, and closes both dangerous partial-failure directions: no state can commit without funding, and no funding can commit when the state CAS fails.

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -11,7 +11,8 @@ The smallest safe implementation is:
 1. prepare the next-hand state without mutating the live table;
 2. use the existing persisted-state database transaction to CAS the poker state and post every required replacement `TABLE_BUY_IN`;
 3. allow that transaction to commit only when both state persistence and ledger funding succeed;
-4. install and broadcast the prepared runtime state only after the database transaction commits.
+4. install and broadcast the prepared runtime state only after the database transaction commits;
+5. keep retrying a recoverable settled rollover at a low bounded frequency until it succeeds, the authoritative state changes, or the table is evicted.
 
 This is limited to replacement funding. Issue #706 owns terminal bot cash-out and issue #707 owns reconciliation inventory.
 
@@ -104,12 +105,16 @@ Add two focused methods to `createTableManager()`:
   - performs the current eligibility, replacement, next-dealer, next-hand, hole-card, blind, and deadline calculations;
   - returns `expectedVersion`, `stateVersion`, `nextCoreState`, `handId`, and `replacementFundings`;
   - does not assign `table.coreState`, touch activity, broadcast, or schedule autoplay.
-- `commitSettledHandRollover({ tableId, expectedVersion, nextCoreState, persistedVersion, nowMs })`
+- `commitSettledHandRollover({ tableId, expectedVersion, nextCoreState, replacementFundings, persistenceReceipt, nowMs })`
   - rechecks that the current runtime table is still on the expected settled version;
-  - requires `nextCoreState.version === expectedVersion + 1` and `persistedVersion` to match;
-  - installs the prepared state and touches activity only after the database result is successful.
+  - requires `nextCoreState.version === expectedVersion + 1` and `persistenceReceipt.newVersion` to match;
+  - accepts the closed `replacementFundings` array returned by prepare plus a persistence receipt returned by the writer;
+  - refuses any candidate with non-empty `replacementFundings` unless the receipt confirms the same table ID, expected version, committed version, and successful atomic funding transaction;
+  - installs the prepared state and touches activity only after that validation succeeds.
 
-Retain `rolloverSettledHand()` as a compatibility wrapper around prepare plus commit for existing in-memory/guest behavior and current callers outside the persistent production path. `server.mjs` must use the explicit prepare/persist/commit path for non-guest tables so production funding cannot be bypassed.
+Retain `rolloverSettledHand()` only as an economy-free compatibility wrapper. A table manager constructed without a persistence bootstrap loader may use it for existing in-memory behavior. In the production manager it may commit directly when `replacementFundings.length === 0`; when replacements require funding, the caller must pass `economyMode: "none"`, and omission or any other value returns `replacement_funding_required` without mutating runtime. `server.mjs` may pass that opt-out only after its existing `isGuestTableId(tableId)` check. Persistent tables always use the explicit prepare/persist/commit path.
+
+The wrapper must never manufacture a successful persistence receipt. The normal `commitSettledHandRollover()` path rejects a funding intent without the real writer result, so a future or overlooked caller cannot accidentally create a funded-looking replacement by invoking prepare plus commit locally. This guard is part of the table-manager contract, not only a convention in `server.mjs`.
 
 Do not store a pending plan on the table object. The prepared object remains local to the already serialized table command.
 
@@ -131,6 +136,8 @@ deferRuntimeVersionUpdate
 Ordinary action, timeout, join, and start-hand callers omit these properties and keep their current behavior. Settled rollover passes the prepared poker state and private hole-card state because the live table has not yet been mutated.
 
 For this prepared path, `deferRuntimeVersionUpdate` prevents `persistMutatedState()` from changing `table.persistedStateVersion` before the prepared `coreState` is installed. After `commitSettledHandRollover()` succeeds, `server.mjs` applies the returned persisted version. If the runtime commit validation unexpectedly fails after the database commit, the server immediately restores the now-funded, now-advanced state from persistence instead of retrying the old rollover.
+
+The successful writer result used as the commit receipt includes the table ID, expected version, new version, `replacementFundingCommitted: true`, and one closed `fundedReplacements` entry per prepared descriptor: `seatNo`, `idempotencyKey`, `fundingDelta`, returned transaction ID, and returned ledger `payload_hash`. The manager compares seat, key, and delta with the prepared input; a plain numeric `persistedVersion` is insufficient for a candidate containing funding intents. Reuse the transaction row already returned by `postTransaction()` rather than introducing another proof store or query.
 
 For a guest table, retain the current economy-free in-memory rollover and do not create a funding intent. For a non-guest table, non-empty replacement funding is mandatory before commit.
 
@@ -171,6 +178,8 @@ Required key components:
 
 Do not include the funding amount in the key. The existing payload hash must reject reuse of the same logical key with a different amount or account.
 
+This deliberately satisfies the issue requirement that the amount be bound to idempotency without putting the amount in the key itself. The key names one logical table/version/seat replacement; `fundingDelta` is mandatory payload and is covered by the ledger payload hash. Recomputing a different amount for the same logical replacement therefore produces an idempotency mismatch instead of a second valid transaction. Literal inclusion of the amount in the key would weaken this protection by allowing two differently calculated deltas for the same generation to appear as separate operations.
+
 The replacement UUID is deterministically derived from table, seat, and version, so it is redundant in the key. The old bot UUID and settled hand ID are useful audit evidence but are not required for uniqueness. Include both identities, `settledHandId`, from/to versions, old/target stack, delta, source `SYSTEM` key, and reason `BOT_REPLACEMENT_BUY_IN` in transaction metadata and reference.
 
 Use the existing `POKER_SYSTEM_ACTOR_USER_ID` as `createdBy`. Missing or invalid system actor configuration fails closed before the state CAS. Do not choose a connected human as the accounting actor.
@@ -189,9 +198,20 @@ For missing/inactive bankroll, insufficient bankroll balance, invalid delta, inv
 
 ### Retry
 
-Add a small settled-rollover retry counter beside the existing rollover timer map in `server.mjs`. Reuse the existing timer and table command queue with a bounded exponential delay. Clear the counter on successful commit, table eviction, or a restored state that is no longer `SETTLED`.
+Add settled-rollover retry metadata beside the existing rollover timer map in `server.mjs`. Reuse one timer and the existing table command queue per table:
 
-The retry recomputes the plan from the restored state. The same table, version, and seat produce the same replacement identity and idempotency key.
+- define fixed module constants `FAST_SETTLED_ROLLOVER_RETRY_DELAYS_MS = [1_000, 5_000, 15_000, 30_000]` and `SLOW_SETTLED_ROLLOVER_RETRY_MS = 60_000`; do not add another ENV;
+- use the fast schedule once for the initial failures;
+- after the fast retry budget is exhausted, switch to one slow retry every 60 seconds;
+- continue the slow retry without a total-attempt limit until the rollover succeeds, authoritative state is no longer the same `SETTLED` generation, or the table is evicted/closed;
+- clear the attempt count and slow-recovery mode on success, state change, eviction, and shutdown;
+- never allow both the reveal timer and recovery timer to exist for the same table.
+
+The slow retry interval is a frequency cap, not a terminal retry limit. It prevents a hot loop while guaranteeing that a temporary bankroll, database, or configuration outage cannot strand an otherwise active table forever.
+
+Identify the retry generation as `<tableId>:<stateVersion>:<handId>`. Store that key with `mode`, `attempt`, `dueAt`, and `timer` in `settledRolloverTimerByTableId`. A changed generation replaces and resets the schedule; a matching generation deduplicates it.
+
+Before every retry after a persistence/funding failure, restore or confirm the authoritative persisted state and recompute the plan from that state. The same table, version, and seat produce the same replacement identity and idempotency key. A restored table already past that generation cancels the retry rather than replaying it.
 
 - If the previous transaction rolled back, no ledger key exists and the retry may post normally.
 - If PostgreSQL committed but the WS process stopped before runtime commit, restart/restore loads the already-advanced poker state, so the old rollover is not planned again.
@@ -200,7 +220,7 @@ The retry recomputes the plan from the restored state. The same table, version, 
 
 Do not catch a PostgreSQL idempotency violation inside the same aborted transaction and then attempt to continue that transaction. Let the writer return failure, restore authoritative state outside the transaction, and rely on the atomic state-plus-ledger commit to distinguish an already-committed rollover from a rolled-back attempt.
 
-Cap retry frequency to avoid a hot loop when the bankroll is empty or misconfigured. Persistent failures remain visible through `klog` and leave the hand safely settled instead of inventing chips.
+On WS process bootstrap or authoritative table restore, an active table restored in `SETTLED` must call `maybeScheduleSettledRollover(tableId)`. This recreates recovery after process restart even though in-memory timer metadata was lost. Persistent failures remain visible through rate-limited `klog` and leave the hand safely settled instead of inventing chips, but they do not permanently disable future recovery attempts.
 
 ## Exact affected files
 
@@ -212,19 +232,23 @@ Cap retry frequency to avoid a hot loop when the bankroll is empty or misconfigu
   - preserve deterministic replacement identity and seat ordering.
 - `ws-server/poker/table/table-manager.mjs`
   - add `prepareSettledHandRollover()` and `commitSettledHandRollover()`;
-  - retain `rolloverSettledHand()` as the compatibility wrapper;
+  - retain `rolloverSettledHand()` only as the guarded economy-free compatibility wrapper;
+  - reject direct commit of non-empty replacement funding without a matching successful persistence receipt;
   - expose the two new methods from the manager object;
   - do not add persisted or table-level pending-funding properties.
 - `ws-server/server.mjs`
   - resolve the configured bankroll and existing system actor once at startup;
   - change `maybeScheduleSettledRollover()` to prepare, atomically persist/fund, commit runtime, then broadcast/autoplay;
   - extend `persistMutatedState()` only with optional prepared-state/funding inputs;
-  - add bounded retry state using the existing settled-rollover timer lifecycle;
-  - clear retries on success and eviction.
+  - add the fixed fast/slow delay constants and extend each `settledRolloverTimerByTableId` record with `mode`, `attempt`, `generationKey`, `dueAt`, and `timer` rather than adding a parallel scheduler;
+  - add `scheduleSettledRolloverRetry()` for fast backoff followed by one 60-second recovery timer per table;
+  - reschedule restored active `SETTLED` tables during bootstrap/restore;
+  - clear retries on success, authoritative state change, shutdown, and eviction.
 - `ws-server/poker/persistence/persisted-state-writer.mjs`
   - accept and validate optional replacement funding descriptors;
   - call the existing WS ledger helper inside the current DB transaction after a successful state CAS;
   - make funding failure transaction-fatal;
+  - return the closed persistence/funding receipt consumed by the table-manager commit guard;
   - reject replacement funding on the file-store path.
 - `ws-server/poker/persistence/chips-ledger.mjs`
   - reuse unchanged if repository verification during implementation confirms its `tx` path and strict `TABLE_BUY_IN` contract remain as analyzed;
@@ -278,7 +302,8 @@ Exit criteria: the migration amount is approved, environment scopes are known, a
 ### Phase 2 — pure replacement funding evidence
 
 - extend the engine result with validated per-seat delta descriptors;
-- split table-manager rollover into prepare and commit while preserving the compatibility wrapper;
+- split table-manager rollover into prepare and receipt-guarded commit;
+- restrict the compatibility wrapper to existing in-memory mode, explicitly confirmed guest mode, or candidates without funding intents;
 - keep all calculations synchronous and side-effect-free until commit.
 
 ### Phase 3 — atomic ledger plus persistence
@@ -286,7 +311,8 @@ Exit criteria: the migration amount is approved, environment scopes are known, a
 - extend the existing writer input with the prepared state and funding descriptors;
 - execute state CAS and all `TABLE_BUY_IN` posts in the same `beginSqlWs()` transaction;
 - update `server.mjs` to commit runtime state only after database success;
-- add controlled restore/backoff behavior and existing-style `klog` events.
+- add fast restore/backoff followed by persistent slow recovery and existing-style `klog` events;
+- ensure bootstrap and authoritative restore reschedule an active settled generation.
 
 ### Phase 4 — staged verification and rollout
 
@@ -303,13 +329,14 @@ No new automated test or test framework is planned.
 3. Repeat with stack 0 and confirm a delta of 100.
 4. Settle a hand with two broke bots and confirm two per-seat transactions plus one state transition commit atomically.
 5. Verify the idempotency keys use the same table/version/seat on retry and no duplicate ledger entry appears.
-6. Temporarily make the stage bankroll insufficient or inactive. Confirm the state remains `SETTLED`, escrow is unchanged, no candidate snapshot/autoplay is emitted, a bounded retry occurs, and recovery succeeds after the account is restored.
+6. Temporarily make the stage bankroll insufficient or inactive long enough to exhaust fast retries. Confirm the state remains `SETTLED`, escrow is unchanged, no candidate snapshot/autoplay is emitted, retry switches to one 60-second timer, and recovery succeeds after the account is restored without any user action.
 7. Force a state-version conflict. Confirm the CAS fails before ledger posting and the persisted state is restored.
-8. Restart the WS service immediately after a successful replacement commit. Confirm bootstrap restores the new hand and does not fund the replacement again.
+8. Restart the WS service while a table is waiting in slow recovery. Confirm bootstrap restores the settled table, recreates the retry, and advances after the dependency recovers. Then restart immediately after a successful replacement commit and confirm the new hand is restored without duplicate funding.
 9. Verify a table with no broke bot performs no ledger operation and follows the current rollover behavior.
-10. Verify a guest table remains economy-free and continues in memory.
-11. Verify inactive cleanup behavior is unchanged and any terminal bot residual remains for #706 rather than being moved by this implementation.
-12. Inspect `klog` output for controlled status/reason/count/delta fields and absence of cards, auth data, and raw sensitive errors.
+10. In the production-configured manager, attempt direct wrapper/commit use for a persistent replacement candidate without a funding receipt. Confirm it returns `replacement_funding_required` or `replacement_funding_unconfirmed` and leaves runtime unchanged.
+11. Verify a guest table explicitly selected by `isGuestTableId()` remains economy-free and continues in memory.
+12. Verify inactive cleanup behavior is unchanged and any terminal bot residual remains for #706 rather than being moved by this implementation.
+13. Inspect `klog` output for controlled status/reason/count/delta/retry-mode fields and absence of cards, auth data, and raw sensitive errors.
 
 ## Deployment and rollback
 
@@ -337,10 +364,10 @@ No new automated test or test framework is planned.
 | Poker gameplay | Intentional fail-closed change: a next hand with a replacement bot no longer starts when funding is unavailable. The table stays settled and retries instead of inventing chips. |
 | Bot replacement | Replacement identity, seat, target stack, dealer progression, cards, and autoplay policy remain the same after a successful commit. |
 | Initial bot funding | Operationally breaking default changes from `TREASURY` to `POKER_BOT_BANKROLL`; the account, allocation, and scoped environment value must exist before rollout. |
-| Runtime API | New prepare/commit methods are additive. The existing `rolloverSettledHand()` wrapper remains for compatibility, while the persistent production caller switches to the safe path. |
+| Runtime API | Conditionally breaking: new prepare/commit methods are additive, but a production persistence-backed caller can no longer use `rolloverSettledHand()` to commit a funded replacement. Guest/in-memory callers remain supported through the guarded economy-free path; every persistent caller must migrate to writer receipt plus commit. |
 | Persistence | `writeMutation()` receives optional additive inputs. Normal action/start/timeout callers remain unchanged. Mandatory replacement funding now participates in the state transaction. |
 | Ledger | Adds one `TABLE_BUY_IN` transaction per replacement seat. No transaction enum, balance semantics, or cash-out behavior changes. |
-| Restore/retry | A failed replacement may keep a table in `SETTLED` longer. Bounded retries and operational monitoring are required. |
+| Restore/retry | A failed replacement may keep a table in `SETTLED` longer. Fast retries transition to a 60-second recovery cadence and survive process restart through restored-state scheduling; operational monitoring is required. |
 | Inactive cleanup | No code change. More correctly backed bot value may remain in escrow until #706 implements terminal return. |
 | Reconciliation | No implementation. Replacement ledger metadata creates cleaner future evidence for #707. |
 | Database | Additive data migration creates and funds one `SYSTEM` account; no table/column/schema contract changes. |
@@ -359,6 +386,9 @@ The most important breaking risk is operational: deploying the code before provi
 - Multiple replacements in one rollover are atomic and independently auditable by deterministic per-seat keys.
 - State conflicts create no ledger entry; ledger failures create no state transition.
 - Retry and restart cannot fund the same table/version/seat twice.
+- Exhausting fast retries cannot permanently strand an active settled table; slow recovery continues until success, state change, or eviction.
+- A persistence-backed replacement candidate with a funding intent cannot be committed through the compatibility wrapper or without a matching writer receipt.
+- `fundingDelta` is bound to the idempotency operation by the existing payload hash; a changed amount for the same table/version/seat is rejected rather than assigned a second key.
 - Initial bot funding after rollout also uses `POKER_BOT_BANKROLL`.
 - Guest tables remain outside the chips economy.
 - Inactive cleanup, terminal cash-out, and reconciliation remain unchanged and explicitly deferred to #706/#707.
@@ -371,7 +401,7 @@ The most important breaking risk is operational: deploying the code before provi
 - Engine replacement returns closed, validated funding evidence without performing I/O.
 - Persistent rollover follows prepare → atomic persist/fund → runtime commit.
 - Existing `TABLE_BUY_IN` validation and transaction helpers are reused; no new framework or generic ledger abstraction is introduced.
-- Failure is fail-closed, logged with `klog`, restored, and retried with bounded delay.
+- Failure is fail-closed, logged with `klog`, restored, retried quickly with bounded backoff, then retried at a bounded slow frequency until a terminal lifecycle condition.
 - The implementation contains no #706 cash-out behavior, #707 inventory, automatic remediation, frontend, CSS, JSP, or CSP work.
 
 ## Plan verdict

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -53,8 +53,8 @@ This is limited to replacement funding. Issue #706 owns terminal bot cash-out an
 
 ## Accounting decision and invariant
 
-- All bot funding created after rollout uses the configured dedicated `POKER_BOT_BANKROLL` `SYSTEM` account.
-- `POKER_BOT_BANKROLL_SYSTEM_KEY` remains the existing configuration property, but its default and deployed value become `POKER_BOT_BANKROLL`.
+- Replacement funding reuses the same existing `SYSTEM` source as current bot seeding. `shared/poker-domain/bots.mjs::getBotConfig()` already resolves `bankrollSystemKey` with the deployed fallback `TREASURY`; #705 leaves that parser, fallback, account, and environment configuration unchanged.
+- The expected source for #705 is therefore the existing `TREASURY` account. No dedicated account, initial allocation, balance migration, new replenishment procedure, or environment change is part of this fix.
 - A replacement transfers the old bot's remaining claim to the deterministic new bot identity and funds only the increase to the existing target of 100.
 - No replacement cash-out is performed in this issue.
 - No direct `chips_accounts.balance` patch is permitted.
@@ -65,7 +65,7 @@ For each replacement:
 oldStack       = integer current settled stack, allowed range 0..1
 targetStack    = BOT_REPLACEMENT_STACK, currently 100
 fundingDelta   = targetStack - oldStack
-ledger entries = SYSTEM(POKER_BOT_BANKROLL, -fundingDelta)
+ledger entries = SYSTEM(TREASURY, -fundingDelta)
                  ESCROW(POKER_TABLE:<tableId>, +fundingDelta)
 ```
 
@@ -128,12 +128,12 @@ Extend the existing optional argument contract with:
 nextStateOverride
 privateStateForHoleCardsOverride
 replacementFundings
-botBankrollSystemKey
+botFundingSystemKey
 systemActorUserId
 deferRuntimeVersionUpdate
 ```
 
-Ordinary action, timeout, join, and start-hand callers omit these properties and keep their current behavior. Settled rollover passes the prepared poker state and private hole-card state because the live table has not yet been mutated.
+Ordinary action, timeout, join, and start-hand callers omit these properties and keep their current behavior. Settled rollover passes the prepared poker state, private hole-card state, and `botFundingSystemKey` resolved from the unchanged shared `bankrollSystemKey` configuration because the live table has not yet been mutated.
 
 For this prepared path, `deferRuntimeVersionUpdate` prevents `persistMutatedState()` from changing `table.persistedStateVersion` before the prepared `coreState` is installed. After `commitSettledHandRollover()` succeeds, `server.mjs` applies the returned persisted version. If the runtime commit validation unexpectedly fails after the database commit, the server immediately restores the now-funded, now-advanced state from persistence instead of retrying the old rollover.
 
@@ -237,7 +237,7 @@ On WS process bootstrap or authoritative table restore, an active table restored
   - expose the two new methods from the manager object;
   - do not add persisted or table-level pending-funding properties.
 - `ws-server/server.mjs`
-  - resolve the configured bankroll and existing system actor once at startup;
+  - resolve the existing bot funding source through the unchanged shared `getBotConfig(process.env)` parser and resolve the existing system actor once at startup;
   - change `maybeScheduleSettledRollover()` to prepare, atomically persist/fund, commit runtime, then broadcast/autoplay;
   - extend `persistMutatedState()` only with optional prepared-state/funding inputs;
   - add the fixed fast/slow delay constants and extend each `settledRolloverTimerByTableId` record with `mode`, `attempt`, `generationKey`, `dueAt`, and `timer` rather than adding a parallel scheduler;
@@ -253,51 +253,36 @@ On WS process bootstrap or authoritative table restore, an active table restored
 - `ws-server/poker/persistence/chips-ledger.mjs`
   - reuse unchanged if repository verification during implementation confirms its `tx` path and strict `TABLE_BUY_IN` contract remain as analyzed;
   - do not broaden it to cash-out, reconciliation, or a generic transaction framework.
-
-### Configuration and account provisioning
-
-- `shared/poker-domain/bots.mjs::getBotConfig()`
-  - change the fallback `bankrollSystemKey` from `TREASURY` to `POKER_BOT_BANKROLL` so initial bot seed and replacement funding share the approved future source.
-- `netlify/functions/_shared/poker-bots.mjs::getBotConfig()`
-  - keep the duplicate compatibility config aligned with the same fallback; do not change autoplay policy.
 - `ws-server/shared/poker-domain/bots.mjs`
-  - re-export `getBotConfig` so `server.mjs` uses the shared parser rather than duplicating environment parsing.
-- `supabase/migrations/20260714113000_poker_bot_bankroll_system_account.sql`
-  - idempotently create active `SYSTEM` account `POKER_BOT_BANKROLL`;
-  - allocate an owner-approved initial amount from `TREASURY` with a balanced, idempotent ledger transaction and locked-account/non-negative guards;
-  - use the existing `ADMIN_ADJUST` transaction type with a dedicated key such as `seed:poker-bot-bankroll:v1`; do not add another enum or directly seed a non-zero balance without ledger entries.
+  - additively re-export the existing `getBotConfig` so `server.mjs` reuses the current funding-source parser rather than duplicating environment parsing.
 - `docs/poker-deployment.md`
-  - document the new default, required account, existing environment variable, system actor requirement, stage/prod scoping, WS preview deployment, monitoring, and rollback order.
+  - document the WS preview requirement, failure monitoring, and that #705 adds no account, migration, environment value, or replenishment workflow.
 - `docs/poker-bots.md`
-  - document the replacement delta invariant and state that terminal return remains owned by #706.
+  - document the replacement delta invariant, continued use of the current `TREASURY` source, and that terminal return remains owned by #706.
 
 ### Explicitly unchanged
 
 - `shared/poker-domain/inactive-cleanup.mjs` and `netlify/functions/_shared/poker-bot-cashout.mjs`: #706 scope; terminal behavior is not changed here.
 - Reconciliation modules or admin mutation endpoints: #707 and future remediation scope.
+- `shared/poker-domain/bots.mjs::getBotConfig()` and `netlify/functions/_shared/poker-bots.mjs::getBotConfig()`: their `TREASURY` fallback and all existing ENV behavior remain unchanged.
+- Chips account provisioning, balances, and migrations: no database or production-data change is required.
 - `poker_seats` schema and rows: replacement identity continues to be represented in persisted poker state and restored through the existing seat-number mapping.
 - Poker action reducer, payout rules, snapshots, WS protocol, bot policy/autoplay decision logic, browser/JSP/HTML/CSS, and CSP.
 - No script is added, so no CSP SHA is required. No CSS is changed; the one-selector-per-line rule is unaffected.
 
+## Deferred optional economy control
+
+GitHub issue #710 owns the optional future evaluation of a dedicated poker bot bankroll. It may consider account isolation, allocation policy, limits, alerts, replenishment, live-table cutover, and provenance after #705 is deployed and verified.
+
+#710 is not a dependency or production-readiness gate for this fix. #705 must not create that account, move balances, change the current funding ENV, or require owner top-ups. The atomic delta funding contract remains valid if a later issue deliberately changes the configured `SYSTEM` source.
+
 ## Implementation phases
 
-### Phase 0 — owner and deployment prerequisites
+### Phase 1 — existing source verification
 
-Owner-controlled decisions and tasks:
-
-- approve the initial chips allocation moved from `TREASURY` to `POKER_BOT_BANKROLL`;
-- confirm `POKER_SYSTEM_ACTOR_USER_ID` is a valid operational UUID in WS preview and production;
-- configure `POKER_BOT_BANKROLL_SYSTEM_KEY=POKER_BOT_BANKROLL` separately for WS preview and production;
-- plan a normal drain/close of pre-rollout poker tables before switching the bankroll, avoiding mixed funding provenance within one live table.
-
-Exit criteria: the migration amount is approved, environment scopes are known, and no active legacy-funded table will cross the bankroll cutover unless it is intentionally flagged for later manual review.
-
-### Phase 1 — additive bankroll provisioning and configuration
-
-- add and apply the idempotent system-account allocation migration;
-- align both existing bot config parsers and the WS re-export;
-- update deployment documentation;
-- verify the account is active and funded before enabling the new default.
+- verify that current initial bot seeding resolves the shared `bankrollSystemKey` to the deployed `TREASURY` source and posts the established `SYSTEM(-) + ESCROW(+)` shape;
+- add only the WS re-export needed to consume the same parser in `server.mjs`;
+- make no migration, account, balance, ENV, or production-data change.
 
 ### Phase 2 — pure replacement funding evidence
 
@@ -324,12 +309,12 @@ Exit criteria: the migration amount is approved, environment scopes are known, a
 
 No new automated test or test framework is planned.
 
-1. Confirm an initial bot seed debits `POKER_BOT_BANKROLL`, not `TREASURY`, and credits the table escrow.
+1. Confirm an initial bot seed continues to debit the existing `TREASURY` account and credit table escrow; #705 must not change that transaction.
 2. Settle a hand with one bot at stack 1. Confirm one replacement `TABLE_BUY_IN` for 99 and a target replacement claim of 100 before blind posting.
 3. Repeat with stack 0 and confirm a delta of 100.
 4. Settle a hand with two broke bots and confirm two per-seat transactions plus one state transition commit atomically.
 5. Verify the idempotency keys use the same table/version/seat on retry and no duplicate ledger entry appears.
-6. Temporarily make the stage bankroll insufficient or inactive long enough to exhaust fast retries. Confirm the state remains `SETTLED`, escrow is unchanged, no candidate snapshot/autoplay is emitted, retry switches to one 60-second timer, and recovery succeeds after the account is restored without any user action.
+6. Cause a controlled ledger failure in the isolated stage flow long enough to exhaust fast retries. Confirm the state remains `SETTLED`, escrow is unchanged, no candidate snapshot/autoplay is emitted, retry switches to one 60-second timer, and recovery succeeds after the dependency is restored without any user action. This verifies failure behavior; it does not introduce a new manual bankroll replenishment process.
 7. Force a state-version conflict. Confirm the CAS fails before ledger posting and the persisted state is restored.
 8. Restart the WS service while a table is waiting in slow recovery. Confirm bootstrap restores the settled table, recreates the retry, and advances after the dependency recovers. Then restart immediately after a successful replacement commit and confirm the new hand is restored without duplicate funding.
 9. Verify a table with no broke bot performs no ledger operation and follows the current rollover behavior.
@@ -342,20 +327,17 @@ No new automated test or test framework is planned.
 
 ### Deployment
 
-1. Apply the additive migration to stage and verify the dedicated account and balanced allocation transaction.
-2. Set the WS-preview-scoped bankroll and system actor configuration.
-3. Run a **WS Preview Deploy** because `ws-server` runtime and persistence code change; an ordinary Netlify deploy preview alone is insufficient.
-4. Complete the manual stage scenarios, including failure, retry, restart, and ledger inspection.
-5. Drain or normally close legacy-funded production tables.
-6. Apply the production migration and production-scoped environment value.
-7. Deploy the WS service, then monitor replacement success/failure, retry counts, bankroll balance, escrow deltas, persistence conflicts, and settled-hand age.
+1. Read-only verify that WS preview resolves the existing bot funding source to `TREASURY` and that the existing system actor configuration is valid; do not change account balances or ENV for #705.
+2. Run a **WS Preview Deploy** because `ws-server` runtime and persistence code change; an ordinary Netlify deploy preview alone is insufficient.
+3. Complete the manual stage scenarios, including failure, retry, restart, and ledger inspection.
+4. Deploy the WS service without a migration, ENV cutover, table drain, or bankroll allocation step.
+5. Monitor replacement success/failure, retry counts, `TREASURY` debit and escrow-credit deltas, persistence conflicts, and settled-hand age.
 
 ### Rollback
 
-- The system account and valid ledger allocation are additive and remain auditable; do not delete the account or reverse committed replacement buy-ins during an application rollback.
 - Reverting to the old WS code reintroduces the P0 unfunded-replacement defect. Before any code rollback, stop new bot tables and drain/close active bot tables or temporarily disable poker traffic.
-- Do not switch an active table from `POKER_BOT_BANKROLL` back to `TREASURY` mid-lifecycle.
-- If the new path fails, the safe runtime state is the prior settled hand. Restore service after fixing configuration/bankroll capacity instead of manually advancing state or patching balances.
+- Do not reverse valid replacement `TABLE_BUY_IN` transactions during an application rollback; they back already committed table claims.
+- If the new path fails, the safe runtime state is the prior settled hand. Restore service after the existing ledger dependency recovers instead of manually advancing state or patching balances.
 
 ## Breaking and operational impact
 
@@ -363,24 +345,24 @@ No new automated test or test framework is planned.
 | --- | --- |
 | Poker gameplay | Intentional fail-closed change: a next hand with a replacement bot no longer starts when funding is unavailable. The table stays settled and retries instead of inventing chips. |
 | Bot replacement | Replacement identity, seat, target stack, dealer progression, cards, and autoplay policy remain the same after a successful commit. |
-| Initial bot funding | Operationally breaking default changes from `TREASURY` to `POKER_BOT_BANKROLL`; the account, allocation, and scoped environment value must exist before rollout. |
+| Initial bot funding | No change. Initial bot seeding and replacement deltas use the current configured source, expected to remain `TREASURY`. |
 | Runtime API | Conditionally breaking: new prepare/commit methods are additive, but a production persistence-backed caller can no longer use `rolloverSettledHand()` to commit a funded replacement. Guest/in-memory callers remain supported through the guarded economy-free path; every persistent caller must migrate to writer receipt plus commit. |
 | Persistence | `writeMutation()` receives optional additive inputs. Normal action/start/timeout callers remain unchanged. Mandatory replacement funding now participates in the state transaction. |
 | Ledger | Adds one `TABLE_BUY_IN` transaction per replacement seat. No transaction enum, balance semantics, or cash-out behavior changes. |
 | Restore/retry | A failed replacement may keep a table in `SETTLED` longer. Fast retries transition to a 60-second recovery cadence and survive process restart through restored-state scheduling; operational monitoring is required. |
 | Inactive cleanup | No code change. More correctly backed bot value may remain in escrow until #706 implements terminal return. |
 | Reconciliation | No implementation. Replacement ledger metadata creates cleaner future evidence for #707. |
-| Database | Additive data migration creates and funds one `SYSTEM` account; no table/column/schema contract changes. |
-| ENV/secrets | No new variable, but existing `POKER_BOT_BANKROLL_SYSTEM_KEY` and `POKER_SYSTEM_ACTOR_USER_ID` become deployment-critical for replacement funding. |
+| Database | No migration, new account, schema change, or production-data mutation. |
+| ENV/secrets | No new or changed value. The implementation consumes the current bot funding parser and existing system actor configuration. |
 | WS/browser contract | None. No snapshot field, message type, JSP, JavaScript browser compatibility, HTML, CSS, or CSP change. |
 | Tests | No new or modified tests. Existing checks are run unchanged, followed by the manual stage verification above. |
 
-The most important breaking risk is operational: deploying the code before provisioning and funding `POKER_BOT_BANKROLL` would intentionally stop replacement rollover at `SETTLED`. That failure mode is safe for accounting but visible to players, so migration and environment ordering are release gates.
+The most important breaking risk is the intentional fail-closed gameplay behavior: if the existing `TREASURY` ledger transfer is unavailable, replacement rollover remains in `SETTLED` and retries instead of inventing chips. There is no new account-provisioning, funding, or ENV release gate.
 
 ## Acceptance criteria
 
 - Every replacement descriptor uses an integer old stack of 0 or 1, target 100, and exact positive delta `target - old`.
-- The configured dedicated bankroll is debited by exactly the sum of replacement deltas and table escrow is credited by the same amount.
+- The existing `TREASURY` source is debited by exactly the sum of replacement deltas and table escrow is credited by the same amount.
 - State CAS and all replacement ledger posts commit or roll back together.
 - The live runtime, snapshots, and bot autoplay do not observe the replacement state before database success.
 - Multiple replacements in one rollover are atomic and independently auditable by deterministic per-seat keys.
@@ -389,7 +371,7 @@ The most important breaking risk is operational: deploying the code before provi
 - Exhausting fast retries cannot permanently strand an active settled table; slow recovery continues until success, state change, or eviction.
 - A persistence-backed replacement candidate with a funding intent cannot be committed through the compatibility wrapper or without a matching writer receipt.
 - `fundingDelta` is bound to the idempotency operation by the existing payload hash; a changed amount for the same table/version/seat is rejected rather than assigned a second key.
-- Initial bot funding after rollout also uses `POKER_BOT_BANKROLL`.
+- Initial bot funding remains unchanged and continues to use the current `TREASURY` source.
 - Guest tables remain outside the chips economy.
 - Inactive cleanup, terminal cash-out, and reconciliation remain unchanged and explicitly deferred to #706/#707.
 - Existing checks pass without adding or changing tests.
@@ -397,7 +379,7 @@ The most important breaking risk is operational: deploying the code before provi
 
 ## Definition of Done
 
-- The owner-approved bankroll allocation and deployment configuration are complete in stage and production scopes.
+- No new account, allocation, migration, ENV change, or manual replenishment workflow is introduced.
 - Engine replacement returns closed, validated funding evidence without performing I/O.
 - Persistent rollover follows prepare → atomic persist/fund → runtime commit.
 - Existing `TABLE_BUY_IN` validation and transaction helpers are reused; no new framework or generic ledger abstraction is introduced.

--- a/docs/poker-bot-replacement-escrow-funding-plan.md
+++ b/docs/poker-bot-replacement-escrow-funding-plan.md
@@ -276,6 +276,7 @@ On WS process bootstrap or authoritative table restore, an active table restored
 - `ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs`
   - add a small transaction-aware harness through the existing `beginSql` injection and exercise the real writer/ledger call boundary;
   - verify successful CAS plus funding commits state and exactly one balanced ledger transaction;
+  - capture the table escrow balance before and after success and assert `escrowAfter === escrowBefore + fundingDelta`; for several replacements in one rollover, use the sum of their deltas;
   - verify a funding exception rolls back both pending state and ledger effects;
   - verify a CAS/version conflict makes zero ledger calls;
   - verify replay of the same table/version/seat is already applied or rejected without a second funding transaction;
@@ -349,7 +350,7 @@ These cases use `node:test` and the existing engine/table-manager suites. They m
 
 Integration tests cover the smallest writer-ledger-state boundary using the existing injectable `beginSql` contract and a transaction-aware deterministic harness:
 
-1. successful state CAS and one replacement funding commit together;
+1. successful state CAS and one replacement funding commit together, with `escrowAfter === escrowBefore + fundingDelta` (or `+ sum(fundingDelta)` for an atomic multi-replacement rollover);
 2. ledger failure rolls back both state and ledger effects and produces no receipt usable by runtime commit;
 3. failed CAS performs no ledger funding;
 4. replay of the deterministic idempotency key cannot fund twice;
@@ -414,7 +415,7 @@ The most important breaking risk is the intentional fail-closed gameplay behavio
 ## Acceptance criteria
 
 - The pure delta helper accepts integer `0 <= oldStack < targetStack`, returns exact `target - old`, and fails closed for invalid values; current replacement eligibility still normally emits descriptors only for old stacks 0 or 1.
-- The existing `TREASURY` source is debited by exactly the sum of replacement deltas and table escrow is credited by the same amount.
+- The existing `TREASURY` source is debited by exactly the sum of replacement deltas, and the integration test proves `escrowAfter === escrowBefore + sum(fundingDelta)` for the committed rollover.
 - State CAS and all replacement ledger posts commit or roll back together.
 - The live runtime, snapshots, and bot autoplay do not observe the replacement state before database success.
 - Multiple replacements in one rollover are atomic and independently auditable by deterministic per-seat keys.
@@ -436,7 +437,7 @@ The most important breaking risk is the intentional fail-closed gameplay behavio
 - Persistent rollover follows prepare → atomic persist/fund → runtime commit.
 - Existing `TABLE_BUY_IN` validation and transaction helpers are reused; no new framework or generic ledger abstraction is introduced.
 - Failure is fail-closed, logged with `klog`, restored, retried quickly with bounded backoff, then retried at a bounded slow frequency until a terminal lifecycle condition.
-- The automated suite proves exact delta boundaries, invalid-input rejection, idempotency, transaction rollback, CAS-before-ledger ordering, receipt-gated runtime commit, and restart retry without duplicate funding.
+- The automated suite proves exact delta boundaries, the escrow balance-delta invariant, invalid-input rejection, idempotency, transaction rollback, CAS-before-ledger ordering, receipt-gated runtime commit, and restart retry without duplicate funding.
 - The implementation contains no #706 cash-out behavior, #707 inventory, automatic remediation, frontend, CSS, JSP, or CSP work.
 
 ## Plan verdict

--- a/docs/poker-bots.md
+++ b/docs/poker-bots.md
@@ -52,8 +52,13 @@ Seat snapshots include bot-specific fields that are persisted and returned by ta
 Bots follow the same funds safety model as human seats:
 
 - buy-in uses `TABLE_BUY_IN` into table escrow,
+- a broke bot replacement preserves the old residual stack and funds only `100 - oldStack` from the currently configured bot `SYSTEM` source (default `TREASURY`) into the table `ESCROW`,
+- replacement funding and the poker-state CAS commit in one database transaction before the replacement becomes visible in WS runtime,
+- replacement retries reuse a deterministic table/version/seat idempotency key and cannot create a second ledger credit after restore,
 - cash-out uses `TABLE_CASH_OUT` out of escrow,
 - timeout/cleanup paths are responsible for returning chips from escrow and avoiding stranded balances.
+
+Terminal bot cash-out and historical escrow reconciliation remain separate lifecycle work; replacement funding does not change those policies.
 
 ## Scope and TBDs
 

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -53,6 +53,8 @@ Operational notes:
 - Bot runtime is guarded by `POKER_BOTS_ENABLED`.
 - Values above are Netlify runtime config env vars (not secrets unless explicitly sensitive).
 - Bot/gameplay orchestration runs server-side in WS runtime (no client-side bot scripts).
+- Bot replacement funding continues to use the existing configured source (default `TREASURY`); it adds no account, migration, environment variable, balance move, or manual replenishment step.
+- A replacement funding failure leaves the table in `SETTLED`, retries with bounded fast backoff, then retries at most once per minute until the same generation succeeds or changes. Monitor `ws_settled_rollover_persist_failed` for the controlled reason, requested replacement count, and total delta.
 
 ### Local development
 
@@ -108,6 +110,8 @@ The preview WS deploy is manual-only and isolated from the production WS workflo
 It targets only the preview host, preview filesystem root, preview service, preview env file, and preview health checks.
 It does not manage Caddy.
 The host is a single shared preview runtime, so automatic deployment from every PR is intentionally disabled: concurrent PRs would overwrite each other and a Netlify preview could silently use another branch's backend.
+
+Changes to bot replacement funding touch the authoritative WS runtime and therefore require a manual WS preview deploy before stage acceptance. Verify a replacement with old stack `0` or `1`, then confirm the next hand starts and the table escrow increased by exactly the funded delta. A Netlify deploy preview alone is not sufficient for this server-side path.
 Repo-side Caddy ownership is unified: `infra/vps/Caddyfile` is the single source of truth for both production and preview WS routing, so any Caddy change for either host must be made in that file.
 
 ### Dispatch a preview deploy for a selected ref

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -54,6 +54,7 @@ Operational notes:
 - Values above are Netlify runtime config env vars (not secrets unless explicitly sensitive).
 - Bot/gameplay orchestration runs server-side in WS runtime (no client-side bot scripts).
 - Bot replacement funding continues to use the existing configured source (default `TREASURY`); it adds no account, migration, environment variable, balance move, or manual replenishment step.
+- Replacement funding is an internal `SYSTEM -> ESCROW` transaction with `created_by = NULL` and closed bot/replacement metadata. It does not depend on `POKER_SYSTEM_ACTOR_USER_ID`; that existing setting still applies to separate legacy bot cash-out paths.
 - A replacement funding failure leaves the table in `SETTLED`, retries with bounded fast backoff, then retries at most once per minute until the same generation succeeds or changes. Monitor `ws_settled_rollover_persist_failed` for the controlled reason, requested replacement count, and total delta.
 
 ### Local development

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -81,6 +81,7 @@ run("node", ["tests/poker-materialize-settlement.payouts.test.mjs"], "poker-mate
 run("node", ["tests/poker-ui.behavior.test.mjs"], "poker-ui-behavior");
 run("node", ["tests/poker-v2-live.behavior.test.mjs"], "poker-v2-live-behavior");
 run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs"], "ws-inactive-cleanup-adapter-behavior");
+run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");
 run("node", ["ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs"], "ws-disconnect-cleanup-runtime-behavior");
 run("node", ["ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs"], "ws-accepted-bot-autoplay-adapter-behavior");
 run("node", ["ws-tests/ws-lobby-join-public-snapshot.behavior.test.mjs"], "ws-lobby-join-public-snapshot-behavior");

--- a/shared/poker-domain/poker-autoplay.mjs
+++ b/shared/poker-domain/poker-autoplay.mjs
@@ -76,7 +76,7 @@ export const runBotAutoplayLoop = async ({
     ? Math.max(maxActions, botsOnlyHandCompletionHardCap)
     : maxActions;
 
-  const buildBotRequestId = (statePublic, botTurnUserId, stepIndex) => {
+  const buildBotRequestId = (statePublic, botTurnUserId, stateVersion, stepIndex) => {
     const handId = typeof statePublic?.handId === "string" && statePublic.handId.trim()
       ? statePublic.handId.trim()
       : "unknown_hand";
@@ -86,7 +86,10 @@ export const runBotAutoplayLoop = async ({
     const actor = typeof botTurnUserId === "string" && botTurnUserId.trim()
       ? botTurnUserId.trim()
       : "unknown_actor";
-    return `bot:${requestId}:${handId}:${phase}:${actor}:${stepIndex}`;
+    const version = Number.isInteger(Number(stateVersion)) && Number(stateVersion) >= 0
+      ? Number(stateVersion)
+      : "unknown_version";
+    return `bot:${requestId}:${handId}:${phase}:${actor}:v${version}:${stepIndex}`;
   };
 
   while (botActionCount < effectiveMaxBotActions) {
@@ -144,7 +147,7 @@ export const runBotAutoplayLoop = async ({
     });
     if (!botChoice || !botChoice.type) { botStopReason = "no_legal_action"; break; }
 
-    const botRequestId = buildBotRequestId(responseFinalState, botTurnUserId, botActionCount + 1);
+    const botRequestId = buildBotRequestId(responseFinalState, botTurnUserId, loopVersion, botActionCount + 1);
     const botAction = { ...botChoice, userId: botTurnUserId, requestId: botRequestId };
     let botApplied;
     try {

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -5,11 +5,26 @@ import {
   bootstrapCoreStateHand,
   buildBootstrappedPokerState,
   buildNextHandStateFromSettled,
+  calculateReplacementFundingDelta,
   replaceBrokeBotsForNextHand
 } from "./poker-engine.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitives.mjs";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test("replacement funding delta preserves residual bot stack", () => {
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 0 }), { ok: true, oldStack: 0, targetStack: 100, fundingDelta: 100 });
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 1 }), { ok: true, oldStack: 1, targetStack: 100, fundingDelta: 99 });
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 99 }), { ok: true, oldStack: 99, targetStack: 100, fundingDelta: 1 });
+});
+
+test("replacement funding delta rejects invalid accounting inputs", () => {
+  for (const oldStack of [-1, Number.NaN, Number.POSITIVE_INFINITY, 100, 101, 1.5]) {
+    assert.equal(calculateReplacementFundingDelta({ oldStack }).ok, false);
+  }
+  assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: 0 }).ok, false);
+  assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: Number.NaN }).ok, false);
+});
 
 function initialCore() {
   return {
@@ -173,4 +188,15 @@ test("replaceBrokeBotsForNextHand swaps too-short bot only after settlement", ()
   assert.equal(recycled.coreState.seatDetailsByUserId[replacementBot.userId].isBot, true);
   assert.equal(recycled.settledState.stacks[replacementBot.userId], 100);
   assert.equal("bot_old" in recycled.settledState.stacks, false);
+  assert.deepEqual(recycled.replacementFundings, [{
+    seatNo: 2,
+    oldBotUserId: "bot_old",
+    replacementBotUserId: replacementBot.userId,
+    oldStack: 1,
+    targetStack: 100,
+    fundingDelta: 99,
+    settledHandId: "settled_bot_replace",
+    fromStateVersion: 30,
+    toStateVersion: 31
+  }]);
 });

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -14,6 +14,21 @@ const ENGINE_ACTIONS = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE"]);
 const MIN_STACK_TO_JOIN_HAND = 2;
 const BOT_REPLACEMENT_STACK = 100;
 
+export function calculateReplacementFundingDelta({ oldStack, targetStack = BOT_REPLACEMENT_STACK } = {}) {
+  if (!Number.isInteger(targetStack) || targetStack <= 0) {
+    return { ok: false, reason: "invalid_target_stack" };
+  }
+  if (!Number.isInteger(oldStack) || oldStack < 0 || oldStack >= targetStack) {
+    return { ok: false, reason: "invalid_old_stack" };
+  }
+  return {
+    ok: true,
+    oldStack,
+    targetStack,
+    fundingDelta: targetStack - oldStack
+  };
+}
+
 function toHex(bytes) {
   return Buffer.from(bytes).toString("hex");
 }
@@ -211,10 +226,15 @@ function nextBotReplacementUserId({ tableId, seatNo, version, existingUserIds })
 
 export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersion }) {
   if (!coreState || typeof coreState !== "object" || Array.isArray(coreState)) {
-    return { coreState, settledState };
+    return { ok: false, reason: "invalid_core_state", coreState, settledState, replacementFundings: [] };
   }
   if (!settledState || typeof settledState !== "object" || Array.isArray(settledState)) {
-    return { coreState, settledState };
+    return { ok: false, reason: "invalid_settled_state", coreState, settledState, replacementFundings: [] };
+  }
+
+  const fromStateVersion = Number(coreState.version);
+  if (!Number.isInteger(fromStateVersion) || !Number.isInteger(nextVersion) || nextVersion !== fromStateVersion + 1) {
+    return { ok: false, reason: "invalid_replacement_version", coreState, settledState, replacementFundings: [] };
   }
 
   const currentMembers = orderedSeatMembers(coreState);
@@ -234,12 +254,36 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
     ? { ...coreState.publicStacks }
     : null;
   const existingUserIds = new Set(nextMembers.map((member) => member.userId));
+  const replacementFundings = [];
 
   for (const member of currentMembers) {
     const userId = member.userId;
     if (nextSeatDetails?.[userId]?.isBot !== true) continue;
     const stack = Number(nextStacks[userId] ?? 0);
-    if (!Number.isFinite(stack) || stack >= MIN_STACK_TO_JOIN_HAND) continue;
+    if (!Number.isFinite(stack)) {
+      return {
+        ok: false,
+        reason: "invalid_old_stack",
+        coreState,
+        settledState,
+        replacementFundings: []
+      };
+    }
+    if (stack >= MIN_STACK_TO_JOIN_HAND) continue;
+
+    const funding = calculateReplacementFundingDelta({
+      oldStack: stack,
+      targetStack: BOT_REPLACEMENT_STACK
+    });
+    if (!funding.ok) {
+      return {
+        ok: false,
+        reason: funding.reason,
+        coreState,
+        settledState,
+        replacementFundings: []
+      };
+    }
 
     const replacementUserId = nextBotReplacementUserId({
       tableId: coreState.roomId,
@@ -270,14 +314,27 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
       delete nextPublicStacks[userId];
       nextPublicStacks[replacementUserId] = BOT_REPLACEMENT_STACK;
     }
+
+    replacementFundings.push({
+      seatNo: member.seat,
+      oldBotUserId: userId,
+      replacementBotUserId: replacementUserId,
+      oldStack: funding.oldStack,
+      targetStack: funding.targetStack,
+      fundingDelta: funding.fundingDelta,
+      settledHandId: typeof settledState.handId === "string" ? settledState.handId : null,
+      fromStateVersion,
+      toStateVersion: nextVersion
+    });
   }
 
   if (!changed) {
-    return { coreState, settledState };
+    return { ok: true, coreState, settledState, replacementFundings: [] };
   }
 
   nextMembers.sort((a, b) => a.seat - b.seat || a.userId.localeCompare(b.userId));
   return {
+    ok: true,
     coreState: {
       ...coreState,
       members: nextMembers,
@@ -288,7 +345,8 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
     settledState: {
       ...settledState,
       stacks: nextStacks
-    }
+    },
+    replacementFundings
   };
 }
 

--- a/ws-server/poker/persistence/chips-ledger.mjs
+++ b/ws-server/poker/persistence/chips-ledger.mjs
@@ -199,7 +199,7 @@ async function runTableBuyIn(sqlTx, {
   const txRows = await sqlTx.unsafe(
     `
 insert into public.chips_transactions (reference, description, metadata, idempotency_key, payload_hash, tx_type, user_id, created_by)
-values ($1, $2, $3::jsonb, $4, $5, $6, $7, $8)
+values ($1, $2, ($3::text)::jsonb, $4, $5, $6, $7, $8)
 returning *;
     `,
     [reference, description, safeMetadataJson, idempotencyKey, payloadHash, txType, payloadUserId, createdBy]

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -778,3 +778,191 @@ test("persisted state writer logs settlement audit failures without private hole
   assert.equal(serializedLogs.includes("AH"), false);
   assert.equal(serializedLogs.includes("AD"), false);
 });
+
+function createReplacementFundingDbHarness({ tableId, version = 7, state, treasuryBalance = 1_000, escrowBalance = 50 } = {}) {
+  const sourceAccount = { id: "10000000-0000-4000-8000-000000000001", system_key: "TREASURY", account_type: "SYSTEM", status: "active", balance: treasuryBalance };
+  const escrowAccount = { id: "10000000-0000-4000-8000-000000000002", system_key: `POKER_TABLE:${tableId}`, account_type: "ESCROW", status: "active", balance: escrowBalance };
+  const durable = {
+    version,
+    state: structuredClone(state),
+    accounts: new Map([[sourceAccount.system_key, sourceAccount], [escrowAccount.system_key, escrowAccount]]),
+    transactions: new Map(),
+    ledgerInsertCount: 0,
+    failFunding: false
+  };
+
+  const beginSql = async (fn) => {
+    const working = {
+      version: durable.version,
+      state: structuredClone(durable.state),
+      accounts: new Map([...durable.accounts].map(([key, account]) => [key, { ...account }])),
+      transactions: new Map([...durable.transactions].map(([key, transaction]) => [key, { ...transaction }])),
+      ledgerInsertCount: durable.ledgerInsertCount
+    };
+    const tx = {
+      unsafe: async (query, params = []) => {
+        const text = String(query);
+        if (text.startsWith("update public.poker_state set version = version + 1")) {
+          if (working.version !== params[1]) return [];
+          working.version += 1;
+          working.state = JSON.parse(params[2]);
+          return [{ version: working.version }];
+        }
+        if (text.startsWith("select version, state from public.poker_state")) {
+          return [{ version: working.version, state: structuredClone(working.state) }];
+        }
+        if (text.includes("from public.chips_accounts") && text.includes("system_key = any")) {
+          return params[0].map((key) => working.accounts.get(key)).filter(Boolean).map((account) => ({ ...account }));
+        }
+        if (text.includes("insert into public.chips_transactions")) {
+          if (durable.failFunding) throw new Error("simulated_funding_failure");
+          const idempotencyKey = params[3];
+          if (working.transactions.has(idempotencyKey)) throw new Error("duplicate_idempotency_key");
+          const transaction = { id: `tx-${working.transactions.size + 1}`, idempotency_key: idempotencyKey, payload_hash: params[4] };
+          working.transactions.set(idempotencyKey, transaction);
+          working.ledgerInsertCount += 1;
+          return [{ ...transaction }];
+        }
+        if (text.includes("select count(*) from apply_balance")) {
+          const entries = JSON.parse(params[0]);
+          for (const entry of entries) {
+            const account = [...working.accounts.values()].find((candidate) => candidate.id === entry.account_id);
+            if (!account || account.balance + entry.amount < 0) throw new Error("insufficient_funds");
+            account.balance += entry.amount;
+          }
+          return [{ updated_accounts: entries.length, expected_accounts: entries.length, guard_ok: true }];
+        }
+        if (text.includes("insert into public.chips_entries")) {
+          const entries = JSON.parse(params[1]);
+          return [{ entries: entries.map((entry, index) => ({ ...entry, entry_seq: index + 1 })) }];
+        }
+        return [];
+      }
+    };
+    const result = await fn(tx);
+    durable.version = working.version;
+    durable.state = working.state;
+    durable.accounts = working.accounts;
+    durable.transactions = working.transactions;
+    durable.ledgerInsertCount = working.ledgerInsertCount;
+    return result;
+  };
+
+  return {
+    beginSql,
+    durable,
+    balance(systemKey) {
+      return durable.accounts.get(systemKey)?.balance;
+    }
+  };
+}
+
+function replacementFundingFixture({ tableId, expectedVersion = 7, oldStack = 1 } = {}) {
+  return [{
+    seatNo: 2,
+    oldBotUserId: "00000000-0000-4000-8000-0000000000b2",
+    replacementBotUserId: "00000000-0000-4000-8000-0000000000c3",
+    oldStack,
+    targetStack: 100,
+    fundingDelta: 100 - oldStack,
+    settledHandId: "hand_replacement_funding",
+    fromStateVersion: expectedVersion,
+    toStateVersion: expectedVersion + 1
+  }];
+}
+
+test("replacement funding atomically increases escrow once and survives writer restart", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000705";
+  const previousState = { tableId, handId: "hand_replacement_funding", phase: "SETTLED", stacks: {} };
+  const nextState = { tableId, handId: "hand_after_replacement", phase: "PREFLOP", stacks: {} };
+  const harness = createReplacementFundingDbHarness({ tableId, state: previousState });
+  const funding = replacementFundingFixture({ tableId });
+  const writerOptions = { env: { SUPABASE_DB_URL: "postgres://example.invalid/db" }, beginSql: harness.beginSql, klog: () => {} };
+  const escrowBefore = harness.balance(`POKER_TABLE:${tableId}`);
+  const firstWriter = createPersistedStateWriter(writerOptions);
+  const first = await firstWriter.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState,
+    replacementFundings: funding,
+    botFundingSystemKey: "TREASURY",
+    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+  });
+
+  assert.equal(first.ok, true);
+  assert.equal(first.replacementFundingCommitted, true);
+  assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + funding[0].fundingDelta);
+  assert.equal(harness.durable.ledgerInsertCount, 1);
+
+  const restartedManager = createTableManager({ maxSeats: 6, tableBootstrapLoader: async () => ({ ok: false }) });
+  assert.equal(restartedManager.restoreTableFromPersisted(tableId, {
+    coreState: {
+      version: harness.durable.version,
+      roomId: tableId,
+      maxSeats: 6,
+      members: [],
+      seats: {},
+      publicStacks: {},
+      seatDetailsByUserId: {},
+      pokerState: harness.durable.state
+    },
+    presenceByUserId: new Map()
+  }).ok, true);
+  const restartPlan = restartedManager.prepareSettledHandRollover({ tableId });
+  assert.equal(restartPlan.changed, false);
+  assert.equal(restartPlan.reason, "hand_not_settled");
+
+  const restartedWriter = createPersistedStateWriter(writerOptions);
+  const replay = await restartedWriter.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState,
+    replacementFundings: funding,
+    botFundingSystemKey: "TREASURY",
+    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+  });
+  assert.equal(replay.alreadyApplied, true);
+  assert.equal(harness.durable.ledgerInsertCount, 1);
+  assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + funding[0].fundingDelta);
+
+  const conflict = await restartedWriter.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState: { ...nextState, handId: "different_candidate" },
+    replacementFundings: funding,
+    botFundingSystemKey: "TREASURY",
+    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+  });
+  assert.equal(conflict.ok, false);
+  assert.equal(conflict.reason, "conflict");
+  assert.equal(harness.durable.ledgerInsertCount, 1);
+});
+
+test("replacement funding failure rolls back persisted state and escrow", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000706";
+  const previousState = { tableId, handId: "hand_replacement_funding", phase: "SETTLED", stacks: {} };
+  const nextState = { tableId, handId: "hand_after_replacement", phase: "PREFLOP", stacks: {} };
+  const harness = createReplacementFundingDbHarness({ tableId, state: previousState });
+  harness.durable.failFunding = true;
+  const escrowBefore = harness.balance(`POKER_TABLE:${tableId}`);
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: harness.beginSql,
+    klog: () => {}
+  });
+  const result = await writer.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState,
+    replacementFundings: replacementFundingFixture({ tableId }),
+    botFundingSystemKey: "TREASURY",
+    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "db_error");
+  assert.equal(harness.durable.version, 7);
+  assert.deepEqual(harness.durable.state, previousState);
+  assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore);
+  assert.equal(harness.durable.ledgerInsertCount, 0);
+});

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -788,6 +788,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
     accounts: new Map([[sourceAccount.system_key, sourceAccount], [escrowAccount.system_key, escrowAccount]]),
     transactions: new Map(),
     ledgerInsertCount: 0,
+    transactionInsertSql: null,
     failFunding: false
   };
 
@@ -815,6 +816,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
           return params[0].map((key) => working.accounts.get(key)).filter(Boolean).map((account) => ({ ...account }));
         }
         if (text.includes("insert into public.chips_transactions")) {
+          durable.transactionInsertSql = text;
           if (durable.failFunding) throw new Error("simulated_funding_failure");
           const idempotencyKey = params[3];
           if (working.transactions.has(idempotencyKey)) throw new Error("duplicate_idempotency_key");
@@ -893,6 +895,7 @@ test("replacement funding without a configured human actor atomically increases 
   assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + funding[0].fundingDelta);
   assert.equal(harness.durable.ledgerInsertCount, 1);
   assert.equal([...harness.durable.transactions.values()][0]?.created_by, null);
+  assert.match(harness.durable.transactionInsertSql, /values\s*\(\$1, \$2, \(\$3::text\)::jsonb,/);
 
   const restartedManager = createTableManager({ maxSeats: 6, tableBootstrapLoader: async () => ({ ok: false }) });
   assert.equal(restartedManager.restoreTableFromPersisted(tableId, {

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -818,7 +818,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
           if (durable.failFunding) throw new Error("simulated_funding_failure");
           const idempotencyKey = params[3];
           if (working.transactions.has(idempotencyKey)) throw new Error("duplicate_idempotency_key");
-          const transaction = { id: `tx-${working.transactions.size + 1}`, idempotency_key: idempotencyKey, payload_hash: params[4] };
+          const transaction = { id: `tx-${working.transactions.size + 1}`, idempotency_key: idempotencyKey, payload_hash: params[4], created_by: params[7] };
           working.transactions.set(idempotencyKey, transaction);
           working.ledgerInsertCount += 1;
           return [{ ...transaction }];
@@ -871,7 +871,7 @@ function replacementFundingFixture({ tableId, expectedVersion = 7, oldStack = 1 
   }];
 }
 
-test("replacement funding atomically increases escrow once and survives writer restart", async () => {
+test("replacement funding without a configured human actor atomically increases escrow once and survives writer restart", async () => {
   const tableId = "00000000-0000-4000-8000-000000000705";
   const previousState = { tableId, handId: "hand_replacement_funding", phase: "SETTLED", stacks: {} };
   const nextState = { tableId, handId: "hand_after_replacement", phase: "PREFLOP", stacks: {} };
@@ -885,14 +885,14 @@ test("replacement funding atomically increases escrow once and survives writer r
     expectedVersion: 7,
     nextState,
     replacementFundings: funding,
-    botFundingSystemKey: "TREASURY",
-    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+    botFundingSystemKey: "TREASURY"
   });
 
   assert.equal(first.ok, true);
   assert.equal(first.replacementFundingCommitted, true);
   assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + funding[0].fundingDelta);
   assert.equal(harness.durable.ledgerInsertCount, 1);
+  assert.equal([...harness.durable.transactions.values()][0]?.created_by, null);
 
   const restartedManager = createTableManager({ maxSeats: 6, tableBootstrapLoader: async () => ({ ok: false }) });
   assert.equal(restartedManager.restoreTableFromPersisted(tableId, {
@@ -918,8 +918,7 @@ test("replacement funding atomically increases escrow once and survives writer r
     expectedVersion: 7,
     nextState,
     replacementFundings: funding,
-    botFundingSystemKey: "TREASURY",
-    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+    botFundingSystemKey: "TREASURY"
   });
   assert.equal(replay.alreadyApplied, true);
   assert.equal(harness.durable.ledgerInsertCount, 1);
@@ -930,8 +929,7 @@ test("replacement funding atomically increases escrow once and survives writer r
     expectedVersion: 7,
     nextState: { ...nextState, handId: "different_candidate" },
     replacementFundings: funding,
-    botFundingSystemKey: "TREASURY",
-    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+    botFundingSystemKey: "TREASURY"
   });
   assert.equal(conflict.ok, false);
   assert.equal(conflict.reason, "conflict");
@@ -955,8 +953,7 @@ test("replacement funding failure rolls back persisted state and escrow", async 
     expectedVersion: 7,
     nextState,
     replacementFundings: replacementFundingFixture({ tableId }),
-    botFundingSystemKey: "TREASURY",
-    systemActorUserId: "00000000-0000-4000-8000-0000000000a1"
+    botFundingSystemKey: "TREASURY"
   });
 
   assert.equal(result.ok, false);

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -6,7 +6,6 @@ const HAND_SETTLED_ACTION_TYPE = "HAND_SETTLED";
 const SETTLEMENT_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const MAX_REPLACEMENT_FUNDINGS = 10;
 
 function normalizeJsonState(value) {
@@ -402,13 +401,12 @@ function normalizeReplacementFundings({ replacementFundings, tableId, expectedVe
   return { ok: true, supplied: true, fundings };
 }
 
-async function writeReplacementFundings({ tx, tableId, fundings, botFundingSystemKey, systemActorUserId }) {
+async function writeReplacementFundings({ tx, tableId, fundings, botFundingSystemKey }) {
   if (fundings.length === 0) {
     return [];
   }
   const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
-  const createdBy = typeof systemActorUserId === "string" ? systemActorUserId.trim() : "";
-  if (!sourceSystemKey || !UUID_RE.test(createdBy)) {
+  if (!sourceSystemKey) {
     const error = new Error("replacement_funding_config_invalid");
     error.code = "replacement_funding_config_invalid";
     throw error;
@@ -451,7 +449,7 @@ async function writeReplacementFundings({ tx, tableId, fundings, botFundingSyste
           metadata: { reason: "BOT_REPLACEMENT_BUY_IN", tableId, seatNo: funding.seatNo }
         }
       ],
-      createdBy,
+      createdBy: null,
       tx
     });
     const transactionId = typeof result?.transaction?.id === "string" ? result.transaction.id : "";
@@ -480,8 +478,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     privateStateForHoleCards = null,
     acceptedActionAudit = null,
     replacementFundingPlan,
-    botFundingSystemKey = null,
-    systemActorUserId = null
+    botFundingSystemKey = null
   }) {
     return beginSql(async (tx) => {
       const persistedState = sanitizePersistedState(nextState);
@@ -497,8 +494,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
           tx,
           tableId,
           fundings: replacementFundingPlan.fundings,
-          botFundingSystemKey,
-          systemActorUserId
+          botFundingSystemKey
         });
         await tx.unsafe("update public.poker_tables set last_activity_at = now() where id = $1;", [tableId]);
         try {
@@ -600,8 +596,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     meta = null,
     acceptedActionAudit = null,
     replacementFundings = undefined,
-    botFundingSystemKey = null,
-    systemActorUserId = null
+    botFundingSystemKey = null
   }) {
     if (!tableId || !Number.isInteger(expectedVersion) || expectedVersion < 0) {
       return { ok: false, reason: "invalid" };
@@ -624,8 +619,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     }
     if (replacementFundingPlan.fundings.length > 0) {
       const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
-      const createdBy = typeof systemActorUserId === "string" ? systemActorUserId.trim() : "";
-      if (!sourceSystemKey || !UUID_RE.test(createdBy)) {
+      if (!sourceSystemKey) {
         return { ok: false, reason: "replacement_funding_config_invalid" };
       }
     }
@@ -656,8 +650,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         privateStateForHoleCards: holeCardPrivateState,
         acceptedActionAudit,
         replacementFundingPlan,
-        botFundingSystemKey,
-        systemActorUserId
+        botFundingSystemKey
       });
     } catch (error) {
       klog("ws_persisted_state_write_error", {

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -1,10 +1,13 @@
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
+import { postTransaction } from "./chips-ledger.mjs";
 import { writePersistedTableToFile } from "./persisted-state-file-store.mjs";
 
 const HAND_SETTLED_ACTION_TYPE = "HAND_SETTLED";
 const SETTLEMENT_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAX_REPLACEMENT_FUNDINGS = 10;
 
 function normalizeJsonState(value) {
   if (!value) return {};
@@ -354,8 +357,132 @@ async function maybeWriteHoleCards({ tx, tableId, state, klog = () => {} }) {
   return { ok: true, playerCount: rows.length };
 }
 
+function normalizeReplacementFundings({ replacementFundings, tableId, expectedVersion }) {
+  if (replacementFundings === undefined) {
+    return { ok: true, supplied: false, fundings: [] };
+  }
+  if (!Array.isArray(replacementFundings) || replacementFundings.length > MAX_REPLACEMENT_FUNDINGS) {
+    return { ok: false, reason: "invalid_replacement_fundings" };
+  }
+  const seenSeats = new Set();
+  const fundings = [];
+  for (const value of replacementFundings) {
+    const seatNo = Number(value?.seatNo);
+    const oldStack = Number(value?.oldStack);
+    const targetStack = Number(value?.targetStack);
+    const fundingDelta = Number(value?.fundingDelta);
+    const fromStateVersion = Number(value?.fromStateVersion);
+    const toStateVersion = Number(value?.toStateVersion);
+    const oldBotUserId = typeof value?.oldBotUserId === "string" ? value.oldBotUserId.trim() : "";
+    const replacementBotUserId = typeof value?.replacementBotUserId === "string" ? value.replacementBotUserId.trim() : "";
+    const settledHandId = typeof value?.settledHandId === "string" ? value.settledHandId.trim() : "";
+    if (!Number.isInteger(seatNo) || seatNo < 1 || seatNo > MAX_REPLACEMENT_FUNDINGS || seenSeats.has(seatNo)
+      || !Number.isInteger(oldStack) || oldStack < 0
+      || !Number.isInteger(targetStack) || targetStack <= oldStack
+      || !Number.isInteger(fundingDelta) || fundingDelta !== targetStack - oldStack
+      || fromStateVersion !== expectedVersion || toStateVersion !== expectedVersion + 1
+      || !oldBotUserId || !replacementBotUserId || !settledHandId) {
+      return { ok: false, reason: "invalid_replacement_fundings" };
+    }
+    seenSeats.add(seatNo);
+    fundings.push({
+      seatNo,
+      oldBotUserId,
+      replacementBotUserId,
+      oldStack,
+      targetStack,
+      fundingDelta,
+      settledHandId,
+      fromStateVersion,
+      toStateVersion,
+      idempotencyKey: `poker:bot-replacement-buyin:v1:${tableId}:${toStateVersion}:${seatNo}`
+    });
+  }
+  fundings.sort((left, right) => left.seatNo - right.seatNo);
+  return { ok: true, supplied: true, fundings };
+}
+
+async function writeReplacementFundings({ tx, tableId, fundings, botFundingSystemKey, systemActorUserId }) {
+  if (fundings.length === 0) {
+    return [];
+  }
+  const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
+  const createdBy = typeof systemActorUserId === "string" ? systemActorUserId.trim() : "";
+  if (!sourceSystemKey || !UUID_RE.test(createdBy)) {
+    const error = new Error("replacement_funding_config_invalid");
+    error.code = "replacement_funding_config_invalid";
+    throw error;
+  }
+  const escrowSystemKey = `POKER_TABLE:${tableId}`;
+  const fundedReplacements = [];
+  for (const funding of fundings) {
+    const result = await postTransaction({
+      userId: null,
+      txType: "TABLE_BUY_IN",
+      idempotencyKey: funding.idempotencyKey,
+      reference: `BOT_REPLACEMENT_BUY_IN:${tableId}:${funding.toStateVersion}:${funding.seatNo}`,
+      description: "Poker bot replacement funding",
+      metadata: {
+        actor: "BOT",
+        reason: "BOT_REPLACEMENT_BUY_IN",
+        tableId,
+        seatNo: funding.seatNo,
+        oldBotUserId: funding.oldBotUserId,
+        replacementBotUserId: funding.replacementBotUserId,
+        settledHandId: funding.settledHandId,
+        fromStateVersion: funding.fromStateVersion,
+        toStateVersion: funding.toStateVersion,
+        oldStack: funding.oldStack,
+        targetStack: funding.targetStack,
+        fundingDelta: funding.fundingDelta,
+        sourceSystemKey
+      },
+      entries: [
+        {
+          accountType: "SYSTEM",
+          systemKey: sourceSystemKey,
+          amount: -funding.fundingDelta,
+          metadata: { reason: "BOT_REPLACEMENT_BUY_IN", tableId, seatNo: funding.seatNo }
+        },
+        {
+          accountType: "ESCROW",
+          systemKey: escrowSystemKey,
+          amount: funding.fundingDelta,
+          metadata: { reason: "BOT_REPLACEMENT_BUY_IN", tableId, seatNo: funding.seatNo }
+        }
+      ],
+      createdBy,
+      tx
+    });
+    const transactionId = typeof result?.transaction?.id === "string" ? result.transaction.id : "";
+    const payloadHash = typeof result?.transaction?.payload_hash === "string" ? result.transaction.payload_hash : "";
+    if (!transactionId || !payloadHash) {
+      const error = new Error("replacement_funding_receipt_invalid");
+      error.code = "replacement_funding_receipt_invalid";
+      throw error;
+    }
+    fundedReplacements.push({
+      seatNo: funding.seatNo,
+      idempotencyKey: funding.idempotencyKey,
+      fundingDelta: funding.fundingDelta,
+      transactionId,
+      payloadHash
+    });
+  }
+  return fundedReplacements;
+}
+
 export function createPersistedStateWriter({ env = process.env, beginSql = beginSqlWs, klog = () => {} } = {}) {
-  async function writeViaDb({ tableId, expectedVersion, nextState, privateStateForHoleCards = null, acceptedActionAudit = null }) {
+  async function writeViaDb({
+    tableId,
+    expectedVersion,
+    nextState,
+    privateStateForHoleCards = null,
+    acceptedActionAudit = null,
+    replacementFundingPlan,
+    botFundingSystemKey = null,
+    systemActorUserId = null
+  }) {
     return beginSql(async (tx) => {
       const persistedState = sanitizePersistedState(nextState);
       const holeCardState = normalizeJsonState(privateStateForHoleCards) || {};
@@ -366,6 +493,13 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
       );
       const newVersion = Number(rows?.[0]?.version);
       if (Number.isInteger(newVersion) && newVersion >= 0) {
+        const fundedReplacements = await writeReplacementFundings({
+          tx,
+          tableId,
+          fundings: replacementFundingPlan.fundings,
+          botFundingSystemKey,
+          systemActorUserId
+        });
         await tx.unsafe("update public.poker_tables set last_activity_at = now() where id = $1;", [tableId]);
         try {
           await maybeWriteHoleCards({ tx, tableId, state: holeCardState, klog });
@@ -399,7 +533,16 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
             reason: error?.message || "unknown"
           });
         }
-        return { ok: true, newVersion };
+        return {
+          ok: true,
+          newVersion,
+          ...(replacementFundingPlan.supplied ? {
+            tableId,
+            expectedVersion,
+            replacementFundingCommitted: true,
+            fundedReplacements
+          } : {})
+        };
       }
 
       const stateRows = await tx.unsafe("select version, state from public.poker_state where table_id = $1 limit 1;", [tableId]);
@@ -447,7 +590,19 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     }, { env });
   }
 
-  async function writeMutation({ tableId, expectedVersion, nextState, privateStateForHoleCards = null, supabaseUrl, supabaseServiceRoleKey, meta = null, acceptedActionAudit = null }) {
+  async function writeMutation({
+    tableId,
+    expectedVersion,
+    nextState,
+    privateStateForHoleCards = null,
+    supabaseUrl,
+    supabaseServiceRoleKey,
+    meta = null,
+    acceptedActionAudit = null,
+    replacementFundings = undefined,
+    botFundingSystemKey = null,
+    systemActorUserId = null
+  }) {
     if (!tableId || !Number.isInteger(expectedVersion) || expectedVersion < 0) {
       return { ok: false, reason: "invalid" };
     }
@@ -463,6 +618,17 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     } catch {
       return { ok: false, reason: "invalid" };
     }
+    const replacementFundingPlan = normalizeReplacementFundings({ replacementFundings, tableId, expectedVersion });
+    if (!replacementFundingPlan.ok) {
+      return { ok: false, reason: replacementFundingPlan.reason };
+    }
+    if (replacementFundingPlan.fundings.length > 0) {
+      const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
+      const createdBy = typeof systemActorUserId === "string" ? systemActorUserId.trim() : "";
+      if (!sourceSystemKey || !UUID_RE.test(createdBy)) {
+        return { ok: false, reason: "replacement_funding_config_invalid" };
+      }
+    }
 
     try {
       const forcedFailureKind = typeof env.WS_TEST_PERSIST_FAIL_KIND === "string" ? env.WS_TEST_PERSIST_FAIL_KIND.trim() : "";
@@ -470,6 +636,9 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         return { ok: false, reason: "conflict" };
       }
       if (env.WS_PERSISTED_STATE_FILE) {
+        if (replacementFundingPlan.fundings.length > 0) {
+          return { ok: false, reason: "ledger_unavailable" };
+        }
         return writePersistedTableToFile({
           filePath: env.WS_PERSISTED_STATE_FILE,
           tableId,
@@ -480,7 +649,16 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
       if (!env.SUPABASE_DB_URL && !supabaseUrl && !supabaseServiceRoleKey) {
         return { ok: false, reason: "config_missing" };
       }
-      return await writeViaDb({ tableId, expectedVersion, nextState: persistedState, privateStateForHoleCards: holeCardPrivateState, acceptedActionAudit });
+      return await writeViaDb({
+        tableId,
+        expectedVersion,
+        nextState: persistedState,
+        privateStateForHoleCards: holeCardPrivateState,
+        acceptedActionAudit,
+        replacementFundingPlan,
+        botFundingSystemKey,
+        systemActorUserId
+      });
     } catch (error) {
       klog("ws_persisted_state_write_error", {
         tableId,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -76,6 +76,45 @@ test("accepted bot autoplay executes and persists when bot is on turn", async ()
   assert.equal(calls.persistArgs.acceptedActionAudit.actorUserId, "bot_2");
 });
 
+test("accepted bot autoplay gives repeated same-street turns distinct version-scoped request ids", async () => {
+  const requestIds = [];
+  let persistedVersion = 117;
+  const state = {
+    version: 117,
+    tableId: "t-repeat-turn",
+    handId: "h-repeat-turn",
+    phase: "TURN",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => persistedVersion,
+    tableSnapshot: () => ({ seats: state.seats }),
+    applyAction: ({ requestId }) => {
+      requestIds.push(requestId);
+      persistedVersion += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: persistedVersion };
+    }
+  };
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  await run({ tableId: state.tableId, trigger: "act", requestId: "same-parent-request" });
+  await run({ tableId: state.tableId, trigger: "act", requestId: "same-parent-request" });
+
+  assert.equal(requestIds.length, 2);
+  assert.notEqual(requestIds[0], requestIds[1]);
+  assert.match(requestIds[0], /:v117:1$/);
+  assert.match(requestIds[1], /:v118:1$/);
+});
+
 test("accepted bot autoplay enriches legal bet with a positive amount", async () => {
   const observed = { action: null };
   const state = {

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -202,6 +202,83 @@ test("rolloverSettledHand delays next-hand bootstrap until explicitly invoked", 
   assert.equal(nextState.turnDeadlineAt > nextState.turnStartedAt, true);
 });
 
+test("persistent bot replacement commits runtime only with matching funding receipt", () => {
+  const tableManager = createTableManager({ maxSeats: 6, tableBootstrapLoader: async () => ({ ok: false }) });
+  const tableId = "00000000-0000-4000-8000-000000000705";
+  const humanUserId = "00000000-0000-4000-8000-0000000000a1";
+  const oldBotUserId = "00000000-0000-4000-8000-0000000000b2";
+  const restored = tableManager.restoreTableFromPersisted(tableId, {
+    coreState: {
+      version: 7,
+      roomId: tableId,
+      maxSeats: 6,
+      members: [{ userId: humanUserId, seat: 1 }, { userId: oldBotUserId, seat: 2 }],
+      seats: { [humanUserId]: 1, [oldBotUserId]: 2 },
+      publicStacks: { [humanUserId]: 199, [oldBotUserId]: 1 },
+      seatDetailsByUserId: {
+        [humanUserId]: { isBot: false, botProfile: null, leaveAfterHand: false },
+        [oldBotUserId]: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false }
+      },
+      pokerState: {
+        roomId: tableId,
+        handId: "hand_replacement_receipt",
+        phase: "SETTLED",
+        dealerSeatNo: 1,
+        seats: [{ userId: humanUserId, seatNo: 1, status: "ACTIVE" }, { userId: oldBotUserId, seatNo: 2, status: "ACTIVE" }],
+        stacks: { [humanUserId]: 199, [oldBotUserId]: 1 },
+        handSettlement: { handId: "hand_replacement_receipt", settledAt: "2026-07-14T00:00:00.000Z", payouts: {} }
+      }
+    },
+    presenceByUserId: new Map([
+      [humanUserId, { userId: humanUserId, seat: 1, connected: true, lastSeenAt: 1, expiresAt: null }],
+      [oldBotUserId, { userId: oldBotUserId, seat: 2, connected: false, lastSeenAt: 1, expiresAt: null }]
+    ])
+  });
+  assert.equal(restored.ok, true);
+  assert.equal(tableManager.join({
+    ws: fakeWs("ws-replacement-receipt"),
+    userId: humanUserId,
+    tableId,
+    requestId: "join-replacement-receipt",
+    nowTs: 1
+  }).ok, true);
+
+  const prepared = tableManager.prepareSettledHandRollover({ tableId, nowMs: 5_000 });
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.changed, true);
+  assert.equal(prepared.replacementFundings[0].fundingDelta, 99);
+  assert.equal(tableManager.persistedPokerState(tableId).phase, "SETTLED");
+
+  const unconfirmed = tableManager.commitSettledHandRollover({ ...prepared, tableId, nowMs: 5_000 });
+  assert.equal(unconfirmed.ok, false);
+  assert.equal(unconfirmed.reason, "replacement_funding_unconfirmed");
+  assert.equal(tableManager.persistedPokerState(tableId).phase, "SETTLED");
+
+  const funding = prepared.replacementFundings[0];
+  const committed = tableManager.commitSettledHandRollover({
+    ...prepared,
+    tableId,
+    persistenceReceipt: {
+      ok: true,
+      tableId,
+      expectedVersion: prepared.expectedVersion,
+      newVersion: prepared.stateVersion,
+      replacementFundingCommitted: true,
+      fundedReplacements: [{
+        seatNo: funding.seatNo,
+        fundingDelta: funding.fundingDelta,
+        idempotencyKey: `poker:bot-replacement-buyin:v1:${tableId}:${prepared.stateVersion}:${funding.seatNo}`,
+        transactionId: "tx-replacement-1",
+        payloadHash: "hash-replacement-1"
+      }]
+    },
+    nowMs: 5_000
+  });
+  assert.equal(committed.ok, true);
+  assert.equal(tableManager.persistedPokerState(tableId).phase, "PREFLOP");
+  assert.equal(tableManager.commitSettledHandRollover({ ...prepared, tableId }).reason, "runtime_version_conflict");
+});
+
 test("authenticated resubscribe restores seated human presence so a fold settlement rolls into the next hand", () => {
   const tableManager = createTableManager({ maxSeats: 6 });
   const tableId = "table_resubscribe_after_fold";

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -965,7 +965,62 @@ export function createTableManager({
     };
   }
 
-  function rolloverSettledHand({ tableId, nowMs = Date.now() } = {}) {
+  function normalizedReplacementFundingShape(value) {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value.map((entry) => ({
+      seatNo: entry?.seatNo,
+      oldBotUserId: entry?.oldBotUserId,
+      replacementBotUserId: entry?.replacementBotUserId,
+      oldStack: entry?.oldStack,
+      targetStack: entry?.targetStack,
+      fundingDelta: entry?.fundingDelta,
+      settledHandId: entry?.settledHandId,
+      fromStateVersion: entry?.fromStateVersion,
+      toStateVersion: entry?.toStateVersion
+    }));
+  }
+
+  function replacementFundingPlansEqual(left, right) {
+    return JSON.stringify(normalizedReplacementFundingShape(left)) === JSON.stringify(normalizedReplacementFundingShape(right));
+  }
+
+  function replacementFundingReceiptMatches({ tableId, expectedVersion, stateVersion, replacementFundings, persistenceReceipt }) {
+    if (!persistenceReceipt || persistenceReceipt.ok !== true) {
+      return false;
+    }
+    if (persistenceReceipt.tableId !== tableId
+      || persistenceReceipt.expectedVersion !== expectedVersion
+      || persistenceReceipt.newVersion !== stateVersion
+      || persistenceReceipt.replacementFundingCommitted !== true) {
+      return false;
+    }
+    const funded = Array.isArray(persistenceReceipt.fundedReplacements)
+      ? persistenceReceipt.fundedReplacements
+      : [];
+    if (funded.length !== replacementFundings.length) {
+      return false;
+    }
+    return replacementFundings.every((entry, index) => {
+      const receiptEntry = funded[index];
+      const expectedKey = `poker:bot-replacement-buyin:v1:${tableId}:${stateVersion}:${entry.seatNo}`;
+      return receiptEntry?.seatNo === entry.seatNo
+        && receiptEntry?.idempotencyKey === expectedKey
+        && receiptEntry?.fundingDelta === entry.fundingDelta
+        && typeof receiptEntry?.transactionId === "string"
+        && receiptEntry.transactionId.length > 0
+        && typeof receiptEntry?.payloadHash === "string"
+        && receiptEntry.payloadHash.length > 0;
+    });
+  }
+
+  function isEconomyFreeRollover({ tableId, economyMode }) {
+    return typeof tableBootstrapLoader !== "function"
+      || (economyMode === "none" && typeof tableId === "string" && tableId.startsWith("guest_table_"));
+  }
+
+  function prepareSettledHandRollover({ tableId, nowMs = Date.now() } = {}) {
     const table = tables.get(tableId);
     if (!table) {
       return { ok: false, changed: false, reason: "table_not_found", stateVersion: 0 };
@@ -985,6 +1040,14 @@ export function createTableManager({
       settledState,
       nextVersion
     });
+    if (!recycled?.ok) {
+      return {
+        ok: false,
+        changed: false,
+        reason: recycled?.reason || "bot_replacement_invalid",
+        stateVersion: table.coreState.version
+      };
+    }
     if (!hasHandEligibleHumanMember({ table, coreState: recycled.coreState, nowMs })) {
       return {
         ok: true,
@@ -1009,20 +1072,100 @@ export function createTableManager({
       };
     }
 
-    table.coreState = {
+    const nextCoreState = {
       ...recycled.coreState,
       version: nextVersion,
       pokerState: stampTurnDeadline(nextHandState, resolveNowMs({ nowMs }))
     };
-    touchTableActivity(table, nowMs);
 
     return {
       ok: true,
       changed: true,
       reason: null,
-      stateVersion: table.coreState.version,
-      handId: table.coreState?.pokerState?.handId ?? null
+      expectedVersion: Number(table.coreState.version),
+      stateVersion: nextVersion,
+      nextCoreState,
+      handId: nextCoreState?.pokerState?.handId ?? null,
+      replacementFundings: normalizedReplacementFundingShape(recycled.replacementFundings)
     };
+  }
+
+  function commitSettledHandRollover({
+    tableId,
+    expectedVersion,
+    nextCoreState,
+    replacementFundings = [],
+    persistenceReceipt = null,
+    economyMode = null,
+    nowMs = Date.now()
+  } = {}) {
+    const table = tables.get(tableId);
+    if (!table) {
+      return { ok: false, changed: false, reason: "table_not_found", stateVersion: 0 };
+    }
+    const currentVersion = Number(table.coreState?.version);
+    const nextVersion = Number(nextCoreState?.version);
+    if (!Number.isInteger(expectedVersion)
+      || currentVersion !== expectedVersion
+      || nextVersion !== expectedVersion + 1
+      || table.coreState?.pokerState?.phase !== "SETTLED") {
+      return { ok: false, changed: false, reason: "runtime_version_conflict", stateVersion: currentVersion };
+    }
+
+    const recalculated = replaceBrokeBotsForNextHand({
+      coreState: table.coreState,
+      settledState: table.coreState.pokerState,
+      nextVersion
+    });
+    if (!recalculated?.ok || !replacementFundingPlansEqual(recalculated.replacementFundings, replacementFundings)) {
+      return { ok: false, changed: false, reason: "replacement_funding_mismatch", stateVersion: currentVersion };
+    }
+
+    const normalizedFundings = normalizedReplacementFundingShape(replacementFundings);
+    const economyFree = isEconomyFreeRollover({ tableId, economyMode });
+    if (normalizedFundings.length > 0 && !economyFree && !replacementFundingReceiptMatches({
+      tableId,
+      expectedVersion,
+      stateVersion: nextVersion,
+      replacementFundings: normalizedFundings,
+      persistenceReceipt
+    })) {
+      return { ok: false, changed: false, reason: "replacement_funding_unconfirmed", stateVersion: currentVersion };
+    }
+
+    table.coreState = nextCoreState;
+    touchTableActivity(table, nowMs);
+    return {
+      ok: true,
+      changed: true,
+      reason: null,
+      stateVersion: nextVersion,
+      handId: nextCoreState?.pokerState?.handId ?? null,
+      replacementFundings: normalizedFundings
+    };
+  }
+
+  function rolloverSettledHand({ tableId, nowMs = Date.now(), economyMode = null } = {}) {
+    const prepared = prepareSettledHandRollover({ tableId, nowMs });
+    if (!prepared?.ok || !prepared.changed) {
+      return prepared;
+    }
+    const hasFunding = prepared.replacementFundings.length > 0;
+    const economyFree = isEconomyFreeRollover({ tableId, economyMode });
+    if (hasFunding && !economyFree) {
+      return {
+        ok: false,
+        changed: false,
+        reason: "replacement_funding_required",
+        stateVersion: prepared.expectedVersion
+      };
+    }
+    return commitSettledHandRollover({
+      ...prepared,
+      tableId,
+      economyMode,
+      nowMs
+    });
   }
 
   function sweepTurnTimeouts({ nowMs = Date.now(), shouldProcessTable = null } = {}) {
@@ -1944,6 +2087,8 @@ export function createTableManager({
     tableSnapshot,
     bootstrapHand,
     applyAction,
+    prepareSettledHandRollover,
+    commitSettledHandRollover,
     rolloverSettledHand,
     maybeApplyTurnTimeout,
     sweepTurnTimeouts,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -29,7 +29,7 @@ import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
-import { parseStakes } from "./shared/poker-domain/bots.mjs";
+import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -60,6 +60,8 @@ const LIVE_HAND_PHASES = new Set(["POSTING_BLINDS", "PREFLOP", "FLOP", "TURN", "
 const DEFAULT_EMPTY_JOINABLE_GRACE_MS = 60_000;
 const DEFAULT_SEATED_RECONNECT_GRACE_MS = 90_000;
 const DEFAULT_ACTIVE_SEAT_FRESH_MS = 120_000;
+const FAST_SETTLED_ROLLOVER_RETRY_DELAYS_MS = [1_000, 5_000, 15_000, 30_000];
+const SLOW_SETTLED_ROLLOVER_RETRY_MS = 60_000;
 
 function resolvePresenceTtlMs(rawValue) {
   const parsed = Number(rawValue);
@@ -249,6 +251,10 @@ const persistedSeatTouchThrottleMs = resolvePositiveInt(
 const streamLog = createStreamLog({ cap: Number(process.env.WS_STREAM_REPLAY_CAP || 128) });
 const tableSnapshotLoader = createTableSnapshotLoader({ env: process.env });
 const persistedStateWriter = persistedStateWriteEnabled ? createPersistedStateWriter({ env: process.env, klog: klogSafe }) : null;
+const botFundingSystemKey = getBotConfig(process.env).bankrollSystemKey;
+const pokerSystemActorUserId = typeof process.env.POKER_SYSTEM_ACTOR_USER_ID === "string"
+  ? process.env.POKER_SYSTEM_ACTOR_USER_ID.trim()
+  : "";
 const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
 const lobbySubscribers = new Set();
@@ -1143,20 +1149,34 @@ function broadcastTableState(tableId, { excludeWs = null } = {}) {
 
 
 
-async function persistMutatedState({ tableId, expectedVersion, mutationKind, acceptedActionAudit = null }) {
+async function persistMutatedState({
+  tableId,
+  expectedVersion,
+  mutationKind,
+  acceptedActionAudit = null,
+  nextStateOverride = null,
+  privateStateForHoleCardsOverride = null,
+  replacementFundings = undefined,
+  replacementFundingSystemKey = null,
+  replacementFundingActorUserId = null,
+  deferRuntimeVersionUpdate = false
+}) {
   if (isGuestTableId(tableId)) {
     return { ok: true, skipped: true, guest: true };
   }
   if (!persistedStateWriter) {
+    if (Array.isArray(replacementFundings) && replacementFundings.length > 0) {
+      return { ok: false, reason: "persistence_required" };
+    }
     return { ok: true, skipped: true };
   }
-  const nextState = tableManager.persistedPokerState(tableId);
+  const nextState = nextStateOverride || tableManager.persistedPokerState(tableId);
   if (!nextState) {
     return { ok: false, reason: "invalid_state" };
   }
-  const privateStateForHoleCards = typeof tableManager.privatePokerStateForAudit === "function"
+  const privateStateForHoleCards = privateStateForHoleCardsOverride || (typeof tableManager.privatePokerStateForAudit === "function"
     ? tableManager.privatePokerStateForAudit(tableId)
-    : nextState;
+    : nextState);
   klogSafe("ws_state_persist_start", { tableId, expectedVersion, mutationKind });
   const persisted = await persistedStateWriter.writeMutation({
     tableId,
@@ -1166,14 +1186,19 @@ async function persistMutatedState({ tableId, expectedVersion, mutationKind, acc
     supabaseUrl: process.env.SUPABASE_URL,
     supabaseServiceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
     meta: { mutationKind },
-    acceptedActionAudit
+    acceptedActionAudit,
+    replacementFundings,
+    botFundingSystemKey: replacementFundingSystemKey,
+    systemActorUserId: replacementFundingActorUserId
   });
   if (!persisted?.ok) {
     klogSafe("ws_state_persist_failed", { tableId, expectedVersion, mutationKind, reason: persisted?.reason || "unknown" });
     return persisted;
   }
   klogSafe("ws_state_persist_result", { ok: true, newVersion: persisted.newVersion ?? null });
-  tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
+  if (!deferRuntimeVersionUpdate) {
+    tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
+  }
   return persisted;
 }
 
@@ -1197,6 +1222,7 @@ async function restoreTableFromPersisted(tableId) {
     if (!applied?.ok) {
       return applied;
     }
+    maybeScheduleSettledRollover(tableId);
     return {
       ...applied,
       restoredTable: restored.table
@@ -1472,6 +1498,166 @@ const tableJanitorPrimitives = {
   inactive_cleanup: executeInactiveCleanupPrimitive
 };
 
+function settledRolloverGenerationKey(tableId, pokerState = tableManager.persistedPokerState(tableId)) {
+  if (!pokerState || pokerState.phase !== "SETTLED") {
+    return null;
+  }
+  const version = tableManager.persistedStateVersion(tableId);
+  const handId = typeof pokerState.handId === "string" && pokerState.handId.trim()
+    ? pokerState.handId.trim()
+    : "unknown";
+  return `${tableId}:${Number.isInteger(version) ? version : "unknown"}:${handId}`;
+}
+
+function scheduleSettledRolloverTimer({ tableId, generationKey, dueAt, attempt = 0, mode = "reveal" }) {
+  clearSettledRolloverTimer(tableId);
+  const nowMs = Date.now();
+  const delayMs = Math.max(0, dueAt - nowMs);
+  klogSafe("ws_settled_rollover_scheduled", { tableId, dueAt, delayMs, attempt, mode });
+  const timer = setTimeout(() => {
+    settledRolloverTimerByTableId.delete(tableId);
+    void enqueueTableCommand({
+      tableId,
+      commandName: "settled_rollover",
+      dedupeKey: "settled_rollover",
+      run: () => runSettledRolloverCommand({ tableId, generationKey, attempt })
+    });
+  }, delayMs);
+  if (typeof timer?.unref === "function") {
+    timer.unref();
+  }
+  settledRolloverTimerByTableId.set(tableId, { timer, dueAt, generationKey, attempt, mode });
+}
+
+function scheduleSettledRolloverRetry({ tableId, generationKey, attempt }) {
+  const pokerState = tableManager.persistedPokerState(tableId);
+  if (settledRolloverGenerationKey(tableId, pokerState) !== generationKey) {
+    return;
+  }
+  const fastDelay = FAST_SETTLED_ROLLOVER_RETRY_DELAYS_MS[attempt - 1];
+  const delayMs = Number.isFinite(fastDelay) ? fastDelay : SLOW_SETTLED_ROLLOVER_RETRY_MS;
+  scheduleSettledRolloverTimer({
+    tableId,
+    generationKey,
+    dueAt: Date.now() + delayMs,
+    attempt,
+    mode: Number.isFinite(fastDelay) ? "fast_retry" : "slow_retry"
+  });
+}
+
+async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }) {
+  const pokerState = tableManager.persistedPokerState(tableId);
+  if (settledRolloverGenerationKey(tableId, pokerState) !== generationKey) {
+    return { ok: true, changed: false, reason: "settled_generation_changed" };
+  }
+  klogSafe("ws_settled_rollover_start", { tableId, attempt });
+  if (!tableManager.hasActiveHumanMember(tableId)) {
+    if (tableManager.hasConnectedHumanPresence(tableId)) {
+      klogSafe("ws_settled_rollover_close_skipped_human_presence", { tableId, phase: pokerState?.phase || null });
+      return { ok: true, changed: false, deferred: true, reason: "human_presence_present" };
+    }
+    return applyInactiveCleanupAndBroadcast({
+      tableId,
+      requestId: `ws-settled-rollover-close:${tableId}`,
+      logPrefix: "ws_settled_rollover_close"
+    });
+  }
+
+  if (isGuestTableId(tableId)) {
+    const guestRollover = tableManager.rolloverSettledHand({ tableId, nowMs: Date.now(), economyMode: "none" });
+    if (!guestRollover?.ok || !guestRollover.changed) {
+      return guestRollover;
+    }
+    broadcastStateSnapshots(tableId);
+    try {
+      scheduleBotStep({ tableId, trigger: "settled_rollover", requestId: null, frameTs: null });
+    } catch (error) {
+      klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
+    }
+    return guestRollover;
+  }
+
+  const prepared = tableManager.prepareSettledHandRollover({ tableId, nowMs: Date.now() });
+  if (!prepared?.ok || !prepared.changed) {
+    klogSafe("ws_settled_rollover_noop", { tableId, reason: prepared?.reason || "unchanged" });
+    return prepared;
+  }
+
+  const candidatePokerState = prepared.nextCoreState?.pokerState;
+  const persisted = await persistMutatedState({
+    tableId,
+    expectedVersion: prepared.expectedVersion,
+    mutationKind: "settled_rollover",
+    nextStateOverride: candidatePokerState,
+    privateStateForHoleCardsOverride: candidatePokerState,
+    replacementFundings: prepared.replacementFundings,
+    replacementFundingSystemKey: botFundingSystemKey,
+    replacementFundingActorUserId: pokerSystemActorUserId,
+    deferRuntimeVersionUpdate: true
+  });
+  if (!persisted?.ok || persisted.alreadyApplied) {
+    if (!persisted?.alreadyApplied) {
+      klogSafe("ws_settled_rollover_persist_failed", {
+        tableId,
+        reason: persisted?.reason || "persist_failed",
+        stateVersion: prepared.stateVersion,
+        replacementCount: prepared.replacementFundings.length,
+        totalFundingDelta: prepared.replacementFundings.reduce((sum, entry) => sum + entry.fundingDelta, 0)
+      });
+    }
+    await recoverFromPersistConflict({
+      tableId,
+      restoreTableFromPersisted,
+      broadcastStateSnapshots,
+      broadcastResyncRequired
+    });
+    if (persisted?.alreadyApplied) {
+      try {
+        scheduleBotStep({ tableId, trigger: "settled_rollover_restore", requestId: null, frameTs: null });
+      } catch (error) {
+        klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
+      }
+    }
+    if (!persisted?.alreadyApplied) {
+      scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
+    }
+    return {
+      ok: Boolean(persisted?.alreadyApplied),
+      changed: false,
+      reason: persisted?.alreadyApplied ? "already_applied_restored" : (persisted?.reason || "persist_failed"),
+      stateVersion: prepared.stateVersion
+    };
+  }
+
+  const rollover = tableManager.commitSettledHandRollover({
+    tableId,
+    expectedVersion: prepared.expectedVersion,
+    nextCoreState: prepared.nextCoreState,
+    replacementFundings: prepared.replacementFundings,
+    persistenceReceipt: persisted,
+    nowMs: Date.now()
+  });
+  if (!rollover?.ok) {
+    await restoreTableFromPersisted(tableId);
+    broadcastStateSnapshots(tableId);
+    try {
+      scheduleBotStep({ tableId, trigger: "settled_rollover_commit_restore", requestId: null, frameTs: null });
+    } catch (error) {
+      klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
+    }
+    return rollover;
+  }
+
+  tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
+  broadcastStateSnapshots(tableId);
+  try {
+    scheduleBotStep({ tableId, trigger: "settled_rollover", requestId: null, frameTs: null });
+  } catch (error) {
+    klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
+  }
+  return rollover;
+}
+
 function maybeScheduleSettledRollover(tableId) {
   const pokerState = tableManager.persistedPokerState(tableId);
   if (!pokerState || pokerState.phase !== "SETTLED") {
@@ -1485,104 +1671,12 @@ function maybeScheduleSettledRollover(tableId) {
     nowMs,
     revealMs: settledRevealMs
   });
+  const generationKey = settledRolloverGenerationKey(tableId, pokerState);
   const existing = settledRolloverTimerByTableId.get(tableId);
-  if (existing && existing.dueAt === dueAt) {
+  if (existing && existing.generationKey === generationKey) {
     return;
   }
-
-  clearSettledRolloverTimer(tableId);
-  const delayMs = Math.max(0, dueAt - nowMs);
-  klogSafe("ws_settled_rollover_scheduled", {
-    tableId,
-    dueAt,
-    delayMs,
-    settledAt: pokerState?.handSettlement?.settledAt || null
-  });
-  const timer = setTimeout(() => {
-    settledRolloverTimerByTableId.delete(tableId);
-    void enqueueTableCommand({
-      tableId,
-      commandName: "settled_rollover",
-      dedupeKey: "settled_rollover",
-      run: async () => {
-        klogSafe("ws_settled_rollover_start", { tableId });
-        if (!tableManager.hasActiveHumanMember(tableId)) {
-          if (tableManager.hasConnectedHumanPresence(tableId)) {
-            klogSafe("ws_settled_rollover_close_skipped_human_presence", {
-              tableId,
-              phase: pokerState?.phase || null
-            });
-            return {
-              ok: true,
-              changed: false,
-              deferred: true,
-              reason: "human_presence_present"
-            };
-          }
-          return applyInactiveCleanupAndBroadcast({
-            tableId,
-            requestId: `ws-settled-rollover-close:${tableId}`,
-            logPrefix: "ws_settled_rollover_close"
-          });
-        }
-        const rollover = tableManager.rolloverSettledHand({ tableId, nowMs: Date.now() });
-        if (!rollover?.ok) {
-          klogSafe("ws_settled_rollover_failed", {
-            tableId,
-            reason: rollover?.reason || rollover?.code || "unknown"
-          });
-          return rollover;
-        }
-        if (!rollover.changed) {
-          klogSafe("ws_settled_rollover_noop", {
-            tableId,
-            reason: rollover?.reason || rollover?.code || "unchanged"
-          });
-          return rollover;
-        }
-
-        const persisted = await persistMutatedState({
-          tableId,
-          expectedVersion: Number(rollover.stateVersion) - 1,
-          mutationKind: "settled_rollover"
-        });
-        if (!persisted?.ok) {
-          await recoverFromPersistConflict({
-            tableId,
-            restoreTableFromPersisted,
-            broadcastStateSnapshots,
-            broadcastResyncRequired
-          });
-          return {
-            ok: false,
-            changed: false,
-            reason: persisted?.reason || "persist_failed",
-            stateVersion: rollover.stateVersion
-          };
-        }
-
-        broadcastStateSnapshots(tableId);
-        try {
-          scheduleBotStep({
-            tableId,
-            trigger: "settled_rollover",
-            requestId: null,
-            frameTs: null
-          });
-        } catch (error) {
-          klogSafe("ws_settled_rollover_bot_autoplay_failed", {
-            tableId,
-            message: error?.message || "unknown"
-          });
-        }
-        return rollover;
-      }
-    });
-  }, delayMs);
-  if (typeof timer?.unref === "function") {
-    timer.unref();
-  }
-  settledRolloverTimerByTableId.set(tableId, { timer, dueAt });
+  scheduleSettledRolloverTimer({ tableId, generationKey, dueAt });
 }
 
 function isSettledRevealPendingForState(pokerState, nowMs = Date.now()) {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -252,9 +252,6 @@ const streamLog = createStreamLog({ cap: Number(process.env.WS_STREAM_REPLAY_CAP
 const tableSnapshotLoader = createTableSnapshotLoader({ env: process.env });
 const persistedStateWriter = persistedStateWriteEnabled ? createPersistedStateWriter({ env: process.env, klog: klogSafe }) : null;
 const botFundingSystemKey = getBotConfig(process.env).bankrollSystemKey;
-const pokerSystemActorUserId = typeof process.env.POKER_SYSTEM_ACTOR_USER_ID === "string"
-  ? process.env.POKER_SYSTEM_ACTOR_USER_ID.trim()
-  : "";
 const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
 const lobbySubscribers = new Set();
@@ -1158,7 +1155,6 @@ async function persistMutatedState({
   privateStateForHoleCardsOverride = null,
   replacementFundings = undefined,
   replacementFundingSystemKey = null,
-  replacementFundingActorUserId = null,
   deferRuntimeVersionUpdate = false
 }) {
   if (isGuestTableId(tableId)) {
@@ -1188,8 +1184,7 @@ async function persistMutatedState({
     meta: { mutationKind },
     acceptedActionAudit,
     replacementFundings,
-    botFundingSystemKey: replacementFundingSystemKey,
-    systemActorUserId: replacementFundingActorUserId
+    botFundingSystemKey: replacementFundingSystemKey
   });
   if (!persisted?.ok) {
     klogSafe("ws_state_persist_failed", { tableId, expectedVersion, mutationKind, reason: persisted?.reason || "unknown" });
@@ -1592,7 +1587,6 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     privateStateForHoleCardsOverride: candidatePokerState,
     replacementFundings: prepared.replacementFundings,
     replacementFundingSystemKey: botFundingSystemKey,
-    replacementFundingActorUserId: pokerSystemActorUserId,
     deferRuntimeVersionUpdate: true
   });
   if (!persisted?.ok || persisted.alreadyApplied) {

--- a/ws-server/shared/poker-domain/bots.mjs
+++ b/ws-server/shared/poker-domain/bots.mjs
@@ -1,1 +1,1 @@
-export { makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";
+export { getBotConfig, makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";

--- a/ws-tests/ws-ws-dependency.guard.test.mjs
+++ b/ws-tests/ws-ws-dependency.guard.test.mjs
@@ -312,7 +312,7 @@ test("ws-local poker autoplay wrapper is the only allowed bridge to repo-root sh
 test("ws-local bots wrapper is the only allowed bridge to repo-root shared bots module", () => {
   const wrapperFile = "ws-server/shared/poker-domain/bots.mjs";
   const wrapperText = fs.readFileSync(wrapperFile, "utf8");
-  assert.match(wrapperText, /export\s*\{\s*makeBotUserId,\s*parseStakes\s*\}\s*from\s*["']\.\.\/\.\.\/\.\.\/shared\/poker-domain\/bots\.mjs["']/);
+  assert.match(wrapperText, /export\s*\{\s*getBotConfig,\s*makeBotUserId,\s*parseStakes\s*\}\s*from\s*["']\.\.\/\.\.\/\.\.\/shared\/poker-domain\/bots\.mjs["']/);
 
   const wsFiles = fs.readdirSync("ws-server", { recursive: true })
     .filter((entry) => typeof entry === "string" && entry.endsWith(".mjs"))


### PR DESCRIPTION
## Summary

- calculates replacement funding as `targetStack - oldStack` and preserves the old bot residual
- splits settled rollover into prepare, atomic persist/fund, and receipt-gated runtime commit
- posts one idempotent `TABLE_BUY_IN` per replacement from the existing configured SYSTEM source (default `TREASURY`) to table ESCROW in the same transaction as the state CAS
- records automatic replacement funding with `created_by = NULL` plus closed bot/replacement metadata, without requiring a new human actor ENV
- stores replacement transaction metadata as a queryable JSONB object for reconciliation
- keeps guest/in-memory rollover economy-free while preventing persistent callers from bypassing funding
- retries failed settled rollover with bounded fast backoff and then one slow retry per minute
- scopes bot autoplay request IDs by authoritative state version so a bot can legally act more than once in one betting street
- adds focused unit and transactional integration coverage for the critical accounting and replay invariants

## Root cause

A broke bot was replaced with a stack of 100 directly in runtime state. The persisted-state writer then saved that state without a corresponding ledger transfer, creating an unbacked table escrow liability.

Preview verification exposed three follow-up regressions:

- replacement funding incorrectly required `POKER_SYSTEM_ACTOR_USER_ID`, which is not part of #705's runtime contract. Three replacements totaling 300 CH repeatedly failed with `replacement_funding_config_invalid`, leaving the hand safely but indefinitely in `SETTLED`;
- bot request IDs used only parent request, hand, phase, actor, and step. When the same bot acted again in the same street after a raise, the manager treated the new legal action as an old replay; timeout safety was the only path that resumed play;
- WS ledger metadata was serialized to a string before a direct `$3::jsonb` cast. postgres.js encoded that string again, so PostgreSQL stored a JSONB scalar string instead of an object. The insert now binds it as text and parses it once with `($3::text)::jsonb`.

## Accounting contract

- funding delta is exactly `100 - oldStack`
- state CAS and all replacement ledger entries commit or roll back together
- idempotency key is `poker:bot-replacement-buyin:v1:<tableId>:<toStateVersion>:<seatNo>`
- runtime state changes only after a matching persistence/funding receipt
- restart or replay cannot post a second funding transaction
- escrow success invariant is `escrowAfter === escrowBefore + sum(fundingDelta)`
- automatic SYSTEM-to-ESCROW funding has no human creator; bot identity, table, seat, versions, stacks, and reason remain in queryable JSONB metadata

## Scope and impact

- no database migration
- no new ENV or account
- no production-data mutation
- current bot funding source remains unchanged and defaults to `TREASURY`
- no WS payload, browser UI, CSS, CSP, or JSP change
- bot autoplay request IDs change additively to include `v<stateVersion>`; retry of the same authoritative version remains idempotent
- terminal bot cash-out remains #706; reconciliation remains #707
- file-store persistence fails closed for replacement funding because it cannot provide atomic ledger semantics
- existing preview rows whose metadata is already a JSONB string are intentionally not rewritten; new rows use object metadata after WS deployment

## Validation

- `npm test`
- focused engine, table-manager, persisted-state-writer, and accepted-bot-autoplay suites
- regression proving replacement funding succeeds without a configured human actor and stores `created_by = NULL`
- regression proving transaction metadata uses the text-to-JSONB boundary and remains queryable as an object
- regression proving repeated same-street bot turns receive distinct version-scoped request IDs
- syntax check and `git diff --check`
- persisted-state-writer suite registered in local, PR, and WS deploy workflows

## Manual stage verification

This changes the authoritative WS runtime. Run the manual WS preview deploy before stage acceptance; a Netlify deploy preview alone is not sufficient. Verify:

1. a bot can act again in the same street after another player raises without waiting for timeout safety;
2. a settled hand that replaces broke bots starts the next hand automatically;
3. table escrow rises by exactly the sum of funded replacement deltas;
4. a new replacement transaction satisfies `jsonb_typeof(metadata) = 'object'` and `metadata->>'reason' = 'BOT_REPLACEMENT_BUY_IN'`.

Closes #705.