### PR TITLE
fix: present poker settlement per pot

### DIFF
--- a/docs/poker-per-pot-settlement-ui-plan.md
+++ b/docs/poker-per-pot-settlement-ui-plan.md
@@ -66,6 +66,15 @@ This is the root cause of the misleading production result. The authoritative st
 
 `poker/poker.js` contains older `buildShowdownWinnerPayoutMap()` and `renderShowdownPanel()` helpers, but they are not a correct reusable settlement model: they aggregate payouts by the same winner union and label entries only as `Pot #N`. That file powers the lobby page rather than `table-v2.html`. Do not copy its lossy classification into v2 or expand this fix into dead/legacy table UI. The new pure projector may replace that older logic in separate cleanup only if the lobby later presents live settlements again.
 
+### Partial patch transport is not materialized
+
+- `poker/poker-ws-client.js::normalizeSnapshot()` passes `table_state`, `stateSnapshot`, and `statePatch` payloads to `poker-v2.js` without merging them into a client-side full snapshot.
+- `ws-server/server.mjs::sendStateDelta()` builds a real partial `statePatch`; an unrelated clock, presence, action, or legal-action patch may omit `showdown` and `handSettlement` entirely.
+- The current `poker-v2.js::mergeSnapshot()` conditionally merges most hand fields but unconditionally assigns normalized showdown and settlement values. An omitted settlement field therefore currently looks the same as an explicit clear and can erase a visible reveal.
+- `onSnapshot()` currently passes only `snapshot.payload` into `mergeSnapshot()`, so the merge layer also loses whether the payload was a full `stateSnapshot`, partial `statePatch`, or initial `table_state`.
+
+PR 1 must correct this merge contract as part of the settlement fix. Otherwise correct award rows could disappear or flicker after an ordinary partial patch.
+
 ## Architecture decision
 
 Implement correctness and animation in two PRs.
@@ -86,7 +95,9 @@ Separating the PRs prevents animation sequencing, timing, and motion preferences
 
 ### Small pure projection helper
 
-Add `poker/poker-settlement-presentation.js` as a JSP-compatible, dependency-free external script loaded before `poker-v2.js`. It exposes one narrow browser namespace, `window.ArcadePokerSettlement`, containing deterministic normalization/projection functions. This keeps accounting-display logic testable without a DOM and avoids a framework or build step.
+Keep the deterministic settlement normalizers and projector inside the existing `poker/poker-v2.js` IIFE. Do not add a second runtime script, browser-global production namespace, HTML dependency, or loading-order/cache boundary.
+
+For focused unit tests, follow the existing guarded poker test-hook pattern from `poker/poker.js`: expose only the pure functions through `window.__POKER_V2_TEST_HOOKS__` when `window.__RUNNING_POKER_UI_TESTS__ === true`. The guard is false in production, so the test surface is unavailable during normal gameplay.
 
 The primary function is `buildSettlementPresentation({ showdown, handSettlement })`. Its closed result is:
 
@@ -128,6 +139,8 @@ For a split pot, reuse the existing server rule exactly: integer floor share, th
 
 If validation fails, stacks remain authoritative and gameplay remains usable. The UI shows a neutral localized `Settlement complete` state without guessed amounts, generic multi-user `Winner` badges, or payout animation. Existing safe client logging may emit one aggregated `klog` event with only the controlled failure reason; never use `console.log` or include cards, email, token, raw payload, or user IDs.
 
+The failure is scoped only to award presentation. Invalid, incomplete, or legacy award data must not clear `revealedShowdownParticipants`, community cards, the viewer's hole cards, or the independently calculated best-hand name/cards. A legacy snapshot with one `showdown.winners` entry but no complete `potsAwarded` may still show the revealed cards and hand summary; it must not invent a pot label, amount, return, or payout animation.
+
 ### Main pot, side pot, and return classification
 
 Use the server order; do not sort pots in the browser.
@@ -151,21 +164,6 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 
 ## PR 1 — exact files and changes
 
-### `poker/poker-settlement-presentation.js` — new pure helper
-
-- add closed normalizers for IDs, chip amounts, per-pot entries, and `handSettlement.payouts`;
-- add `allocatePotRecipients(amount, orderedWinnerIds)` using the existing server split/remainder rule;
-- add `classifyPot({ reason, potIndex, eligibleUserIds, winners, sidePotNumber })` with the main/side/return rules above;
-- add `buildSettlementPresentation({ showdown, handSettlement })` and construct `pots` plus `byUserId` in server order;
-- expose only the functions required by `poker-v2.js` and focused unit tests through `window.ArcadePokerSettlement`;
-- use function/`var` syntax compatible with the current non-module poker page and JSP delivery; do not rely on bundlers or Node-only APIs.
-
-### `poker/table-v2.html`
-
-- load `/poker/poker-settlement-presentation.js` with `defer` immediately before `/poker/poker-v2.js`, preserving deterministic deferred-script order;
-- add one hidden settlement summary inside `.poker-center-layer`, with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"`;
-- keep all behavior in external scripts; add no inline JavaScript.
-
 ### `js/i18n.js`
 
 - add PL/EN keys for `Main pot`, `Side pot {number}`, `Returned`, `Settlement complete`, and the settlement summary accessible label;
@@ -175,21 +173,40 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 
 ### `poker/poker-v2.js`
 
+- add closed pure normalizers for IDs, chip amounts, per-pot entries, and `handSettlement.payouts` inside the existing IIFE;
+- add pure `allocatePotRecipients(amount, orderedWinnerIds)` using the existing server split/remainder rule;
+- add pure `classifyPot({ reason, potIndex, eligibleUserIds, winners, sidePotNumber })` with the main/side/return rules above;
+- add pure `buildSettlementPresentation({ showdown, handSettlement })` and construct `pots` plus `byUserId` in server order;
+- expose those pure functions only under the existing explicit test flag through `window.__POKER_V2_TEST_HOOKS__`; add no production global API;
 - extend `normalizeShowdown()` to preserve normalized `potsAwarded` and `potAwardedTotal` instead of dropping them;
 - extend `normalizeHandSettlement()` to preserve normalized `payouts`;
-- add `state.settlementPresentation` or derive it once in `mergeSnapshot()` through `ArcadePokerSettlement.buildSettlementPresentation()` when phase is `SETTLED`;
-- detect a missing/invalid `window.ArcadePokerSettlement` helper and fall back to the neutral state instead of throwing during snapshot handling;
+- add `state.settlementPresentation` and derive it through the local `buildSettlementPresentation()` only when a complete authoritative settlement is available;
 - replace `stickyWinnerReveal.winners` with a cloned immutable `settlementPresentation`; retain revealed cards and community cards;
 - add `lastPresentedSettlementHandId` so duplicate/replayed snapshots for the same hand cannot restart or extend an expired reveal window;
 - calculate the local reveal deadline from `handSettlement.settledAt + WINNER_REVEAL_MS`, falling back to receipt time only when the server timestamp is absent; never reset the deadline for the same hand;
 - replace `getDisplayWinnerUserIds()`/`isWinnerSeat()` with `getDisplaySettlementPresentation()` and `getSeatSettlementAwards(userId)` for labels and amounts;
 - retain a separate helper for which compared hands/cards are revealed; award recipients and revealed showdown participants are different concepts;
 - add `renderSettlementSummary()` and call it from `render()`;
+- let `renderSettlementSummary()` create and reuse one semantic DOM container inside the existing `.poker-center-layer`, with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"`; do not change `table-v2.html`;
 - change `renderSeats()` to append ordered award rows at each recipient seat and remove the generic `Winner` title from per-pot settlements;
 - keep the evaluated hand name/cards as secondary showdown detail, not as proof that the seat won every pot;
 - extend `captureVisualSnapshot()` with the closed presentation/award IDs rather than the winner union;
 - in PR 1, remove only the `payoutLike` aggregate branch from `animateChipDiff()`; keep the existing contribution-to-pot animation;
 - keep `shouldDeferSnapshotUntilRevealEnds()` and `scheduleRevealDismiss()`, but key their state by the settlement hand ID so a queued next-hand snapshot is applied exactly once.
+
+### Explicit snapshot/patch merge contract
+
+Change `onSnapshot()` to pass `{ kind, initial, payload }` metadata into `mergeSnapshot()` and retain the same metadata with `pendingPostRevealSnapshot`. Add a small own-property helper so omission can be distinguished from explicit `null` in both root and `public` branches.
+
+- Full `stateSnapshot`: treat settlement fields as authoritative. In `SETTLED`, rebuild from the complete `showdown` plus `handSettlement`; if that pair is incomplete or invalid, clear only the award presentation to its neutral fallback while preserving independent reveal data. Explicit `null` or absence outside `SETTLED` clears the non-sticky current settlement.
+- Initial `table_state`: treat the settlement fields present in the initial authoritative view as the baseline. Later `table_state` messages are merge-like because the protocol/client tests allow partial table state.
+- `statePatch` with neither `showdown` nor `handSettlement`: preserve normalized settlement data, `state.settlementPresentation`, sticky award rows, revealed cards, and the original reveal deadline.
+- `statePatch` with explicit `showdown: null` or `handSettlement: null`: clear the corresponding current-hand data, current presentation, and same-hand sticky reveal. A next-hand payload is deferred before merge, so its clear cannot erase the still-readable previous reveal prematurely.
+- `statePatch` for the same hand containing both complete settlement fields: validate and replace the current presentation without restarting its deadline. A patch containing only one updated settlement half must not combine it speculatively with stale data to invent a new presentation; retain the last valid presentation until a complete pair or an authoritative clear arrives.
+- Payload with a different hand ID or a non-`SETTLED` next-hand phase: clear current settlement only after the existing reveal deferral releases it. If reveal is active, queue the whole `{ kind, initial, payload }` frame rather than only its payload.
+- Full `stateSnapshot` received during reconnect/resync in `SETTLED`: rebuild the static model from that snapshot and use the remaining `settledAt` deadline; do not classify it as a live animation transition.
+
+The merge rules apply independently from showdown-card privacy. An omitted award field cannot clear revealed-card state, and an invalid award projection cannot suppress otherwise valid revealed participants.
 
 ### `poker/poker-v2.css`
 
@@ -201,7 +218,7 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 
 ### Focused tests
 
-- `tests/poker-settlement-presentation.unit.test.mjs` — load only the pure browser helper in the existing VM style and test deterministic model output.
+- `tests/poker-settlement-presentation.unit.test.mjs` — load `poker-v2.js` in the existing VM style with `window.__RUNNING_POKER_UI_TESTS__ = true` and test only the guarded pure projection hooks.
 - `tests/poker-v2-live.behavior.test.mjs` — extend the existing poker DOM/WS harness for labels, seat rows, sticky settlement, next-hand transition, and safe fallback.
 - `ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs` and `ws-server/poker/read-model/state-snapshot.behavior.test.mjs` — strengthen existing settled-snapshot assertions to prove ordered `potsAwarded`, `eligibleUserIds`, `winners`, total, and aggregate payouts survive transport. No read-model source change is expected.
 
@@ -215,9 +232,12 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 - multiple recipients are never collectively labeled as winners of the whole hand;
 - no pot-to-seat animation runs from the aggregate winner union;
 - duplicate snapshots do not extend the reveal or render rows twice;
+- a partial same-hand `statePatch` that omits `showdown` and `handSettlement` preserves award rows, revealed cards, and the original reveal deadline;
+- an explicit clear or released next-hand transition removes the previous settlement at the defined boundary;
 - a full initial/reconnect `SETTLED` snapshot renders a static summary immediately without fabricating a live transition;
 - the next hand remains deferred only for the remaining reveal deadline and is then applied once;
 - malformed or legacy settlement data cannot produce guessed labels/amounts or block gameplay.
+- malformed or legacy award data does not remove valid revealed cards or best-hand details;
 - PL/EN language changes update settlement labels without changing amounts or classification.
 
 ## PR 2 — sequential award animation
@@ -273,6 +293,9 @@ The existing behavior harness must cover:
 - compared losing players retaining revealed cards without award badges;
 - full `SETTLED` snapshot on first load/reconnect rendering static content;
 - duplicate resync for the same hand not duplicating awards or extending the timer;
+- partial same-hand `statePatch` without `showdown` and `handSettlement` preserving award rows, revealed cards, and the original deadline;
+- explicit settlement `null` clearing current award presentation, while a deferred next-hand patch waits for the reveal boundary;
+- malformed/legacy awards falling back neutrally without removing revealed cards or the best-hand summary;
 - next-hand snapshot deferred until the remaining reveal deadline, then applied once;
 - narrow/mobile DOM remaining usable with multiple rows;
 - reduced motion retaining all information;
@@ -293,18 +316,19 @@ Use a controlled table or fixture that produces known contributions and compare 
 7. Different players winning different pots: verify no seat is presented as winner of another pot.
 8. Fold-ended hand: verify the sole recipient is the main-pot winner, not a return.
 9. During `SETTLED`, disconnect/reconnect and request full resync; verify static information remains exact and does not replay or duplicate.
-10. Receive the next hand while reveal is active; verify the settlement remains readable and the queued snapshot applies once afterward.
-11. Test desktop and narrow mobile widths with the maximum realistic number of award rows and action controls visible.
-12. Enable reduced motion and verify complete static labels with no chip-flight nodes.
-13. Switch between Polish and English and verify only labels change; classification and chip amounts remain identical.
-14. Block or delay the new helper script during failure testing; the poker page must fail safe without invented winner labels and must not expose raw HTML or block unrelated controls.
-15. For PR 2, compare animation order/destinations with the already visible static rows; the static result must remain correct if animation is interrupted.
+10. While the reveal is visible, apply a same-hand partial patch containing only turn/presence data; verify award rows, revealed cards, and deadline do not change.
+11. Apply an explicit settlement clear and a next-hand patch separately; verify the explicit same-hand clear is honored, while the next-hand payload waits for the reveal boundary and then applies once.
+12. Feed a legacy/malformed award shape with valid revealed participants; verify neutral award copy while cards and the best-hand summary remain visible.
+13. Test desktop and narrow mobile widths with the maximum realistic number of award rows and action controls visible.
+14. Enable reduced motion and verify complete static labels with no chip-flight nodes.
+15. Switch between Polish and English and verify only labels change; classification and chip amounts remain identical.
+16. For PR 2, compare animation order/destinations with the already visible static rows; the static result must remain correct if animation is interrupted.
 
 ## Preview, rollout, and rollback
 
 ### Preview requirements
 
-- Both implementation PRs require a Netlify Deploy Preview because they change browser JavaScript, HTML, CSS, and visual behavior.
+- Both implementation PRs require a Netlify Deploy Preview because they change browser JavaScript, CSS, localization, and visual behavior.
 - A WS Preview Deploy is not required for the planned implementation because no WS server source, protocol, persistence, settlement, or timing changes are needed.
 - The browser preview must still connect to a compatible preview WS and inspect a real `SETTLED` payload to confirm `potsAwarded` and `handSettlement.payouts` are present.
 - If implementation analysis unexpectedly requires any change under `ws-server/`, stop and update this plan; that revised PR must run a WS Preview Deploy before merge.
@@ -320,7 +344,7 @@ Use a controlled table or fixture that produces known contributions and compare 
 
 - PR 1 can roll back to the prior renderer without changing authoritative server state, balances, or stored hands.
 - PR 2 can independently remove only the settlement animation and retain PR 1's correct static summary.
-- Mixed cached versions are safe because the WS fields are additive/existing and old clients continue their previous presentation until refreshed.
+- The implementation stays in the existing `poker-v2.js`, so rollback has no cross-file runtime helper version to coordinate. Old cached JavaScript continues its previous presentation until normal revalidation.
 
 ## Breaking and operational impact
 
@@ -330,15 +354,15 @@ Use a controlled table or fixture that produces known contributions and compare 
 | WS contract | No schema/version change. Existing `potsAwarded`, totals, payouts, and compatibility `winners` are consumed more fully. |
 | Browser behavior | Intentional visible change: generic `Winner` badges and aggregate payout animation are replaced by localized exact per-pot labels and amounts. |
 | Reveal timing | No server change. Client reveal becomes keyed to the original `settledAt`/hand ID and cannot be restarted by duplicate snapshots. |
-| Reconnect/resync | Initial settled state is static; duplicate state does not replay awards. This is an intentional idempotency improvement. |
-| HTML/JSP | One external deferred helper and one semantic container. The helper uses browser-compatible non-module JavaScript and requires no build transform. |
+| Patch/reconnect/resync | Omitted patch fields preserve settlement; explicit clears and new-hand transitions clear it at defined boundaries. Initial settled state is static and duplicate state does not replay awards. |
+| HTML/JSP | No markup or script-tag change. The existing non-module `poker-v2.js` creates the semantic container with DOM APIs and remains JSP-compatible. |
 | Localization | Additive PL/EN settlement keys in the existing dictionary; no new i18n system. |
 | CSS | Additive responsive selectors only, with one line per selector. Reduced motion becomes explicitly supported. |
-| CSP | No inline script or external origin. Existing same-origin `script-src` covers the new file, so no SHA or provider-domain change is required. |
+| CSP | No script is added and no inline code changes, so no CSP SHA or provider-domain change is required. |
 | Database/ENV/secrets | None. No migration, configuration, or secret. |
 | Deployment | Netlify preview/production only under the planned scope; no WS Preview Deploy. |
 
-The browser-global `window.ArcadePokerSettlement` is an additive page-local interface. The main compatibility risk is old cached `poker-v2.js` loading with new HTML or the reverse; both scripts must fail closed when the helper is absent, and versioned deploy cache invalidation must be verified on preview.
+The guarded `window.__POKER_V2_TEST_HOOKS__` exists only when the explicit test flag is true and is not a production API. Text and class changes can break screenshot expectations or UI tests/selectors that assert the literal `Winner` label or `.poker-seat-winner-*`; update those consumers in the implementation PR. This does not affect poker actions, settlement, or economy.
 
 ## Definition of Done
 
@@ -346,11 +370,13 @@ The browser-global `window.ArcadePokerSettlement` is an additive page-local inte
 - Main pots, numbered side pots, returns, split shares, and multi-pot recipients are labeled and summed exactly.
 - A return is never rendered or animated as `Winner`.
 - Static settlement remains correct without animation, on mobile, with reduced motion, and after reconnect/resync.
+- Partial patches preserve omitted settlement fields; explicit clears and new-hand transitions clear them only at the documented boundary.
+- Invalid or legacy award data disables only award labels/amounts/animation and retains valid revealed cards and best-hand details.
 - Duplicate snapshots cannot duplicate awards, replay animation, or extend the same hand's reveal deadline.
 - The next hand is applied once after the readable remaining reveal window.
 - Focused pure unit and browser behavior cases pass together with existing repository checks.
 - PR 1 is verified before PR 2 starts.
-- No poker rule, ledger, DB, ENV, WS contract, CSP origin, or server timing change is introduced.
+- No new runtime script, HTML change, CSP SHA, poker rule, ledger, DB, ENV, WS contract, CSP origin, or server timing change is introduced.
 
 ## Plan verdict
 

--- a/docs/poker-per-pot-settlement-ui-plan.md
+++ b/docs/poker-per-pot-settlement-ui-plan.md
@@ -1,6 +1,6 @@
 # Poker per-pot settlement presentation
 
-Status: proposed implementation plan. This document is planning-only and does not change poker runtime behavior.
+Status: accepted and implemented on PR #711. The owner approved delivering both phases in one PR.
 
 ## Goal
 
@@ -18,7 +18,7 @@ In scope:
 - retain the existing showdown-card reveal and best-hand information without using the generic `Winner` badge as the settlement model;
 - make settlement display stable across the `SETTLED` reveal window, next-hand deferral, reconnect, and duplicate snapshots;
 - add focused unit and browser behavior coverage for settlement presentation;
-- add sequential chip-flow animation only in a follow-up PR after the information model is correct.
+- add sequential chip-flow animation in the same PR, implemented only after and on top of the validated static information model.
 
 Out of scope:
 
@@ -73,23 +73,23 @@ This is the root cause of the misleading production result. The authoritative st
 - The current `poker-v2.js::mergeSnapshot()` conditionally merges most hand fields but unconditionally assigns normalized showdown and settlement values. An omitted settlement field therefore currently looks the same as an explicit clear and can erase a visible reveal.
 - `onSnapshot()` currently passes only `snapshot.payload` into `mergeSnapshot()`, so the merge layer also loses whether the payload was a full `stateSnapshot`, partial `statePatch`, or initial `table_state`.
 
-PR 1 must correct this merge contract as part of the settlement fix. Otherwise correct award rows could disappear or flicker after an ordinary partial patch.
+Phase 1 must correct this merge contract as part of the settlement fix. Otherwise correct award rows could disappear or flicker after an ordinary partial patch.
 
 ## Architecture decision
 
-Implement correctness and animation in two PRs.
+Implement correctness and animation as two ordered phases in one PR.
 
-### PR 1 — authoritative static per-pot presentation
+### Phase 1 — authoritative static per-pot presentation
 
 Preserve existing settlement fields, project them through one small pure browser helper, render ordered per-pot information, and remove the incorrect aggregate payout animation. Keep the existing bet-to-pot animation unchanged.
 
 This PR fixes the user-visible meaning without changing settlement timing, server state, or WS payloads. It is independently releasable and is the blocker for correctness.
 
-### PR 2 — sequential per-pot animation
+### Phase 2 — sequential per-pot animation
 
-After PR 1 is verified, reuse the same presentation model and existing chip-flight primitives to animate each ordered award. Animation remains decorative: the complete static summary and per-seat amounts render immediately and remain the source of truth.
+After Phase 1 is covered by focused tests, reuse the same presentation model and existing chip-flight primitives to animate each ordered award. Animation remains decorative: the complete static summary and per-seat amounts render immediately and remain the source of truth.
 
-Separating the PRs prevents animation sequencing, timing, and motion preferences from delaying or obscuring the accounting fix. PR 2 must not modify how pots are calculated or introduce another settlement model.
+Keeping the phases ordered prevents animation sequencing, timing, and motion preferences from obscuring the accounting fix. Phase 2 must not modify how pots are calculated or introduce another settlement model; both phases are reviewed and rolled back together in PR #711.
 
 ## Client settlement model
 
@@ -162,7 +162,7 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 - A return row uses `Returned` and never `Winner`, `Main pot`, or `Side pot` styling/copy.
 - `showdown.winners` may be retained for revealed-hand compatibility but cannot determine award labels, amounts, or chip destinations.
 
-## PR 1 — exact files and changes
+## Phase 1 — exact files and changes
 
 ### `js/i18n.js`
 
@@ -191,7 +191,7 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 - change `renderSeats()` to append ordered award rows at each recipient seat and remove the generic `Winner` title from per-pot settlements;
 - keep the evaluated hand name/cards as secondary showdown detail, not as proof that the seat won every pot;
 - extend `captureVisualSnapshot()` with the closed presentation/award IDs rather than the winner union;
-- in PR 1, remove only the `payoutLike` aggregate branch from `animateChipDiff()`; keep the existing contribution-to-pot animation;
+- remove only the `payoutLike` aggregate branch from `animateChipDiff()`; keep the existing contribution-to-pot animation until Phase 2 delegates settlement flow to exact awards;
 - keep `shouldDeferSnapshotUntilRevealEnds()` and `scheduleRevealDismiss()`, but key their state by the settlement hand ID so a queued next-hand snapshot is applied exactly once.
 
 ### Explicit snapshot/patch merge contract
@@ -222,7 +222,7 @@ The merge rules apply independently from showdown-card privacy. An omitted award
 - `tests/poker-v2-live.behavior.test.mjs` — extend the existing poker DOM/WS harness for labels, seat rows, sticky settlement, next-hand transition, and safe fallback.
 - `ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs` and `ws-server/poker/read-model/state-snapshot.behavior.test.mjs` — strengthen existing settled-snapshot assertions to prove ordered `potsAwarded`, `eligibleUserIds`, `winners`, total, and aggregate payouts survive transport. No read-model source change is expected.
 
-### PR 1 acceptance
+### Phase 1 acceptance
 
 - a single contested pot renders as `Main pot` with its exact recipient amount;
 - main plus one or several side pots render in server order with stable numbering;
@@ -240,9 +240,9 @@ The merge rules apply independently from showdown-card privacy. An omitted award
 - malformed or legacy award data does not remove valid revealed cards or best-hand details;
 - PL/EN language changes update settlement labels without changing amounts or classification.
 
-## PR 2 — sequential award animation
+## Phase 2 — sequential award animation
 
-PR 2 may start only after PR 1 is deployed and its static presentation is verified.
+Phase 2 starts only after the Phase 1 model and static behavior pass their focused tests. Owner approval explicitly allows both phases to ship in this PR.
 
 ### Exact files and functions
 
@@ -271,7 +271,7 @@ No change to `ws-server/server.mjs::maybeScheduleSettledRollover()`, `resolveSet
 
 ### Pure unit cases
 
-The PR 1 unit suite must cover:
+The Phase 1 unit suite must cover:
 
 - one main pot;
 - main pot plus one side pot;
@@ -299,7 +299,7 @@ The existing behavior harness must cover:
 - next-hand snapshot deferred until the remaining reveal deadline, then applied once;
 - narrow/mobile DOM remaining usable with multiple rows;
 - reduced motion retaining all information;
-- PR 2 only: no replay after resync, ordered animations, split destinations, return destination, and cancellation on hand change.
+- animation phase: no replay after resync, ordered animations, split destinations, return destination, and cancellation on hand change.
 
 Run the existing repository checks in addition to the focused tests. Do not broaden engine/ledger test scope because their rules are unchanged.
 
@@ -322,28 +322,28 @@ Use a controlled table or fixture that produces known contributions and compare 
 13. Test desktop and narrow mobile widths with the maximum realistic number of award rows and action controls visible.
 14. Enable reduced motion and verify complete static labels with no chip-flight nodes.
 15. Switch between Polish and English and verify only labels change; classification and chip amounts remain identical.
-16. For PR 2, compare animation order/destinations with the already visible static rows; the static result must remain correct if animation is interrupted.
+16. Compare animation order/destinations with the already visible static rows; the static result must remain correct if animation is interrupted.
 
 ## Preview, rollout, and rollback
 
 ### Preview requirements
 
-- Both implementation PRs require a Netlify Deploy Preview because they change browser JavaScript, CSS, localization, and visual behavior.
+- PR #711 requires a Netlify Deploy Preview because it changes browser JavaScript, CSS, localization, and visual behavior.
 - A WS Preview Deploy is not required for the planned implementation because no WS server source, protocol, persistence, settlement, or timing changes are needed.
 - The browser preview must still connect to a compatible preview WS and inspect a real `SETTLED` payload to confirm `potsAwarded` and `handSettlement.payouts` are present.
 - If implementation analysis unexpectedly requires any change under `ws-server/`, stop and update this plan; that revised PR must run a WS Preview Deploy before merge.
 
 ### Rollout
 
-1. Merge and deploy PR 1 first.
-2. Verify exact labels/amounts in production-like play before enabling any new settlement animation.
-3. Monitor only existing safe client telemetry for controlled invalid-presentation reasons; no new user/table/card identifiers.
-4. Implement and deploy PR 2 separately after the static behavior is accepted.
+1. Verify Phase 1 exact labels/amounts and Phase 2 destinations together on the Netlify Deploy Preview.
+2. Confirm reduced-motion and reconnect/resync behavior before merge.
+3. Merge and deploy PR #711 as one browser release.
+4. Monitor only existing safe client telemetry for controlled invalid-presentation reasons; no new user/table/card identifiers.
 
 ### Rollback
 
-- PR 1 can roll back to the prior renderer without changing authoritative server state, balances, or stored hands.
-- PR 2 can independently remove only the settlement animation and retain PR 1's correct static summary.
+- The PR can roll back to the prior renderer without changing authoritative server state, balances, or stored hands.
+- If only animation proves problematic, a follow-up can remove `animateSettlementAwards()` while retaining the exact static summary and projector.
 - The implementation stays in the existing `poker-v2.js`, so rollback has no cross-file runtime helper version to coordinate. Old cached JavaScript continues its previous presentation until normal revalidation.
 
 ## Breaking and operational impact
@@ -375,11 +375,11 @@ The guarded `window.__POKER_V2_TEST_HOOKS__` exists only when the explicit test 
 - Duplicate snapshots cannot duplicate awards, replay animation, or extend the same hand's reveal deadline.
 - The next hand is applied once after the readable remaining reveal window.
 - Focused pure unit and browser behavior cases pass together with existing repository checks.
-- PR 1 is verified before PR 2 starts.
+- The pure/static phase is verified before the animation phase within the same PR.
 - No new runtime script, HTML change, CSP SHA, poker rule, ledger, DB, ENV, WS contract, CSP origin, or server timing change is introduced.
 
 ## Plan verdict
 
 The backend already holds and publishes the information required for correct UX. The defect is a browser projection bug: `normalizeShowdown()` and `normalizeHandSettlement()` discard the detailed award model, after which badges and animation use the lossy union `showdown.winners`.
 
-The smallest safe fix is a static, validated per-pot presentation in PR 1 and a separate decorative animation PR 2. This restores accounting meaning immediately, keeps the server and ledger untouched, and gives animation one reusable authoritative client model instead of duplicating or guessing settlement logic.
+The smallest safe fix is a static, validated per-pot presentation followed by decorative animation in the same accepted PR. This restores accounting meaning, keeps the server and ledger untouched, and gives animation one reusable authoritative client model instead of duplicating or guessing settlement logic.

--- a/docs/poker-per-pot-settlement-ui-plan.md
+++ b/docs/poker-per-pot-settlement-ui-plan.md
@@ -1,0 +1,359 @@
+# Poker per-pot settlement presentation
+
+Status: proposed implementation plan. This document is planning-only and does not change poker runtime behavior.
+
+## Goal
+
+Present every settled poker award according to its accounting meaning instead of marking the union of all recipients as equivalent `Winner` seats.
+
+The browser must show the exact server settlement as ordered main pot, side pots, and unmatched-bet returns. A player who only receives a return must never be described as a winner. Split pots and one player receiving several awards must remain exact and understandable on desktop, mobile, reconnect, resync, and reduced-motion clients.
+
+## Scope
+
+In scope:
+
+- preserve and validate the existing `showdown.potsAwarded`, `showdown.potAwardedTotal`, and `handSettlement.payouts` data in the browser;
+- build one deterministic client presentation model containing ordered pots and exact per-recipient amounts;
+- render a compact ordered settlement summary and per-seat award rows such as `+288 Main pot`, `+6 Side pot 1`, and `+1 Returned`;
+- retain the existing showdown-card reveal and best-hand information without using the generic `Winner` badge as the settlement model;
+- make settlement display stable across the `SETTLED` reveal window, next-hand deferral, reconnect, and duplicate snapshots;
+- add focused unit and browser behavior coverage for settlement presentation;
+- add sequential chip-flow animation only in a follow-up PR after the information model is correct.
+
+Out of scope:
+
+- changing hand evaluation, pot construction, payout, ledger, escrow, or poker rules;
+- changing persisted poker state or database schemas;
+- changing WS settlement timing merely to accommodate animation;
+- replaying historical hands or adding a hand-history screen;
+- repairing unrelated audit-row serialization or introducing a new animation framework;
+- adding environment variables, secrets, external assets, or third-party dependencies.
+
+## Confirmed current architecture
+
+### Server settlement is authoritative
+
+- `ws-server/poker/shared/settlement/poker-side-pots.mjs::buildSidePots()` orders contribution bands by increasing contribution level. The first contested band is the main pot and later contested bands are side pots. A final band with one eligible user represents unmatched excess.
+- `ws-server/poker/shared/settlement/poker-payout.mjs::awardPotsAtShowdown()` evaluates each pot independently. It emits ordered `showdown.potsAwarded` entries containing `amount`, ordered `winners`, and `eligibleUserIds`.
+- Split-pot chips are allocated as `Math.floor(amount / winners.length)`, with one remainder chip assigned in the stable winner/seat order already stored in `pot.winners`.
+- The same function also builds `showdown.winners` as the union of every user who received chips from any pot. That union is compatibility data, not proof that every member jointly won the main pot.
+- `ws-server/poker/shared/settlement/poker-materialize-showdown.mjs::materializeShowdownAndPayout()` stores aggregate per-user totals in `handSettlement.payouts` and moves the hand to `SETTLED`.
+- The `all_folded` path produces a singleton award for the whole contested pot. It is a legitimate main-pot result and must not be reclassified as a return merely because only one user remains eligible.
+
+No engine or ledger defect is indicated by the analyzed flow. The implementation must consume this settlement without changing it.
+
+### WS snapshot already preserves per-pot data
+
+- `ws-server/poker/read-model/room-core-snapshot.mjs::normalizeShowdown()` and `ws-server/poker/read-model/state-snapshot.mjs::normalizeShowdown()` already project `winners`, `potsAwarded`, `potAwardedTotal`, `reason`, and `handId`.
+- Both read models also project `handSettlement.handId`, `settledAt`, and `payouts`.
+- `room-core-snapshot.mjs::resolveRevealedShowdownParticipants()` already uses `potsAwarded[].eligibleUserIds` to reveal compared hands without exposing unrelated private cards.
+- Existing read-model behavior tests confirm that terminal settlement fields reach seated players and observers.
+
+The first implementation does not require an additive or breaking WS contract change. `showdown.winners` remains available for compatibility, but the poker table UI must no longer use it as its sole presentation source.
+
+### Exact loss and misleading presentation in the browser
+
+The per-pot information is lost in `poker/poker-v2.js`:
+
+1. `normalizeShowdown()` retains only `winners`, `reason`, `handId`, and revealed cards; it discards `potsAwarded` and `potAwardedTotal`.
+2. `normalizeHandSettlement()` retains only `handId` and `settledAt`; it discards `payouts`.
+3. `syncStickyWinnerReveal()` stores only the union of winner IDs, revealed cards, and community cards.
+4. `getDisplayWinnerUserIds()` and `isWinnerSeat()` treat every member of the union as the same kind of winner.
+5. `renderSeats()` renders the same `Winner` badge for each union member.
+6. `captureVisualSnapshot()` stores only the union, and `animateChipDiff()` divides the entire pot decrease approximately equally among those IDs for visual purposes. This can animate the main pot toward a side-pot recipient or a player who only received a return.
+
+This is the root cause of the misleading production result. The authoritative stack and ledger outcome can be correct while the browser labels and animation are wrong.
+
+`poker/poker.js` contains older `buildShowdownWinnerPayoutMap()` and `renderShowdownPanel()` helpers, but they are not a correct reusable settlement model: they aggregate payouts by the same winner union and label entries only as `Pot #N`. That file powers the lobby page rather than `table-v2.html`. Do not copy its lossy classification into v2 or expand this fix into dead/legacy table UI. The new pure projector may replace that older logic in separate cleanup only if the lobby later presents live settlements again.
+
+## Architecture decision
+
+Implement correctness and animation in two PRs.
+
+### PR 1 — authoritative static per-pot presentation
+
+Preserve existing settlement fields, project them through one small pure browser helper, render ordered per-pot information, and remove the incorrect aggregate payout animation. Keep the existing bet-to-pot animation unchanged.
+
+This PR fixes the user-visible meaning without changing settlement timing, server state, or WS payloads. It is independently releasable and is the blocker for correctness.
+
+### PR 2 — sequential per-pot animation
+
+After PR 1 is verified, reuse the same presentation model and existing chip-flight primitives to animate each ordered award. Animation remains decorative: the complete static summary and per-seat amounts render immediately and remain the source of truth.
+
+Separating the PRs prevents animation sequencing, timing, and motion preferences from delaying or obscuring the accounting fix. PR 2 must not modify how pots are calculated or introduce another settlement model.
+
+## Client settlement model
+
+### Small pure projection helper
+
+Add `poker/poker-settlement-presentation.js` as a JSP-compatible, dependency-free external script loaded before `poker-v2.js`. It exposes one narrow browser namespace, `window.ArcadePokerSettlement`, containing deterministic normalization/projection functions. This keeps accounting-display logic testable without a DOM and avoids a framework or build step.
+
+The primary function is `buildSettlementPresentation({ showdown, handSettlement })`. Its closed result is:
+
+```text
+handId
+settledAt
+totalAmount
+pots[]
+  awardId
+  potIndex
+  kind              main | side | return
+  sidePotNumber     null for main/return, positive integer for side
+  amount            total amount represented by this pot entry
+  recipients[]
+    userId
+    amount           exact share for this recipient
+byUserId
+  <userId>[]         ordered recipient awards for that seat
+valid
+failureReason       controlled local reason, never raw snapshot content
+```
+
+`awardId` is deterministic for the snapshot: `<handId>:pot:<potIndex>`. The helper must not mutate the snapshot, read the DOM, use time/randomness, log user identifiers, or infer poker rules not present in the payload.
+
+### Validation and exact shares
+
+The projector fails closed unless:
+
+- showdown and settlement hand IDs are present and equal;
+- pot amounts and aggregate payouts are finite non-negative integers;
+- `potAwardedTotal` equals the sum of `potsAwarded[].amount`;
+- each pot has unique non-empty eligible IDs and unique non-empty winner IDs;
+- every winner is eligible for that pot;
+- every non-zero pot has at least one recipient;
+- per-pot shares reconstructed in the server-provided winner order sum exactly to the pot amount;
+- accumulated per-user shares exactly match `handSettlement.payouts` in both directions.
+
+For a split pot, reuse the existing server rule exactly: integer floor share, then one remainder chip for each earliest ordered winner until the remainder is exhausted. Do not divide the total settlement across `showdown.winners`.
+
+If validation fails, stacks remain authoritative and gameplay remains usable. The UI shows a neutral localized `Settlement complete` state without guessed amounts, generic multi-user `Winner` badges, or payout animation. Existing safe client logging may emit one aggregated `klog` event with only the controlled failure reason; never use `console.log` or include cards, email, token, raw payload, or user IDs.
+
+### Main pot, side pot, and return classification
+
+Use the server order; do not sort pots in the browser.
+
+1. `showdown.reason === "all_folded"`: the single whole-pot award is `Main pot`, even though only one player is eligible.
+2. `showdown.reason === "computed"`: pot index `0` is `Main pot` and must be contested by at least two eligible users.
+3. Later computed entries with two or more eligible users are `Side pot 1`, `Side pot 2`, and so on in their original order. Return entries do not increment side-pot numbering.
+4. A later computed entry is `Returned` only when it has exactly one unique eligible user and exactly that same sole recipient. It is the unmatched contribution band, not a won pot.
+5. A singleton or reordered shape that does not meet these rules is invalid rather than guessed.
+
+This classification distinguishes a real uncontested main-pot win after folds from a returned unmatched bet.
+
+### Split and multi-pot presentation
+
+- A split pot is one ordered pot row with several recipients and exact individual shares.
+- Every recipient seat receives its own amount from that pot, including any deterministic remainder chip.
+- One user winning multiple pots receives multiple ordered seat rows rather than one ambiguous aggregate badge.
+- Different users winning different pots receive only the rows that apply to them.
+- A return row uses `Returned` and never `Winner`, `Main pot`, or `Side pot` styling/copy.
+- `showdown.winners` may be retained for revealed-hand compatibility but cannot determine award labels, amounts, or chip destinations.
+
+## PR 1 — exact files and changes
+
+### `poker/poker-settlement-presentation.js` — new pure helper
+
+- add closed normalizers for IDs, chip amounts, per-pot entries, and `handSettlement.payouts`;
+- add `allocatePotRecipients(amount, orderedWinnerIds)` using the existing server split/remainder rule;
+- add `classifyPot({ reason, potIndex, eligibleUserIds, winners, sidePotNumber })` with the main/side/return rules above;
+- add `buildSettlementPresentation({ showdown, handSettlement })` and construct `pots` plus `byUserId` in server order;
+- expose only the functions required by `poker-v2.js` and focused unit tests through `window.ArcadePokerSettlement`;
+- use function/`var` syntax compatible with the current non-module poker page and JSP delivery; do not rely on bundlers or Node-only APIs.
+
+### `poker/table-v2.html`
+
+- load `/poker/poker-settlement-presentation.js` with `defer` immediately before `/poker/poker-v2.js`, preserving deterministic deferred-script order;
+- add one hidden settlement summary inside `.poker-center-layer`, with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"`;
+- keep all behavior in external scripts; add no inline JavaScript.
+
+### `js/i18n.js`
+
+- add PL/EN keys for `Main pot`, `Side pot {number}`, `Returned`, `Settlement complete`, and the settlement summary accessible label;
+- keep semantic classification in the pure projector as `kind` plus `sidePotNumber`; `poker-v2.js` resolves visible copy through the existing `t()`/`window.I18N.format()` APIs;
+- listen to the existing `langchange` event or allow the next normal `render()` to rebuild the visible settlement so changing language cannot leave stale labels;
+- do not embed English presentation copy in the settlement model.
+
+### `poker/poker-v2.js`
+
+- extend `normalizeShowdown()` to preserve normalized `potsAwarded` and `potAwardedTotal` instead of dropping them;
+- extend `normalizeHandSettlement()` to preserve normalized `payouts`;
+- add `state.settlementPresentation` or derive it once in `mergeSnapshot()` through `ArcadePokerSettlement.buildSettlementPresentation()` when phase is `SETTLED`;
+- detect a missing/invalid `window.ArcadePokerSettlement` helper and fall back to the neutral state instead of throwing during snapshot handling;
+- replace `stickyWinnerReveal.winners` with a cloned immutable `settlementPresentation`; retain revealed cards and community cards;
+- add `lastPresentedSettlementHandId` so duplicate/replayed snapshots for the same hand cannot restart or extend an expired reveal window;
+- calculate the local reveal deadline from `handSettlement.settledAt + WINNER_REVEAL_MS`, falling back to receipt time only when the server timestamp is absent; never reset the deadline for the same hand;
+- replace `getDisplayWinnerUserIds()`/`isWinnerSeat()` with `getDisplaySettlementPresentation()` and `getSeatSettlementAwards(userId)` for labels and amounts;
+- retain a separate helper for which compared hands/cards are revealed; award recipients and revealed showdown participants are different concepts;
+- add `renderSettlementSummary()` and call it from `render()`;
+- change `renderSeats()` to append ordered award rows at each recipient seat and remove the generic `Winner` title from per-pot settlements;
+- keep the evaluated hand name/cards as secondary showdown detail, not as proof that the seat won every pot;
+- extend `captureVisualSnapshot()` with the closed presentation/award IDs rather than the winner union;
+- in PR 1, remove only the `payoutLike` aggregate branch from `animateChipDiff()`; keep the existing contribution-to-pot animation;
+- keep `shouldDeferSnapshotUntilRevealEnds()` and `scheduleRevealDismiss()`, but key their state by the settlement hand ID so a queued next-hand snapshot is applied exactly once.
+
+### `poker/poker-v2.css`
+
+- add compact summary, pot-row, recipient, per-seat award-row, and `Returned` variants;
+- allow several award rows at one seat without covering the avatar, cards, status, action badge, or turn clock;
+- constrain and wrap the center summary on narrow screens, with an internal maximum height only if all rows cannot fit safely;
+- add a `prefers-reduced-motion: reduce` rule that disables existing chip-flight and pulse animation without hiding settlement information;
+- write every new selector on one line as required by the project style.
+
+### Focused tests
+
+- `tests/poker-settlement-presentation.unit.test.mjs` — load only the pure browser helper in the existing VM style and test deterministic model output.
+- `tests/poker-v2-live.behavior.test.mjs` — extend the existing poker DOM/WS harness for labels, seat rows, sticky settlement, next-hand transition, and safe fallback.
+- `ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs` and `ws-server/poker/read-model/state-snapshot.behavior.test.mjs` — strengthen existing settled-snapshot assertions to prove ordered `potsAwarded`, `eligibleUserIds`, `winners`, total, and aggregate payouts survive transport. No read-model source change is expected.
+
+### PR 1 acceptance
+
+- a single contested pot renders as `Main pot` with its exact recipient amount;
+- main plus one or several side pots render in server order with stable numbering;
+- an unmatched contribution renders only as `Returned`;
+- a split pot shows one pot and exact shares whose sum equals its amount;
+- one user can display several distinct award rows;
+- multiple recipients are never collectively labeled as winners of the whole hand;
+- no pot-to-seat animation runs from the aggregate winner union;
+- duplicate snapshots do not extend the reveal or render rows twice;
+- a full initial/reconnect `SETTLED` snapshot renders a static summary immediately without fabricating a live transition;
+- the next hand remains deferred only for the remaining reveal deadline and is then applied once;
+- malformed or legacy settlement data cannot produce guessed labels/amounts or block gameplay.
+- PL/EN language changes update settlement labels without changing amounts or classification.
+
+## PR 2 — sequential award animation
+
+PR 2 may start only after PR 1 is deployed and its static presentation is verified.
+
+### Exact files and functions
+
+- `poker/poker-v2.js::captureVisualSnapshot()` — retain the settlement hand ID and immutable ordered awards needed to identify a new live settlement.
+- `poker/poker-v2.js::animateChipDiff()` — delegate the settlement branch to a new `animateSettlementAwards(previousVisual, nextVisual)` while leaving bet-to-pot behavior unchanged.
+- `poker/poker-v2.js::spawnChipFly()` — reuse unchanged for each recipient trajectory; do not create another animation engine.
+- add page-lifetime `lastAnimatedSettlementHandId`, `settlementAnimationGeneration`, and a bounded list of animation timers so stale callbacks can be cancelled on hand change, disconnect, or teardown.
+- `poker/poker-v2.css` — add only small award-active/returned visual states and reduced-motion overrides, one line per selector.
+- `tests/poker-v2-live.behavior.test.mjs` — add live transition, split, return, duplicate resync, reconnect, cancellation, and reduced-motion cases.
+
+### Animation contract
+
+- render the complete static summary and seat awards before starting animation;
+- animate `Main pot`, then each `Side pot N`, then each `Returned` entry in the exact presentation order;
+- for a split pot, animate the same pot step toward every recipient using that recipient's exact share for color/quantity selection;
+- animate a return as `Returned`, never as a winner flow;
+- keep the total sequence within the existing reveal window by using a bounded stagger; if there are too many recipients, shorten decorative spacing rather than delay server rollover;
+- do not replay animation for the same `handId` after duplicate snapshots, patch resync, reconnect, or full snapshot;
+- animate only when the current page observed a live transition for that same hand into `SETTLED`; an initial/reconnect snapshot already in `SETTLED` is static;
+- cancel pending callbacks when the hand changes or the client disconnects;
+- when `matchMedia('(prefers-reduced-motion: reduce)')` matches, create no flying-chip DOM nodes or timers. Static information remains complete and immediate.
+
+No change to `ws-server/server.mjs::maybeScheduleSettledRollover()`, `resolveSettledRevealDueAt()`, or `WS_POKER_SETTLED_REVEAL_MS` is planned. Animation is subordinate to the authoritative reveal/rollover lifecycle.
+
+## Required automated verification
+
+### Pure unit cases
+
+The PR 1 unit suite must cover:
+
+- one main pot;
+- main pot plus one side pot;
+- main pot plus several side pots with stable numbering;
+- a computed singleton unmatched band classified as `Returned`;
+- an `all_folded` singleton classified as `Main pot`, not returned;
+- an even split and an odd split with the remainder following server winner order;
+- one recipient winning several pots;
+- different recipients winning different pots;
+- exact `byUserId` totals matching `handSettlement.payouts`;
+- invalid amount, duplicate recipient, winner outside eligibility, hand mismatch, total mismatch, payout mismatch, and malformed return shapes failing closed.
+
+### Browser behavior cases
+
+The existing behavior harness must cover:
+
+- exact summary and per-seat copy/amounts for the user-story example;
+- returned chips never rendering `Winner`;
+- compared losing players retaining revealed cards without award badges;
+- full `SETTLED` snapshot on first load/reconnect rendering static content;
+- duplicate resync for the same hand not duplicating awards or extending the timer;
+- next-hand snapshot deferred until the remaining reveal deadline, then applied once;
+- narrow/mobile DOM remaining usable with multiple rows;
+- reduced motion retaining all information;
+- PR 2 only: no replay after resync, ordered animations, split destinations, return destination, and cancellation on hand change.
+
+Run the existing repository checks in addition to the focused tests. Do not broaden engine/ledger test scope because their rules are unchanged.
+
+## Manual verification
+
+Use a controlled table or fixture that produces known contributions and compare every UI amount with the received WS snapshot.
+
+1. Single winner: verify `Main pot <amount>` and no generic multi-seat winner treatment.
+2. Main plus side: verify each ordered pool, exact recipient, and exact seat amount.
+3. Several side pots: verify numbering does not skip or count a return.
+4. Unmatched excess: verify `Returned` at the correct seat and no winner styling/copy for that row.
+5. Split pot: verify recipient shares, including an odd remainder, sum to the pot.
+6. One player winning several pots: verify separate rows and correct aggregate stack change.
+7. Different players winning different pots: verify no seat is presented as winner of another pot.
+8. Fold-ended hand: verify the sole recipient is the main-pot winner, not a return.
+9. During `SETTLED`, disconnect/reconnect and request full resync; verify static information remains exact and does not replay or duplicate.
+10. Receive the next hand while reveal is active; verify the settlement remains readable and the queued snapshot applies once afterward.
+11. Test desktop and narrow mobile widths with the maximum realistic number of award rows and action controls visible.
+12. Enable reduced motion and verify complete static labels with no chip-flight nodes.
+13. Switch between Polish and English and verify only labels change; classification and chip amounts remain identical.
+14. Block or delay the new helper script during failure testing; the poker page must fail safe without invented winner labels and must not expose raw HTML or block unrelated controls.
+15. For PR 2, compare animation order/destinations with the already visible static rows; the static result must remain correct if animation is interrupted.
+
+## Preview, rollout, and rollback
+
+### Preview requirements
+
+- Both implementation PRs require a Netlify Deploy Preview because they change browser JavaScript, HTML, CSS, and visual behavior.
+- A WS Preview Deploy is not required for the planned implementation because no WS server source, protocol, persistence, settlement, or timing changes are needed.
+- The browser preview must still connect to a compatible preview WS and inspect a real `SETTLED` payload to confirm `potsAwarded` and `handSettlement.payouts` are present.
+- If implementation analysis unexpectedly requires any change under `ws-server/`, stop and update this plan; that revised PR must run a WS Preview Deploy before merge.
+
+### Rollout
+
+1. Merge and deploy PR 1 first.
+2. Verify exact labels/amounts in production-like play before enabling any new settlement animation.
+3. Monitor only existing safe client telemetry for controlled invalid-presentation reasons; no new user/table/card identifiers.
+4. Implement and deploy PR 2 separately after the static behavior is accepted.
+
+### Rollback
+
+- PR 1 can roll back to the prior renderer without changing authoritative server state, balances, or stored hands.
+- PR 2 can independently remove only the settlement animation and retain PR 1's correct static summary.
+- Mixed cached versions are safe because the WS fields are additive/existing and old clients continue their previous presentation until refreshed.
+
+## Breaking and operational impact
+
+| Area | Impact |
+| --- | --- |
+| Poker rules and ledger | None. Pot construction, payout, stack mutation, escrow, and settlement persistence remain authoritative and unchanged. |
+| WS contract | No schema/version change. Existing `potsAwarded`, totals, payouts, and compatibility `winners` are consumed more fully. |
+| Browser behavior | Intentional visible change: generic `Winner` badges and aggregate payout animation are replaced by localized exact per-pot labels and amounts. |
+| Reveal timing | No server change. Client reveal becomes keyed to the original `settledAt`/hand ID and cannot be restarted by duplicate snapshots. |
+| Reconnect/resync | Initial settled state is static; duplicate state does not replay awards. This is an intentional idempotency improvement. |
+| HTML/JSP | One external deferred helper and one semantic container. The helper uses browser-compatible non-module JavaScript and requires no build transform. |
+| Localization | Additive PL/EN settlement keys in the existing dictionary; no new i18n system. |
+| CSS | Additive responsive selectors only, with one line per selector. Reduced motion becomes explicitly supported. |
+| CSP | No inline script or external origin. Existing same-origin `script-src` covers the new file, so no SHA or provider-domain change is required. |
+| Database/ENV/secrets | None. No migration, configuration, or secret. |
+| Deployment | Netlify preview/production only under the planned scope; no WS Preview Deploy. |
+
+The browser-global `window.ArcadePokerSettlement` is an additive page-local interface. The main compatibility risk is old cached `poker-v2.js` loading with new HTML or the reverse; both scripts must fail closed when the helper is absent, and versioned deploy cache invalidation must be verified on preview.
+
+## Definition of Done
+
+- The complete server settlement reaches a validated client presentation model without using `showdown.winners` as the award source.
+- Main pots, numbered side pots, returns, split shares, and multi-pot recipients are labeled and summed exactly.
+- A return is never rendered or animated as `Winner`.
+- Static settlement remains correct without animation, on mobile, with reduced motion, and after reconnect/resync.
+- Duplicate snapshots cannot duplicate awards, replay animation, or extend the same hand's reveal deadline.
+- The next hand is applied once after the readable remaining reveal window.
+- Focused pure unit and browser behavior cases pass together with existing repository checks.
+- PR 1 is verified before PR 2 starts.
+- No poker rule, ledger, DB, ENV, WS contract, CSP origin, or server timing change is introduced.
+
+## Plan verdict
+
+The backend already holds and publishes the information required for correct UX. The defect is a browser projection bug: `normalizeShowdown()` and `normalizeHandSettlement()` discard the detailed award model, after which badges and animation use the lossy union `showdown.winners`.
+
+The smallest safe fix is a static, validated per-pot presentation in PR 1 and a separate decorative animation PR 2. This restores accounting meaning immediately, keeps the server and ledger untouched, and gives animation one reusable authoritative client model instead of duplicating or guessing settlement logic.

--- a/docs/poker-per-pot-settlement-ui-plan.md
+++ b/docs/poker-per-pot-settlement-ui-plan.md
@@ -183,7 +183,7 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 - add `state.settlementPresentation` and derive it through the local `buildSettlementPresentation()` only when a complete authoritative settlement is available;
 - replace `stickyWinnerReveal.winners` with a cloned immutable `settlementPresentation`; retain revealed cards and community cards;
 - add `lastPresentedSettlementHandId` so duplicate/replayed snapshots for the same hand cannot restart or extend an expired reveal window;
-- calculate the local reveal deadline from `handSettlement.settledAt + WINNER_REVEAL_MS`, falling back to receipt time only when the server timestamp is absent; never reset the deadline for the same hand;
+- calculate the local reveal deadline from `handSettlement.settledAt + WINNER_REVEAL_MS`; for a same-hand live transition observed by the page, guarantee one `WINNER_REVEAL_MS` window from receipt because persistence/broadcast latency can consume the server-side interval, while initial/reconnect/resync snapshots use only the remaining authoritative deadline; never reset the deadline for the same hand;
 - replace `getDisplayWinnerUserIds()`/`isWinnerSeat()` with `getDisplaySettlementPresentation()` and `getSeatSettlementAwards(userId)` for labels and amounts;
 - retain a separate helper for which compared hands/cards are revealed; award recipients and revealed showdown participants are different concepts;
 - add `renderSettlementSummary()` and call it from `render()`;
@@ -199,6 +199,7 @@ This classification distinguishes a real uncontested main-pot win after folds fr
 Change `onSnapshot()` to pass `{ kind, initial, payload }` metadata into `mergeSnapshot()` and retain the same metadata with `pendingPostRevealSnapshot`. Add a small own-property helper so omission can be distinguished from explicit `null` in both root and `public` branches.
 
 - Full `stateSnapshot`: treat settlement fields as authoritative. In `SETTLED`, rebuild from the complete `showdown` plus `handSettlement`; if that pair is incomplete or invalid, clear only the award presentation to its neutral fallback while preserving independent reveal data. Explicit `null` or absence outside `SETTLED` clears the non-sticky current settlement.
+- A non-initial full `stateSnapshot` is also the normal live broadcast shape in the current server. A same-hand transition from an active phase into `SETTLED` is eligible for the local reveal window and animation exactly like `statePatch`; frame kind alone must not suppress it.
 - Initial `table_state`: treat the settlement fields present in the initial authoritative view as the baseline. Later `table_state` messages are merge-like because the protocol/client tests allow partial table state.
 - `statePatch` with neither `showdown` nor `handSettlement`: preserve normalized settlement data, `state.settlementPresentation`, sticky award rows, revealed cards, and the original reveal deadline.
 - `statePatch` with explicit `showdown: null` or `handSettlement: null`: clear the corresponding current-hand data, current presentation, and same-hand sticky reveal. A next-hand payload is deferred before merge, so its clear cannot erase the still-readable previous reveal prematurely.
@@ -248,8 +249,8 @@ Phase 2 starts only after the Phase 1 model and static behavior pass their focus
 
 - `poker/poker-v2.js::captureVisualSnapshot()` — retain the settlement hand ID and immutable ordered awards needed to identify a new live settlement.
 - `poker/poker-v2.js::animateChipDiff()` — delegate the settlement branch to a new `animateSettlementAwards(previousVisual, nextVisual)` while leaving bet-to-pot behavior unchanged.
-- `poker/poker-v2.js::spawnChipFly()` — reuse unchanged for each recipient trajectory; do not create another animation engine.
-- add page-lifetime `lastAnimatedSettlementHandId`, `settlementAnimationGeneration`, and a bounded list of animation timers so stale callbacks can be cancelled on hand change, disconnect, or teardown.
+- `poker/poker-v2.js::spawnChipFly()` — reuse it for each recipient trajectory with an optional duration parameter so settlement flow can remain readable without slowing the existing bet-to-pot effect; do not create another animation engine.
+- add page-lifetime `lastAnimatedSettlementHandId`, `settlementAnimationGeneration`, and bounded lists of animation timers and active settlement nodes so stale callbacks and already-running settlement chips can be cancelled on hand change, disconnect, resync, or teardown without removing independent bet-to-pot nodes.
 - `poker/poker-v2.css` — add only small award-active/returned visual states and reduced-motion overrides, one line per selector.
 - `tests/poker-v2-live.behavior.test.mjs` — add live transition, split, return, duplicate resync, reconnect, cancellation, and reduced-motion cases.
 
@@ -260,9 +261,10 @@ Phase 2 starts only after the Phase 1 model and static behavior pass their focus
 - for a split pot, animate the same pot step toward every recipient using that recipient's exact share for color/quantity selection;
 - animate a return as `Returned`, never as a winner flow;
 - keep the total sequence within the existing reveal window by using a bounded stagger; if there are too many recipients, shorten decorative spacing rather than delay server rollover;
-- do not replay animation for the same `handId` after duplicate snapshots, patch resync, reconnect, or full snapshot;
+- do not replay animation for the same `handId` after duplicate snapshots, resync, reconnect, or an initial/recovery full snapshot; a non-initial full snapshot that is the page's first observed same-hand transition into `SETTLED` remains eligible;
 - animate only when the current page observed a live transition for that same hand into `SETTLED`; an initial/reconnect snapshot already in `SETTLED` is static;
 - cancel pending callbacks when the hand changes or the client disconnects;
+- remove already-running settlement fly nodes when cancellation occurs, while leaving unrelated bet-to-pot fly nodes untouched;
 - when `matchMedia('(prefers-reduced-motion: reduce)')` matches, create no flying-chip DOM nodes or timers. Static information remains complete and immediate.
 
 No change to `ws-server/server.mjs::maybeScheduleSettledRollover()`, `resolveSettledRevealDueAt()`, or `WS_POKER_SETTLED_REVEAL_MS` is planned. Animation is subordinate to the authoritative reveal/rollover lifecycle.
@@ -297,6 +299,7 @@ The existing behavior harness must cover:
 - explicit settlement `null` clearing current award presentation, while a deferred next-hand patch waits for the reveal boundary;
 - malformed/legacy awards falling back neutrally without removing revealed cards or the best-hand summary;
 - next-hand snapshot deferred until the remaining reveal deadline, then applied once;
+- delayed live settlement delivered after its server timestamp window has elapsed still receives a complete local reveal window, while the queued next-hand snapshot is applied once afterward;
 - narrow/mobile DOM remaining usable with multiple rows;
 - reduced motion retaining all information;
 - animation phase: no replay after resync, ordered animations, split destinations, return destination, and cancellation on hand change.

--- a/docs/poker-per-pot-settlement-ui-plan.md
+++ b/docs/poker-per-pot-settlement-ui-plan.md
@@ -262,6 +262,7 @@ Phase 2 starts only after the Phase 1 model and static behavior pass their focus
 - animate a return as `Returned`, never as a winner flow;
 - keep the total sequence within the existing reveal window by using a bounded stagger; if there are too many recipients, shorten decorative spacing rather than delay server rollover;
 - do not replay animation for the same `handId` after duplicate snapshots, resync, reconnect, or an initial/recovery full snapshot; a non-initial full snapshot that is the page's first observed same-hand transition into `SETTLED` remains eligible;
+- after reconnect/resync, keep animation suppression active across partial `statePatch` frames and release it only after the next authoritative full `stateSnapshot` (or an explicitly initial full `table_state`); the authoritative frame that releases suppression is itself rendered statically;
 - animate only when the current page observed a live transition for that same hand into `SETTLED`; an initial/reconnect snapshot already in `SETTLED` is static;
 - cancel pending callbacks when the hand changes or the client disconnects;
 - remove already-running settlement fly nodes when cancellation occurs, while leaving unrelated bet-to-pot fly nodes untouched;

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -351,7 +351,13 @@ homeBonusLoadError: { en: 'Could not load available bonuses.', pl: 'Nie udało s
     pokerShowdownWinnerSingleSuffix: { en: 'won', pl: 'wygrał' },
     pokerShowdownWinnerMultiPrefix: { en: 'Winners', pl: 'Wygrali' },
     pokerShowdownFlyoutPayouts: { en: 'Payouts', pl: 'Wygrane' },
-    pokerShowdownFlyoutCards: { en: 'Winner cards', pl: 'Karty zwycięzcy' }
+    pokerShowdownFlyoutCards: { en: 'Winner cards', pl: 'Karty zwycięzcy' },
+    pokerSettlementMainPot: { en: 'Main pot', pl: 'Pula główna' },
+    pokerSettlementSidePot: { en: 'Side pot {number}', pl: 'Pula boczna {number}' },
+    pokerSettlementReturned: { en: 'Returned', pl: 'Zwrot' },
+    pokerSettlementComplete: { en: 'Settlement complete', pl: 'Rozliczenie zakończone' },
+    pokerSettlementSummaryAria: { en: 'Hand settlement', pl: 'Rozliczenie rozdania' },
+    pokerSettlementPlayer: { en: 'Player', pl: 'Gracz' }
   };
 
   let currentLang = 'en';

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -32,12 +32,13 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat-action-badge--raise{background:linear-gradient(180deg, rgba(214,116,25,0.96), rgba(140,72,16,0.96)); color:#fff0d7;}
 .poker-seat-action-badge--all-in{background:linear-gradient(180deg, rgba(220,179,30,0.98), rgba(156,114,14,0.98)); color:#2f2304;}
 
-.poker-seat-winner-badge{position:absolute; left:50%; top:-18px; transform:translateX(-50%); min-width:68px; padding:5px 8px 6px; border-radius:14px; border:1px solid rgba(255,226,160,0.72); background:linear-gradient(180deg, rgba(86,57,16,0.96), rgba(24,16,8,0.94)); color:#fff4d2; font-size:0.62rem; font-weight:800; letter-spacing:0.08em; text-transform:uppercase; box-shadow:0 8px 18px rgba(0,0,0,0.34), inset 0 1px 1px rgba(255,244,208,0.24); z-index:6; pointer-events:none; display:flex; flex-direction:column; align-items:center; gap:4px;}
-.poker-seat-winner-title{line-height:1;}
-.poker-seat-winner-label{font-size:0.5rem; font-weight:700; letter-spacing:0.04em; line-height:1.05; text-transform:uppercase; color:#ffe7b4;}
-.poker-seat-winner-cards{display:flex; flex-wrap:wrap; justify-content:center; gap:3px; max-width:74px;}
-.poker-seat-winner-card{display:flex; align-items:center; justify-content:center; min-width:20px; height:14px; padding:0 3px; border-radius:999px; background:rgba(245,248,255,0.96); color:#0f172a; font-size:0.48rem; font-weight:700; line-height:1; box-shadow:0 3px 7px rgba(0,0,0,0.24);}
-.poker-seat-winner-card--red{color:#b91c1c;}
+.poker-seat-settlement-badge{position:absolute; left:50%; top:-28px; transform:translateX(-50%); min-width:92px; max-width:132px; padding:5px 7px 6px; border-radius:14px; border:1px solid rgba(255,226,160,0.72); background:linear-gradient(180deg, rgba(52,39,18,0.97), rgba(18,14,9,0.95)); color:#fff4d2; font-size:0.58rem; font-weight:800; box-shadow:0 8px 18px rgba(0,0,0,0.34), inset 0 1px 1px rgba(255,244,208,0.24); z-index:6; pointer-events:none; display:flex; flex-direction:column; align-items:center; gap:3px;}
+.poker-seat-settlement-award{line-height:1.15; white-space:nowrap; color:#ffe7b4;}
+.poker-seat-settlement-award--return{color:#bcefd8;}
+.poker-seat-settlement-hand-label{font-size:0.48rem; font-weight:700; letter-spacing:0.04em; line-height:1.05; text-transform:uppercase; color:#f7d89a;}
+.poker-seat-settlement-hand-cards{display:flex; flex-wrap:wrap; justify-content:center; gap:3px; max-width:116px;}
+.poker-seat-settlement-hand-card{display:flex; align-items:center; justify-content:center; min-width:20px; height:14px; padding:0 3px; border-radius:999px; background:rgba(245,248,255,0.96); color:#0f172a; font-size:0.48rem; font-weight:700; line-height:1; box-shadow:0 3px 7px rgba(0,0,0,0.24);}
+.poker-seat-settlement-hand-card--red{color:#b91c1c;}
 
 .poker-seat-avatar{position:relative; overflow:hidden; isolation:isolate; width:76px; height:76px; margin:0 auto 7px; border-radius:50%; border:2px solid rgba(255,202,127,0.6); background:radial-gradient(circle at 50% 24%, rgba(255,235,214,0.22), rgba(26,25,30,0.74) 42%, rgba(7,8,10,0.98) 78%), linear-gradient(155deg, rgba(23,26,34,0.95), rgba(8,9,13,0.99)); box-shadow:0 8px 18px rgba(0,0,0,0.48); display:flex; align-items:flex-end; justify-content:center; font-size:0.8rem; letter-spacing:0.04em; color:#ebf2ff; padding-bottom:8px;}
 .poker-seat-avatar::before{content:""; position:absolute; inset:18%; border-radius:50%; background:radial-gradient(circle, rgba(52,211,113,0.26) 0%, rgba(52,211,113,0.18) 34%, rgba(52,211,113,0.05) 60%, transparent 75%); opacity:0; transform:scale(0.42); z-index:0; pointer-events:none;}
@@ -77,7 +78,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-seat--active .poker-seat-status{color:#8df8bf; border-color:rgba(97,241,163,0.72); background:rgba(19,58,39,0.72);}
 
-.poker-seat--winner .poker-seat-avatar{border-color:rgba(255,219,133,0.88); box-shadow:0 0 0 3px rgba(255,210,99,0.15), 0 12px 22px rgba(0,0,0,0.5);}
+.poker-seat--pot-winner .poker-seat-avatar{border-color:rgba(255,219,133,0.88); box-shadow:0 0 0 3px rgba(255,210,99,0.15), 0 12px 22px rgba(0,0,0,0.5);}
+.poker-seat--returned .poker-seat-avatar{border-color:rgba(119,224,177,0.78);}
 
 .poker-seat--folded{opacity:0.42;}
 
@@ -96,6 +98,14 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat--hero .poker-seat-best-hand-label{text-align:right;}
 
 .poker-center-layer{position:absolute; left:50%; top:42%; transform:translate(-50%, -50%); width:min(86%, 350px); text-align:center; z-index:7;}
+.poker-settlement-summary{width:min(100%, 330px); max-height:154px; margin:10px auto 0; padding:7px; overflow:auto; border:1px solid rgba(255,226,160,0.34); border-radius:13px; background:rgba(4,10,16,0.88); box-shadow:0 10px 22px rgba(0,0,0,0.38); color:#f8efd6; font-size:0.66rem; text-align:left;}
+.poker-settlement-summary[hidden]{display:none;}
+.poker-settlement-summary__row{display:grid; grid-template-columns:auto minmax(0,1fr); gap:8px; align-items:start; padding:4px 5px; border-radius:8px;}
+.poker-settlement-summary__row + .poker-settlement-summary__row{margin-top:2px; border-top:1px solid rgba(255,255,255,0.08);}
+.poker-settlement-summary__row--return{color:#bcefd8;}
+.poker-settlement-summary__label{font-weight:800; white-space:nowrap;}
+.poker-settlement-summary__recipients{overflow-wrap:anywhere; text-align:right; color:#e5ecf8;}
+.poker-settlement-summary__fallback{padding:5px; text-align:center; font-weight:700;}
 .poker-pot-chip-stack{position:relative; margin:10px auto 0; width:112px; height:78px;}
 
 .poker-pot-pill{display:inline-flex; padding:8px 24px; border-radius:22px; border:1px solid rgba(255,208,128,0.38); background:linear-gradient(180deg, rgba(8,16,26,0.88), rgba(2,6,10,0.95)); font-size:2rem; font-weight:700; line-height:1; color:#f8efd6; box-shadow:0 10px 20px rgba(0,0,0,0.45), inset 0 1px 1px rgba(255,255,255,0.13);}
@@ -295,6 +305,10 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 @media (min-width:480px){.poker-scene{height:min(76vh, 860px);} .poker-seat{width:126px;} .poker-hero-cards{bottom:136px;} .poker-card{width:50px; height:68px;}}
 
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
+
+@media (max-width:420px){.poker-settlement-summary{max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
+
+@media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before{animation:none!important;}}
 
 .poker-v2-xp-badge{position:fixed; top:calc(env(safe-area-inset-top) + 14px); right:calc(env(safe-area-inset-right) + 12px); z-index:30; min-width:58px; padding:8px 10px; border-radius:14px; border:1px solid rgba(255,223,180,0.34); background:linear-gradient(180deg, rgba(16,24,37,0.88), rgba(7,10,15,0.96)); color:#e8eefb; text-decoration:none; font-size:0.88rem; font-weight:700; text-align:center; box-shadow:0 9px 17px rgba(0,0,0,0.48), inset 0 1px 1px rgba(255,255,255,0.2);}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -181,7 +181,7 @@
   var settlementAnimationGeneration = 0;
   var settlementAnimationTimers = [];
   var settlementAnimationNodes = [];
-  var suppressNextSettlementAnimation = false;
+  var suppressSettlementAnimationUntilAuthoritativeSnapshot = false;
   var els = {};
 
   function cloneState(source){
@@ -3408,7 +3408,7 @@
           if (!rejoinSeatAfterReconnect()) autoJoinSeat();
         } else if (status === 'reconnecting'){
           cancelSettlementAnimations();
-          suppressNextSettlementAnimation = true;
+          suppressSettlementAnimationUntilAuthoritativeSnapshot = true;
           rememberSeatForReconnect();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;
@@ -3418,7 +3418,7 @@
           syncClosedTableRedirectFromSignal(info && info.reason ? info.reason : null);
         } else if (status === 'resync'){
           cancelSettlementAnimations();
-          suppressNextSettlementAnimation = true;
+          suppressSettlementAnimationUntilAuthoritativeSnapshot = true;
         } else if (status === 'failed'){
           cancelSettlementAnimations();
           state.wsReady = false;
@@ -3443,10 +3443,11 @@
         var frame = {
           kind: snapshot && typeof snapshot.kind === 'string' ? snapshot.kind : 'stateSnapshot',
           initial: !!(snapshot && snapshot.initial),
-          suppressSettlementAnimation: suppressNextSettlementAnimation,
+          suppressSettlementAnimation: suppressSettlementAnimationUntilAuthoritativeSnapshot,
           payload: payload
         };
-        suppressNextSettlementAnimation = false;
+        var authoritativeSnapshot = frame.kind === 'stateSnapshot' || (frame.kind === 'table_state' && frame.initial);
+        if (authoritativeSnapshot) suppressSettlementAnimationUntilAuthoritativeSnapshot = false;
         if (shouldDeferSnapshotUntilRevealEnds(payload)){
           pendingPostRevealSnapshot = frame;
           scheduleRevealDismiss();

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -168,11 +168,17 @@
   var stickyWinnerReveal = {
     handId: null,
     visibleUntilMs: 0,
-    winners: [],
+    settlementPresentation: null,
+    showdownWinnerUserIds: [],
     revealedShowdownCardsByUserId: {},
     communityCards: []
   };
   var pendingPostRevealSnapshot = null;
+  var lastPresentedSettlementHandId = null;
+  var lastAnimatedSettlementHandId = null;
+  var lastSettlementFailureKey = null;
+  var settlementAnimationGeneration = 0;
+  var settlementAnimationTimers = [];
   var els = {};
 
   function cloneState(source){
@@ -313,6 +319,7 @@
       wsReady: false,
       showdown: null,
       handSettlement: null,
+      settlementPresentation: null,
       revealedShowdownCardsByUserId: {}
     };
   }
@@ -381,6 +388,20 @@
       }
     } catch (_err){}
     return fallback || key;
+  }
+
+  function tf(key, values, fallback){
+    try {
+      if (window.I18N && typeof window.I18N.format === 'function'){
+        var translated = window.I18N.format(key, values || {});
+        if (translated) return translated;
+      }
+    } catch (_err){}
+    var output = t(key, fallback || key);
+    Object.keys(values || {}).forEach(function(name){
+      output = output.replace(new RegExp('\\{' + name + '\\}', 'g'), String(values[name]));
+    });
+    return output;
   }
 
   function getAccessToken(){
@@ -893,7 +914,7 @@
       handId: state.handId || null,
       committedByUserId: Object.assign({}, seatCommittedByUserId),
       lastActionByUserId: Object.assign({}, state.lastBettingRoundActionByUserId || {}),
-      winners: getDisplayWinnerUserIds()
+      settlementPresentation: cloneSettlementPresentation(getDisplaySettlementPresentation())
     };
   }
 
@@ -935,11 +956,17 @@
   function normalizeShowdown(source){
     if (!isObject(source)) return null;
     var showdown = {
-      winners: Array.isArray(source.winners) ? source.winners.filter(function(userId){
-        return typeof userId === 'string' && !!userId;
-      }) : [],
+      winners: Array.isArray(source.winners) ? source.winners.slice() : [],
       reason: typeof source.reason === 'string' ? source.reason : null,
-      handId: typeof source.handId === 'string' ? source.handId : null
+      handId: typeof source.handId === 'string' ? source.handId : null,
+      potAwardedTotal: source.potAwardedTotal,
+      potsAwarded: Array.isArray(source.potsAwarded) ? source.potsAwarded.map(function(pot){
+        return isObject(pot) ? {
+          amount: pot.amount,
+          winners: Array.isArray(pot.winners) ? pot.winners.slice() : pot.winners,
+          eligibleUserIds: Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds.slice() : pot.eligibleUserIds
+        } : pot;
+      }) : source.potsAwarded
     };
     if (Array.isArray(source.revealedShowdownParticipants)){
       showdown.revealedShowdownParticipants = source.revealedShowdownParticipants
@@ -963,7 +990,160 @@
     if (!isObject(source)) return null;
     return {
       handId: typeof source.handId === 'string' ? source.handId : null,
-      settledAt: typeof source.settledAt === 'string' ? source.settledAt : null
+      settledAt: typeof source.settledAt === 'string' ? source.settledAt : null,
+      payouts: isObject(source.payouts) ? Object.assign({}, source.payouts) : source.payouts
+    };
+  }
+
+  function invalidSettlementPresentation(reason, handId, settledAt){
+    return {
+      valid: false,
+      failureReason: reason || 'invalid_settlement',
+      handId: handId || null,
+      settledAt: settledAt || null,
+      totalAmount: 0,
+      pots: [],
+      byUserId: {}
+    };
+  }
+
+  function normalizeSettlementUserId(value){
+    return typeof value === 'string' && value.trim() ? value.trim() : null;
+  }
+
+  function normalizeSettlementChipAmount(value){
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+
+  function normalizeSettlementUserIds(source){
+    if (!Array.isArray(source) || !source.length) return null;
+    var result = [];
+    var seen = Object.create(null);
+    for (var i = 0; i < source.length; i++){
+      var userId = normalizeSettlementUserId(source[i]);
+      if (!userId || seen[userId]) return null;
+      seen[userId] = true;
+      result.push(userId);
+    }
+    return result;
+  }
+
+  function normalizeSettlementPayouts(source){
+    if (!isObject(source)) return null;
+    var result = Object.create(null);
+    var keys = Object.keys(source);
+    for (var i = 0; i < keys.length; i++){
+      var userId = normalizeSettlementUserId(keys[i]);
+      var amount = normalizeSettlementChipAmount(source[keys[i]]);
+      if (!userId || amount == null || hasOwn(result, userId)) return null;
+      if (amount > 0) result[userId] = amount;
+    }
+    return result;
+  }
+
+  function allocatePotRecipients(amount, orderedWinnerIds){
+    var safeAmount = normalizeSettlementChipAmount(amount);
+    var winners = normalizeSettlementUserIds(orderedWinnerIds);
+    if (safeAmount == null || !winners || (safeAmount > 0 && !winners.length)) return null;
+    var baseShare = Math.floor(safeAmount / winners.length);
+    var remainder = safeAmount - (baseShare * winners.length);
+    return winners.map(function(userId, index){
+      return { userId: userId, amount: baseShare + (index < remainder ? 1 : 0) };
+    });
+  }
+
+  function classifySettlementPot(reason, potIndex, eligibleUserIds, winners, sidePotNumber){
+    if (reason === 'all_folded'){
+      if (potIndex !== 0 || eligibleUserIds.length !== 1 || winners.length !== 1 || eligibleUserIds[0] !== winners[0]) return null;
+      return { kind: 'main', sidePotNumber: null };
+    }
+    if (reason !== 'computed') return null;
+    if (potIndex === 0){
+      if (eligibleUserIds.length < 2) return null;
+      return { kind: 'main', sidePotNumber: null };
+    }
+    if (eligibleUserIds.length >= 2) return { kind: 'side', sidePotNumber: sidePotNumber };
+    if (eligibleUserIds.length === 1 && winners.length === 1 && eligibleUserIds[0] === winners[0]) return { kind: 'return', sidePotNumber: null };
+    return null;
+  }
+
+  function buildSettlementPresentation(input){
+    var showdown = input && input.showdown;
+    var settlement = input && input.handSettlement;
+    var handId = showdown && normalizeSettlementUserId(showdown.handId);
+    var settlementHandId = settlement && normalizeSettlementUserId(settlement.handId);
+    var settledAt = settlement && typeof settlement.settledAt === 'string' ? settlement.settledAt : null;
+    if (!isObject(showdown) || !isObject(settlement)) return invalidSettlementPresentation('missing_settlement_pair', handId || settlementHandId, settledAt);
+    if (!handId || !settlementHandId || handId !== settlementHandId) return invalidSettlementPresentation('hand_id_mismatch', handId || settlementHandId, settledAt);
+    var reason = typeof showdown.reason === 'string' ? showdown.reason.trim().toLowerCase() : '';
+    var totalAmount = normalizeSettlementChipAmount(showdown.potAwardedTotal);
+    var payouts = normalizeSettlementPayouts(settlement.payouts);
+    var sourcePots = showdown.potsAwarded;
+    if (totalAmount == null || !payouts || !Array.isArray(sourcePots) || !sourcePots.length) return invalidSettlementPresentation('malformed_totals', handId, settledAt);
+    if (reason === 'all_folded' && sourcePots.length !== 1) return invalidSettlementPresentation('malformed_all_folded', handId, settledAt);
+
+    var pots = [];
+    var byUserId = Object.create(null);
+    var calculatedPayouts = Object.create(null);
+    var calculatedTotal = 0;
+    var sidePotNumber = 0;
+    for (var potIndex = 0; potIndex < sourcePots.length; potIndex++){
+      var sourcePot = sourcePots[potIndex];
+      if (!isObject(sourcePot)) return invalidSettlementPresentation('malformed_pot', handId, settledAt);
+      var amount = normalizeSettlementChipAmount(sourcePot.amount);
+      var winners = normalizeSettlementUserIds(sourcePot.winners);
+      var eligibleUserIds = normalizeSettlementUserIds(sourcePot.eligibleUserIds);
+      if (amount == null || !winners || !eligibleUserIds) return invalidSettlementPresentation('malformed_pot', handId, settledAt);
+      for (var winnerIndex = 0; winnerIndex < winners.length; winnerIndex++){
+        if (eligibleUserIds.indexOf(winners[winnerIndex]) === -1) return invalidSettlementPresentation('ineligible_winner', handId, settledAt);
+      }
+      var nextSidePotNumber = sidePotNumber + 1;
+      var classification = classifySettlementPot(reason, potIndex, eligibleUserIds, winners, nextSidePotNumber);
+      if (!classification) return invalidSettlementPresentation('invalid_pot_classification', handId, settledAt);
+      if (classification.kind === 'side') sidePotNumber = nextSidePotNumber;
+      var recipients = allocatePotRecipients(amount, winners);
+      if (!recipients) return invalidSettlementPresentation('invalid_split', handId, settledAt);
+      var recipientTotal = 0;
+      var awardId = handId + ':pot:' + potIndex;
+      recipients.forEach(function(recipient){
+        recipientTotal += recipient.amount;
+        calculatedPayouts[recipient.userId] = (calculatedPayouts[recipient.userId] || 0) + recipient.amount;
+        if (!byUserId[recipient.userId]) byUserId[recipient.userId] = [];
+        byUserId[recipient.userId].push({
+          awardId: awardId,
+          potIndex: potIndex,
+          kind: classification.kind,
+          sidePotNumber: classification.sidePotNumber,
+          amount: recipient.amount
+        });
+      });
+      if (recipientTotal !== amount) return invalidSettlementPresentation('split_total_mismatch', handId, settledAt);
+      pots.push({
+        awardId: awardId,
+        potIndex: potIndex,
+        kind: classification.kind,
+        sidePotNumber: classification.sidePotNumber,
+        amount: amount,
+        recipients: recipients,
+        eligibleUserIds: eligibleUserIds
+      });
+      calculatedTotal += amount;
+    }
+    if (calculatedTotal !== totalAmount) return invalidSettlementPresentation('pot_total_mismatch', handId, settledAt);
+    var payoutKeys = Object.keys(payouts).sort();
+    var calculatedKeys = Object.keys(calculatedPayouts).filter(function(userId){ return calculatedPayouts[userId] > 0; }).sort();
+    if (payoutKeys.join('|') !== calculatedKeys.join('|')) return invalidSettlementPresentation('payout_users_mismatch', handId, settledAt);
+    for (var payoutIndex = 0; payoutIndex < payoutKeys.length; payoutIndex++){
+      if (payouts[payoutKeys[payoutIndex]] !== calculatedPayouts[payoutKeys[payoutIndex]]) return invalidSettlementPresentation('payout_amount_mismatch', handId, settledAt);
+    }
+    return {
+      valid: true,
+      failureReason: null,
+      handId: handId,
+      settledAt: settledAt,
+      totalAmount: totalAmount,
+      pots: pots,
+      byUserId: byUserId
     };
   }
 
@@ -988,20 +1168,34 @@
     return next;
   }
 
+  function cloneSettlementPresentation(source){
+    return source ? cloneState(source) : null;
+  }
+
+  function resolveSettlementRevealDueAt(presentation){
+    var settledAtMs = presentation && presentation.settledAt ? Date.parse(presentation.settledAt) : NaN;
+    return Number.isFinite(settledAtMs) && settledAtMs <= Date.now() + 1000 ? settledAtMs + WINNER_REVEAL_MS : Date.now() + WINNER_REVEAL_MS;
+  }
+
   function syncStickyWinnerReveal(){
     var handId = state.handId || (state.handSettlement && state.handSettlement.handId) || (state.showdown && state.showdown.handId) || null;
-    var winners = state.showdown && Array.isArray(state.showdown.winners) ? state.showdown.winners.filter(Boolean) : [];
-    if (!handId || !winners.length || state.phase !== 'SETTLED'){
-      return;
-    }
-    if (stickyWinnerReveal.handId !== handId || stickyWinnerReveal.visibleUntilMs <= Date.now()){
+    if (!handId || state.phase !== 'SETTLED' || (!state.showdown && !state.settlementPresentation)) return;
+    if (stickyWinnerReveal.handId !== handId && lastPresentedSettlementHandId !== handId){
+      var visibleUntilMs = resolveSettlementRevealDueAt(state.settlementPresentation || state.handSettlement);
       stickyWinnerReveal = {
         handId: handId,
-        visibleUntilMs: Date.now() + WINNER_REVEAL_MS,
-        winners: winners.slice(),
+        visibleUntilMs: visibleUntilMs,
+        settlementPresentation: cloneSettlementPresentation(state.settlementPresentation),
+        showdownWinnerUserIds: state.showdown && Array.isArray(state.showdown.winners) ? state.showdown.winners.filter(function(userId){ return typeof userId === 'string' && !!userId; }) : [],
         revealedShowdownCardsByUserId: cloneRevealedShowdownCards(state.revealedShowdownCardsByUserId),
         communityCards: Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : []
       };
+      lastPresentedSettlementHandId = handId;
+    } else if (stickyWinnerReveal.handId === handId){
+      stickyWinnerReveal.settlementPresentation = cloneSettlementPresentation(state.settlementPresentation);
+      stickyWinnerReveal.showdownWinnerUserIds = state.showdown && Array.isArray(state.showdown.winners) ? state.showdown.winners.filter(function(userId){ return typeof userId === 'string' && !!userId; }) : [];
+      stickyWinnerReveal.revealedShowdownCardsByUserId = cloneRevealedShowdownCards(state.revealedShowdownCardsByUserId);
+      stickyWinnerReveal.communityCards = Array.isArray(state.communityCards) ? state.communityCards.slice(0, 5) : [];
     }
   }
 
@@ -1034,9 +1228,9 @@
       revealDismissTimer = null;
       stickyWinnerReveal.visibleUntilMs = 0;
       if (pendingPostRevealSnapshot){
-        var nextPayload = pendingPostRevealSnapshot;
+        var nextFrame = pendingPostRevealSnapshot;
         pendingPostRevealSnapshot = null;
-        mergeSnapshot(nextPayload);
+        mergeSnapshot(nextFrame.payload, nextFrame);
       }
       render();
       autoJoinSeat();
@@ -1050,16 +1244,33 @@
     return !!(nextHandId && sticky.handId && nextHandId !== sticky.handId);
   }
 
-  function getDisplayWinnerUserIds(){
-    if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.length){
-      return state.showdown.winners;
-    }
+  function getDisplaySettlementPresentation(){
+    if (state.phase === 'SETTLED' && state.settlementPresentation) return state.settlementPresentation;
     var sticky = getActiveWinnerReveal();
-    return sticky ? sticky.winners.slice() : [];
+    return sticky ? sticky.settlementPresentation : null;
   }
 
-  function mergeSnapshot(payload){
+  function getSeatSettlementAwards(userId){
+    var presentation = getDisplaySettlementPresentation();
+    if (!presentation || !presentation.valid || !presentation.byUserId || !Array.isArray(presentation.byUserId[userId])) return [];
+    return presentation.byUserId[userId].slice();
+  }
+
+  function hasOwn(source, key){
+    return !!source && Object.prototype.hasOwnProperty.call(source, key);
+  }
+
+  function readSnapshotField(payload, publicObj, key){
+    if (hasOwn(payload, key)) return { present: true, value: payload[key] };
+    if (hasOwn(publicObj, key)) return { present: true, value: publicObj[key] };
+    return { present: false, value: undefined };
+  }
+
+  function mergeSnapshot(payload, frame){
     if (!isObject(payload)) return;
+    var frameKind = frame && typeof frame.kind === 'string' ? frame.kind : 'stateSnapshot';
+    var frameInitial = !!(frame && frame.initial);
+    var authoritativeFull = frameKind === 'stateSnapshot' || (frameKind === 'table_state' && frameInitial);
     var snapshotTableId = typeof payload.tableId === 'string' && payload.tableId ? payload.tableId : null;
     var publicObj = isObject(payload.public) ? payload.public : {};
     var privateObj = isObject(payload.private) ? payload.private : {};
@@ -1068,8 +1279,8 @@
     var handObj = isObject(payload.hand) ? payload.hand : isObject(publicObj.hand) ? publicObj.hand : {};
     var turnObj = isObject(payload.turn) ? payload.turn : isObject(publicObj.turn) ? publicObj.turn : {};
     var potObj = isObject(payload.pot) ? payload.pot : isObject(publicObj.pot) ? publicObj.pot : {};
-    var showdownObj = isObject(payload.showdown) ? payload.showdown : isObject(publicObj.showdown) ? publicObj.showdown : null;
-    var handSettlementObj = isObject(payload.handSettlement) ? payload.handSettlement : isObject(publicObj.handSettlement) ? publicObj.handSettlement : null;
+    var showdownField = readSnapshotField(payload, publicObj, 'showdown');
+    var handSettlementField = readSnapshotField(payload, publicObj, 'handSettlement');
     var legalSource = payload.legalActions != null ? payload.legalActions : publicObj.legalActions;
     var constraintsPrimary = payload.actionConstraints != null ? payload.actionConstraints : publicObj.actionConstraints;
     var lastActionMapSource = payload.lastBettingRoundActionByUserId != null ? payload.lastBettingRoundActionByUserId : publicObj.lastBettingRoundActionByUserId;
@@ -1140,11 +1351,37 @@
     if (legalActions.length || Array.isArray(legalSource) || (isObject(legalSource) && Array.isArray(legalSource.actions))){
       state.legalActions = legalActions;
     }
-    state.showdown = normalizeShowdown(showdownObj);
-    state.handSettlement = normalizeHandSettlement(handSettlementObj);
-    state.revealedShowdownCardsByUserId = mapRevealedShowdownCards(state.showdown);
+    if (authoritativeFull || showdownField.present){
+      state.showdown = normalizeShowdown(showdownField.value);
+      state.revealedShowdownCardsByUserId = mapRevealedShowdownCards(state.showdown);
+    }
+    if (authoritativeFull || handSettlementField.present) state.handSettlement = normalizeHandSettlement(handSettlementField.value);
+    var handChanged = !!(state.handId && previousHandId && state.handId !== previousHandId);
+    var explicitSettlementClear = (showdownField.present && showdownField.value == null) || (handSettlementField.present && handSettlementField.value == null);
+    var completeSettlementPair = showdownField.present && handSettlementField.present && state.showdown && state.handSettlement;
+    if (state.phase !== 'SETTLED' || handChanged || explicitSettlementClear){
+      state.settlementPresentation = null;
+      if (explicitSettlementClear && stickyWinnerReveal.handId === (state.handId || previousHandId)){
+        clearWinnerRevealTimer();
+        stickyWinnerReveal.visibleUntilMs = 0;
+      }
+      cancelSettlementAnimations();
+    } else if ((authoritativeFull && state.showdown && state.handSettlement) || completeSettlementPair){
+      state.settlementPresentation = buildSettlementPresentation({ showdown: state.showdown, handSettlement: state.handSettlement });
+      if (!state.settlementPresentation.valid){
+        var failureKey = String(state.settlementPresentation.handId || state.handId || 'unknown') + ':' + state.settlementPresentation.failureReason;
+        if (failureKey !== lastSettlementFailureKey){
+          lastSettlementFailureKey = failureKey;
+          klog('poker_settlement_presentation_invalid', { reason: state.settlementPresentation.failureReason });
+        }
+      }
+    } else if (authoritativeFull && (showdownField.present || handSettlementField.present)){
+      state.settlementPresentation = invalidSettlementPresentation('missing_settlement_pair', state.handId, state.handSettlement && state.handSettlement.settledAt);
+    } else if (authoritativeFull){
+      state.settlementPresentation = null;
+    }
     state.lastBettingRoundActionByUserId = normalizeLastBettingRoundActionByUserId(lastActionMapSource);
-    if (state.handId && previousHandId && state.handId !== previousHandId && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
+    if (handChanged && (previousPhase === 'SETTLED' || stickyWinnerReveal.handId === previousHandId)){
       clearWinnerRevealTimer();
       stickyWinnerReveal.visibleUntilMs = 0;
     }
@@ -1494,9 +1731,30 @@
     };
   }
 
-  function isWinnerSeat(seat){
+  function getSettlementAwardLabel(award){
+    if (!award) return '';
+    if (award.kind === 'main') return t('pokerSettlementMainPot', 'Main pot');
+    if (award.kind === 'side') return tf('pokerSettlementSidePot', { number: award.sidePotNumber }, 'Side pot {number}');
+    if (award.kind === 'return') return t('pokerSettlementReturned', 'Returned');
+    return '';
+  }
+
+  function hasWonContestedPot(seat){
     if (!seat || typeof seat.userId !== 'string') return false;
-    return getDisplayWinnerUserIds().indexOf(seat.userId) !== -1;
+    return getSeatSettlementAwards(seat.userId).some(function(award){ return award.kind === 'main' || award.kind === 'side'; });
+  }
+
+  function hasReturnedChips(seat){
+    if (!seat || typeof seat.userId !== 'string') return false;
+    return getSeatSettlementAwards(seat.userId).some(function(award){ return award.kind === 'return'; });
+  }
+
+  function shouldShowShowdownHandSummary(seat){
+    if (!seat || typeof seat.userId !== 'string') return false;
+    if (getSeatSettlementAwards(seat.userId).length) return true;
+    if (state.showdown && Array.isArray(state.showdown.winners) && state.showdown.winners.indexOf(seat.userId) !== -1) return true;
+    var sticky = getActiveWinnerReveal();
+    return !!(sticky && Array.isArray(sticky.showdownWinnerUserIds) && sticky.showdownWinnerUserIds.indexOf(seat.userId) !== -1);
   }
 
   function getSeatRevealCards(seat){
@@ -1879,8 +2137,51 @@
     return ids;
   }
 
-  function animateChipDiff(previousVisual, nextVisual){
+  function prefersReducedMotion(){
+    try { return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches); } catch (_err){ return false; }
+  }
+
+  function cancelSettlementAnimations(){
+    settlementAnimationGeneration += 1;
+    settlementAnimationTimers.forEach(function(timerId){
+      try { window.clearTimeout(timerId); } catch (_err){}
+    });
+    settlementAnimationTimers = [];
+  }
+
+  function animateSettlementAwards(previousVisual, nextVisual, sceneRect, potFrom, frame){
+    var presentation = nextVisual && nextVisual.settlementPresentation;
+    if (!presentation || !presentation.valid || !Array.isArray(presentation.pots) || !presentation.pots.length) return;
+    if (!frame || frame.kind !== 'statePatch' || frame.initial) return;
+    if (!previousVisual || previousVisual.phase === 'SETTLED' || nextVisual.phase !== 'SETTLED') return;
+    if (!nextVisual.handId || previousVisual.handId !== nextVisual.handId || presentation.handId !== nextVisual.handId) return;
+    if (lastAnimatedSettlementHandId === presentation.handId || prefersReducedMotion()) return;
+    lastAnimatedSettlementHandId = presentation.handId;
+    cancelSettlementAnimations();
+    var generation = settlementAnimationGeneration;
+    var seatByUserId = {};
+    state.seats.forEach(function(seat){ if (seat && seat.userId) seatByUserId[seat.userId] = seat; });
+    var availableMs = Math.max(200, WINNER_REVEAL_MS - CHIP_FLY_MS - 240);
+    var stepGapMs = Math.min(480, Math.max(150, Math.floor(availableMs / Math.max(1, presentation.pots.length))));
+    presentation.pots.forEach(function(pot, potIndex){
+      var timerId = window.setTimeout(function(){
+        if (generation !== settlementAnimationGeneration || state.handId !== presentation.handId) return;
+        pot.recipients.forEach(function(recipient, recipientIndex){
+          var seat = seatByUserId[recipient.userId];
+          if (!seat || !Number.isInteger(seat.seatNo)) return;
+          var target = resolvePointFromPercent(renderedSeatStackAnchors[seat.seatNo] || renderedSeatBetAnchors[seat.seatNo], sceneRect);
+          if (!target) return;
+          var color = resolveFlyChipColorFromAmount(recipient.amount);
+          for (var chipIndex = 0; chipIndex < 3; chipIndex++) spawnChipFly(potFrom, target, color, recipientIndex * 34 + chipIndex * 42);
+        });
+      }, potIndex * stepGapMs);
+      settlementAnimationTimers.push(timerId);
+    });
+  }
+
+  function animateChipDiff(previousVisual, nextVisual, frame){
     if (!previousVisual || !nextVisual || !els.scene || !els.chipFxLayer) return;
+    if (prefersReducedMotion()) return;
     if (typeof els.scene.getBoundingClientRect !== 'function') return;
     var sceneRect = els.scene.getBoundingClientRect();
     if (sceneRect.width <= 0 || sceneRect.height <= 0) return;
@@ -1905,25 +2206,27 @@
         sent += chips;
       });
     }
-    var previousPot = Math.max(0, Number(previousVisual.potTotal) || 0);
-    var nextPot = Math.max(0, Number(nextVisual.potTotal) || 0);
-    var winners = Array.isArray(nextVisual.winners) ? nextVisual.winners : [];
-    var payoutLike = previousPot > 0 && nextPot < previousPot && winners.length > 0 && nextVisual.phase === 'SETTLED';
-    if (payoutLike){
-      var seatByUser = {};
-      state.seats.forEach(function(seat){ if (seat && seat.userId) seatByUser[seat.userId] = seat; });
-      winners.forEach(function(userId, index){
-        var winnerSeat = seatByUser[userId];
-        if (!winnerSeat || !Number.isInteger(winnerSeat.seatNo)) return;
-        var target = resolvePointFromPercent(renderedSeatStackAnchors[winnerSeat.seatNo] || renderedSeatBetAnchors[winnerSeat.seatNo], sceneRect);
-        if (!target) return;
-        var payoutAmount = Math.max(1, Math.round((previousPot - nextPot) / Math.max(1, winners.length)));
-        var payoutColor = resolveFlyChipColorFromAmount(payoutAmount);
-        for (var i = 0; i < 4; i++){
-          spawnChipFly(potFrom, target, payoutColor, (index * 50) + (i * 36));
-        }
-      });
-    }
+    animateSettlementAwards(previousVisual, nextVisual, sceneRect, potFrom, frame);
+  }
+
+  function appendShowdownHandSummary(container, seat){
+    if (!container || !shouldShowShowdownHandSummary(seat)) return;
+    var summary = getWinnerHandSummary(seat);
+    if (!summary) return;
+    var label = document.createElement('div');
+    label.className = 'poker-seat-settlement-hand-label';
+    label.textContent = summary.label;
+    container.appendChild(label);
+    var cards = document.createElement('div');
+    cards.className = 'poker-seat-settlement-hand-cards';
+    summary.cards.forEach(function(card){
+      var normalizedCard = normalizeCard(card);
+      var chip = document.createElement('span');
+      chip.className = 'poker-seat-settlement-hand-card' + (normalizedCard && (normalizedCard.s === 'H' || normalizedCard.s === 'D') ? ' poker-seat-settlement-hand-card--red' : '');
+      chip.textContent = normalizedCard ? (normalizedCard.r + SUIT_SYMBOLS[normalizedCard.s]) : '?';
+      cards.appendChild(chip);
+    });
+    container.appendChild(cards);
   }
 
   function renderSeats(){
@@ -1958,7 +2261,8 @@
       article.className = 'poker-seat'
         + (active ? ' poker-seat--active' : '')
         + (folded ? ' poker-seat--folded' : '')
-        + (seat && isWinnerSeat(seat) ? ' poker-seat--winner' : '')
+        + (seat && hasWonContestedPot(seat) ? ' poker-seat--pot-winner' : '')
+        + (seat && hasReturnedChips(seat) ? ' poker-seat--returned' : '')
         + (hero ? ' poker-seat--hero' : '')
         + (!seat ? ' poker-seat--empty' : '');
       article.style.left = anchor.x + '%';
@@ -2009,31 +2313,20 @@
         actionBadge.style.top = badgePosition.top;
         article.appendChild(actionBadge);
       }
-      if (seat && isWinnerSeat(seat)){
-        var winnerBadge = document.createElement('div');
-        winnerBadge.className = 'poker-seat-winner-badge';
-        var winnerTitle = document.createElement('div');
-        winnerTitle.className = 'poker-seat-winner-title';
-        winnerTitle.textContent = 'Winner';
-        winnerBadge.appendChild(winnerTitle);
-        var winnerSummary = getWinnerHandSummary(seat);
-        if (winnerSummary){
-          var winnerLabel = document.createElement('div');
-          winnerLabel.className = 'poker-seat-winner-label';
-          winnerLabel.textContent = winnerSummary.label;
-          winnerBadge.appendChild(winnerLabel);
-          var winnerCards = document.createElement('div');
-          winnerCards.className = 'poker-seat-winner-cards';
-          winnerSummary.cards.forEach(function(card){
-            var normalizedWinnerCard = normalizeCard(card);
-            var chip = document.createElement('span');
-            chip.className = 'poker-seat-winner-card' + (normalizedWinnerCard && (normalizedWinnerCard.s === 'H' || normalizedWinnerCard.s === 'D') ? ' poker-seat-winner-card--red' : '');
-            chip.textContent = normalizedWinnerCard ? (normalizedWinnerCard.r + SUIT_SYMBOLS[normalizedWinnerCard.s]) : '?';
-            winnerCards.appendChild(chip);
-          });
-          winnerBadge.appendChild(winnerCards);
-        }
-        article.appendChild(winnerBadge);
+      var seatSettlementAwards = seat ? getSeatSettlementAwards(seat.userId) : [];
+      var seatHasShowdownSummary = !!(seat && shouldShowShowdownHandSummary(seat) && getWinnerHandSummary(seat));
+      if (seat && (seatSettlementAwards.length || seatHasShowdownSummary)){
+        var settlementBadge = document.createElement('div');
+        settlementBadge.className = 'poker-seat-settlement-badge';
+        seatSettlementAwards.forEach(function(award){
+          var awardRow = document.createElement('div');
+          awardRow.className = 'poker-seat-settlement-award poker-seat-settlement-award--' + award.kind;
+          awardRow.dataset.awardId = award.awardId;
+          awardRow.textContent = '+' + formatNumber(award.amount) + ' ' + getSettlementAwardLabel(award);
+          settlementBadge.appendChild(awardRow);
+        });
+        appendShowdownHandSummary(settlementBadge, seat);
+        article.appendChild(settlementBadge);
       }
       if (cards.children.length) article.appendChild(cards);
       article.appendChild(name);
@@ -2505,6 +2798,58 @@
     }
   }
 
+  function resolveSettlementRecipientName(userId){
+    for (var i = 0; i < state.seats.length; i++){
+      if (state.seats[i] && state.seats[i].userId === userId) return getDisplayName(state.seats[i]);
+    }
+    return shortId(userId) || t('pokerSettlementPlayer', 'Player');
+  }
+
+  function renderSettlementSummary(){
+    if (!els.centerLayer) return;
+    if (!els.settlementSummary){
+      els.settlementSummary = document.createElement('div');
+      els.settlementSummary.className = 'poker-settlement-summary';
+      els.settlementSummary.setAttribute('role', 'status');
+      els.settlementSummary.setAttribute('aria-live', 'polite');
+      els.settlementSummary.setAttribute('aria-atomic', 'true');
+      els.settlementSummary.setAttribute('aria-label', t('pokerSettlementSummaryAria', 'Hand settlement'));
+      els.centerLayer.appendChild(els.settlementSummary);
+    }
+    els.settlementSummary.setAttribute('aria-label', t('pokerSettlementSummaryAria', 'Hand settlement'));
+    els.settlementSummary.innerHTML = '';
+    var presentation = getDisplaySettlementPresentation();
+    if (!presentation){
+      els.settlementSummary.hidden = true;
+      return;
+    }
+    els.settlementSummary.hidden = false;
+    if (!presentation.valid){
+      var fallback = document.createElement('div');
+      fallback.className = 'poker-settlement-summary__fallback';
+      fallback.textContent = t('pokerSettlementComplete', 'Settlement complete');
+      els.settlementSummary.appendChild(fallback);
+      return;
+    }
+    presentation.pots.forEach(function(pot){
+      var row = document.createElement('div');
+      row.className = 'poker-settlement-summary__row poker-settlement-summary__row--' + pot.kind;
+      row.dataset.awardId = pot.awardId;
+      var label = document.createElement('span');
+      label.className = 'poker-settlement-summary__label';
+      label.textContent = getSettlementAwardLabel(pot) + ' ' + formatNumber(pot.amount);
+      var recipients = document.createElement('span');
+      recipients.className = 'poker-settlement-summary__recipients';
+      recipients.textContent = pot.recipients.map(function(recipient){
+        var name = resolveSettlementRecipientName(recipient.userId);
+        return pot.recipients.length > 1 ? name + ' +' + formatNumber(recipient.amount) : name;
+      }).join(', ');
+      row.appendChild(label);
+      row.appendChild(recipients);
+      els.settlementSummary.appendChild(row);
+    });
+  }
+
   function render(){
     if (els.potPill) els.potPill.textContent = 'Pot ' + formatNumber(state.potTotal || 0);
     renderCommunityCards();
@@ -2513,6 +2858,7 @@
     positionHeroCards();
     renderSeatChips();
     renderPotChips();
+    renderSettlementSummary();
     renderDealerChip();
     renderInfoPanel();
     renderControls();
@@ -2892,6 +3238,7 @@
   function selectElements(){
     els.screen = document.getElementById('pokerTableScreen');
     if (typeof document.querySelector === 'function') els.scene = document.querySelector('.poker-scene');
+    if (typeof document.querySelector === 'function') els.centerLayer = document.querySelector('.poker-center-layer');
     if (!els.scene) els.scene = els.screen;
     els.xpBadge = document.getElementById('xpBadge');
     els.bootSplash = document.getElementById('pokerBootSplash');
@@ -2958,6 +3305,7 @@
   function stopLiveMode(){
     stopTurnClock();
     clearWinnerRevealTimer();
+    cancelSettlementAnimations();
     cancelClosedTableRedirect();
     resetAutoJoinRetryState();
     autoJoinAttempted = false;
@@ -3061,17 +3409,22 @@
       },
       onSnapshot: function(snapshot){
         var payload = snapshot && snapshot.payload ? snapshot.payload : null;
+        var frame = {
+          kind: snapshot && typeof snapshot.kind === 'string' ? snapshot.kind : 'stateSnapshot',
+          initial: !!(snapshot && snapshot.initial),
+          payload: payload
+        };
         if (shouldDeferSnapshotUntilRevealEnds(payload)){
-          pendingPostRevealSnapshot = payload;
+          pendingPostRevealSnapshot = frame;
           scheduleRevealDismiss();
           return;
         }
         var previousVisual = captureVisualSnapshot();
-        mergeSnapshot(payload);
+        mergeSnapshot(payload, frame);
         maybeExecuteQueuedPreaction();
         render();
         var nextVisual = captureVisualSnapshot();
-        animateChipDiff(previousVisual, nextVisual);
+        animateChipDiff(previousVisual, nextVisual, frame);
         autoJoinSeat();
       },
       onProtocolError: function(info){
@@ -3185,6 +3538,7 @@
     shouldAutoJoin = readAutoJoinParam();
     bindMenu();
     bindControls();
+    document.addEventListener('langchange', function(){ render(); });
     var guestSessionCandidate = readGuestMode() ? readGuestSession() : null;
     if (!tableId){
       startDemoMode();
@@ -3204,6 +3558,14 @@
     _mergeSnapshot: mergeSnapshot,
     _resolveAllInPlan: resolveAllInPlan
   };
+
+  if (window.__RUNNING_POKER_UI_TESTS__ === true){
+    window.__POKER_V2_TEST_HOOKS__ = {
+      allocatePotRecipients: allocatePotRecipients,
+      classifySettlementPot: classifySettlementPot,
+      buildSettlementPresentation: buildSettlementPresentation
+    };
+  }
 
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init, { once: true });
   else init();

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -179,6 +179,7 @@
   var lastSettlementFailureKey = null;
   var settlementAnimationGeneration = 0;
   var settlementAnimationTimers = [];
+  var settlementAnimationNodes = [];
   var els = {};
 
   function cloneState(source){
@@ -2098,7 +2099,7 @@
   }
 
   function spawnChipFly(fromPoint, toPoint, color, delayMs){
-    if (!els.chipFxLayer || !fromPoint || !toPoint) return;
+    if (!els.chipFxLayer || !fromPoint || !toPoint) return null;
     var tone = color || 'white';
     var fly = createChipFlyAsset(tone);
     fly.style.left = Math.round(fromPoint.x) + 'px';
@@ -2109,6 +2110,7 @@
     fly.style.setProperty('--chip-dy', Math.round(toPoint.y - fromPoint.y) + 'px');
     els.chipFxLayer.appendChild(fly);
     window.setTimeout(function(){ if (fly && fly.parentNode) fly.parentNode.removeChild(fly); }, CHIP_FLY_MS + Math.max(0, delayMs || 0) + 40);
+    return fly;
   }
 
   function resolveBetAnimationUserIds(previousVisual, nextVisual){
@@ -2147,6 +2149,10 @@
       try { window.clearTimeout(timerId); } catch (_err){}
     });
     settlementAnimationTimers = [];
+    settlementAnimationNodes.forEach(function(node){
+      if (node && node.parentNode) node.parentNode.removeChild(node);
+    });
+    settlementAnimationNodes = [];
   }
 
   function animateSettlementAwards(previousVisual, nextVisual, sceneRect, potFrom, frame){
@@ -2172,7 +2178,13 @@
           var target = resolvePointFromPercent(renderedSeatStackAnchors[seat.seatNo] || renderedSeatBetAnchors[seat.seatNo], sceneRect);
           if (!target) return;
           var color = resolveFlyChipColorFromAmount(recipient.amount);
-          for (var chipIndex = 0; chipIndex < 3; chipIndex++) spawnChipFly(potFrom, target, color, recipientIndex * 34 + chipIndex * 42);
+          for (var chipIndex = 0; chipIndex < 3; chipIndex++){
+            var fly = spawnChipFly(potFrom, target, color, recipientIndex * 34 + chipIndex * 42);
+            if (!fly) continue;
+            fly.classList.add('poker-chip-fly--settlement');
+            fly.dataset.settlementAnimation = presentation.handId;
+            settlementAnimationNodes.push(fly);
+          }
         });
       }, potIndex * stepGapMs);
       settlementAnimationTimers.push(timerId);
@@ -3384,6 +3396,7 @@
           }
           if (!rejoinSeatAfterReconnect()) autoJoinSeat();
         } else if (status === 'reconnecting'){
+          cancelSettlementAnimations();
           rememberSeatForReconnect();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;
@@ -3392,15 +3405,18 @@
         } else if (status === 'command_result') {
           syncClosedTableRedirectFromSignal(info && info.reason ? info.reason : null);
         } else if (status === 'failed'){
+          cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.error;
           setError(info && info.code ? info.code : 'Live connection failed');
         } else if (status === 'error'){
+          cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.error;
           syncClosedTableRedirectFromSignal(info && info.code ? info.code : null);
           setError(info && info.code ? info.code : 'Live table unavailable');
         } else if (status === 'closed'){
+          cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.disconnected;
           renderInfoPanel();

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -55,6 +55,7 @@
   var CLOSED_TABLE_REDIRECT_SECONDS = 5;
   var WINNER_REVEAL_MS = 4_000;
   var CHIP_FLY_MS = 420;
+  var SETTLEMENT_CHIP_FLY_MS = 780;
   var AUTO_JOIN_RETRY_DELAYS_MS = [250, 750, 1500, 3000];
   var CHIP_DENOMINATIONS = [
     { value: 1000, color: 'yellow' },
@@ -180,6 +181,7 @@
   var settlementAnimationGeneration = 0;
   var settlementAnimationTimers = [];
   var settlementAnimationNodes = [];
+  var suppressNextSettlementAnimation = false;
   var els = {};
 
   function cloneState(source){
@@ -1178,11 +1180,12 @@
     return Number.isFinite(settledAtMs) && settledAtMs <= Date.now() + 1000 ? settledAtMs + WINNER_REVEAL_MS : Date.now() + WINNER_REVEAL_MS;
   }
 
-  function syncStickyWinnerReveal(){
+  function syncStickyWinnerReveal(minimumVisibleUntilMs){
     var handId = state.handId || (state.handSettlement && state.handSettlement.handId) || (state.showdown && state.showdown.handId) || null;
     if (!handId || state.phase !== 'SETTLED' || (!state.showdown && !state.settlementPresentation)) return;
     if (stickyWinnerReveal.handId !== handId && lastPresentedSettlementHandId !== handId){
       var visibleUntilMs = resolveSettlementRevealDueAt(state.settlementPresentation || state.handSettlement);
+      if (Number.isFinite(minimumVisibleUntilMs)) visibleUntilMs = Math.max(visibleUntilMs, minimumVisibleUntilMs);
       stickyWinnerReveal = {
         handId: handId,
         visibleUntilMs: visibleUntilMs,
@@ -1386,7 +1389,13 @@
       clearWinnerRevealTimer();
       stickyWinnerReveal.visibleUntilMs = 0;
     }
-    syncStickyWinnerReveal();
+    var liveSettlementTransition = !frameInitial
+      && !(frame && frame.suppressSettlementAnimation)
+      && !!previousHandId
+      && previousHandId === state.handId
+      && previousPhase !== 'SETTLED'
+      && state.phase === 'SETTLED';
+    syncStickyWinnerReveal(liveSettlementTransition ? Date.now() + WINNER_REVEAL_MS : null);
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
     state.statusText = LIVE_STATUS_COPY.live;
     if (!autoJoinErrorActive) state.errorText = '';
@@ -2098,18 +2107,19 @@
     };
   }
 
-  function spawnChipFly(fromPoint, toPoint, color, delayMs){
+  function spawnChipFly(fromPoint, toPoint, color, delayMs, durationMs){
     if (!els.chipFxLayer || !fromPoint || !toPoint) return null;
     var tone = color || 'white';
     var fly = createChipFlyAsset(tone);
     fly.style.left = Math.round(fromPoint.x) + 'px';
     fly.style.top = Math.round(fromPoint.y) + 'px';
-    fly.style.animationDuration = CHIP_FLY_MS + 'ms';
+    var resolvedDurationMs = Number.isFinite(durationMs) && durationMs > 0 ? durationMs : CHIP_FLY_MS;
+    fly.style.animationDuration = resolvedDurationMs + 'ms';
     fly.style.animationDelay = Math.max(0, delayMs || 0) + 'ms';
     fly.style.setProperty('--chip-dx', Math.round(toPoint.x - fromPoint.x) + 'px');
     fly.style.setProperty('--chip-dy', Math.round(toPoint.y - fromPoint.y) + 'px');
     els.chipFxLayer.appendChild(fly);
-    window.setTimeout(function(){ if (fly && fly.parentNode) fly.parentNode.removeChild(fly); }, CHIP_FLY_MS + Math.max(0, delayMs || 0) + 40);
+    window.setTimeout(function(){ if (fly && fly.parentNode) fly.parentNode.removeChild(fly); }, resolvedDurationMs + Math.max(0, delayMs || 0) + 40);
     return fly;
   }
 
@@ -2158,7 +2168,8 @@
   function animateSettlementAwards(previousVisual, nextVisual, sceneRect, potFrom, frame){
     var presentation = nextVisual && nextVisual.settlementPresentation;
     if (!presentation || !presentation.valid || !Array.isArray(presentation.pots) || !presentation.pots.length) return;
-    if (!frame || frame.kind !== 'statePatch' || frame.initial) return;
+    if (!frame || frame.initial || frame.suppressSettlementAnimation) return;
+    if (frame.kind !== 'statePatch' && frame.kind !== 'stateSnapshot') return;
     if (!previousVisual || previousVisual.phase === 'SETTLED' || nextVisual.phase !== 'SETTLED') return;
     if (!nextVisual.handId || previousVisual.handId !== nextVisual.handId || presentation.handId !== nextVisual.handId) return;
     if (lastAnimatedSettlementHandId === presentation.handId || prefersReducedMotion()) return;
@@ -2167,7 +2178,7 @@
     var generation = settlementAnimationGeneration;
     var seatByUserId = {};
     state.seats.forEach(function(seat){ if (seat && seat.userId) seatByUserId[seat.userId] = seat; });
-    var availableMs = Math.max(200, WINNER_REVEAL_MS - CHIP_FLY_MS - 240);
+    var availableMs = Math.max(200, WINNER_REVEAL_MS - SETTLEMENT_CHIP_FLY_MS - 240);
     var stepGapMs = Math.min(480, Math.max(150, Math.floor(availableMs / Math.max(1, presentation.pots.length))));
     presentation.pots.forEach(function(pot, potIndex){
       var timerId = window.setTimeout(function(){
@@ -2179,7 +2190,7 @@
           if (!target) return;
           var color = resolveFlyChipColorFromAmount(recipient.amount);
           for (var chipIndex = 0; chipIndex < 3; chipIndex++){
-            var fly = spawnChipFly(potFrom, target, color, recipientIndex * 34 + chipIndex * 42);
+            var fly = spawnChipFly(potFrom, target, color, recipientIndex * 34 + chipIndex * 42, SETTLEMENT_CHIP_FLY_MS);
             if (!fly) continue;
             fly.classList.add('poker-chip-fly--settlement');
             fly.dataset.settlementAnimation = presentation.handId;
@@ -3397,6 +3408,7 @@
           if (!rejoinSeatAfterReconnect()) autoJoinSeat();
         } else if (status === 'reconnecting'){
           cancelSettlementAnimations();
+          suppressNextSettlementAnimation = true;
           rememberSeatForReconnect();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;
@@ -3404,6 +3416,9 @@
           renderControls();
         } else if (status === 'command_result') {
           syncClosedTableRedirectFromSignal(info && info.reason ? info.reason : null);
+        } else if (status === 'resync'){
+          cancelSettlementAnimations();
+          suppressNextSettlementAnimation = true;
         } else if (status === 'failed'){
           cancelSettlementAnimations();
           state.wsReady = false;
@@ -3428,8 +3443,10 @@
         var frame = {
           kind: snapshot && typeof snapshot.kind === 'string' ? snapshot.kind : 'stateSnapshot',
           initial: !!(snapshot && snapshot.initial),
+          suppressSettlementAnimation: suppressNextSettlementAnimation,
           payload: payload
         };
+        suppressNextSettlementAnimation = false;
         if (shouldDeferSnapshotUntilRevealEnds(payload)){
           pendingPostRevealSnapshot = frame;
           scheduleRevealDismiss();

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -79,6 +79,7 @@ run("node", ["tests/poker-inactive-cleanup.behavior.test.mjs"], "poker-inactive-
 run("node", ["tests/poker-materialize-settlement.payouts.test.mjs"], "poker-materialize-settlement-payouts");
 
 run("node", ["tests/poker-ui.behavior.test.mjs"], "poker-ui-behavior");
+run("node", ["tests/poker-settlement-presentation.unit.test.mjs"], "poker-settlement-presentation-unit");
 run("node", ["tests/poker-v2-live.behavior.test.mjs"], "poker-v2-live-behavior");
 run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs"], "ws-inactive-cleanup-adapter-behavior");
 run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");

--- a/tests/poker-settlement-presentation.unit.test.mjs
+++ b/tests/poker-settlement-presentation.unit.test.mjs
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+
+function loadHooks(){
+  const source = fs.readFileSync(path.join(process.cwd(), 'poker', 'poker-v2.js'), 'utf8');
+  const sandbox = {
+    window: {
+      __RUNNING_POKER_UI_TESTS__: true,
+      location: { search: '' }
+    },
+    document: {
+      readyState: 'loading',
+      addEventListener(){},
+      getElementById(){ return null; },
+      querySelector(){ return null; }
+    },
+    URLSearchParams,
+    Date,
+    console
+  };
+  sandbox.window.document = sandbox.document;
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: 'poker/poker-v2.js' });
+  return sandbox.window.__POKER_V2_TEST_HOOKS__;
+}
+
+function plain(value){
+  return JSON.parse(JSON.stringify(value));
+}
+
+function project(hooks, showdown, payouts, settledAt = '2026-07-14T12:00:00.000Z'){
+  return plain(hooks.buildSettlementPresentation({
+    showdown,
+    handSettlement: { handId: showdown.handId, settledAt, payouts }
+  }));
+}
+
+test('projects ordered main, side, and returned awards with exact per-seat amounts', () => {
+  const hooks = loadHooks();
+  const presentation = project(hooks, {
+    handId: 'hand-1',
+    reason: 'computed',
+    potAwardedTotal: 345,
+    potsAwarded: [
+      { amount: 300, winners: ['a'], eligibleUserIds: ['a', 'b', 'c'] },
+      { amount: 40, winners: ['b'], eligibleUserIds: ['b', 'c'] },
+      { amount: 5, winners: ['c'], eligibleUserIds: ['c'] }
+    ]
+  }, { a: 300, b: 40, c: 5 });
+
+  assert.equal(presentation.valid, true);
+  assert.deepEqual(presentation.pots.map((pot) => [pot.kind, pot.sidePotNumber, pot.amount]), [
+    ['main', null, 300],
+    ['side', 1, 40],
+    ['return', null, 5]
+  ]);
+  assert.deepEqual(presentation.byUserId.a.map((award) => award.amount), [300]);
+  assert.deepEqual(presentation.byUserId.b.map((award) => award.amount), [40]);
+  assert.deepEqual(presentation.byUserId.c.map((award) => award.amount), [5]);
+});
+
+test('uses server winner order for split-pot floor shares and remainder chips', () => {
+  const hooks = loadHooks();
+  const presentation = project(hooks, {
+    handId: 'hand-split',
+    reason: 'computed',
+    potAwardedTotal: 5,
+    potsAwarded: [{ amount: 5, winners: ['b', 'a'], eligibleUserIds: ['a', 'b'] }]
+  }, { b: 3, a: 2 });
+
+  assert.equal(presentation.valid, true);
+  assert.deepEqual(presentation.pots[0].recipients, [
+    { userId: 'b', amount: 3 },
+    { userId: 'a', amount: 2 }
+  ]);
+});
+
+test('classifies all-folded singleton award as main pot instead of return', () => {
+  const hooks = loadHooks();
+  const presentation = project(hooks, {
+    handId: 'hand-fold',
+    reason: 'all_folded',
+    potAwardedTotal: 12,
+    potsAwarded: [{ amount: 12, winners: ['a'], eligibleUserIds: ['a'] }]
+  }, { a: 12 });
+
+  assert.equal(presentation.valid, true);
+  assert.equal(presentation.pots[0].kind, 'main');
+});
+
+test('fails closed for malformed identities, amounts, totals, payouts, and return shapes', () => {
+  const hooks = loadHooks();
+  const base = {
+    handId: 'hand-invalid',
+    reason: 'computed',
+    potAwardedTotal: 10,
+    potsAwarded: [{ amount: 10, winners: ['a'], eligibleUserIds: ['a', 'b'] }]
+  };
+  const cases = [
+    [{ ...base, potsAwarded: [{ amount: -1, winners: ['a'], eligibleUserIds: ['a', 'b'] }] }, { a: 10 }],
+    [{ ...base, potsAwarded: [{ amount: Number.NaN, winners: ['a'], eligibleUserIds: ['a', 'b'] }] }, { a: 10 }],
+    [{ ...base, potsAwarded: [{ amount: '10', winners: ['a'], eligibleUserIds: ['a', 'b'] }] }, { a: 10 }],
+    [{ ...base, potsAwarded: [{ amount: Number.MAX_SAFE_INTEGER + 1, winners: ['a'], eligibleUserIds: ['a', 'b'] }] }, { a: 10 }],
+    [{ ...base, potsAwarded: [{ amount: 10, winners: ['a', 'a'], eligibleUserIds: ['a', 'b'] }] }, { a: 10 }],
+    [{ ...base, potsAwarded: [{ amount: 10, winners: ['c'], eligibleUserIds: ['a', 'b'] }] }, { c: 10 }],
+    [{ ...base, potAwardedTotal: 11 }, { a: 10 }],
+    [base, { a: 9 }],
+    [{ ...base, potsAwarded: [base.potsAwarded[0], { amount: 1, winners: ['b'], eligibleUserIds: ['a'] }], potAwardedTotal: 11 }, { a: 10, b: 1 }]
+  ];
+
+  cases.forEach(([showdown, payouts]) => assert.equal(project(hooks, showdown, payouts).valid, false));
+  const mismatch = plain(hooks.buildSettlementPresentation({
+    showdown: base,
+    handSettlement: { handId: 'different-hand', settledAt: null, payouts: { a: 10 } }
+  }));
+  assert.equal(mismatch.valid, false);
+  assert.equal(mismatch.failureReason, 'hand_id_mismatch');
+});

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -2381,7 +2381,11 @@ test('poker v2 animates a live per-pot settlement once and skips it for resync o
         handSettlement: { handId: 'hand-animation', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 18, 'player-b': 2 } }
       }
     };
-    if (statusBeforeSettlement) ws.onStatus(statusBeforeSettlement, {});
+    if (statusBeforeSettlement){
+      ws.onStatus(statusBeforeSettlement, {});
+      ws.onSnapshot({ kind: 'statePatch', payload: { tableId: 'table-1', public: { pot: { total: 20 } } } });
+      await harness.flush();
+    }
     ws.onSnapshot({
       kind: 'stateSnapshot',
       payload: settlementPayload
@@ -2417,6 +2421,8 @@ test('poker v2 animates a live per-pot settlement once and skips it for resync o
   await disconnectResult.harness.flush();
   assert.equal(disconnectResult.harness.elements.pokerChipFxLayer.children.length, 0, 'disconnect must keep later settlement pots cancelled');
   const resynced = (await settle(false, 'resync')).harness;
+  const resyncedSummary = findChildByClass(resynced.elements.pokerCenterLayer, 'poker-settlement-summary');
+  assert.equal(resyncedSummary.hidden, false, 'the authoritative settlement after a resync remains visible statically');
   assert.equal(resynced.elements.pokerChipFxLayer.children.length, 0, 'a resync snapshot must not replay settlement chips');
   const staticOnly = (await settle(true)).harness;
   assert.equal(staticOnly.elements.pokerChipFxLayer.children.length, 0);

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -122,7 +122,7 @@ function createHarness(options = {}){
     'pokerV2AmountPreactionWrap', 'pokerV2AmountPreaction', 'pokerV2AmountPreactionText',
     'pokerV2AllInPreactionWrap', 'pokerV2AllInPreaction', 'pokerV2AllInPreactionText',
     'pokerV2AmountInput', 'pokerV2AmountInputWrap', 'pokerV2AmountValue',
-    'pokerTableScreen', 'pokerBootSplash'
+    'pokerTableScreen', 'pokerCenterLayer', 'pokerBootSplash'
   ].forEach((id) => {
     elements[id] = makeElement(id);
   });
@@ -215,6 +215,7 @@ function createHarness(options = {}){
           return wsClient;
         }
       },
+      matchMedia(){ return { matches: options.reducedMotion === true }; },
       setInterval(fn){
         intervalTimers.push(fn);
         return intervalTimers.length;
@@ -240,7 +241,11 @@ function createHarness(options = {}){
       readyState: 'loading',
       addEventListener(type, fn){ documentEvents[type] = documentEvents[type] || []; documentEvents[type].push(fn); },
       getElementById(id){ return elements[id] || null; },
-      querySelector(selector){ if (selector === '.poker-scene') return elements.pokerTableScreen || null; return null; },
+      querySelector(selector){
+        if (selector === '.poker-scene') return elements.pokerTableScreen || null;
+        if (selector === '.poker-center-layer') return elements.pokerCenterLayer || null;
+        return null;
+      },
       createElement(tag){ return makeElement(tag); }
     },
     URLSearchParams,
@@ -331,6 +336,10 @@ function findSeatByLabel(harness, label){
 
 function findSeatChild(seatNode, className){
   return (seatNode.children || []).find((child) => child.className === className);
+}
+
+function findChildByClass(node, className){
+  return (node.children || []).find((child) => String(child.className || '').split(/\s+/).includes(className));
 }
 
 test('poker v2 boots live mode, preserves table links, and sends WS commands', async () => {
@@ -1932,7 +1941,7 @@ test('poker v2 keeps the dealer chip fixed while action moves between players', 
   assert.equal(harness.elements.pokerDealerChip.style.top, initialTop);
 });
 
-test('poker v2 shows winner badges and reveals showdown participant cards during settled state', async () => {
+test('poker v2 preserves showdown hand summaries and revealed cards for legacy settled state', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -1980,16 +1989,12 @@ test('poker v2 shows winner badges and reveals showdown participant cards during
   await harness.flush();
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
-  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
-  const heroBadge = findSeatChild(heroSeat, 'poker-seat-winner-badge');
+  const villainBadge = findSeatChild(villainSeat, 'poker-seat-settlement-badge');
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
-  const villainBadgeLabel = findSeatChild(villainBadge, 'poker-seat-winner-label');
-  const villainBadgeCards = findSeatChild(villainBadge, 'poker-seat-winner-cards');
+  const villainBadgeLabel = findSeatChild(villainBadge, 'poker-seat-settlement-hand-label');
+  const villainBadgeCards = findSeatChild(villainBadge, 'poker-seat-settlement-hand-cards');
 
   assert.ok(villainBadge);
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
-  assert.ok(heroBadge);
   assert.ok(villainBadgeLabel);
   assert.equal(villainBadgeLabel.textContent.length > 0, true);
   assert.equal(villainBadgeCards.children.length, 5);
@@ -2057,7 +2062,7 @@ test('poker v2 reveals showdown cards for compared losing players without winner
   assert.equal(losingCards.children.length, 2);
   assert.equal(losingCards.children[0].className.includes('poker-card--back'), false);
   assert.equal(losingCards.children[1].className.includes('poker-card--back'), false);
-  assert.equal(findSeatChild(losingSeat, 'poker-seat-winner-badge'), undefined);
+  assert.equal(findSeatChild(losingSeat, 'poker-seat-settlement-badge'), undefined);
 });
 
 test('poker v2 keeps the previous reveal visible for the full local window before switching to the next hand', async () => {
@@ -2133,7 +2138,7 @@ test('poker v2 keeps the previous reveal visible for the full local window befor
   await harness.flush();
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  assert.ok(findSeatChild(villainSeat, 'poker-seat-winner-badge'));
+  assert.ok(findSeatChild(villainSeat, 'poker-seat-settlement-badge'));
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
   assert.ok(villainCards);
   assert.equal(villainCards.children.length, 2);
@@ -2146,7 +2151,7 @@ test('poker v2 keeps the previous reveal visible for the full local window befor
   await harness.flush();
 
   const switchedVillainSeat = findSeatByLabel(harness, 'Villain 1');
-  assert.equal(findSeatChild(switchedVillainSeat, 'poker-seat-winner-badge'), undefined);
+  assert.equal(findSeatChild(switchedVillainSeat, 'poker-seat-settlement-badge'), undefined);
   const switchedVillainCards = findSeatChild(switchedVillainSeat, 'poker-seat-cards');
   assert.ok(switchedVillainCards);
   assert.equal(switchedVillainCards.children.length, 2);
@@ -2230,7 +2235,7 @@ test('poker v2 does not switch away from the settled reveal scene before the loc
 
   assert.equal(harness.elements.pokerCommunityCards.children.length, 5, 'reveal board should stay visible until the local reveal window ends');
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  assert.ok(findSeatChild(villainSeat, 'poker-seat-winner-badge'));
+  assert.ok(findSeatChild(villainSeat, 'poker-seat-settlement-badge'));
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
   assert.ok(villainCards);
   assert.equal(villainCards.children[0].className.includes('poker-card--back'), false);
@@ -2279,15 +2284,124 @@ test('poker v2 keeps showdown participant cards hidden when the hand ends withou
   await harness.flush();
 
   const villainSeat = findSeatByLabel(harness, 'Villain 1');
-  const villainBadge = findSeatChild(villainSeat, 'poker-seat-winner-badge');
+  const villainBadge = findSeatChild(villainSeat, 'poker-seat-settlement-badge');
   const villainCards = findSeatChild(villainSeat, 'poker-seat-cards');
 
-  assert.ok(villainBadge);
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-title').textContent, 'Winner');
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-label'), undefined);
-  assert.equal(findSeatChild(villainBadge, 'poker-seat-winner-cards'), undefined);
+  assert.equal(villainBadge, undefined, 'an all-folded legacy settlement must not invent an award badge');
   assert.equal(villainCards.children[0].className, 'poker-card poker-card--back');
   assert.equal(villainCards.children[1].className, 'poker-card poker-card--back');
+});
+
+test('poker v2 renders exact main, side, and returned awards and preserves them across omitted patch fields', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    initial: true,
+    payload: {
+      tableId: 'table-1',
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [
+        { userId: 'user-1', seat: 1, displayName: 'Player A' },
+        { userId: 'player-b', seat: 2, displayName: 'Player B' },
+        { userId: 'player-c', seat: 3, displayName: 'Player C' }
+      ] },
+      public: {
+        hand: { handId: 'hand-awards', status: 'SETTLED', dealerSeatNo: 1 },
+        board: { cards: ['2H', '3H', '4H', '9C', 'KD'] },
+        pot: { total: 0 },
+        showdown: {
+          handId: 'hand-awards',
+          reason: 'computed',
+          winners: ['user-1', 'player-b', 'player-c'],
+          potAwardedTotal: 295,
+          potsAwarded: [
+            { amount: 288, winners: ['user-1'], eligibleUserIds: ['user-1', 'player-b', 'player-c'] },
+            { amount: 6, winners: ['player-b'], eligibleUserIds: ['player-b', 'player-c'] },
+            { amount: 1, winners: ['player-c'], eligibleUserIds: ['player-c'] }
+          ]
+        },
+        handSettlement: { handId: 'hand-awards', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 288, 'player-b': 6, 'player-c': 1 } }
+      },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  const summary = findChildByClass(harness.elements.pokerCenterLayer, 'poker-settlement-summary');
+  assert.ok(summary);
+  assert.equal(summary.hidden, false);
+  assert.deepEqual(summary.children.map((row) => row.children[0].textContent), ['Main pot 288', 'Side pot 1 6', 'Returned 1']);
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  const playerBSeat = findSeatByLabel(harness, 'Player B');
+  const playerCSeat = findSeatByLabel(harness, 'Player C');
+  assert.equal(findChildByClass(findSeatChild(heroSeat, 'poker-seat-settlement-badge'), 'poker-seat-settlement-award').textContent, '+288 Main pot');
+  assert.equal(findChildByClass(findSeatChild(playerBSeat, 'poker-seat-settlement-badge'), 'poker-seat-settlement-award').textContent, '+6 Side pot 1');
+  assert.equal(findChildByClass(findSeatChild(playerCSeat, 'poker-seat-settlement-badge'), 'poker-seat-settlement-award--return').textContent, '+1 Returned');
+  assert.equal(/poker-seat--pot-winner/.test(playerCSeat.className), false, 'a return must not style the seat as a pot winner');
+  assert.equal(harness.elements.pokerChipFxLayer.children.length, 0, 'initial settled snapshots stay static');
+
+  ws.onSnapshot({ kind: 'statePatch', payload: { tableId: 'table-1', public: { pot: { total: 0 } } } });
+  await harness.flush();
+  assert.equal(summary.hidden, false);
+  assert.equal(summary.children.length, 3, 'omitted settlement fields must preserve the presentation');
+
+  ws.onSnapshot({ kind: 'statePatch', payload: { tableId: 'table-1', public: { showdown: null } } });
+  await harness.flush();
+  assert.equal(summary.hidden, true, 'an explicit clear must remove the presentation');
+});
+
+test('poker v2 animates a live per-pot settlement once and skips it for reduced motion', async () => {
+  async function settle(reducedMotion){
+    const harness = createHarness({ reducedMotion });
+    harness.fireDomContentLoaded();
+    await harness.flush();
+    const ws = harness.getCreateOptions();
+    ws.onSnapshot({
+      kind: 'stateSnapshot',
+      initial: true,
+      payload: {
+        tableId: 'table-1',
+        table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [
+          { userId: 'user-1', seat: 1, displayName: 'Player A' },
+          { userId: 'player-b', seat: 2, displayName: 'Player B' }
+        ] },
+        public: { hand: { handId: 'hand-animation', status: 'RIVER' }, pot: { total: 20 }, stacks: { 'user-1': 90, 'player-b': 90 } },
+        you: { seat: 1 }
+      }
+    });
+    await harness.flush();
+    const settlementPayload = {
+      tableId: 'table-1',
+      public: {
+        hand: { handId: 'hand-animation', status: 'SETTLED' },
+        pot: { total: 0 },
+        showdown: { handId: 'hand-animation', reason: 'computed', winners: ['user-1'], potAwardedTotal: 20, potsAwarded: [{ amount: 20, winners: ['user-1'], eligibleUserIds: ['user-1', 'player-b'] }] },
+        handSettlement: { handId: 'hand-animation', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 20 } }
+      }
+    };
+    ws.onSnapshot({
+      kind: 'statePatch',
+      payload: settlementPayload
+    });
+    await harness.flush();
+    harness.advanceTime(0);
+    await harness.flush();
+    return { harness, settlementPayload };
+  }
+
+  const animatedResult = await settle(false);
+  const animated = animatedResult.harness;
+  assert.equal(animated.elements.pokerChipFxLayer.children.length > 0, true);
+  const flyCount = animated.elements.pokerChipFxLayer.children.length;
+  animated.getCreateOptions().onSnapshot({ kind: 'statePatch', payload: animatedResult.settlementPayload });
+  await animated.flush();
+  animated.advanceTime(0);
+  await animated.flush();
+  assert.equal(animated.elements.pokerChipFxLayer.children.length, flyCount, 'duplicate settlement patches must not replay chip flows');
+  const staticOnly = (await settle(true)).harness;
+  assert.equal(staticOnly.elements.pokerChipFxLayer.children.length, 0);
 });
 
 test('poker v2 falls back to demo mode when tableId is missing', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -2352,8 +2352,8 @@ test('poker v2 renders exact main, side, and returned awards and preserves them 
   assert.equal(summary.hidden, true, 'an explicit clear must remove the presentation');
 });
 
-test('poker v2 animates a live per-pot settlement once and skips it for reduced motion', async () => {
-  async function settle(reducedMotion){
+test('poker v2 animates a live per-pot settlement once and skips it for resync or reduced motion', async () => {
+  async function settle(reducedMotion, statusBeforeSettlement){
     const harness = createHarness({ reducedMotion });
     harness.fireDomContentLoaded();
     await harness.flush();
@@ -2381,8 +2381,9 @@ test('poker v2 animates a live per-pot settlement once and skips it for reduced 
         handSettlement: { handId: 'hand-animation', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 18, 'player-b': 2 } }
       }
     };
+    if (statusBeforeSettlement) ws.onStatus(statusBeforeSettlement, {});
     ws.onSnapshot({
-      kind: 'statePatch',
+      kind: 'stateSnapshot',
       payload: settlementPayload
     });
     await harness.flush();
@@ -2395,6 +2396,7 @@ test('poker v2 animates a live per-pot settlement once and skips it for reduced 
   const animated = animatedResult.harness;
   assert.equal(animated.elements.pokerChipFxLayer.children.length > 0, true);
   assert.equal(animated.elements.pokerChipFxLayer.children.every((node) => node.classList.contains('poker-chip-fly--settlement')), true);
+  assert.equal(animated.elements.pokerChipFxLayer.children.every((node) => node.style.animationDuration === '780ms'), true);
   const flyCount = animated.elements.pokerChipFxLayer.children.length;
   animated.getCreateOptions().onSnapshot({ kind: 'statePatch', payload: animatedResult.settlementPayload });
   await animated.flush();
@@ -2414,8 +2416,66 @@ test('poker v2 animates a live per-pot settlement once and skips it for reduced 
   disconnectResult.harness.advanceTime(1000);
   await disconnectResult.harness.flush();
   assert.equal(disconnectResult.harness.elements.pokerChipFxLayer.children.length, 0, 'disconnect must keep later settlement pots cancelled');
+  const resynced = (await settle(false, 'resync')).harness;
+  assert.equal(resynced.elements.pokerChipFxLayer.children.length, 0, 'a resync snapshot must not replay settlement chips');
   const staticOnly = (await settle(true)).harness;
   assert.equal(staticOnly.elements.pokerChipFxLayer.children.length, 0);
+});
+
+test('poker v2 preserves a live settlement reveal received after the server timestamp window elapsed', async () => {
+  const nowMs = 1_700_000_300_000;
+  const harness = createHarness({ nowMs });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    initial: true,
+    payload: {
+      tableId: 'table-1',
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [
+        { userId: 'user-1', seat: 1, displayName: 'Player A' },
+        { userId: 'player-b', seat: 2, displayName: 'Player B' }
+      ] },
+      public: { hand: { handId: 'hand-delayed-settlement', status: 'RIVER' }, pot: { total: 20 }, stacks: { 'user-1': 90, 'player-b': 90 } },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      public: {
+        hand: { handId: 'hand-delayed-settlement', status: 'SETTLED' },
+        pot: { total: 0 },
+        showdown: { handId: 'hand-delayed-settlement', reason: 'computed', winners: ['user-1'], potAwardedTotal: 20, potsAwarded: [{ amount: 20, winners: ['user-1'], eligibleUserIds: ['user-1', 'player-b'] }] },
+        handSettlement: { handId: 'hand-delayed-settlement', settledAt: new Date(nowMs - 10_000).toISOString(), payouts: { 'user-1': 20 } }
+      }
+    }
+  });
+  await harness.flush();
+  harness.advanceTime(0);
+  await harness.flush();
+  assert.equal(harness.elements.pokerChipFxLayer.children.length > 0, true, 'a delayed live stateSnapshot must still animate');
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      public: { hand: { handId: 'hand-after-delayed-settlement', status: 'PREFLOP' }, pot: { total: 3 } }
+    }
+  });
+  await harness.flush();
+  const summary = findChildByClass(harness.elements.pokerCenterLayer, 'poker-settlement-summary');
+  assert.equal(summary.hidden, false, 'the next hand must wait for the local reveal window');
+
+  harness.advanceTime(3999);
+  await harness.flush();
+  assert.equal(summary.hidden, false);
+  harness.advanceTime(1);
+  await harness.flush();
+  assert.equal(summary.hidden, true, 'the queued next hand appears after the full local reveal window');
 });
 
 test('poker v2 falls back to demo mode when tableId is missing', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -2377,8 +2377,8 @@ test('poker v2 animates a live per-pot settlement once and skips it for reduced 
       public: {
         hand: { handId: 'hand-animation', status: 'SETTLED' },
         pot: { total: 0 },
-        showdown: { handId: 'hand-animation', reason: 'computed', winners: ['user-1'], potAwardedTotal: 20, potsAwarded: [{ amount: 20, winners: ['user-1'], eligibleUserIds: ['user-1', 'player-b'] }] },
-        handSettlement: { handId: 'hand-animation', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 20 } }
+        showdown: { handId: 'hand-animation', reason: 'computed', winners: ['user-1', 'player-b'], potAwardedTotal: 20, potsAwarded: [{ amount: 18, winners: ['user-1'], eligibleUserIds: ['user-1', 'player-b'] }, { amount: 2, winners: ['player-b'], eligibleUserIds: ['player-b'] }] },
+        handSettlement: { handId: 'hand-animation', settledAt: new Date(Date.now()).toISOString(), payouts: { 'user-1': 18, 'player-b': 2 } }
       }
     };
     ws.onSnapshot({
@@ -2394,12 +2394,26 @@ test('poker v2 animates a live per-pot settlement once and skips it for reduced 
   const animatedResult = await settle(false);
   const animated = animatedResult.harness;
   assert.equal(animated.elements.pokerChipFxLayer.children.length > 0, true);
+  assert.equal(animated.elements.pokerChipFxLayer.children.every((node) => node.classList.contains('poker-chip-fly--settlement')), true);
   const flyCount = animated.elements.pokerChipFxLayer.children.length;
   animated.getCreateOptions().onSnapshot({ kind: 'statePatch', payload: animatedResult.settlementPayload });
   await animated.flush();
   animated.advanceTime(0);
   await animated.flush();
   assert.equal(animated.elements.pokerChipFxLayer.children.length, flyCount, 'duplicate settlement patches must not replay chip flows');
+  animated.getCreateOptions().onSnapshot({ kind: 'statePatch', payload: { tableId: 'table-1', public: { showdown: null } } });
+  await animated.flush();
+  assert.equal(animated.elements.pokerChipFxLayer.children.length, 0, 'explicit clear must remove already-running settlement chips');
+  animated.advanceTime(1000);
+  await animated.flush();
+  assert.equal(animated.elements.pokerChipFxLayer.children.length, 0, 'cancelled later pots must not create new settlement chips');
+  const disconnectResult = await settle(false);
+  disconnectResult.harness.getCreateOptions().onStatus('reconnecting', {});
+  await disconnectResult.harness.flush();
+  assert.equal(disconnectResult.harness.elements.pokerChipFxLayer.children.length, 0, 'disconnect must remove already-running settlement chips');
+  disconnectResult.harness.advanceTime(1000);
+  await disconnectResult.harness.flush();
+  assert.equal(disconnectResult.harness.elements.pokerChipFxLayer.children.length, 0, 'disconnect must keep later settlement pots cancelled');
   const staticOnly = (await settle(true)).harness;
   assert.equal(staticOnly.elements.pokerChipFxLayer.children.length, 0);
 });

--- a/ws-server/poker/reconnect/resync.behavior.test.mjs
+++ b/ws-server/poker/reconnect/resync.behavior.test.mjs
@@ -182,39 +182,73 @@ async function writePersistedFile(fixture) {
   return { dir, filePath };
 }
 
-async function nextMessageOfType(ws, type, { timeoutMs = 5000, skipTypes = [] } = {}) {
-  const started = Date.now();
-  while (true) {
-    const remaining = timeoutMs - (Date.now() - started);
-    if (remaining <= 0) {
-      throw new Error(`Timed out waiting for message type: ${type}`);
-    }
-    const frame = await nextMessage(ws, remaining, `nextMessageOfType(${type})`);
-    if (frame?.type === type) {
-      return frame;
-    }
-    if (skipTypes.includes(frame?.type)) {
-      continue;
-    }
-    throw new Error(`Unexpected frame while waiting for ${type}: ${frame?.type || "unknown"}`);
-  }
+function nextMessageOfType(ws, type, { timeoutMs = 5000, skipTypes = [] } = {}) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    const onMessage = (data) => {
+      const frame = JSON.parse(String(data));
+      if (frame?.type === type) {
+        cleanup();
+        resolve(frame);
+        return;
+      }
+      if (skipTypes.includes(frame?.type)) return;
+      cleanup();
+      reject(new Error(`Unexpected frame while waiting for ${type}: ${frame?.type || "unknown"}`));
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before message type ${type}: ${code}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for message type: ${type}`));
+    }, timeoutMs);
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
 }
 
-async function nextMessageForRequest(ws, type, requestId, { timeoutMs = 5000, skipTypes = [] } = {}) {
-  const started = Date.now();
-  while (true) {
-    const remaining = timeoutMs - (Date.now() - started);
-    if (remaining <= 0) {
-      throw new Error(`Timed out waiting for ${type} requestId=${requestId}`);
-    }
-    const frame = await nextMessage(ws, remaining, `nextMessageForRequest(${type}, ${requestId})`);
-    if (frame?.type === type && frame?.requestId === requestId) {
-      return frame;
-    }
-    if (skipTypes.includes(frame?.type)) {
-      continue;
-    }
-  }
+function nextMessageForRequest(ws, type, requestId, { timeoutMs = 5000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    const onMessage = (data) => {
+      const frame = JSON.parse(String(data));
+      if (frame?.type !== type || frame?.requestId !== requestId) return;
+      cleanup();
+      resolve(frame);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code) => {
+      cleanup();
+      reject(new Error(`Socket closed before ${type} requestId=${requestId}: ${code}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${type} requestId=${requestId}`));
+    }, timeoutMs);
+    ws.on("message", onMessage);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
 }
 
 
@@ -480,6 +514,7 @@ test("resync accepts roomId without payload.tableId", async () => {
     const auth2 = await auth(client2, token, "req-auth-roomid-c2");
     assert.equal(auth2.type, "authOk");
 
+    const resyncedPromise = nextMessage(client2, 5000, "resync-roomid-c2");
     sendFrame(client2, {
       version: "1.0",
       type: "resync",
@@ -488,7 +523,7 @@ test("resync accepts roomId without payload.tableId", async () => {
       ts: "2026-02-28T00:00:21Z",
       payload: {}
     });
-    const resynced = await nextMessage(client2, 5000, "resync-roomid-c2");
+    const resynced = await resyncedPromise;
     assert.equal(resynced.type, "table_state");
     assert.equal(resynced.payload.tableId, "table_roomid_resync");
     assert.equal(resynced.payload.members.length, 1);
@@ -1426,26 +1461,31 @@ test("recoverable persistence conflict does not force resync and explicit resync
     const ws = await connectClient(port);
     await hello(ws, "hello-conflict-resync");
     await auth(ws, token, "auth-conflict-resync");
+    const joinedPromise = nextMessageOfType(ws, "table_state", { skipTypes: ["commandResult"] });
     sendFrame(ws, { version: "1.0", type: "table_join", requestId: "join-conflict-resync", ts: "2026-02-28T03:00:00Z", payload: { tableId } });
-    await nextMessageOfType(ws, "table_state", { skipTypes: ["commandResult"] });
+    await joinedPromise;
+    const baselinePromise = nextMessageForRequest(ws, "stateSnapshot", "snap-conflict-resync", { skipTypes: ["commandResult", "statePatch"] });
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-conflict-resync", ts: "2026-02-28T03:00:01Z", payload: { tableId, view: "snapshot" } });
-    const baseline = await nextMessageForRequest(ws, "stateSnapshot", "snap-conflict-resync", { skipTypes: ["commandResult", "statePatch"] });
+    const baseline = await baselinePromise;
     const handId = baseline.payload.public.hand.handId;
 
     const forcedRaw = JSON.parse(await fs.readFile(filePath, "utf8"));
     forcedRaw.tables[tableId].stateRow.version = baseline.payload.stateVersion + 3;
     await fs.writeFile(filePath, `${JSON.stringify(forcedRaw)}\n`, "utf8");
 
+    const rejectedPromise = nextMessageForRequest(ws, "commandResult", "act-conflict-resync", { skipTypes: ["stateSnapshot", "statePatch"], timeoutMs: 10000 });
     sendFrame(ws, { version: "1.0", type: "act", requestId: "act-conflict-resync", ts: "2026-02-28T03:00:02Z", payload: { tableId, handId, action: "fold" } });
-    const rejected = await nextMessageForRequest(ws, "commandResult", "act-conflict-resync", { skipTypes: ["stateSnapshot", "statePatch"], timeoutMs: 10000 });
+    const rejected = await rejectedPromise;
     assert.equal(rejected.payload.status, "rejected");
     const maybeImmediateRecovery = await attemptMessage(ws, 400);
     assert.notEqual(maybeImmediateRecovery?.type, "resync");
 
+    const resyncedPromise = nextMessageOfType(ws, "table_state", { skipTypes: ["commandResult"] });
     sendFrame(ws, { version: "1.0", type: "resync", requestId: "resync-after-conflict", ts: "2026-02-28T03:00:03Z", payload: { tableId } });
-    await nextMessageOfType(ws, "table_state", { skipTypes: ["commandResult"] });
+    await resyncedPromise;
+    const hydratedPromise = nextMessageForRequest(ws, "stateSnapshot", "snap-after-conflict", { skipTypes: ["commandResult", "statePatch"] });
     sendFrame(ws, { version: "1.0", type: "table_state_sub", requestId: "snap-after-conflict", ts: "2026-02-28T03:00:04Z", payload: { tableId, view: "snapshot" } });
-    const hydrated = await nextMessageForRequest(ws, "stateSnapshot", "snap-after-conflict", { skipTypes: ["commandResult", "statePatch"] });
+    const hydrated = await hydratedPromise;
     assert.equal(hydrated.payload.stateVersion, forcedRaw.tables[tableId].stateRow.version);
     ws.close();
   } finally {


### PR DESCRIPTION
## Summary

- preserves and validates authoritative `showdown.potsAwarded`, `potAwardedTotal`, and `handSettlement.payouts` in poker v2
- renders ordered `Main pot`, `Side pot N`, and `Returned` rows centrally and at each recipient seat; returns are never styled as pot wins
- fixes partial `statePatch` merge semantics so omitted settlement fields remain visible while explicit clears and next-hand transitions are respected
- replaces the lossy aggregate winner animation with sequential per-pot chip flows using exact recipient shares
- keeps reconnect/resync static, prevents duplicate animation replay, and supports `prefers-reduced-motion`
- updates the accepted Speckit plan to record delivery of both ordered phases in this PR

## Verification

- `npm test`
- `node --test tests/poker-settlement-presentation.unit.test.mjs tests/poker-v2-live.behavior.test.mjs`
- `npm run syntax`
- `git diff --check`

The focused cases cover main/side/return classification, split-pot remainder order, malformed data fail-closed behavior, omitted and explicit patch fields, static reconnect snapshots, duplicate replay protection, and reduced motion.

## Breaking impact

No DB migration, ENV, secret, poker-rule, ledger, persisted-state, WS-contract, HTML script, or CSP change. This intentionally replaces generic `Winner` labels and `.poker-seat-winner-*` presentation with exact localized per-pot settlement UI. Existing screenshot assertions or selectors tied to the old winner label/classes require updates.

## Preview

A Netlify Deploy Preview is required because browser JavaScript, CSS, localization, and visual behavior changed. A WS Preview Deploy is not required because no `ws-server/` code or WS contract changed.