### PR TITLE
fix: handle poker bust lifecycle and manual rebuy

### DIFF
--- a/docs/poker-human-bust-and-rebuy-analysis.md
+++ b/docs/poker-human-bust-and-rebuy-analysis.md
@@ -1,0 +1,609 @@
+# Poker human bust and rebuy analysis
+
+Status: analysis only  
+Date: 2026-07-14  
+Observed environment: WS Preview / stage database  
+Observed table: `7e22c318-0c3d-42dc-8481-2e7d7ff5756c`
+
+## TL;DR
+
+The player correctly lost the last 43 CH and reached stack `0`. The next hand correctly excluded that player, but the table still treated the player as an active seated human. The browser therefore continued to render the seat while the server returned no legal actions. Bots continued playing three-handed.
+
+This is an incomplete busted-player lifecycle, not an illegal poker-engine action.
+
+The recommended cash-game UX is:
+
+1. show `Out of chips / Sitting out` immediately after settlement;
+2. keep the seat reserved while the connected player decides;
+3. offer an explicit `Buy in 100 CH` action and `Return to lobby`;
+4. let the other players or bots continue;
+5. seat the player into a new hand only after an atomic, idempotent USER-to-ESCROW rebuy succeeds.
+
+Arcade Hub must not silently debit another 100 CH. Automatic rebuy is appropriate only as a separate, explicit opt-in setting.
+
+The investigation also found a critical accounting defect: after the player busted, rollover removed the player's `0` stack from `poker_state`, while `poker_seats.stack` still contained the original `100`. Disconnect cleanup then fell back to that stale row and returned 100 CH to the user. The busted-player UX must not be implemented before this cash-out source-of-truth defect is fixed.
+
+## Evidence from table `7e22c318`
+
+The system journal no longer contained searchable events for this table. The stage database still contained the authoritative action audit, settlement audit, seat rows, poker state, and chips ledger entries.
+
+### Timeline
+
+| UTC | Event | Evidence |
+| --- | --- | --- |
+| 18:25:23 | Player joins with 100 CH | Ledger posts `USER -100`, `ESCROW +100` as `TABLE_BUY_IN`. |
+| 18:28:34.951 | Player bets the remaining 43 CH | Accepted action audit records `BET 43`, `actorStackBefore: 43`, `actorStackAfter: 0`. |
+| 18:28:37.188 | Bot calls 43 CH | Pot continues normally. |
+| 18:28:40.522 | Hand settles | Bot at seat 4 receives the 195 CH pot. The evaluated pair with Q kicker beats the player's pair with T kicker. The settlement itself is consistent. |
+| about 18:28:44 | Next hand starts | The new hand contains only the three bots. The busted player is not dealt in. |
+| 18:28:44–18:29:21 | Bots continue playing | Multiple accepted bot actions are present for subsequent hands. |
+| 18:29:25.348 | Inactive cleanup runs | Ledger posts `ESCROW -100`, `USER +100`, despite the settled player stack having been `0`. |
+
+There was no automatic rebuy transaction after the bust. The only later user ledger movement was the incorrect 100 CH cash-out.
+
+## Current runtime flow
+
+### 1. Rollover excludes a broke human from the next hand
+
+`ws-server/poker/engine/poker-engine.mjs` defines `MIN_STACK_TO_JOIN_HAND = 2`. `isContinuationEligibleByStack()` therefore excludes a member whose stack is `0` or `1`. `buildNextHandStateFromSettled()` builds the next hand from eligible members only.
+
+`replaceBrokeBotsForNextHand()` handles only seats marked as bots. It replaces and funds broke bots, but has no corresponding human-bust transition.
+
+Result for this table: the player's table membership remained, but the next `pokerState.seats`, `handSeats`, and `stacks` contained only bots.
+
+### 2. The table still counts the busted user as an active human
+
+`hasActiveHumanMember()` in `ws-server/poker/table/table-manager.mjs` checks only whether `coreState.members` contains a non-bot. It does not check stack or a sit-out/busted state.
+
+That keeps settled rollover and bot autoplay alive. Continuing the game for the remaining players is correct, but the human needs an explicit sitting-out state and recovery action.
+
+### 3. The action contract correctly returns no actions
+
+`computeSharedLegalActions()` in `ws-server/poker/shared/poker-primitives.mjs` returns an empty action set when `stack <= 0`. A busted player must not be allowed to bet, call, check, raise, or fold in a hand in which they were not dealt.
+
+The problem is therefore not that action buttons were disabled. The problem is that the UI did not explain why and did not offer a rebuy or leave flow.
+
+### 4. The client continues to render the seat
+
+`deriveCurrentSeat()` in `poker/poker-v2.js` derives the hero seat from the table-level seat list or `youSeat`. `renderControls()` treats a signed-in seated user as joined even when the resolved stack is `0`.
+
+This produces the observed state:
+
+- hero seat remains visible;
+- stack is `0`;
+- the hero is not part of the new hand;
+- legal actions are empty;
+- action controls cannot be used;
+- no dedicated `Out of chips` explanation or recovery CTA appears.
+
+## Critical accounting finding
+
+This incident exposed a source-of-truth gap between `poker_state.state.stacks` and `poker_seats.stack`.
+
+Before rollover, the authoritative settled state recorded the human stack as `0`. Rollover then built a new hand containing only eligible players and removed the busted user's stack entry. The corresponding `poker_seats` row still contained the original buy-in value `100`.
+
+`stateFirstStackAmount()` in `shared/poker-domain/inactive-cleanup.mjs` prefers the stack in `poker_state`, but falls back to `poker_seats.stack` when the user is absent from state. For this table that fallback selected stale `100`, and cleanup paid it to the user.
+
+This violates the intended accounting invariant:
+
+> A user cash-out must equal the user's authoritative remaining table stack, never the original buy-in or an unverified fallback.
+
+### Required accounting contract before rebuy work
+
+- Declare one authoritative stack for every active human table lifecycle, including `0` after a bust.
+- Keep any `poker_seats.stack` projection transactionally synchronized with authoritative gameplay state, or stop using it as a cash-out fallback.
+- Rollover must not erase the only durable proof that a busted player's balance is `0`.
+- Cleanup must fail closed and flag manual review when the cash-out amount cannot be proven. It must not refund a stale positive seat value.
+- Process restart/restore, ordinary leave, disconnect cleanup, table close, and rebuy must use the same source-of-truth rule.
+- Add an accounting invariant covering the complete session: user buy-ins minus user cash-outs must equal the user's net table loss retained in escrow/distributed through the table lifecycle.
+
+This should be treated as a high-priority accounting fix. The UI issue is visible, but the incorrect 100 CH refund changes ledger balances.
+
+## Recommended product behavior
+
+Arcade Hub currently behaves like a cash/ring game: the user selects a buy-in, funds table escrow, can leave and cash out, and bots continue across hands. It should therefore use cash-game bust semantics rather than tournament elimination semantics.
+
+Official PokerStars documentation provides useful precedent:
+
+- cash-game players can explicitly add chips through a buy-in/refill dialog, and the amount is confirmed before it is taken from the account ([Play Money cash-game refill](https://www.pokerstars.com/help/articles/pkr-feat-joining-pm-games/211807/));
+- automatic rebuy is a user-configured setting with explicit trigger conditions such as losing all chips ([Auto Rebuy](https://www.pokerstars.com/help/articles/auto-rebuy/140280/));
+- cash tables enforce defined minimum and maximum buy-ins ([cash-game buy-in limits](https://www.pokerstars.com/help/articles/ring-game-min-buy-in/96431/)).
+
+### Recommended first release
+
+After the settlement reveal, when a human's authoritative stack is `0`:
+
+1. Mark the user as `Out of chips` / `Sitting out` for presentation and lifecycle purposes.
+2. Keep the seat reserved while authenticated WS presence is healthy. Existing disconnect cleanup releases it after a disconnect; a hard timeout for a connected watcher is a separate product decision.
+3. Show a modal or prominent table panel with:
+   - current Arcade balance;
+   - `Buy in 100 CH` as the primary action;
+   - an optional permitted buy-in selector if table limits support it;
+   - `Return to lobby`;
+   - optionally `Keep watching`, without holding the seat indefinitely.
+4. Keep bots and other funded players playing. Do not pause their hands while the busted user decides.
+5. Keep normal poker action buttons visible but disabled, with an `Out of chips` reason. Do not show a generic `Waiting for action` state for the hero.
+6. If the reservation expires or the player chooses the lobby, release the seat and cash out exactly the authoritative residual, normally `0`.
+
+### Rebuy transaction contract
+
+A rebuy must be a new explicit command, not a replay of `table_join` against an existing active seat. It should:
+
+- be accepted only while the human is not in an active hand;
+- validate table status, seat ownership, table buy-in limits, and user balance;
+- atomically transfer the confirmed amount from the USER ledger account to the table ESCROW;
+- atomically update the authoritative table stack and its seat projection;
+- use a deterministic request-scoped idempotency key;
+- expose the funded player only after the database transaction succeeds;
+- join the player at the next hand boundary, never midway through a hand;
+- fail without changing the table stack when ledger funding fails or the user has insufficient balance.
+
+### Automatic rebuy
+
+Do not automatically withdraw 100 CH in the first release. A silent debit would make repeated losses surprising and could consume bonuses or the entire Arcade balance without a fresh decision.
+
+Auto-rebuy can be added later only as an explicit opt-in preference with:
+
+- a visible enabled state;
+- a selected target amount or stack threshold;
+- table buy-in limits;
+- insufficient-balance behavior;
+- an easy disable control;
+- idempotent funding and the same hand-boundary rule as manual rebuy.
+
+Auto-rebuy is explicitly out of scope for the implementation described below. It is tracked separately in [GitHub issue #712](https://github.com/krzysztofcal/arcadePlatform/issues/712) and depends on the accounting, out-of-chips lifecycle, and manual rebuy work being deployed and verified first.
+
+## Additional edge case: a one-chip stack
+
+The shared engine currently requires at least 2 CH to join the next hand. That is appropriate as a bot replacement policy, but it is questionable for humans. A player with 1 CH can normally post a partial blind and be all-in; the existing blind-posting code already caps the posted blind at the available stack.
+
+Human eligibility should therefore be reviewed separately from bot replacement. The likely contract is:
+
+- human with stack `> 0`: eligible for the next hand, including a forced partial-blind all-in;
+- human with stack `0`: busted/sitting out and offered rebuy;
+- bot with stack below the configured replacement threshold: replaced using the existing funded replacement flow.
+
+## Speckit-style implementation plan
+
+### Goal
+
+Deliver the smallest safe cash-game lifecycle in which:
+
+- losing the final chip cannot produce an incorrect cash-out;
+- a funded human with at least 1 CH can participate;
+- a human at 0 CH is explicitly `OUT_OF_CHIPS` and is not dealt in;
+- the player can consciously buy in for another 100 CH or leave;
+- a successful rebuy becomes playable only at the next hand boundary;
+- bots continue while the connected human decides;
+- no automatic debit exists.
+
+### Architecture decision
+
+Keep the existing engine, WS server, chips ledger, table escrow, CAS writer, bot autoplay, and persisted poker tables. Do not introduce a second wallet, a new ledger type, or a separate rebuy service.
+
+The implementation should formalize the existing distinction between:
+
+- **table seats and table stacks**: every active seat, including a human at stack `0` or waiting for the next hand;
+- **`handSeats`**: only players dealt into the current hand.
+
+During action phases, the existing legal-action code already prefers `handSeats`, so a table-level out-of-chips or newly re-funded seat can remain visible without becoming eligible to act in the current hand.
+
+Use these additive properties:
+
+- `coreState.publicStacks[userId]`: current table stack projection, including `0`;
+- persisted `pokerState.stacks[userId]`: durable stack evidence for every active table seat, not only current `handSeats`;
+- `pokerState.waitingForNextHandByUserId[userId] = true`: an already funded human who must wait for the next deal;
+- snapshot `private.playerState.status`: `ACTIVE`, `WAITING_NEXT_HAND`, or `OUT_OF_CHIPS`;
+- snapshot `private.playerState.stack`: authoritative non-negative table stack;
+- snapshot `private.playerState.canRebuy`: true only for an authenticated human with status `OUT_OF_CHIPS` at an open table.
+
+The client must treat `private.playerState` as optional for backward compatibility and derive the old behavior when it is absent.
+
+No database migration is required. `poker_seats.stack` remains the lifecycle projection, but it must be updated transactionally from the authoritative state before it can be used by leave or cleanup.
+
+### Delivery strategy
+
+Implement this as two ordered runtime PRs after this documentation PR:
+
+1. **Accounting and lifecycle safety:** preserve zero stacks, synchronize the human seat-stack projection, fail closed on ambiguous cash-out, expose `OUT_OF_CHIPS`, and fix the 1 CH human edge case.
+2. **Explicit rebuy and UI:** add the authoritative rebuy command, USER-to-ESCROW transaction, waiting-for-next-hand transition, and table prompt.
+
+The second PR must not deploy before the first PR has passed stage reconciliation and a bust-cleanup smoke test.
+
+### Phase 0 — read-only impact inventory
+
+Files and operational surfaces:
+
+- new `scripts/poker-human-stack-audit.mjs` using the existing DB configuration and `klog` conventions;
+- `public.poker_actions` settlement and accepted-action audit;
+- `public.poker_state`;
+- `public.poker_seats`;
+- `public.chips_transactions`, `public.chips_entries`, and `public.chips_accounts`.
+
+Tasks:
+
+1. Add a read-only operator query or existing-admin-compatible report that finds active human seats where:
+   - the seat projection is positive;
+   - the current poker state has no stack entry for that user, or has a different stack;
+   - the last settlement audit proves the human reached `0`.
+2. Inventory historical positive `TABLE_CASH_OUT` entries occurring after an audited stack-0 settlement.
+3. Produce counts and transaction IDs only; do not mutate balances in this implementation.
+4. Flag ambiguous historical cases for manual review. Do not infer that every mismatch should be reversed.
+
+Acceptance:
+
+- the query is read-only and bounded;
+- the observed stage table `7e22c318` is detected;
+- no production balance is changed;
+- remediation remains a separate owner-approved operation.
+
+### Phase 1 — authoritative human stack through rollover and cash-out
+
+#### `ws-server/poker/engine/poker-engine.mjs`
+
+Change:
+
+- split the current `MIN_STACK_TO_JOIN_HAND` policy into human and bot rules;
+- update `isContinuationEligibleByStack()`, `orderedEligibleSeatMembers()`, and `buildNextHandStateFromSettled()` so a human with stack `> 0` is eligible, while bot replacement may retain its existing `< 2` policy;
+- preserve every active table member in table-level `seats` and `stacks`, including a busted human with `0`;
+- keep only eligible funded players in `handSeats`;
+- keep `replaceBrokeBotsForNextHand()` bot-only and do not fund humans from SYSTEM accounts;
+- clear `waitingForNextHandByUserId[userId]` when that funded human is admitted to the next hand.
+
+Invariants:
+
+- a human stack `0` survives rollover as durable evidence;
+- a human stack `1` can post a partial blind and be all-in;
+- a busted human never appears in `handSeats`;
+- bot replacement funding behavior remains unchanged.
+
+#### `ws-server/poker/table/table-manager.mjs`
+
+Change:
+
+- extend `prepareSettledHandRollover()` to return a normalized `humanStackUpdates` intent for active non-bot members, including zero;
+- project settled human stacks into `nextCoreState.publicStacks` before building the next hand;
+- extend `commitSettledHandRollover()` receipt validation so runtime state cannot commit unless the persistence receipt confirms the human stack projection and any bot replacement funding;
+- make `hasActiveHumanMember()` explicitly distinguish table presence from hand eligibility. A connected out-of-chips human still keeps the table experience alive, but is not an action participant.
+
+Properties:
+
+```text
+humanStackUpdates[] = {
+  userId,
+  seatNo,
+  stack,
+  settledHandId,
+  fromStateVersion,
+  toStateVersion
+}
+```
+
+The intent is internal server data, not part of the public WS snapshot.
+
+#### `ws-server/server.mjs`
+
+Change `runSettledRolloverCommand()` and `persistMutatedState()` wiring to pass `humanStackUpdates` through the same prepare → persist → commit boundary already used by bot replacement funding.
+
+Failure behavior:
+
+- if the state CAS or human seat-stack update fails, the DB transaction rolls back;
+- runtime remains on the previous settled state;
+- the existing bounded/slow settled-rollover retry is used;
+- no next hand is broadcast from an uncommitted candidate.
+
+#### `ws-server/poker/persistence/persisted-state-writer.mjs`
+
+Change:
+
+- normalize and validate `humanStackUpdates` against table ID, seat number, state versions, unique user/seat, and non-negative integer stack;
+- after successful poker-state CAS and inside the same SQL transaction, update only matching `ACTIVE`, `is_bot = false` seat rows;
+- require every intended row to match exactly once;
+- return a persistence receipt proving the seat-stack projection was committed;
+- do not update bot seat rows through this path and do not change the bot ledger behavior from issue #705.
+
+This makes the following atomic:
+
+```text
+poker_state CAS + human poker_seats.stack projection + bot replacement funding
+```
+
+#### `shared/poker-domain/inactive-cleanup.mjs` and `shared/poker-domain/leave.mjs`
+
+Add a focused `shared/poker-domain/human-stack-accounting.mjs` helper and use it from both lifecycle modules. Replace the permissive positive fallback with this shared cash-out resolver.
+
+Contract:
+
+- explicit state stack, including `0`, wins;
+- a synchronized seat projection can be used when state intentionally omits the user only if its lifecycle evidence is unambiguous;
+- state-missing plus positive legacy seat stack is `stack_ambiguous`, not an automatic refund;
+- ambiguous cleanup/leave fails closed, logs with `klog`, and requires restore or manual review;
+- amount `0` completes lifecycle cleanup without creating a ledger transaction;
+- ordinary leave and disconnect cleanup use the same resolver.
+
+Do not use `console.log`. Logs must contain table ID, reason code, source (`state`, `seat_projection`, or `ambiguous`), and aggregate amount, without email or profile data.
+
+#### `ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs`
+
+Change `normalizePublicStacks()` so a valid persisted gameplay stack takes precedence over a seat projection for the same user. The seat projection remains a fallback for table members not present in the current hand state.
+
+Restore acceptance:
+
+- an out-of-chips active human restores with stack `0` and remains seated but not dealt in;
+- a human with stack `1` restores as hand-eligible;
+- a stale positive seat row cannot override state stack `0`;
+- replacement bot restore behavior stays intact.
+
+### Phase 2 — public and private `OUT_OF_CHIPS` presentation contract
+
+#### `ws-server/poker/read-model/room-core-snapshot.mjs`
+
+Change:
+
+- merge table members with current hand seats instead of dropping members not present in `handSeats`;
+- merge `coreState.publicStacks` with live hand stacks per user instead of choosing one entire map;
+- mark a non-bot table seat with authoritative stack `0` as `OUT_OF_CHIPS`;
+- add optional `private.playerState` for the authenticated viewer;
+- preserve `legalActions.actions = []` for `OUT_OF_CHIPS` and `WAITING_NEXT_HAND`.
+
+Snapshot example:
+
+```json
+{
+  "private": {
+    "userId": "...",
+    "seat": 1,
+    "holeCards": [],
+    "playerState": {
+      "status": "OUT_OF_CHIPS",
+      "stack": 0,
+      "canRebuy": true
+    }
+  }
+}
+```
+
+This is an additive WS contract change. `showdown`, `handSettlement`, bot autoplay, and per-pot settlement remain unchanged.
+
+#### `poker/poker-v2.js`
+
+Change snapshot normalization and rendering to:
+
+- prefer `private.playerState` when present;
+- show `Out of chips · Sitting out` instead of `Waiting for action` for the hero;
+- keep the established action-button positions visible and disabled;
+- clear queued pre-actions when status becomes `OUT_OF_CHIPS` or `WAITING_NEXT_HAND`;
+- never infer that empty `legalActions` alone means bust;
+- render the same state after reconnect or full resync without replaying settlement animation.
+
+The seat can remain reserved while the authenticated WS presence is healthy. Existing disconnect/presence cleanup releases it after disconnect. A forced timeout for a connected watcher is not required in the first release and can be considered separately if seat hoarding becomes a product issue.
+
+### Phase 3 — explicit manual rebuy
+
+#### Shared authoritative domain
+
+Files:
+
+- new `shared/poker-domain/table-buy-in.mjs` containing the existing normalized USER-to-ESCROW `TABLE_BUY_IN` posting operation;
+- `shared/poker-domain/join.mjs` changed to use that helper without changing join semantics;
+- new `shared/poker-domain/rebuy.mjs` containing `executePokerRebuyAuthoritative()`;
+- new `ws-server/shared/poker-domain/rebuy.mjs` re-exporting the shared domain entrypoint.
+
+Add `executePokerRebuyAuthoritative()` with these preconditions:
+
+- authenticated non-bot user;
+- table status `OPEN`;
+- user owns an `ACTIVE` seat at that table;
+- authoritative table stack is exactly `0`;
+- user is absent from current `handSeats`;
+- requested amount is exactly 100 CH for the first release;
+- request ID is present.
+
+Inside one SQL transaction:
+
+1. call the existing `ensurePokerRequest()` pattern with kind `REBUY`; return the previously stored result for an identical completed request before evaluating current stack preconditions;
+2. lock table, seat, and poker state;
+3. validate the authoritative out-of-chips state;
+4. CAS/update poker state to add stack `100` and `waitingForNextHandByUserId[userId] = true` without adding the user to current `handSeats`;
+5. post existing `TABLE_BUY_IN` entries `USER -100` and `ESCROW +100` through `postUserTableBuyIn()`;
+6. update `poker_seats.stack = 100`;
+7. update table activity and store the successful poker request result in the same transaction;
+8. commit and return the new state version plus ledger receipt.
+
+Recommended idempotency key:
+
+```text
+poker:rebuy:v1:<tableId>:<userId>:<requestId>
+```
+
+The amount remains in the ledger payload hash. Reusing a request ID with a different amount must be rejected as a mismatch, not treated as a second operation. The stored `poker_requests` result supplies process-restart replay semantics before the already-funded stack would otherwise fail the `stack === 0` precondition.
+
+Failure behavior:
+
+- insufficient USER balance: reject with `insufficient_chips`, no state or seat change;
+- state/CAS conflict: rollback, restore authoritative table, no debit;
+- duplicate same request and payload: return the original successful result;
+- duplicate request with different payload: reject;
+- table closed, seat released, stack no longer zero, or user already in a hand: reject without ledger writes;
+- process failure before SQL commit: no visible runtime change;
+- process failure after SQL commit: reconnect/restore shows `WAITING_NEXT_HAND` and does not fund again.
+
+#### WS command path
+
+Files and touchpoints:
+
+- new `ws-server/poker/persistence/authoritative-rebuy-adapter.mjs` following the join/leave adapter pattern;
+- new `ws-server/poker/handlers/rebuy.mjs`;
+- `ws-server/server.mjs` dispatch for canonical `table_rebuy` and client alias `rebuy`;
+- `poker/poker-ws-client.js` method `sendRebuy(payload, requestId)`;
+- `docs/ws-poker-protocol.md` request/result and additive snapshot fields.
+
+After authoritative rebuy succeeds, restore or apply the committed state, broadcast one snapshot, and schedule normal settled rollover/bot autoplay. Do not hand-build a client-only stack update.
+
+#### UI
+
+Files:
+
+- `poker/table-v2.html`;
+- `poker/poker-v2.js`;
+- `poker/poker-v2.css`;
+- existing `window.ChipsClient.fetchBalance()` for the displayed Arcade balance; do not add a second balance endpoint.
+
+UI behavior:
+
+- show a prominent non-destructive panel or modal after settlement: `Out of chips`;
+- explain that the player is sitting out while the table continues;
+- primary CTA: `Buy in 100 CH`;
+- secondary CTA: `Return to lobby`;
+- optional tertiary action: close the prompt and keep watching without re-enabling poker actions;
+- show pending state while the command is in flight and prevent duplicate clicks;
+- on success show `Funded · Joining next hand` until rollover admits the player;
+- on insufficient balance show the controlled error and a link to the account/chips surface;
+- preserve a stable action-button layout and mobile readability.
+
+Modify the existing external scripts only. Do not add inline JavaScript, a new script tag, CSP SHA, or external image origin. JavaScript must remain compatible with the existing page/JSP-compatible browser style. CSS must use one line per selector.
+
+### Tests required by the accounting risk
+
+Keep the suite focused on critical invariants.
+
+#### Deterministic unit tests
+
+Files:
+
+- `ws-server/poker/engine/engine-rollover.behavior.test.mjs`;
+- `ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs`;
+- new `shared/poker-domain/human-stack-accounting.behavior.test.mjs`.
+
+Cases:
+
+- human `0` remains table-seated, is excluded from `handSeats`, and remains stack `0`;
+- human `1` enters the next hand and posts a partial blind;
+- broke bot replacement behavior is unchanged;
+- `OUT_OF_CHIPS`, `WAITING_NEXT_HAND`, and `ACTIVE` are derived deterministically;
+- state stack `0` cannot be overridden by seat stack `100`;
+- missing state plus stale positive seat projection returns `stack_ambiguous`.
+
+#### Transaction and integration tests
+
+Files:
+
+- `ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs`;
+- `shared/poker-domain/inactive-cleanup.behavior.test.mjs`;
+- `shared/poker-domain/leave.behavior.test.mjs`;
+- new `shared/poker-domain/rebuy.behavior.test.mjs`;
+- new `ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs`;
+- new `ws-server/poker/handlers/rebuy.behavior.test.mjs`;
+- `ws-server/poker/reconnect/resync.behavior.test.mjs`;
+- `tests/poker-ws-client.test.mjs`;
+- `tests/poker-v2-live.behavior.test.mjs`.
+
+Cases:
+
+1. bust `100 → 0`, rollover, disconnect cleanup: cash-out is `0`, not `100`;
+2. bust, rollover, explicit leave: cash-out is `0`;
+3. state CAS failure: seat projection and runtime do not commit;
+4. restart after bust: stack remains `0` and player remains `OUT_OF_CHIPS`;
+5. successful rebuy: `USER -100`, `ESCROW +100`, seat/state stack `100` exactly once;
+6. same rebuy request twice: one ledger transaction;
+7. failed ledger funding: no persisted or runtime stack change;
+8. rebuy during a bot hand: hero stays out of current `handSeats` and enters only the next hand;
+9. restart after committed rebuy: `WAITING_NEXT_HAND` restores without a second debit;
+10. leave after funded rebuy but before the next hand: exactly 100 CH is returned;
+11. reconnect/resync at stack `0`: static out-of-chips UI, no actions;
+12. action buttons remain stable and disabled while the rebuy prompt is visible.
+
+Ledger invariants:
+
+```text
+rebuy USER delta == -100
+rebuy table ESCROW delta == +100
+sum(rebuy entries) == 0
+cash-out after audited bust == 0
+```
+
+### Manual verification
+
+Requires both Netlify Deploy Preview and WS Preview Deploy because the plan changes the browser and WS server.
+
+On stage:
+
+1. buy in for 100 CH and record user/escrow balances;
+2. lose the full stack naturally or through a controlled test table;
+3. verify settlement, `Out of chips · Sitting out`, disabled stable actions, and continuing bots;
+4. disconnect and reconnect before rebuy; verify stack remains `0` and no refund occurs;
+5. rebuy 100 CH; verify one user debit, one escrow credit, and `Joining next hand`;
+6. verify no cards/actions in the already-running hand;
+7. verify normal participation in the next hand;
+8. repeat the same request ID and verify no second debit;
+9. test insufficient balance;
+10. test `Return to lobby` both before and after a successful rebuy;
+11. verify mobile layout and keyboard focus;
+12. inspect `klog` for controlled reason codes and absence of email/token data.
+
+### Rollout and rollback
+
+Rollout order:
+
+1. run the read-only discrepancy inventory on stage and production;
+2. deploy accounting/lifecycle safety to WS Preview;
+3. verify bust → rollover → disconnect/leave produces zero cash-out;
+4. deploy accounting/lifecycle safety to production and observe before enabling rebuy UI;
+5. deploy rebuy WS command to preview, then the Netlify UI;
+6. smoke-test the complete flow;
+7. deploy WS production before the UI that sends `table_rebuy`;
+8. monitor ambiguous cash-out, rebuy failure, duplicate, and restore logs.
+
+Rollback:
+
+- accounting safety can be rolled back only after confirming no active table relies on the new preserved-zero/waiting state;
+- after a rebuy has committed, do not roll WS back to a version that cannot understand `waitingForNextHandByUserId`; drain or close active affected tables first;
+- browser rollback is safe because snapshot fields are additive, but the old UI will not offer rebuy;
+- never reverse ledger entries automatically during rollback;
+- historical incorrect cash-outs remain manual-review items.
+
+### Breaking-impact analysis
+
+No intended breaking changes:
+
+- no DB migration;
+- no new ENV or secret;
+- no new CSP source or inline script;
+- no changes to hand ranking, pot settlement, bot strategy, or replacement funding;
+- `private.playerState` and `OUT_OF_CHIPS` seat status are additive;
+- old snapshots without the fields remain accepted by the client.
+
+Potentially breaking internal semantics:
+
+- `pokerState.seats` becomes the table-seat set while `handSeats` is the dealt-player set; every engine/reducer caller that falls back from `handSeats` to `seats` must be audited;
+- human stack `1` becomes eligible instead of silently excluded;
+- cleanup and leave will fail closed for ambiguous legacy positive seat projections instead of paying them automatically;
+- runtime rollover commit receipts gain mandatory human projection evidence;
+- deployment order matters because old WS code does not understand committed waiting-for-next-hand rebuys.
+
+Operational impact:
+
+- support may see `stack_ambiguous` cases requiring manual review;
+- the read-only inventory may reveal historical stage or production discrepancies;
+- the observed stage refund must not be used as an automatic remediation template for all historical rows.
+
+### Definition of Done
+
+- A human who reaches `0` is never dealt into the next hand and receives no legal poker actions.
+- The UI says `Out of chips`, not merely `Waiting for action`.
+- The player can explicitly rebuy or leave; no silent ledger debit occurs.
+- Other funded seats continue playing.
+- A successful rebuy moves exactly the confirmed amount from USER to ESCROW once and seats the player only in a later hand.
+- A failed or duplicated rebuy cannot create chips or debit twice.
+- A busted player who leaves or disconnects receives `0`, not the original buy-in.
+- Restore and cleanup cannot replace an authoritative `0` with a stale positive seat stack.
+- A human with 1 CH can post a partial blind rather than being silently stranded.
+- Accounting and rebuy tests listed above are green.
+- Stage inventory and manual WS Preview smoke tests are complete.
+- Auto-rebuy remains absent from runtime and tracked only by issue #712.
+
+## Conclusion
+
+The observed inability to act after losing the stack is expected at the poker-action layer, but the surrounding lifecycle and UX are incomplete. The professional cash-game response is a sitting-out/out-of-chips state with an explicit rebuy offer and a lobby exit, while play continues for funded participants.
+
+The immediate priority is not the modal. It is fixing the stack source of truth that caused an incorrect 100 CH refund after this bust. Once cash-out integrity is guaranteed, manual rebuy is the smallest safe and user-friendly next feature.

--- a/docs/poker-human-bust-and-rebuy-analysis.md
+++ b/docs/poker-human-bust-and-rebuy-analysis.md
@@ -203,13 +203,13 @@ No database migration is required. `poker_seats.stack` remains a transactionally
 
 ### Delivery strategy
 
-Implement this as three strictly ordered runtime PRs after this documentation PR:
+The owner approved implementation of the three strictly ordered phases in PR #713:
 
-1. **PR 1 — accounting P0 only:** preserve the authoritative human stack, including `0`; synchronize the seat projection; make cleanup and leave fail closed when the authoritative stack is absent; verify restart/restore; and add the read-only discrepancy inventory. Do not add `OUT_OF_CHIPS`, change the 1 CH rule, or change browser UI in this PR.
-2. **PR 2 — lifecycle and UI:** expose `OUT_OF_CHIPS / SITTING_OUT`, distinguish table seats from current-hand participants, allow a human with 1 CH to play, and keep disabled actions plus the explanatory message stable. Do not add ledger funding or a rebuy command in this PR.
-3. **PR 3 — explicit manual rebuy:** add the authoritative command, USER-to-ESCROW transaction, waiting-for-next-hand transition, and rebuy prompt.
+1. **Phase 1 — accounting P0:** preserve the authoritative human stack, including `0`; synchronize the seat projection; make cleanup and leave fail closed when the authoritative stack is absent; verify restart/restore; and add the read-only discrepancy inventory.
+2. **Phase 2 — lifecycle and UI:** expose `OUT_OF_CHIPS / SITTING_OUT`, distinguish table seats from current-hand participants, allow a human with 1 CH to play, and keep disabled actions plus the explanatory message stable.
+3. **Phase 3 — explicit manual rebuy:** add the authoritative command, USER-to-ESCROW transaction, waiting-for-next-hand transition, and rebuy prompt.
 
-Each PR is independently deployable and reviewable. PR 2 must not deploy before PR 1 passes production-shaped stage inventory and bust-cleanup smoke tests. PR 3 must not deploy before PR 2 proves the out-of-chips lifecycle across rollover and reconnect.
+The phases remain independently reviewable and must be verified in that order within the same preview deployment. Accounting acceptance is a prerequisite for accepting lifecycle behavior, and lifecycle acceptance is a prerequisite for accepting manual rebuy. Auto-rebuy remains a separate future issue.
 
 ### Phase 0 / runtime PR 1 — read-only impact inventory
 
@@ -564,11 +564,7 @@ cash-out after audited bust == 0
 
 ### Manual verification
 
-Preview requirements follow the three-PR boundary:
-
-- runtime PR 1 requires WS Preview Deploy plus stage DB/ledger inspection; it has no browser change and does not require Netlify Preview for accounting acceptance;
-- runtime PR 2 requires both WS Preview Deploy and Netlify Deploy Preview;
-- runtime PR 3 requires both WS Preview Deploy and Netlify Deploy Preview.
+PR #713 requires both WS Preview Deploy and Netlify Deploy Preview. Verify the three phases in order on that shared preview: accounting and ledger evidence first, then out-of-chips lifecycle/UI, then explicit rebuy.
 
 On stage:
 
@@ -590,15 +586,12 @@ On stage:
 Rollout order:
 
 1. run the read-only discrepancy inventory on stage and production;
-2. deploy runtime PR 1 accounting P0 to WS Preview;
-3. verify bust → rollover → disconnect/leave produces zero cash-out;
-4. deploy accounting P0 to production and observe `stack_ambiguous` plus restore behavior before any lifecycle release;
-5. deploy runtime PR 2 lifecycle changes to WS Preview and Netlify Preview, then verify 1 CH, `OUT_OF_CHIPS`, stable actions, reconnect, and continued bot play;
-6. deploy and observe runtime PR 2 in production before enabling rebuy;
-7. deploy runtime PR 3 rebuy WS command to preview, then the Netlify UI;
-8. smoke-test the complete explicit rebuy flow, including the post-rollover `canRebuy` boundary;
-9. deploy rebuy WS production before the UI that sends `table_rebuy`;
-10. monitor ambiguous cash-out, rebuy failure, duplicate, and restore logs.
+2. deploy PR #713 to WS Preview and Netlify Preview;
+3. verify bust → rollover → disconnect/leave produces zero cash-out before testing rebuy;
+4. verify 1 CH, `OUT_OF_CHIPS`, stable actions, reconnect, and continued bot play;
+5. smoke-test the complete explicit rebuy flow, including the post-rollover `canRebuy` boundary, duplicate request, insufficient balance, and leave-before-next-hand behavior;
+6. deploy the merged WS server to production before the web release can send `table_rebuy`;
+7. verify one production bust/rebuy lifecycle and monitor ambiguous cash-out, rebuy failure, duplicate, and restore logs.
 
 Rollback:
 

--- a/docs/poker-human-bust-and-rebuy-analysis.md
+++ b/docs/poker-human-bust-and-rebuy-analysis.md
@@ -91,7 +91,7 @@ This violates the intended accounting invariant:
 ### Required accounting contract before rebuy work
 
 - Declare one authoritative stack for every active human table lifecycle, including `0` after a bust.
-- Keep any `poker_seats.stack` projection transactionally synchronized with authoritative gameplay state, or stop using it as a cash-out fallback.
+- Keep `poker_seats.stack` transactionally synchronized as an operational projection, but never use it as a cash-out fallback for an active table lifecycle.
 - Rollover must not erase the only durable proof that a busted player's balance is `0`.
 - Cleanup must fail closed and flag manual review when the cash-out amount cannot be proven. It must not refund a stale positive seat value.
 - Process restart/restore, ordinary leave, disconnect cleanup, table close, and rebuy must use the same source-of-truth rule.
@@ -195,22 +195,23 @@ Use these additive properties:
 - `pokerState.waitingForNextHandByUserId[userId] = true`: an already funded human who must wait for the next deal;
 - snapshot `private.playerState.status`: `ACTIVE`, `WAITING_NEXT_HAND`, or `OUT_OF_CHIPS`;
 - snapshot `private.playerState.stack`: authoritative non-negative table stack;
-- snapshot `private.playerState.canRebuy`: true only for an authenticated human with status `OUT_OF_CHIPS` at an open table.
+- snapshot `private.playerState.canRebuy`: true only for an authenticated human with status `OUT_OF_CHIPS` at an open table, after authoritative rollover has removed that user from `handSeats`.
 
 The client must treat `private.playerState` as optional for backward compatibility and derive the old behavior when it is absent.
 
-No database migration is required. `poker_seats.stack` remains the lifecycle projection, but it must be updated transactionally from the authoritative state before it can be used by leave or cleanup.
+No database migration is required. `poker_seats.stack` remains a transactionally synchronized operational projection for inventory and diagnostics. It is not authoritative cash-out evidence and must never be used by leave or cleanup to replace a missing active-lifecycle stack.
 
 ### Delivery strategy
 
-Implement this as two ordered runtime PRs after this documentation PR:
+Implement this as three strictly ordered runtime PRs after this documentation PR:
 
-1. **Accounting and lifecycle safety:** preserve zero stacks, synchronize the human seat-stack projection, fail closed on ambiguous cash-out, expose `OUT_OF_CHIPS`, and fix the 1 CH human edge case.
-2. **Explicit rebuy and UI:** add the authoritative rebuy command, USER-to-ESCROW transaction, waiting-for-next-hand transition, and table prompt.
+1. **PR 1 — accounting P0 only:** preserve the authoritative human stack, including `0`; synchronize the seat projection; make cleanup and leave fail closed when the authoritative stack is absent; verify restart/restore; and add the read-only discrepancy inventory. Do not add `OUT_OF_CHIPS`, change the 1 CH rule, or change browser UI in this PR.
+2. **PR 2 — lifecycle and UI:** expose `OUT_OF_CHIPS / SITTING_OUT`, distinguish table seats from current-hand participants, allow a human with 1 CH to play, and keep disabled actions plus the explanatory message stable. Do not add ledger funding or a rebuy command in this PR.
+3. **PR 3 — explicit manual rebuy:** add the authoritative command, USER-to-ESCROW transaction, waiting-for-next-hand transition, and rebuy prompt.
 
-The second PR must not deploy before the first PR has passed stage reconciliation and a bust-cleanup smoke test.
+Each PR is independently deployable and reviewable. PR 2 must not deploy before PR 1 passes production-shaped stage inventory and bust-cleanup smoke tests. PR 3 must not deploy before PR 2 proves the out-of-chips lifecycle across rollover and reconnect.
 
-### Phase 0 — read-only impact inventory
+### Phase 0 / runtime PR 1 — read-only impact inventory
 
 Files and operational surfaces:
 
@@ -237,24 +238,21 @@ Acceptance:
 - no production balance is changed;
 - remediation remains a separate owner-approved operation.
 
-### Phase 1 — authoritative human stack through rollover and cash-out
+### Phase 1 / runtime PR 1 — accounting P0 only
 
 #### `ws-server/poker/engine/poker-engine.mjs`
 
 Change:
 
-- split the current `MIN_STACK_TO_JOIN_HAND` policy into human and bot rules;
-- update `isContinuationEligibleByStack()`, `orderedEligibleSeatMembers()`, and `buildNextHandStateFromSettled()` so a human with stack `> 0` is eligible, while bot replacement may retain its existing `< 2` policy;
-- preserve every active table member in table-level `seats` and `stacks`, including a busted human with `0`;
-- keep only eligible funded players in `handSeats`;
+- update `buildNextHandStateFromSettled()` so settled rollover carries the proven stack for every active non-bot table member into durable `pokerState.stacks`, including `0`, independently of the next hand's participant arrays;
+- preserve the current `MIN_STACK_TO_JOIN_HAND`, `isContinuationEligibleByStack()`, `orderedEligibleSeatMembers()`, `seats`, and `handSeats` behavior in this accounting PR;
 - keep `replaceBrokeBotsForNextHand()` bot-only and do not fund humans from SYSTEM accounts;
-- clear `waitingForNextHandByUserId[userId]` when that funded human is admitted to the next hand.
+- do not add presentation status, waiting-for-next-hand behavior, or the 1 CH rule change in this PR.
 
 Invariants:
 
 - a human stack `0` survives rollover as durable evidence;
-- a human stack `1` can post a partial blind and be all-in;
-- a busted human never appears in `handSeats`;
+- hand eligibility and player-visible behavior are unchanged by the P0 accounting fix;
 - bot replacement funding behavior remains unchanged.
 
 #### `ws-server/poker/table/table-manager.mjs`
@@ -264,7 +262,7 @@ Change:
 - extend `prepareSettledHandRollover()` to return a normalized `humanStackUpdates` intent for active non-bot members, including zero;
 - project settled human stacks into `nextCoreState.publicStacks` before building the next hand;
 - extend `commitSettledHandRollover()` receipt validation so runtime state cannot commit unless the persistence receipt confirms the human stack projection and any bot replacement funding;
-- make `hasActiveHumanMember()` explicitly distinguish table presence from hand eligibility. A connected out-of-chips human still keeps the table experience alive, but is not an action participant.
+- leave `hasActiveHumanMember()` and other lifecycle/presentation behavior unchanged until runtime PR 2.
 
 Properties:
 
@@ -314,27 +312,46 @@ Add a focused `shared/poker-domain/human-stack-accounting.mjs` helper and use it
 
 Contract:
 
-- explicit state stack, including `0`, wins;
-- a synchronized seat projection can be used when state intentionally omits the user only if its lifecycle evidence is unambiguous;
-- state-missing plus positive legacy seat stack is `stack_ambiguous`, not an automatic refund;
+- the active lifecycle cash-out amount comes exclusively from the authoritative numeric stack in `poker_state.state.stacks`, including `0`;
+- an absent, invalid, or out-of-range authoritative stack is always `stack_ambiguous`, regardless of the value or timestamp in `poker_seats.stack`;
+- `poker_seats.stack`, `updated_at`, recent action rows, and the original buy-in are never sufficient fallback evidence for an online cash-out;
 - ambiguous cleanup/leave fails closed, logs with `klog`, and requires restore or manual review;
 - amount `0` completes lifecycle cleanup without creating a ledger transaction;
 - ordinary leave and disconnect cleanup use the same resolver.
 
-Do not use `console.log`. Logs must contain table ID, reason code, source (`state`, `seat_projection`, or `ambiguous`), and aggregate amount, without email or profile data.
+Do not use `console.log`. Logs must contain table ID, reason code, source (`authoritative_state` or `ambiguous`), and aggregate amount when proven, without email or profile data.
 
 #### `ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs`
 
-Change `normalizePublicStacks()` so a valid persisted gameplay stack takes precedence over a seat projection for the same user. The seat projection remains a fallback for table members not present in the current hand state.
+Change `normalizePublicStacks()` so active human lifecycle restoration requires a valid persisted gameplay stack for every active human seat. A missing human stack is an explicit restore-integrity error and must remain fail-closed; it must not be reconstructed from `poker_seats.stack`. Preserve the existing bot-specific restore rules separately.
 
 Restore acceptance:
 
 - an out-of-chips active human restores with stack `0` and remains seated but not dealt in;
-- a human with stack `1` restores as hand-eligible;
+- a human with stack `1` restores without changing the existing PR 1 eligibility policy;
 - a stale positive seat row cannot override state stack `0`;
+- a missing human state stack cannot be replaced by any seat-row value;
 - replacement bot restore behavior stays intact.
 
-### Phase 2 — public and private `OUT_OF_CHIPS` presentation contract
+### Phase 2 / runtime PR 2 — `OUT_OF_CHIPS` lifecycle and UI
+
+#### `ws-server/poker/engine/poker-engine.mjs` and `ws-server/poker/table/table-manager.mjs`
+
+Change:
+
+- split the current `MIN_STACK_TO_JOIN_HAND` policy into human and bot rules;
+- update `isContinuationEligibleByStack()`, `orderedEligibleSeatMembers()`, and `buildNextHandStateFromSettled()` so a human with stack `> 0` is eligible, while bot replacement may retain its existing `< 2` policy;
+- formalize table-level seats/stacks as all active table members and `handSeats` as only players dealt into the current hand;
+- keep a busted human at table stack `0` but outside `handSeats`;
+- make `hasActiveHumanMember()` distinguish table presence from hand eligibility, so a connected out-of-chips human keeps the table experience alive without becoming an action participant;
+- do not add rebuy funding, a rebuy command, or `WAITING_NEXT_HAND` in this PR.
+
+Acceptance:
+
+- a human stack `1` can post a partial blind and be all-in;
+- a human stack `0` remains table-seated but is never dealt in;
+- bot autoplay continues while the human is sitting out;
+- the accounting source-of-truth rules from runtime PR 1 remain unchanged.
 
 #### `ws-server/poker/read-model/room-core-snapshot.mjs`
 
@@ -343,8 +360,8 @@ Change:
 - merge table members with current hand seats instead of dropping members not present in `handSeats`;
 - merge `coreState.publicStacks` with live hand stacks per user instead of choosing one entire map;
 - mark a non-bot table seat with authoritative stack `0` as `OUT_OF_CHIPS`;
-- add optional `private.playerState` for the authenticated viewer;
-- preserve `legalActions.actions = []` for `OUT_OF_CHIPS` and `WAITING_NEXT_HAND`.
+- add optional `private.playerState` with `status` and `stack` for the authenticated viewer;
+- preserve `legalActions.actions = []` for `OUT_OF_CHIPS`.
 
 Snapshot example:
 
@@ -356,8 +373,7 @@ Snapshot example:
     "holeCards": [],
     "playerState": {
       "status": "OUT_OF_CHIPS",
-      "stack": 0,
-      "canRebuy": true
+      "stack": 0
     }
   }
 }
@@ -378,7 +394,25 @@ Change snapshot normalization and rendering to:
 
 The seat can remain reserved while the authenticated WS presence is healthy. Existing disconnect/presence cleanup releases it after disconnect. A forced timeout for a connected watcher is not required in the first release and can be considered separately if seat hoarding becomes a product issue.
 
-### Phase 3 — explicit manual rebuy
+### Phase 3 / runtime PR 3 — explicit manual rebuy
+
+#### Rebuy availability contract
+
+Extend `private.playerState` with `canRebuy` only in this PR. It is true only when all of these are true in the same authoritative snapshot:
+
+- the viewer is the authenticated non-bot seat owner;
+- table status is `OPEN`;
+- authoritative table stack is exactly `0`;
+- the user is absent from current `handSeats` after settled rollover;
+- the user does not already have a committed `WAITING_NEXT_HAND` rebuy.
+
+During `SETTLED`, the busted user can still be present in the completed hand's `handSeats`; `canRebuy` must remain false in that snapshot. The rollover snapshot that excludes the user from the new hand is the first snapshot allowed to expose `canRebuy: true`. The client must render the rebuy CTA only from explicit `canRebuy === true`, never from stack `0` or empty legal actions alone.
+
+Touchpoints:
+
+- `ws-server/poker/read-model/room-core-snapshot.mjs` derives `canRebuy` from the complete condition above and adds `WAITING_NEXT_HAND` only after a committed rebuy;
+- `ws-server/poker/engine/poker-engine.mjs` clears `waitingForNextHandByUserId[userId]` only when rollover actually admits the funded human to a new `handSeats` set;
+- `poker/poker-v2.js` shows the rebuy CTA only for explicit `canRebuy === true` and shows `Funded · Joining next hand` for `WAITING_NEXT_HAND`.
 
 #### Shared authoritative domain
 
@@ -395,7 +429,7 @@ Add `executePokerRebuyAuthoritative()` with these preconditions:
 - table status `OPEN`;
 - user owns an `ACTIVE` seat at that table;
 - authoritative table stack is exactly `0`;
-- user is absent from current `handSeats`;
+- user is absent from current `handSeats` after authoritative rollover;
 - requested amount is exactly 100 CH for the first release;
 - request ID is present.
 
@@ -477,12 +511,15 @@ Files:
 
 Cases:
 
-- human `0` remains table-seated, is excluded from `handSeats`, and remains stack `0`;
-- human `1` enters the next hand and posts a partial blind;
-- broke bot replacement behavior is unchanged;
-- `OUT_OF_CHIPS`, `WAITING_NEXT_HAND`, and `ACTIVE` are derived deterministically;
-- state stack `0` cannot be overridden by seat stack `100`;
-- missing state plus stale positive seat projection returns `stack_ambiguous`.
+- runtime PR 1: settled human stack `0` remains in the authoritative stack map even when that user is absent from next-hand participant arrays;
+- runtime PR 1: state stack `0` cannot be overridden by seat stack `100`;
+- runtime PR 1: missing state plus any seat projection returns `stack_ambiguous`;
+- runtime PR 1: broke bot replacement behavior is unchanged;
+- runtime PR 2: human `0` remains table-seated, is excluded from `handSeats`, and derives `OUT_OF_CHIPS`;
+- runtime PR 2: human `1` enters the next hand and posts a partial blind;
+- runtime PR 3: `WAITING_NEXT_HAND` and rebuy availability are derived deterministically.
+
+The accounting PR must not be expanded merely to share one combined test file.
 
 #### Transaction and integration tests
 
@@ -503,7 +540,7 @@ Cases:
 1. bust `100 → 0`, rollover, disconnect cleanup: cash-out is `0`, not `100`;
 2. bust, rollover, explicit leave: cash-out is `0`;
 3. state CAS failure: seat projection and runtime do not commit;
-4. restart after bust: stack remains `0` and player remains `OUT_OF_CHIPS`;
+4. runtime PR 1 restart after bust: authoritative stack remains `0`, cleanup remains safe, and no stale refund occurs;
 5. successful rebuy: `USER -100`, `ESCROW +100`, seat/state stack `100` exactly once;
 6. same rebuy request twice: one ledger transaction;
 7. failed ledger funding: no persisted or runtime stack change;
@@ -512,6 +549,9 @@ Cases:
 10. leave after funded rebuy but before the next hand: exactly 100 CH is returned;
 11. reconnect/resync at stack `0`: static out-of-chips UI, no actions;
 12. action buttons remain stable and disabled while the rebuy prompt is visible.
+13. completed-hand `SETTLED` snapshot with the busted user still in `handSeats`: `canRebuy` is false and no rebuy CTA is rendered;
+14. first authoritative post-rollover snapshot without that user in `handSeats`: `canRebuy` is true and the rebuy CTA is rendered.
+15. runtime PR 2 restart/reconnect after bust: the player renders as `OUT_OF_CHIPS` without rebuy behavior being present yet.
 
 Ledger invariants:
 
@@ -524,7 +564,11 @@ cash-out after audited bust == 0
 
 ### Manual verification
 
-Requires both Netlify Deploy Preview and WS Preview Deploy because the plan changes the browser and WS server.
+Preview requirements follow the three-PR boundary:
+
+- runtime PR 1 requires WS Preview Deploy plus stage DB/ledger inspection; it has no browser change and does not require Netlify Preview for accounting acceptance;
+- runtime PR 2 requires both WS Preview Deploy and Netlify Deploy Preview;
+- runtime PR 3 requires both WS Preview Deploy and Netlify Deploy Preview.
 
 On stage:
 
@@ -546,13 +590,15 @@ On stage:
 Rollout order:
 
 1. run the read-only discrepancy inventory on stage and production;
-2. deploy accounting/lifecycle safety to WS Preview;
+2. deploy runtime PR 1 accounting P0 to WS Preview;
 3. verify bust → rollover → disconnect/leave produces zero cash-out;
-4. deploy accounting/lifecycle safety to production and observe before enabling rebuy UI;
-5. deploy rebuy WS command to preview, then the Netlify UI;
-6. smoke-test the complete flow;
-7. deploy WS production before the UI that sends `table_rebuy`;
-8. monitor ambiguous cash-out, rebuy failure, duplicate, and restore logs.
+4. deploy accounting P0 to production and observe `stack_ambiguous` plus restore behavior before any lifecycle release;
+5. deploy runtime PR 2 lifecycle changes to WS Preview and Netlify Preview, then verify 1 CH, `OUT_OF_CHIPS`, stable actions, reconnect, and continued bot play;
+6. deploy and observe runtime PR 2 in production before enabling rebuy;
+7. deploy runtime PR 3 rebuy WS command to preview, then the Netlify UI;
+8. smoke-test the complete explicit rebuy flow, including the post-rollover `canRebuy` boundary;
+9. deploy rebuy WS production before the UI that sends `table_rebuy`;
+10. monitor ambiguous cash-out, rebuy failure, duplicate, and restore logs.
 
 Rollback:
 
@@ -578,6 +624,7 @@ Potentially breaking internal semantics:
 - `pokerState.seats` becomes the table-seat set while `handSeats` is the dealt-player set; every engine/reducer caller that falls back from `handSeats` to `seats` must be audited;
 - human stack `1` becomes eligible instead of silently excluded;
 - cleanup and leave will fail closed for ambiguous legacy positive seat projections instead of paying them automatically;
+- `poker_seats.stack` is no longer accepted as cash-out evidence when the active lifecycle stack is missing, even when its timestamp is recent;
 - runtime rollover commit receipts gain mandatory human projection evidence;
 - deployment order matters because old WS code does not understand committed waiting-for-next-hand rebuys.
 

--- a/docs/ws-poker-protocol.md
+++ b/docs/ws-poker-protocol.md
@@ -53,6 +53,8 @@ Example envelope:
 | `resume` | `{ "sessionId": string, "lastSeq": integer }` | Requests stream resume from last acknowledged sequence. |
 | `ping` | `{ "clientTime": string }` | Keepalive/latency probe. No state mutation. |
 | `join` | `{ "tableId": string }` | Legacy alias of `table_join`; default runtime behavior is authoritative seat/join mutation (idempotent). Optional observe-only runtime mode can make it transport-only. Requires auth. |
+| `table_rebuy` | `{ "tableId": string, "amount": 100 }` | Canonical explicit manual rebuy for an eligible out-of-chips seat. Requires auth and `requestId`; funding and authoritative state commit atomically. |
+| `rebuy` | `{ "tableId": string, "amount": 100 }` | Legacy client alias of `table_rebuy`. Atomically debits 100 CH from the authenticated USER account, credits table ESCROW, and queues the out-of-chips seat for the next hand. Requires auth and `requestId`. |
 | `act` | `{ "handId": string, "action": "fold"|"check"|"call"|"bet"|"raise", "amount": integer }` | Requests poker action mutation. Requires auth and turn validity. |
 | `leave` | `{ "reason": string }` | Requests leave/cashout workflow. |
 | `ack` | `{ "seq": integer }` | Acknowledges latest processed server sequence (flow-control aid). |
@@ -182,7 +184,7 @@ Canonical payload branches:
 - `payload.table: object`
 - `payload.you: object`
 - `payload.public: object`
-- `payload.private?: object` (only for the authenticated seated user; omitted for observers). Runtime includes `{ userId, seat, holeCards }` for seated users.
+- `payload.private?: object` (only for the authenticated seated user; omitted for observers). Runtime includes `{ userId, seat, holeCards, playerState? }` for seated users.
 
 Canonical room-core fields in `payload.public`:
 
@@ -206,6 +208,15 @@ Canonical compatibility fields:
 - `payload.you.seat: number | null` (null for authenticated non-seated observer)
 
 Missing room-core data MUST fail safe to canonical defaults and never expose foreign private state: `public.hand.status` resolves to `"LOBBY"` (members present) or `"EMPTY"` (no members), `public.pot.total` resolves to `0`, list fields resolve to `[]`, and optional scalars remain `null` when unavailable.
+
+Out-of-chips lifecycle contract delta:
+
+- `payload.private.playerState` is additive and has `{ status: "ACTIVE"|"OUT_OF_CHIPS"|"WAITING_NEXT_HAND", stack: integer, canRebuy: boolean }`;
+- `canRebuy` is true only for the authenticated active non-bot seat owner at an open table, with authoritative stack `0`, after the player is absent from current `handSeats` and before a rebuy is committed;
+- canonical `table_rebuy` and alias `rebuy` accept only `{ tableId, amount: 100 }` and require a unique request ID;
+- successful rebuy is one atomic `TABLE_BUY_IN` (`USER -100`, table `ESCROW +100`) plus state/seat projection and sets `WAITING_NEXT_HAND` without adding the player to a hand already in progress;
+- repeated delivery of the same successful request ID returns its stored result and does not debit again;
+- insufficient balance, a nonzero/ambiguous stack, current-hand membership, a closed table, or a non-active/bot seat rejects without visible runtime mutation.
 
 Poker profile avatar contract delta: authenticated non-bot seats may include an additive `profile` object in `table_state.payload.seats` and `stateSnapshot.payload.public.seats`:
 
@@ -293,7 +304,7 @@ Close vs error event rules:
 
 ## Idempotency
 
-- Every stateful client command (`table_join`/`join`, `act`, `leave`, `resync`, `table_state_sub`) MUST include `requestId` UUID.
+- Every stateful client command (`table_join`/`join`, `table_rebuy`/`rebuy`, `act`, `leave`, `resync`, `table_state_sub`) MUST include `requestId` UUID.
 - Server MUST treat `(userId, roomId, type, requestId)` as idempotency scope.
 - Duplicate request handling:
   - If original command already resolved, server MUST return same `commandResult` semantics (or `error.code = "DUPLICATE_REQUEST"` with prior outcome reference) and MUST NOT apply mutation twice.
@@ -351,6 +362,7 @@ Gameplay write commands are authoritative over WS. `start_hand` and `act` use `c
 - `join` / `table_join` payload: `{ tableId, seatNo?, autoSeat?, preferredSeatNo?, buyIn }` (`buyIn` required for gameplay-equivalent authoritative joins)
 - `start_hand` payload: `{ tableId }`
 - `act` payload: `{ handId, action, amount? }`
+- `table_rebuy` / `rebuy` payload: `{ tableId, amount: 100 }`
 
 Success contract:
 

--- a/netlify/functions/_shared/poker-reducer.mjs
+++ b/netlify/functions/_shared/poker-reducer.mjs
@@ -718,7 +718,7 @@ const applyLeaveTable = (state, { userId, requestId } = {}) => {
   const stackMap = copyMap(state.stacks);
   const hasStackEntry = Object.prototype.hasOwnProperty.call(stackMap, userId);
   const alreadyLeft = !!state.leftTableByUserId?.[userId];
-  if (!userInHandSeats && !userInTableSeats && !alreadyLeft) {
+  if (!userInHandSeats && !userInTableSeats && !hasStackEntry && !alreadyLeft) {
     throw new Error("invalid_player");
   }
   if (alreadyLeft && !userInHandSeats && !userInTableSeats && !hasStackEntry) {

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -216,6 +216,16 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 }
 
 .poker-confirm-modal[hidden]{display:none;}
+.poker-rebuy-panel{position:fixed;left:50%;bottom:max(18px, env(safe-area-inset-bottom));z-index:64;width:min(92vw, 420px);transform:translateX(-50%);}
+.poker-rebuy-panel[hidden]{display:none;}
+.poker-rebuy-panel__card{padding:20px;border:1px solid rgba(255,219,154,.3);border-radius:22px;background:linear-gradient(180deg,rgba(20,25,37,.98),rgba(7,10,17,.98));box-shadow:0 18px 50px rgba(0,0,0,.58);text-align:center;}
+.poker-rebuy-panel__eyebrow{color:#efc36f;font-size:.75rem;font-weight:800;letter-spacing:.12em;text-transform:uppercase;}
+.poker-rebuy-panel__title{margin-top:4px;color:#fff4dc;font-size:1.5rem;font-weight:800;}
+.poker-rebuy-panel__copy{margin:8px 0;color:#c7d0df;font-size:.92rem;line-height:1.45;}
+.poker-rebuy-panel__balance{margin:12px 0;color:#fff;font-weight:700;}
+.poker-rebuy-panel__actions{display:grid;grid-template-columns:1fr 1fr;gap:9px;}
+.poker-rebuy-panel__watch{grid-column:1/-1;}
+.poker-rebuy-panel__account{display:inline-block;margin-top:12px;color:#8fc4ff;font-weight:700;}
 
 .poker-confirm-dialog{
   width:min(320px, 100%);

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -2557,12 +2557,12 @@
     var outOfChips = !!playerState && playerState.status === 'OUT_OF_CHIPS';
     var waiting = !!playerState && playerState.status === 'WAITING_NEXT_HAND';
     var show = ((outOfChips && playerState.canRebuy === true) || waiting) && !rebuyPanelDismissed;
+    if (els.rebuyBtn) els.rebuyBtn.hidden = waiting;
     els.rebuyPanel.hidden = !show;
     if (!show) return;
     if (els.rebuyTitle) els.rebuyTitle.textContent = waiting ? 'Buy-in confirmed' : 'Out of chips';
     if (els.rebuyCopy) els.rebuyCopy.textContent = waiting ? 'Funded · Joining next hand' : 'The table will keep playing. Buy in to join the next hand.';
     if (els.rebuyBtn) {
-      els.rebuyBtn.hidden = waiting;
       els.rebuyBtn.disabled = rebuyInFlight || !isWsReady() || playerState.canRebuy !== true;
       els.rebuyBtn.textContent = rebuyInFlight ? 'Buying in…' : 'Buy in 100 CH';
     }
@@ -3222,6 +3222,7 @@
     renderRebuyPanel();
     return sendCommand('sendRebuy', { tableId: state.tableId, amount: 100 }).then(function(){
       state.statusText = 'Buy-in accepted';
+      rebuyPanelDismissed = true;
     }).catch(function(error){
       var reason = error && (error.code || error.message) ? String(error.code || error.message) : 'rebuy_failed';
       if (els.rebuyAccountLink) els.rebuyAccountLink.hidden = reason !== 'insufficient_chips';

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -166,6 +166,9 @@
   var bootReady = false;
   var queuedPreaction = null;
   var queuedPreactionInFlight = false;
+  var rebuyInFlight = false;
+  var rebuyPanelDismissed = false;
+  var rebuyBalanceLoading = false;
   var stickyWinnerReveal = {
     handId: null,
     visibleUntilMs: 0,
@@ -323,7 +326,8 @@
       showdown: null,
       handSettlement: null,
       settlementPresentation: null,
-      revealedShowdownCardsByUserId: {}
+      revealedShowdownCardsByUserId: {},
+      playerState: null
     };
   }
 
@@ -1270,6 +1274,15 @@
     return { present: false, value: undefined };
   }
 
+  function normalizePlayerState(value){
+    if (!isObject(value)) return null;
+    var status = typeof value.status === 'string' ? value.status.trim().toUpperCase() : '';
+    if (status !== 'ACTIVE' && status !== 'OUT_OF_CHIPS' && status !== 'WAITING_NEXT_HAND') return null;
+    var stack = Number(value.stack);
+    if (!Number.isInteger(stack) || stack < 0) return null;
+    return { status: status, stack: stack, canRebuy: value.canRebuy === true };
+  }
+
   function mergeSnapshot(payload, frame){
     if (!isObject(payload)) return;
     var frameKind = frame && typeof frame.kind === 'string' ? frame.kind : 'stateSnapshot';
@@ -1285,6 +1298,9 @@
     var potObj = isObject(payload.pot) ? payload.pot : isObject(publicObj.pot) ? publicObj.pot : {};
     var showdownField = readSnapshotField(payload, publicObj, 'showdown');
     var handSettlementField = readSnapshotField(payload, publicObj, 'handSettlement');
+    var playerStateField = hasOwn(payload, 'private') && isObject(payload.private) && hasOwn(payload.private, 'playerState')
+      ? { present: true, value: payload.private.playerState }
+      : { present: false, value: undefined };
     var legalSource = payload.legalActions != null ? payload.legalActions : publicObj.legalActions;
     var constraintsPrimary = payload.actionConstraints != null ? payload.actionConstraints : publicObj.actionConstraints;
     var lastActionMapSource = payload.lastBettingRoundActionByUserId != null ? payload.lastBettingRoundActionByUserId : publicObj.lastBettingRoundActionByUserId;
@@ -1350,6 +1366,13 @@
     if (Number.isInteger(payload.youSeat)) state.youSeat = payload.youSeat;
     else if (Number.isInteger(youObj.seat)) state.youSeat = youObj.seat;
     else if (payload.youSeat == null && youObj.seat == null) state.youSeat = null;
+
+    if (playerStateField.present) state.playerState = normalizePlayerState(playerStateField.value);
+    else if (authoritativeFull) state.playerState = null;
+    if (!state.playerState || (state.playerState.status !== 'OUT_OF_CHIPS' && state.playerState.status !== 'WAITING_NEXT_HAND')) {
+      rebuyPanelDismissed = false;
+    }
+    if (state.playerState && (state.playerState.status === 'OUT_OF_CHIPS' || state.playerState.status === 'WAITING_NEXT_HAND')) clearQueuedPreaction();
 
     var legalActions = normalizeLegalActions(legalSource);
     if (legalActions.length || Array.isArray(legalSource) || (isObject(legalSource) && Array.isArray(legalSource.actions))){
@@ -2506,6 +2529,47 @@
     return !!(state.wsReady && wsClient && typeof wsClient.isReady === 'function' && wsClient.isReady());
   }
 
+  function currentPlayerStatus(){
+    return state.playerState && typeof state.playerState.status === 'string' ? state.playerState.status : 'ACTIVE';
+  }
+
+  function isPlayerSittingOut(){
+    var status = currentPlayerStatus();
+    return status === 'OUT_OF_CHIPS' || status === 'WAITING_NEXT_HAND';
+  }
+
+  function refreshRebuyBalance(){
+    if (rebuyBalanceLoading || !els.rebuyBalance || !window.ChipsClient || typeof window.ChipsClient.fetchBalance !== 'function') return;
+    rebuyBalanceLoading = true;
+    Promise.resolve(window.ChipsClient.fetchBalance()).then(function(balance){
+      var amount = balance && Number.isFinite(Number(balance.balance)) ? Number(balance.balance) : Number(balance);
+      if (Number.isFinite(amount)) els.rebuyBalance.textContent = 'Balance: ' + formatNumber(amount) + ' CH · Buy-in: 100 CH';
+    }).catch(function(){
+      els.rebuyBalance.textContent = 'Buy-in: 100 CH';
+    }).then(function(){
+      rebuyBalanceLoading = false;
+    });
+  }
+
+  function renderRebuyPanel(){
+    if (!els.rebuyPanel) return;
+    var playerState = state.playerState || null;
+    var outOfChips = !!playerState && playerState.status === 'OUT_OF_CHIPS';
+    var waiting = !!playerState && playerState.status === 'WAITING_NEXT_HAND';
+    var show = (outOfChips || waiting) && !rebuyPanelDismissed;
+    els.rebuyPanel.hidden = !show;
+    if (!show) return;
+    if (els.rebuyTitle) els.rebuyTitle.textContent = waiting ? 'Buy-in confirmed' : 'Out of chips';
+    if (els.rebuyCopy) els.rebuyCopy.textContent = waiting ? 'Funded · Joining next hand' : 'The table will keep playing. Buy in to join the next hand.';
+    if (els.rebuyBtn) {
+      els.rebuyBtn.hidden = waiting;
+      els.rebuyBtn.disabled = rebuyInFlight || !isWsReady() || playerState.canRebuy !== true;
+      els.rebuyBtn.textContent = rebuyInFlight ? 'Buying in…' : 'Buy in 100 CH';
+    }
+    if (els.rebuyLobbyBtn) els.rebuyLobbyBtn.disabled = rebuyInFlight || !isWsReady();
+    if (outOfChips) refreshRebuyBalance();
+  }
+
   function renderInfoPanel(){
     if (els.liveStatus) els.liveStatus.textContent = state.statusText || '';
     if (els.tableMeta) {
@@ -2520,7 +2584,11 @@
       els.errorText.hidden = !state.errorText;
     }
     if (els.turnText){
-      if (isUsersTurn()){
+      if (currentPlayerStatus() === 'OUT_OF_CHIPS'){
+        els.turnText.textContent = 'Out of chips · Sitting out';
+      } else if (currentPlayerStatus() === 'WAITING_NEXT_HAND'){
+        els.turnText.textContent = 'Funded · Joining next hand';
+      } else if (isUsersTurn()){
         els.turnText.textContent = 'Your turn.';
       } else if (state.turnUserId){
         els.turnText.textContent = 'Acting: ' + shortId(state.turnUserId);
@@ -2530,6 +2598,7 @@
     }
     if (els.xpBadge) els.xpBadge.hidden = !!isGuestMode;
     if (els.guestPanel) els.guestPanel.hidden = !isGuestMode;
+    renderRebuyPanel();
   }
 
   function resolvePrimaryAction(allowed){
@@ -2694,7 +2763,8 @@
     var allInPlan = resolveAllInPlan(allowed);
     var stackAmount = resolveStack(state.currentUserId);
     var amountBounds = resolveAmountBounds(amountAction, stackAmount);
-    var preactionMode = !!(signedIn && seated && liveReady && activeHand && !usersTurn && !isCurrentUserFolded());
+    var playerSittingOut = isPlayerSittingOut();
+    var preactionMode = !!(signedIn && seated && liveReady && activeHand && !usersTurn && !isCurrentUserFolded() && !playerSittingOut);
     var projectedAllowed = preactionMode ? resolveProjectedAllowedActions() : [];
     var preactionPrimary = resolvePrimaryAction(projectedAllowed);
     var preactionAmountAction = resolveAmountAction(projectedAllowed);
@@ -2704,9 +2774,9 @@
     var displayAmountAction = amountAction || preactionAmountAction || 'BET';
     var showActionButtons = signedIn && seated;
     var showLiveActionButtons = showActionButtons && !preactionMode;
-    var actionControlsLocked = !liveReady || !usersTurn || controlsLocked;
+    var actionControlsLocked = !liveReady || !usersTurn || controlsLocked || playerSittingOut;
     var joinDisabled = !signedIn || seated || !state.tableId || !liveReady;
-    if (!seated || !activeHand || isCurrentUserFolded()) clearQueuedPreaction();
+    if (!seated || !activeHand || isCurrentUserFolded() || playerSittingOut) clearQueuedPreaction();
     if (preactionMode) {
       syncQueuedPreactionWithPreactionState({
         foldVisible: isFoldAvailable(),
@@ -3145,6 +3215,23 @@
     });
   }
 
+  function requestManualRebuy(){
+    if (rebuyInFlight || !state.playerState || state.playerState.canRebuy !== true) return Promise.resolve();
+    rebuyInFlight = true;
+    setError('');
+    renderRebuyPanel();
+    return sendCommand('sendRebuy', { tableId: state.tableId, amount: 100 }).then(function(){
+      state.statusText = 'Buy-in accepted';
+    }).catch(function(error){
+      var reason = error && (error.code || error.message) ? String(error.code || error.message) : 'rebuy_failed';
+      if (els.rebuyAccountLink) els.rebuyAccountLink.hidden = reason !== 'insufficient_chips';
+      setError(reason === 'insufficient_chips' ? 'Not enough CH for a 100 CH buy-in' : reason);
+    }).then(function(){
+      rebuyInFlight = false;
+      render();
+    });
+  }
+
   function bindMenu(){
     if (!els.menuToggle || !els.menuPanel) return;
     els.menuToggle.addEventListener('click', function(){
@@ -3221,6 +3308,12 @@
     if (els.leaveConfirmCancel) els.leaveConfirmCancel.addEventListener('click', function(){
       closeLeaveConfirm();
     });
+    if (els.rebuyBtn) els.rebuyBtn.addEventListener('click', requestManualRebuy);
+    if (els.rebuyLobbyBtn) els.rebuyLobbyBtn.addEventListener('click', leaveAndReturnToLobby);
+    if (els.rebuyWatchBtn) els.rebuyWatchBtn.addEventListener('click', function(){
+      rebuyPanelDismissed = true;
+      renderRebuyPanel();
+    });
     if (els.startBtn) els.startBtn.addEventListener('click', function(){
       setError('');
       sendCommand('sendStartHand', { tableId: state.tableId }).then(function(){
@@ -3291,6 +3384,14 @@
     els.leaveConfirmModal = document.getElementById('pokerV2LeaveConfirmModal');
     els.leaveConfirmYes = document.getElementById('pokerV2LeaveConfirmYes');
     els.leaveConfirmCancel = document.getElementById('pokerV2LeaveConfirmCancel');
+    els.rebuyPanel = document.getElementById('pokerV2RebuyPanel');
+    els.rebuyTitle = document.getElementById('pokerV2RebuyTitle');
+    els.rebuyCopy = document.getElementById('pokerV2RebuyCopy');
+    els.rebuyBalance = document.getElementById('pokerV2RebuyBalance');
+    els.rebuyBtn = document.getElementById('pokerV2RebuyBtn');
+    els.rebuyLobbyBtn = document.getElementById('pokerV2RebuyLobbyBtn');
+    els.rebuyWatchBtn = document.getElementById('pokerV2RebuyWatchBtn');
+    els.rebuyAccountLink = document.getElementById('pokerV2RebuyAccountLink');
     els.closedTableModal = document.getElementById('pokerV2ClosedTableModal');
     els.closedTableTitle = document.getElementById('pokerV2ClosedTableTitle');
     els.closedTableCountdown = document.getElementById('pokerV2ClosedTableCountdown');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -2556,7 +2556,7 @@
     var playerState = state.playerState || null;
     var outOfChips = !!playerState && playerState.status === 'OUT_OF_CHIPS';
     var waiting = !!playerState && playerState.status === 'WAITING_NEXT_HAND';
-    var show = (outOfChips || waiting) && !rebuyPanelDismissed;
+    var show = ((outOfChips && playerState.canRebuy === true) || waiting) && !rebuyPanelDismissed;
     els.rebuyPanel.hidden = !show;
     if (!show) return;
     if (els.rebuyTitle) els.rebuyTitle.textContent = waiting ? 'Buy-in confirmed' : 'Out of chips';

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -398,6 +398,7 @@
       requestResync: requestResync,
       sendAct: function(payload, requestId){ return sendCommand('act', payload || {}, requestId); },
       sendJoin: function(payload, requestId){ return sendCommand('join', payload || { tableId: tableId }, requestId); },
+      sendRebuy: function(payload, requestId){ return sendCommand('rebuy', payload || { tableId: tableId, amount: 100 }, requestId); },
       sendLeave: function(payload, requestId){ return sendCommand('leave', payload || { tableId: tableId }, requestId); },
       sendLeaveQueued: function(payload, requestId){ return queueCommand('leave', payload || { tableId: tableId }, requestId); },
       sendStartHand: function(payload, requestId){ return sendCommand('start_hand', payload || { tableId: tableId }, requestId); }

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -137,6 +137,21 @@
       </div>
     </div>
 
+    <div class="poker-rebuy-panel" id="pokerV2RebuyPanel" role="dialog" aria-modal="false" aria-labelledby="pokerV2RebuyTitle" hidden>
+      <div class="poker-rebuy-panel__card">
+        <div class="poker-rebuy-panel__eyebrow">Sitting out</div>
+        <div class="poker-rebuy-panel__title" id="pokerV2RebuyTitle">Out of chips</div>
+        <p class="poker-rebuy-panel__copy" id="pokerV2RebuyCopy">The table will keep playing. Buy in to join the next hand.</p>
+        <div class="poker-rebuy-panel__balance" id="pokerV2RebuyBalance">Buy-in: 100 CH</div>
+        <div class="poker-rebuy-panel__actions">
+          <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2RebuyBtn">Buy in 100 CH</button>
+          <button type="button" class="poker-live-btn" id="pokerV2RebuyLobbyBtn">Return to lobby</button>
+          <button type="button" class="poker-live-btn poker-rebuy-panel__watch" id="pokerV2RebuyWatchBtn">Keep watching</button>
+        </div>
+        <a class="poker-rebuy-panel__account" id="pokerV2RebuyAccountLink" href="/account.html" hidden>Open chips account</a>
+      </div>
+    </div>
+
     <div class="poker-confirm-modal poker-closed-table-modal" id="pokerV2ClosedTableModal" role="status" aria-live="assertive" hidden>
       <div class="poker-confirm-dialog poker-closed-table-dialog">
         <div class="poker-confirm-title poker-closed-table-title" id="pokerV2ClosedTableTitle">This table has ended. Returning to lobby in 5 seconds…</div>

--- a/scripts/poker-human-stack-audit.mjs
+++ b/scripts/poker-human-stack-audit.mjs
@@ -1,0 +1,57 @@
+import { beginSqlWs } from "../ws-server/poker/bootstrap/persisted-bootstrap-db.mjs";
+import { klog } from "../ws-server/poker/persistence/sql-admin.mjs";
+import { resolveAuthoritativeHumanStack } from "../shared/poker-domain/human-stack-accounting.mjs";
+
+const MAX_ROWS = 500;
+
+function parseState(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+const rows = await beginSqlWs((tx) => tx.unsafe(
+  `select t.id as table_id, s.user_id, s.seat_no, s.stack as seat_stack, ps.version as state_version, ps.state
+   from public.poker_tables t
+   join public.poker_seats s on s.table_id = t.id
+   left join public.poker_state ps on ps.table_id = t.id
+   where t.status = 'OPEN' and s.status = 'ACTIVE' and s.is_bot = false
+   order by t.id, s.seat_no
+   limit $1;`,
+  [MAX_ROWS]
+));
+
+const LIVE_HAND_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER", "SHOWDOWN"]);
+const findings = [];
+let liveProjectionDrift = 0;
+for (const row of rows || []) {
+  const state = parseState(row.state);
+  const evidence = resolveAuthoritativeHumanStack({ state, userId: row.user_id });
+  const seatStack = Number(row.seat_stack);
+  if (!evidence.ok) {
+    findings.push({ tableId: row.table_id, seatNo: Number(row.seat_no), stateVersion: Number(row.state_version) || null, reason: evidence.reason, seatStack: Number.isInteger(seatStack) ? seatStack : null });
+    continue;
+  }
+  if (!Number.isInteger(seatStack) || seatStack !== evidence.amount) {
+    const phase = String(state?.phase || state?.status || "").trim().toUpperCase();
+    if (LIVE_HAND_PHASES.has(phase)) {
+      liveProjectionDrift += 1;
+      continue;
+    }
+    findings.push({ tableId: row.table_id, seatNo: Number(row.seat_no), stateVersion: Number(row.state_version) || null, reason: "seat_projection_mismatch", authoritativeStack: evidence.amount, seatStack: Number.isInteger(seatStack) ? seatStack : null });
+  }
+}
+
+klog("poker_human_stack_audit", {
+  mode: "read_only",
+  scanned: Array.isArray(rows) ? rows.length : 0,
+  findings: findings.length,
+  liveProjectionDrift,
+  truncated: Array.isArray(rows) && rows.length >= MAX_ROWS,
+  samples: findings.slice(0, 50)
+});

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -73,6 +73,8 @@ run("node", ["tests/poker-handSeats-seats-undefined.behavior.test.mjs"], "poker-
 run("node", ["tests/poker-handSeats-reset.behavior.test.mjs"], "poker-handseats-reset-behavior");
 run("node", ["tests/poker-legal-actions.left-player.invalid-player.behavior.test.mjs"], "poker-legal-actions-left-player-invalid-player-behavior");
 run("node", ["shared/poker-domain/leave.behavior.test.mjs"], "poker-domain-leave-behavior");
+run("node", ["shared/poker-domain/human-stack-accounting.behavior.test.mjs"], "poker-domain-human-stack-accounting-behavior");
+run("node", ["shared/poker-domain/rebuy.behavior.test.mjs"], "poker-domain-rebuy-behavior");
 run("node", ["tests/poker-table-list.left-player-filter.behavior.test.mjs"], "poker-table-list-left-player-filter-behavior");
 run("node", ["shared/poker-domain/inactive-cleanup.behavior.test.mjs"], "poker-domain-inactive-cleanup-behavior");
 run("node", ["tests/poker-inactive-cleanup.behavior.test.mjs"], "poker-inactive-cleanup-behavior");
@@ -83,6 +85,8 @@ run("node", ["tests/poker-settlement-presentation.unit.test.mjs"], "poker-settle
 run("node", ["tests/poker-v2-live.behavior.test.mjs"], "poker-v2-live-behavior");
 run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs"], "ws-inactive-cleanup-adapter-behavior");
 run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");
+run("node", ["ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs"], "ws-authoritative-rebuy-adapter-behavior");
+run("node", ["ws-server/poker/handlers/rebuy.behavior.test.mjs"], "ws-rebuy-handler-behavior");
 run("node", ["ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs"], "ws-disconnect-cleanup-runtime-behavior");
 run("node", ["ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs"], "ws-accepted-bot-autoplay-adapter-behavior");
 run("node", ["ws-tests/ws-lobby-join-public-snapshot.behavior.test.mjs"], "ws-lobby-join-public-snapshot-behavior");

--- a/shared/poker-domain/human-stack-accounting.behavior.test.mjs
+++ b/shared/poker-domain/human-stack-accounting.behavior.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { requireAuthoritativeHumanStack, resolveAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
+
+test("authoritative human stack preserves zero and ignores a stale seat projection", () => {
+  const result = resolveAuthoritativeHumanStack({ state: { stacks: { human: 0 } }, userId: "human", seatStack: 100 });
+  assert.equal(result.ok, true);
+  assert.equal(result.amount, 0);
+  assert.equal(result.source, "authoritative_state");
+});
+
+test("missing or invalid authoritative stack is ambiguous regardless of seat projection", () => {
+  const missing = resolveAuthoritativeHumanStack({ state: { stacks: {} }, userId: "human", seatStack: 100 });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.reason, "stack_ambiguous");
+  assert.equal(missing.source, "ambiguous");
+  assert.equal(resolveAuthoritativeHumanStack({ state: { stacks: { human: -1 } }, userId: "human" }).ok, false);
+  assert.equal(resolveAuthoritativeHumanStack({ state: { stacks: { human: Number.NaN } }, userId: "human" }).ok, false);
+});
+
+test("required authoritative stack fails closed with the controlled reason", () => {
+  assert.throws(() => requireAuthoritativeHumanStack({ state: {}, userId: "human" }), (error) => error?.code === "stack_ambiguous" && error?.status === 409);
+});

--- a/shared/poker-domain/human-stack-accounting.mjs
+++ b/shared/poker-domain/human-stack-accounting.mjs
@@ -1,0 +1,32 @@
+function asState(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value;
+}
+
+function normalizeNonNegativeStack(value) {
+  const stack = Number(value);
+  return Number.isSafeInteger(stack) && stack >= 0 ? stack : null;
+}
+
+export function resolveAuthoritativeHumanStack({ state, userId } = {}) {
+  const normalizedState = asState(state);
+  const normalizedUserId = typeof userId === "string" ? userId.trim() : "";
+  const stacks = asState(normalizedState?.stacks);
+  if (!normalizedUserId || !stacks || !Object.prototype.hasOwnProperty.call(stacks, normalizedUserId)) {
+    return { ok: false, reason: "stack_ambiguous", source: "ambiguous", amount: null };
+  }
+  const amount = normalizeNonNegativeStack(stacks[normalizedUserId]);
+  if (amount === null) {
+    return { ok: false, reason: "stack_ambiguous", source: "ambiguous", amount: null };
+  }
+  return { ok: true, reason: null, source: "authoritative_state", amount };
+}
+
+export function requireAuthoritativeHumanStack(args = {}) {
+  const result = resolveAuthoritativeHumanStack(args);
+  if (result.ok) return result;
+  const error = new Error(result.reason);
+  error.code = result.reason;
+  error.status = 409;
+  throw error;
+}

--- a/shared/poker-domain/inactive-cleanup.mjs
+++ b/shared/poker-domain/inactive-cleanup.mjs
@@ -1,3 +1,5 @@
+import { requireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
+
 const normalizeState = (value) => {
   if (!value) return {};
   if (typeof value === "string") {
@@ -79,14 +81,6 @@ function resolveStateStacks(state) {
   if (!state || typeof state !== "object" || Array.isArray(state)) return {};
   if (!state.stacks || typeof state.stacks !== "object" || Array.isArray(state.stacks)) return {};
   return state.stacks;
-}
-
-function stateFirstStackAmount({ state, seat, userId }) {
-  const stateStack = normalizeNonNegativeInt(resolveStateStacks(state)?.[userId]);
-  if (stateStack != null) return { amount: stateStack, source: "state" };
-  const seatStack = normalizeNonNegativeInt(seat?.stack);
-  if (seatStack != null) return { amount: seatStack, source: "seat" };
-  return { amount: 0, source: "none" };
 }
 
 function resolveSeatPresenceFreshness({ seat, nowMs, staleAfterMs }) {
@@ -285,7 +279,13 @@ export async function executeInactiveCleanup({
 
     const stacks = { ...resolveStateStacks(state) };
     if (seatWasActive) {
-      const targetCashout = stateFirstStackAmount({ state, seat, userId: normalizedUserId });
+      let targetCashout;
+      try {
+        targetCashout = requireAuthoritativeHumanStack({ state, userId: normalizedUserId });
+      } catch (error) {
+        klog("poker_inactive_cleanup_stack_ambiguous", { tableId, reason: error?.code || "stack_ambiguous", source: "ambiguous" });
+        throw error;
+      }
       await postCashout({
         postTransaction,
         tx,
@@ -348,7 +348,10 @@ export async function executeInactiveCleanup({
 
     for (const row of allSeatRows || []) {
       if (row?.is_bot === true) continue;
-      const closeCashout = stateFirstStackAmount({ state: { stacks }, seat: row, userId: row.user_id });
+      const hasPendingAuthoritativeStack = Object.prototype.hasOwnProperty.call(stacks, row?.user_id);
+      if (String(row?.status || "").toUpperCase() !== "ACTIVE" && !hasPendingAuthoritativeStack) continue;
+      if (seatWasActive && row?.user_id === normalizedUserId) continue;
+      const closeCashout = requireAuthoritativeHumanStack({ state: { stacks }, userId: row.user_id });
       klog("poker_inactive_cleanup_post_hand_cashout", {
         tableId,
         userId: row?.user_id ?? null,

--- a/shared/poker-domain/join.behavior.test.mjs
+++ b/shared/poker-domain/join.behavior.test.mjs
@@ -84,10 +84,12 @@ test("shared join module imports without Netlify adapter dependency at module lo
   const stagedDir = path.join(tempDir, "shared", "poker-domain");
   const stagedJoin = path.join(stagedDir, "join.mjs");
   const stagedBots = path.join(stagedDir, "bots.mjs");
+  const stagedTableBuyIn = path.join(stagedDir, "table-buy-in.mjs");
   try {
     await fs.mkdir(stagedDir, { recursive: true });
     await fs.copyFile("shared/poker-domain/join.mjs", stagedJoin);
     await fs.copyFile("shared/poker-domain/bots.mjs", stagedBots);
+    await fs.copyFile("shared/poker-domain/table-buy-in.mjs", stagedTableBuyIn);
     const module = await import(pathToFileURL(stagedJoin).href);
     assert.equal(typeof module.executePokerJoinAuthoritative, "function");
   } finally {

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -1,4 +1,5 @@
 import { asSeatSnapshot, computeTargetBotCount, getBotConfig, loadSeatRows, seedBotsForJoin, shouldSeedBotsOnJoin } from "./bots.mjs";
+import { postUserTableBuyIn } from "./table-buy-in.mjs";
 
 const BUY_IN_IDEMPOTENCY_CONSTRAINT = "chips_transactions_idempotency_key_unique";
 
@@ -711,7 +712,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         klog("shared_join_seat_retry", { seatNo: resolvedSeatNo, occupiedCount: occupied.size });
       }
 
-      const escrowSystemKey = `POKER_TABLE:${tableId}`;
       const idempotencyKey = requestId
         ? `join-buyin:${tableId}:${userId}:${requestId}`
         : `join-buyin:${tableId}:${userId}:${resolvedSeatNo}:${resolvedBuyIn}`;
@@ -719,16 +719,13 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       let buyInDuplicated = false;
       klog("shared_join_ledger_start", { buyIn: resolvedBuyIn });
       try {
-        await runPostTransaction({
-        userId,
-        txType: "TABLE_BUY_IN",
-        idempotencyKey,
-        entries: [
-          { accountType: "USER", amount: -resolvedBuyIn },
-          { accountType: "ESCROW", systemKey: escrowSystemKey, amount: resolvedBuyIn }
-        ],
-        createdBy: userId,
-        tx
+        await postUserTableBuyIn({
+          postTransaction: runPostTransaction,
+          tx,
+          tableId,
+          userId,
+          amount: resolvedBuyIn,
+          idempotencyKey
         });
       } catch (error) {
         if (!isBuyInIdempotencyDuplicate(error)) throw error;

--- a/shared/poker-domain/leave.behavior.test.mjs
+++ b/shared/poker-domain/leave.behavior.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { isStateStorageValid as realIsStateStorageValid } from "../../netlify/functions/_shared/poker-state-utils.mjs";
+import { applyLeaveTable as realApplyLeaveTable } from "../../netlify/functions/_shared/poker-reducer.mjs";
 import { requireAuthoritativeHumanStack as realRequireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
 
 const root = process.cwd();
@@ -19,6 +20,7 @@ const userId = "99999999-9999-4999-8999-999999999999";
 const makeMocks = () => {
   const calls = { cashouts: 0, actions: 0, deleteSeat: 0, storeResult: 0, updates: 0, closeTable: 0, holeCardDelete: 0 };
   const state = { version: 2, value: { tableId, phase: "INIT", seats: [{ userId, seatNo: 1 }], stacks: { [userId]: 50 }, leftTableByUserId: {} } };
+  const seatRowsByUserId = new Map();
   let tableStatus = "OPEN";
   const requests = new Map();
   const tx = { unsafe: async (query, params) => {
@@ -26,6 +28,7 @@ const makeMocks = () => {
     if (text.includes("select id, status from public.poker_tables")) return [{ id: tableId, status: tableStatus }];
     if (text.includes("from public.poker_state")) return [{ version: state.version, state: state.value }];
     if (text.includes("select seat_no, status, stack from public.poker_seats") && text.includes("for update")) {
+      if (seatRowsByUserId.has(params[1])) return [seatRowsByUserId.get(params[1])];
       const seat = Array.isArray(state.value?.seats)
         ? state.value.seats.find((entry) => entry && entry.userId === params[1])
         : null;
@@ -52,6 +55,7 @@ const makeMocks = () => {
     if (text.includes("delete from public.poker_seats")) {
       calls.deleteSeat += 1;
       const targetUserId = params[1];
+      seatRowsByUserId.delete(targetUserId);
       if (Array.isArray(state.value?.seats)) {
         state.value.seats = state.value.seats.filter((seat) => seat && seat.userId !== targetUserId);
       }
@@ -75,6 +79,7 @@ const makeMocks = () => {
   return {
     calls,
     state,
+    seatRowsByUserId,
     requests,
     mocks: {
       ensurePokerRequest: async (_tx, { requestId }) => requests.get(requestId) || { status: "proceed" },
@@ -159,6 +164,80 @@ for (const settledPhase of ["SETTLED", "HAND_DONE"]) {
   assert.equal(ctx.calls.cashouts, 1);
   assert.equal(ctx.calls.deleteSeat, 1);
   assert.equal(result.state.state.seats.some((seat) => seat.userId === userId), false);
+  assert.equal(result.state.state.stacks[userId], undefined);
+}
+
+{
+  const stackOnlyState = {
+    tableId,
+    phase: "TURN",
+    handId: "hand-bots-only-with-pending-human-stack",
+    handSeed: "seed-bots-only-with-pending-human-stack",
+    seats: [{ userId: "bot-1", seatNo: 2, isBot: true }, { userId: "bot-2", seatNo: 3, isBot: true }],
+    handSeats: [{ userId: "bot-1", seatNo: 2 }, { userId: "bot-2", seatNo: 3 }],
+    stacks: { [userId]: 318, "bot-1": 400, "bot-2": 3282 },
+    leftTableByUserId: {},
+    sitOutByUserId: {},
+    pendingAutoSitOutByUserId: {},
+    missedTurnsByUserId: {},
+    foldedByUserId: { "bot-1": false, "bot-2": false },
+    actedThisRoundByUserId: { "bot-1": false, "bot-2": false },
+    betThisRoundByUserId: { "bot-1": 0, "bot-2": 0 },
+    toCallByUserId: { "bot-1": 0, "bot-2": 0 },
+    contributionsByUserId: { "bot-1": 0, "bot-2": 0 },
+    allInByUserId: { "bot-1": false, "bot-2": false },
+    community: ["2H", "3D", "4S", "5C"],
+    communityDealt: 4,
+    currentBet: 0,
+    pot: 0,
+    potTotal: 0,
+    turnUserId: "bot-1"
+  };
+  const reduced = realApplyLeaveTable(stackOnlyState, { userId, requestId: "stack-only-reducer" });
+  assert.equal(reduced.state.leftTableByUserId[userId], true);
+  assert.equal(reduced.state.stacks[userId], undefined);
+  assert.deepEqual(reduced.state.handSeats, stackOnlyState.handSeats);
+}
+
+{
+  const ctx = makeMocks();
+  ctx.state.value = {
+    tableId,
+    phase: "TURN",
+    handId: "hand-bots-only-cashout",
+    handSeed: "seed-bots-only-cashout",
+    seats: [{ userId: "bot-1", seatNo: 2, isBot: true }, { userId: "bot-2", seatNo: 3, isBot: true }],
+    handSeats: [{ userId: "bot-1", seatNo: 2 }, { userId: "bot-2", seatNo: 3 }],
+    stacks: { [userId]: 318, "bot-1": 400, "bot-2": 3282 },
+    leftTableByUserId: {},
+    foldedByUserId: { "bot-1": false, "bot-2": false },
+    actedThisRoundByUserId: { "bot-1": false, "bot-2": false }
+  };
+  ctx.seatRowsByUserId.set(userId, { seat_no: 1, status: "ACTIVE", stack: 318 });
+  ctx.mocks.applyLeaveTable = (stateInput) => ({
+    state: {
+      ...stateInput,
+      stacks: { "bot-1": 400, "bot-2": 3282 },
+      leftTableByUserId: { [userId]: true }
+    },
+    events: [{ type: "PLAYER_LEFT_TABLE", userId }]
+  });
+  const executePokerLeave = loadExecutePokerLeave(ctx.mocks);
+  const result = await executePokerLeave({
+    beginSql: ctx.beginSql,
+    tableId,
+    userId,
+    requestId: "stack-only-cashout",
+    includeState: true,
+    runPostLeaveBotAutoplay: false,
+    klog: () => {}
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.cashedOut, 318);
+  assert.equal(ctx.calls.cashouts, 1);
+  assert.equal(ctx.calls.deleteSeat, 1);
+  assert.equal(result.state.state.phase, "TURN");
   assert.equal(result.state.state.stacks[userId], undefined);
 }
 

--- a/shared/poker-domain/leave.behavior.test.mjs
+++ b/shared/poker-domain/leave.behavior.test.mjs
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { isStateStorageValid as realIsStateStorageValid } from "../../netlify/functions/_shared/poker-state-utils.mjs";
+import { requireAuthoritativeHumanStack as realRequireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
 
 const root = process.cwd();
 const loadExecutePokerLeave = (mocks) => {
   const source = fs.readFileSync(path.join(root, "shared/poker-domain/leave.mjs"), "utf8");
   const withoutImports = source.replace(/^\s*import[\s\S]*?;\s*$/gm, "");
   const rewritten = withoutImports.replace(/export\s+async\s+function\s+executePokerLeave\s*\(/, "async function executePokerLeave(");
-  const factory = new Function("mocks", `"use strict"; const { postTransaction, deletePokerRequest, ensurePokerRequest, storePokerRequestResult, updatePokerStateOptimistic, advanceIfNeeded, applyLeaveTable, isStateStorageValid, withoutPrivateState, buildSeatBotMap, isBotTurn, deriveCommunityCards, deriveRemainingDeck, isHoleCardsTableMissing, loadHoleCardsByUserId, hasParticipatingHumanInHand, runAdvanceLoop, runBotAutoplayLoop } = mocks; ${rewritten}; return executePokerLeave;`);
+  const factory = new Function("mocks", `"use strict"; const { postTransaction, deletePokerRequest, ensurePokerRequest, storePokerRequestResult, updatePokerStateOptimistic, advanceIfNeeded, applyLeaveTable, isStateStorageValid, withoutPrivateState, buildSeatBotMap, isBotTurn, deriveCommunityCards, deriveRemainingDeck, isHoleCardsTableMissing, loadHoleCardsByUserId, hasParticipatingHumanInHand, runAdvanceLoop, runBotAutoplayLoop, requireAuthoritativeHumanStack } = mocks; ${rewritten}; return executePokerLeave;`);
   return factory(mocks);
 };
 
@@ -94,6 +95,7 @@ const makeMocks = () => {
       hasParticipatingHumanInHand: () => true,
       runAdvanceLoop: (s) => ({ nextState: s }),
       runBotAutoplayLoop: async () => ({ responseFinalState: state.value, loopVersion: state.version, botActionCount: 0, botStopReason: "not_applicable" }),
+      requireAuthoritativeHumanStack: realRequireAuthoritativeHumanStack,
     },
     beginSql: async (fn) => fn(tx),
   };

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -158,6 +158,11 @@ const hasLiveHandSignal = (state) => {
   return ["PREFLOP", "FLOP", "TURN", "RIVER", "SHOWDOWN"].includes(phase);
 };
 
+const isUserInCurrentHand = (state, userId) => {
+  const handSeats = Array.isArray(state?.handSeats) ? state.handSeats : parseSeats(state?.seats);
+  return handSeats.some((seat) => seat?.userId === userId);
+};
+
 const toClosedInertState = (stateInput, stacks) => ({
   ...stateInput,
   phase: "HAND_DONE",
@@ -627,7 +632,7 @@ export async function executePokerLeave({
         }
 
         const leaveState = normalizeState(leaveApplied.state);
-        const deferDetachUntilHandComplete = hasLiveHandSignal(leaveState);
+        const deferDetachUntilHandComplete = hasLiveHandSignal(leaveState) && isUserInCurrentHand(currentState, userId);
         const baseSeats = deferDetachUntilHandComplete
           ? parseSeats(currentState.seats)
           : (Array.isArray(leaveState.seats) ? leaveState.seats : parseSeats(currentState.seats));
@@ -804,7 +809,7 @@ export async function executePokerLeave({
           }
         }
 
-        const shouldDetachSeatAndStack = !hasLiveHandSignal(latestState);
+        const shouldDetachSeatAndStack = !deferDetachUntilHandComplete || !hasLiveHandSignal(latestState);
         let detachedCashOutAmount = 0;
         if (shouldDetachSeatAndStack) {
           const latestStacks = parseStacks(latestState.stacks);

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -1,6 +1,7 @@
 import { postTransaction } from "../../netlify/functions/_shared/chips-ledger.mjs";
 import { deletePokerRequest, ensurePokerRequest, storePokerRequestResult } from "../../netlify/functions/_shared/poker-idempotency.mjs";
 import { updatePokerStateOptimistic } from "../../netlify/functions/_shared/poker-state-write.mjs";
+import { requireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
 import { advanceIfNeeded, applyLeaveTable } from "../../netlify/functions/_shared/poker-reducer.mjs";
 import { isStateStorageValid, withoutPrivateState } from "../../netlify/functions/_shared/poker-state-utils.mjs";
 import { buildSeatBotMap, isBotTurn } from "../../netlify/functions/_shared/poker-bots.mjs";
@@ -554,10 +555,15 @@ export async function executePokerLeave({
         }
         const rawSeatStack = seatRow ? seatRow.stack : null;
         const stackValue = normalizeSeatStack(rawSeatStack);
-        const stateStackRaw = currentState?.stacks?.[userId];
-        const stateStack = normalizeNonNegativeInt(Number(stateStackRaw));
-        const seatStack = normalizeNonNegativeInt(Number(rawSeatStack));
-        const cashOutAmount = stateStack ?? seatStack ?? 0;
+        let authoritativeStack;
+        try {
+          authoritativeStack = requireAuthoritativeHumanStack({ state: currentState, userId });
+        } catch (error) {
+          klog("poker_leave_stack_ambiguous", { tableId, userId, seatNo, reason: error?.code || "stack_ambiguous", source: "ambiguous" });
+          throw makeError(409, "stack_ambiguous");
+        }
+        const stateStack = authoritativeStack.amount;
+        const cashOutAmount = authoritativeStack.amount;
         const isStackMissing = rawSeatStack == null;
         if (isStackMissing) {
           klog("poker_leave_stack_missing", { tableId, userId: userId, seatNo });
@@ -631,7 +637,7 @@ export async function executePokerLeave({
         const seats = parseSeats(baseSeats);
         const updatedStacks = parseStacks(baseStacks);
         if (deferDetachUntilHandComplete) {
-          const restoredStack = stateStack ?? seatStack;
+          const restoredStack = stateStack;
           if (normalizeNonNegativeInt(restoredStack) != null && normalizeNonNegativeInt(updatedStacks[userId]) == null) {
             updatedStacks[userId] = restoredStack;
           }
@@ -812,7 +818,13 @@ export async function executePokerLeave({
             hasSeatInState: latestSeats.some((seatItem) => seatItem?.userId === userId),
             hasStackInState: Object.prototype.hasOwnProperty.call(latestStacks, userId)
           });
-          detachedCashOutAmount = normalizeNonNegativeInt(Number(latestStacks[userId])) ?? cashOutAmount;
+          try {
+            const latestHasAuthoritativeStack = Object.prototype.hasOwnProperty.call(latestStacks, userId);
+            detachedCashOutAmount = requireAuthoritativeHumanStack({ state: latestHasAuthoritativeStack ? latestState : currentState, userId }).amount;
+          } catch (error) {
+            klog("poker_leave_post_hand_stack_ambiguous", { tableId, userId, reason: error?.code || "stack_ambiguous", source: "ambiguous" });
+            throw makeError(409, "stack_ambiguous");
+          }
           klog("poker_leave_post_hand_cashout", {
             tableId,
             userId,
@@ -888,7 +900,7 @@ export async function executePokerLeave({
           userId: userId,
           amount: shouldDetachSeatAndStack ? detachedCashOutAmount : 0,
           seatNo,
-          stackSource: stateStack != null ? "state" : seatStack != null ? "seat" : "none",
+          stackSource: "authoritative_state",
           hadStack: stackValue != null,
           deferred: !shouldDetachSeatAndStack,
         });
@@ -914,9 +926,7 @@ export async function executePokerLeave({
             if (row?.is_bot === true) continue;
             const targetUserId = typeof row?.user_id === "string" ? row.user_id : null;
             if (!targetUserId) continue;
-            const stateStackAmount = normalizeNonNegativeInt(Number(closedStacks[targetUserId]));
-            const seatStackAmount = normalizeNonNegativeInt(Number(row?.stack));
-            const closeCashoutAmount = stateStackAmount ?? seatStackAmount ?? 0;
+            const closeCashoutAmount = requireAuthoritativeHumanStack({ state: { stacks: closedStacks }, userId: targetUserId }).amount;
             if (closeCashoutAmount > 0) {
               await postTransaction({
                 userId: targetUserId,

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { executePokerRebuyAuthoritative } from "./rebuy.mjs";
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [] } = {}) {
+  let store = {
+    table: { id: "table-1", status: "OPEN" },
+    seat: { user_id: "user-1", seat_no: 2, stack: 0, status: "ACTIVE", is_bot: false },
+    stateVersion: 7,
+    state: { phase: "PREFLOP", handId: "hand-1", handSeats, seats: handSeats, stacks: { "user-1": 0, bot: 90 } },
+    requests: {},
+    ledger: { user: 500, escrow: 200, posts: 0 }
+  };
+
+  const beginSql = async (fn) => {
+    const draft = clone(store);
+    const tx = {
+      __draft: draft,
+      unsafe: async (query, params = []) => {
+        const sql = String(query).toLowerCase();
+        if (sql.includes("select result_json") && sql.includes("poker_requests")) {
+          const row = draft.requests[params[2]];
+          return row ? [{ result_json: row.result_json, created_at: row.created_at }] : [];
+        }
+        if (sql.includes("insert into public.poker_requests")) {
+          if (draft.requests[params[2]]) return [];
+          draft.requests[params[2]] = { result_json: null, created_at: new Date().toISOString() };
+          return [{ request_id: params[2] }];
+        }
+        if (sql.includes("update public.poker_requests set result_json")) {
+          draft.requests[params[2]].result_json = params[4];
+          return [];
+        }
+        if (sql.includes("delete from public.poker_requests")) {
+          delete draft.requests[params[2]];
+          return [];
+        }
+        if (sql.includes("from public.poker_tables") && sql.includes("for update")) return [draft.table];
+        if (sql.includes("from public.poker_seats") && sql.includes("for update")) return [draft.seat];
+        if (sql.includes("update public.poker_seats")) {
+          if (draft.seat.user_id !== params[1] || draft.seat.seat_no !== params[2]) return [];
+          draft.seat.stack = params[3];
+          return [{ user_id: draft.seat.user_id }];
+        }
+        if (sql.includes("update public.poker_tables")) return [];
+        throw new Error(`unexpected_sql:${sql.slice(0, 80)}`);
+      }
+    };
+    const result = await fn(tx);
+    store = draft;
+    return result;
+  };
+
+  const loadStateForUpdate = async (tx) => ({ ok: true, version: tx.__draft.stateVersion, state: clone(tx.__draft.state) });
+  const updateStateLocked = async (tx, { nextState }) => {
+    if (stateUpdateFails) return { ok: false, reason: "conflict" };
+    tx.__draft.stateVersion += 1;
+    tx.__draft.state = clone(nextState);
+    return { ok: true, newVersion: tx.__draft.stateVersion };
+  };
+  const postTransactionFn = async ({ entries, tx }) => {
+    if (ledgerFails) throw Object.assign(new Error("insufficient_funds"), { code: "insufficient_funds" });
+    const userDelta = entries.find((entry) => entry.accountType === "USER")?.amount || 0;
+    const escrowDelta = entries.find((entry) => entry.accountType === "ESCROW")?.amount || 0;
+    tx.__draft.ledger.user += userDelta;
+    tx.__draft.ledger.escrow += escrowDelta;
+    tx.__draft.ledger.posts += 1;
+    return { transaction: { id: "ledger-1" } };
+  };
+
+  const execute = (requestId = "request-1") => executePokerRebuyAuthoritative({
+    beginSql,
+    tableId: "table-1",
+    userId: "user-1",
+    requestId,
+    amount: 100,
+    postTransactionFn,
+    loadStateForUpdate,
+    updateStateLocked,
+    validateStateForStorage: () => true
+  });
+  return { execute, read: () => clone(store) };
+}
+
+test("manual rebuy atomically funds USER to ESCROW and queues the next hand", async () => {
+  const harness = createHarness();
+  const before = harness.read();
+  const result = await harness.execute();
+  const after = harness.read();
+  assert.equal(result.ok, true);
+  assert.equal(after.ledger.user, before.ledger.user - 100);
+  assert.equal(after.ledger.escrow, before.ledger.escrow + 100);
+  assert.equal(after.state.stacks["user-1"], 100);
+  assert.equal(after.state.waitingForNextHandByUserId["user-1"], true);
+  assert.equal(after.seat.stack, 100);
+  assert.deepEqual(after.state.handSeats, []);
+});
+
+test("stored rebuy result survives restart semantics and cannot fund twice", async () => {
+  const harness = createHarness();
+  const first = await harness.execute("same-request");
+  const second = await harness.execute("same-request");
+  const after = harness.read();
+  assert.equal(first.ok, true);
+  assert.equal(second.replayed, true);
+  assert.equal(after.ledger.posts, 1);
+  assert.equal(after.ledger.user, 400);
+  assert.equal(after.ledger.escrow, 300);
+});
+
+test("failed ledger funding rolls back state, seat, request, and balances", async () => {
+  const harness = createHarness({ ledgerFails: true });
+  const before = harness.read();
+  await assert.rejects(harness.execute(), (error) => error?.code === "insufficient_funds");
+  assert.deepEqual(harness.read(), before);
+});
+
+test("state update conflict prevents any rebuy ledger funding", async () => {
+  const harness = createHarness({ stateUpdateFails: true });
+  const before = harness.read();
+  await assert.rejects(harness.execute(), (error) => error?.code === "state_conflict");
+  assert.deepEqual(harness.read(), before);
+  assert.equal(harness.read().ledger.posts, 0);
+});
+
+test("rebuy is rejected while the busted player remains in current handSeats", async () => {
+  const harness = createHarness({ handSeats: [{ userId: "user-1", seatNo: 2 }] });
+  await assert.rejects(harness.execute(), (error) => error?.code === "rebuy_not_available");
+  assert.equal(harness.read().ledger.posts, 0);
+});

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -8,6 +8,7 @@ function clone(value) {
 }
 
 function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [], state = null, validateStateForStorage = () => true } = {}) {
+  const lockOrder = [];
   let store = {
     table: { id: "table-1", status: "OPEN" },
     seat: { user_id: "user-1", seat_no: 2, stack: 0, status: "ACTIVE", is_bot: false },
@@ -40,8 +41,14 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
           delete draft.requests[params[2]];
           return [];
         }
-        if (sql.includes("from public.poker_tables") && sql.includes("for update")) return [draft.table];
-        if (sql.includes("from public.poker_seats") && sql.includes("for update")) return [draft.seat];
+        if (sql.includes("from public.poker_tables") && sql.includes("for update")) {
+          lockOrder.push("table");
+          return [draft.table];
+        }
+        if (sql.includes("from public.poker_seats") && sql.includes("for update")) {
+          lockOrder.push("seat");
+          return [draft.seat];
+        }
         if (sql.includes("update public.poker_seats")) {
           if (draft.seat.user_id !== params[1] || draft.seat.seat_no !== params[2]) return [];
           draft.seat.stack = params[3];
@@ -56,7 +63,10 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
     return result;
   };
 
-  const loadStateForUpdate = async (tx) => ({ ok: true, version: tx.__draft.stateVersion, state: clone(tx.__draft.state) });
+  const loadStateForUpdate = async (tx) => {
+    lockOrder.push("state");
+    return { ok: true, version: tx.__draft.stateVersion, state: clone(tx.__draft.state) };
+  };
   const updateStateLocked = async (tx, { nextState }) => {
     if (stateUpdateFails) return { ok: false, reason: "conflict" };
     tx.__draft.stateVersion += 1;
@@ -84,7 +94,7 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
     updateStateLocked,
     validateStateForStorage
   });
-  return { execute, read: () => clone(store) };
+  return { execute, read: () => clone(store), readLockOrder: () => lockOrder.slice() };
 }
 
 test("manual rebuy atomically funds USER to ESCROW and queues the next hand", async () => {
@@ -99,6 +109,7 @@ test("manual rebuy atomically funds USER to ESCROW and queues the next hand", as
   assert.equal(after.state.waitingForNextHandByUserId["user-1"], true);
   assert.equal(after.seat.stack, 100);
   assert.deepEqual(after.state.handSeats, []);
+  assert.deepEqual(harness.readLockOrder(), ["state", "table", "seat"]);
 });
 
 test("stored rebuy result survives restart semantics and cannot fund twice", async () => {

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -1,17 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { executePokerRebuyAuthoritative } from "./rebuy.mjs";
+import { isStateStorageValid } from "../../ws-server/poker/snapshot-runtime/poker-state-utils.mjs";
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [] } = {}) {
+function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [], state = null, validateStateForStorage = () => true } = {}) {
   let store = {
     table: { id: "table-1", status: "OPEN" },
     seat: { user_id: "user-1", seat_no: 2, stack: 0, status: "ACTIVE", is_bot: false },
     stateVersion: 7,
-    state: { phase: "PREFLOP", handId: "hand-1", handSeats, seats: handSeats, stacks: { "user-1": 0, bot: 90 } },
+    state: state || { phase: "PREFLOP", handId: "hand-1", handSeats, seats: handSeats, stacks: { "user-1": 0, bot: 90 } },
     requests: {},
     ledger: { user: 500, escrow: 200, posts: 0 }
   };
@@ -81,7 +82,7 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
     postTransactionFn,
     loadStateForUpdate,
     updateStateLocked,
-    validateStateForStorage: () => true
+    validateStateForStorage
   });
   return { execute, read: () => clone(store) };
 }
@@ -131,4 +132,32 @@ test("rebuy is rejected while the busted player remains in current handSeats", a
   const harness = createHarness({ handSeats: [{ userId: "user-1", seatNo: 2 }] });
   await assert.rejects(harness.execute(), (error) => error?.code === "rebuy_not_available");
   assert.equal(harness.read().ledger.posts, 0);
+});
+
+test("manual rebuy accepts a live persisted hand with compact community card codes", async () => {
+  const botSeat = { userId: "bot", seatNo: 3 };
+  const harness = createHarness({
+    state: {
+      phase: "FLOP",
+      handId: "hand-live",
+      handSeats: [botSeat],
+      seats: [botSeat],
+      stacks: { "user-1": 0, bot: 90 },
+      community: ["AS", "KD", "QC"],
+      communityDealt: 3,
+      contributionsByUserId: { bot: 10 },
+      sidePots: []
+    },
+    validateStateForStorage: (state) => isStateStorageValid(state, {
+      requireNoDeck: true,
+      requireHandSeed: false,
+      requireCommunityDealt: false
+    })
+  });
+
+  const result = await harness.execute();
+
+  assert.equal(result.ok, true);
+  assert.equal(harness.read().state.stacks["user-1"], 100);
+  assert.deepEqual(harness.read().state.community, ["AS", "KD", "QC"]);
 });

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -9,6 +9,7 @@ function clone(value) {
 
 function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [], state = null, validateStateForStorage = () => true } = {}) {
   const lockOrder = [];
+  let seatProjectionSql = "";
   let store = {
     table: { id: "table-1", status: "OPEN" },
     seat: { user_id: "user-1", seat_no: 2, stack: 0, status: "ACTIVE", is_bot: false },
@@ -50,6 +51,7 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
           return [draft.seat];
         }
         if (sql.includes("update public.poker_seats")) {
+          seatProjectionSql = String(query);
           if (draft.seat.user_id !== params[1] || draft.seat.seat_no !== params[2]) return [];
           draft.seat.stack = params[3];
           return [{ user_id: draft.seat.user_id }];
@@ -94,7 +96,7 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
     updateStateLocked,
     validateStateForStorage
   });
-  return { execute, read: () => clone(store), readLockOrder: () => lockOrder.slice() };
+  return { execute, read: () => clone(store), readLockOrder: () => lockOrder.slice(), readSeatProjectionSql: () => seatProjectionSql };
 }
 
 test("manual rebuy atomically funds USER to ESCROW and queues the next hand", async () => {
@@ -110,6 +112,8 @@ test("manual rebuy atomically funds USER to ESCROW and queues the next hand", as
   assert.equal(after.seat.stack, 100);
   assert.deepEqual(after.state.handSeats, []);
   assert.deepEqual(harness.readLockOrder(), ["state", "table", "seat"]);
+  assert.match(harness.readSeatProjectionSql(), /set stack = \$4/i);
+  assert.doesNotMatch(harness.readSeatProjectionSql(), /updated_at/i);
 });
 
 test("stored rebuy result survives restart semantics and cannot fund twice", async () => {

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -1,0 +1,168 @@
+import { ensurePokerRequest, storePokerRequestResult } from "../../netlify/functions/_shared/poker-idempotency.mjs";
+import { requireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
+import { postUserTableBuyIn } from "./table-buy-in.mjs";
+
+export const POKER_REBUY_AMOUNT = 100;
+const POKER_REQUEST_KIND = "REBUY";
+const PENDING_STALE_SEC = 30;
+
+function makeError(code, status = 409) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function parseState(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string") throw makeError("state_invalid");
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+  } catch {
+    // Normalize every malformed persisted value to one controlled code.
+  }
+  throw makeError("state_invalid");
+}
+
+function currentHandUserIds(state) {
+  const source = Array.isArray(state?.handSeats) ? state.handSeats : (Array.isArray(state?.seats) ? state.seats : []);
+  return new Set(source.map((seat) => String(seat?.userId || "").trim()).filter(Boolean));
+}
+
+function normalizeStoredResult(result) {
+  if (!result || typeof result !== "object" || result.ok !== true) return null;
+  const stack = Number(result.stack);
+  const stateVersion = Number(result.stateVersion);
+  if (!Number.isInteger(stack) || stack !== POKER_REBUY_AMOUNT) return null;
+  if (!Number.isInteger(stateVersion) || stateVersion <= 0) return null;
+  return result;
+}
+
+export async function executePokerRebuyAuthoritative({
+  beginSql,
+  tableId,
+  userId,
+  requestId,
+  amount = POKER_REBUY_AMOUNT,
+  postTransactionFn,
+  loadStateForUpdate,
+  updateStateLocked,
+  validateStateForStorage,
+  klog = () => {}
+}) {
+  if (typeof beginSql !== "function" || typeof postTransactionFn !== "function") throw makeError("temporarily_unavailable", 503);
+  if (typeof loadStateForUpdate !== "function" || typeof updateStateLocked !== "function" || typeof validateStateForStorage !== "function") {
+    throw makeError("temporarily_unavailable", 503);
+  }
+  if (!tableId || !userId || !requestId) throw makeError("invalid_request", 400);
+  const normalizedAmount = Number(amount);
+  if (!Number.isInteger(normalizedAmount) || normalizedAmount !== POKER_REBUY_AMOUNT) throw makeError("invalid_rebuy_amount", 400);
+
+  return beginSql(async (tx) => {
+    const request = await ensurePokerRequest(tx, {
+      tableId,
+      userId,
+      requestId,
+      kind: POKER_REQUEST_KIND,
+      pendingStaleSec: PENDING_STALE_SEC
+    });
+    if (request.status === "stored") {
+      const stored = normalizeStoredResult(request.result);
+      if (!stored) throw makeError("request_result_invalid");
+      klog("poker_rebuy_replayed", { tableId, requestId, stateVersion: stored.stateVersion });
+      return { ...stored, replayed: true };
+    }
+    if (request.status === "pending") throw makeError("request_pending");
+
+    const tableRows = await tx.unsafe(
+      "select id, status from public.poker_tables where id = $1 for update;",
+      [tableId]
+    );
+    const table = tableRows?.[0] || null;
+    if (!table) throw makeError("table_not_found", 404);
+    if (String(table.status || "").toUpperCase() !== "OPEN") throw makeError("table_not_open");
+
+    const seatRows = await tx.unsafe(
+      `select user_id, seat_no, stack, status, is_bot
+       from public.poker_seats
+       where table_id = $1 and user_id = $2
+       for update;`,
+      [tableId, userId]
+    );
+    const seat = seatRows?.[0] || null;
+    if (!seat || String(seat.status || "").toUpperCase() !== "ACTIVE") throw makeError("seat_not_active");
+    if (seat.is_bot === true) throw makeError("rebuy_not_allowed");
+    const seatNo = Number(seat.seat_no);
+    if (!Number.isInteger(seatNo) || seatNo < 1) throw makeError("state_invalid");
+
+    const locked = await loadStateForUpdate(tx, tableId);
+    if (!locked?.ok) throw makeError(locked?.reason === "not_found" ? "state_missing" : "state_invalid");
+    const state = parseState(locked.state);
+    const stackEvidence = requireAuthoritativeHumanStack({ state, userId });
+    if (stackEvidence.amount !== 0) throw makeError("rebuy_not_available");
+    if (currentHandUserIds(state).has(userId)) throw makeError("rebuy_not_available");
+    if (state?.waitingForNextHandByUserId?.[userId] === true) throw makeError("rebuy_not_available");
+
+    const nextState = {
+      ...state,
+      stacks: {
+        ...(state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks) ? state.stacks : {}),
+        [userId]: normalizedAmount
+      },
+      waitingForNextHandByUserId: {
+        ...(state.waitingForNextHandByUserId && typeof state.waitingForNextHandByUserId === "object" && !Array.isArray(state.waitingForNextHandByUserId)
+          ? state.waitingForNextHandByUserId
+          : {}),
+        [userId]: true
+      }
+    };
+    if (!validateStateForStorage(nextState)) throw makeError("state_invalid");
+
+    const updated = await updateStateLocked(tx, { tableId, nextState });
+    if (!updated?.ok) throw makeError(updated?.reason === "not_found" ? "state_missing" : "state_conflict");
+
+    const idempotencyKey = `poker:rebuy:v1:${tableId}:${userId}:${requestId}`;
+    const ledger = await postUserTableBuyIn({
+      postTransaction: postTransactionFn,
+      tx,
+      tableId,
+      userId,
+      amount: normalizedAmount,
+      idempotencyKey,
+      reference: `poker-rebuy:${tableId}`,
+      metadata: { tableId, seatNo, reason: "manual_rebuy" }
+    });
+
+    const projectedRows = await tx.unsafe(
+      `update public.poker_seats
+       set stack = $4, updated_at = now()
+       where table_id = $1 and user_id = $2 and seat_no = $3 and status = 'ACTIVE' and is_bot = false
+       returning user_id;`,
+      [tableId, userId, seatNo, normalizedAmount]
+    );
+    if (projectedRows?.length !== 1) throw makeError("seat_projection_conflict");
+    await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
+
+    const result = {
+      ok: true,
+      tableId,
+      userId,
+      seatNo,
+      stack: normalizedAmount,
+      status: "WAITING_NEXT_HAND",
+      stateVersion: Number(updated.newVersion),
+      ledgerTransactionId: ledger?.transaction?.id || null,
+      requestId
+    };
+    await storePokerRequestResult(tx, {
+      tableId,
+      userId,
+      requestId,
+      kind: POKER_REQUEST_KIND,
+      result
+    });
+    klog("poker_rebuy_committed", { tableId, seatNo, stateVersion: result.stateVersion, amount: normalizedAmount });
+    return result;
+  });
+}

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -102,6 +102,13 @@ export async function executePokerRebuyAuthoritative({
     }
     if (request.status === "pending") throw makeError("request_pending");
 
+    // Match the high-frequency persistence order: poker_state -> seat/table.
+    // Reversing this order can deadlock with bot autoplay, which updates state
+    // before projecting seats and table activity.
+    const locked = await loadStateForUpdate(tx, tableId);
+    if (!locked?.ok) throw makeError(locked?.reason === "not_found" ? "state_missing" : "state_invalid");
+    const state = parseState(locked.state);
+
     const tableRows = await tx.unsafe(
       "select id, status from public.poker_tables where id = $1 for update;",
       [tableId]
@@ -123,9 +130,6 @@ export async function executePokerRebuyAuthoritative({
     const seatNo = Number(seat.seat_no);
     if (!Number.isInteger(seatNo) || seatNo < 1) throw makeError("state_invalid");
 
-    const locked = await loadStateForUpdate(tx, tableId);
-    if (!locked?.ok) throw makeError(locked?.reason === "not_found" ? "state_missing" : "state_invalid");
-    const state = parseState(locked.state);
     const stackEvidence = requireAuthoritativeHumanStack({ state, userId });
     if (stackEvidence.amount !== 0) throw makeError("rebuy_not_available");
     if (currentHandUserIds(state).has(userId)) throw makeError("rebuy_not_available");

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -30,6 +30,33 @@ function currentHandUserIds(state) {
   return new Set(source.map((seat) => String(seat?.userId || "").trim()).filter(Boolean));
 }
 
+function normalizeCardCodeForValidation(cardCode) {
+  if (typeof cardCode !== "string") return null;
+  const code = cardCode.trim().toUpperCase();
+  if (!/^(10|[2-9TJQKA])[CDHS]$/.test(code)) return null;
+  const suit = code.slice(-1);
+  const rankCode = code.slice(0, -1);
+  const rank = rankCode === "A"
+    ? 14
+    : rankCode === "K"
+      ? 13
+      : rankCode === "Q"
+        ? 12
+        : rankCode === "J"
+          ? 11
+          : rankCode === "T"
+            ? 10
+            : Number(rankCode);
+  return Number.isInteger(rank) && rank >= 2 && rank <= 14 ? { r: rank, s: suit } : null;
+}
+
+function normalizeStateForStorageValidation(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state) || !Array.isArray(state.community)) return state;
+  const community = state.community.map((card) => typeof card === "string" ? normalizeCardCodeForValidation(card) : card);
+  if (community.some((card) => !card)) return state;
+  return { ...state, community };
+}
+
 function normalizeStoredResult(result) {
   if (!result || typeof result !== "object" || result.ok !== true) return null;
   const stack = Number(result.stack);
@@ -117,7 +144,7 @@ export async function executePokerRebuyAuthoritative({
         [userId]: true
       }
     };
-    if (!validateStateForStorage(nextState)) throw makeError("state_invalid");
+    if (!validateStateForStorage(normalizeStateForStorageValidation(nextState))) throw makeError("state_invalid");
 
     const updated = await updateStateLocked(tx, { tableId, nextState });
     if (!updated?.ok) throw makeError(updated?.reason === "not_found" ? "state_missing" : "state_conflict");

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -167,7 +167,7 @@ export async function executePokerRebuyAuthoritative({
 
     const projectedRows = await tx.unsafe(
       `update public.poker_seats
-       set stack = $4, updated_at = now()
+       set stack = $4
        where table_id = $1 and user_id = $2 and seat_no = $3 and status = 'ACTIVE' and is_bot = false
        returning user_id;`,
       [tableId, userId, seatNo, normalizedAmount]

--- a/shared/poker-domain/table-buy-in.mjs
+++ b/shared/poker-domain/table-buy-in.mjs
@@ -1,0 +1,36 @@
+function makeError(code) {
+  const error = new Error(code);
+  error.code = code;
+  return error;
+}
+
+export async function postUserTableBuyIn({
+  postTransaction,
+  tx,
+  tableId,
+  userId,
+  amount,
+  idempotencyKey,
+  createdBy = userId,
+  reference = null,
+  metadata = {}
+}) {
+  const normalizedAmount = Number(amount);
+  if (typeof postTransaction !== "function") throw makeError("temporarily_unavailable");
+  if (!tableId || !userId || !idempotencyKey) throw makeError("invalid_buy_in");
+  if (!Number.isInteger(normalizedAmount) || normalizedAmount <= 0) throw makeError("invalid_buy_in");
+
+  return postTransaction({
+    userId,
+    txType: "TABLE_BUY_IN",
+    idempotencyKey,
+    reference,
+    metadata,
+    entries: [
+      { accountType: "USER", amount: -normalizedAmount },
+      { accountType: "ESCROW", systemKey: `POKER_TABLE:${tableId}`, amount: normalizedAmount }
+    ],
+    createdBy,
+    tx
+  });
+}

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -993,10 +993,12 @@ test('poker v2 renders authoritative out-of-chips state with stable disabled act
   harness.elements.pokerV2RebuyBtn.click();
   await harness.flush();
   assert.equal(JSON.stringify(harness.rebuyPayloads), JSON.stringify([{ tableId: 'table-1', amount: 100 }]));
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'accepted rebuy must close the prompt immediately');
 
   ws.onSnapshot(snapshot({ status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false }));
   await harness.flush();
   assert.equal(harness.elements.pokerV2TurnText.textContent, 'Funded · Joining next hand');
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'waiting snapshot must not reopen an accepted rebuy prompt');
   assert.equal(harness.elements.pokerV2RebuyBtn.hidden, true);
 });
 

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -115,6 +115,7 @@ function createHarness(options = {}){
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
     'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
+    'pokerV2RebuyPanel', 'pokerV2RebuyTitle', 'pokerV2RebuyCopy', 'pokerV2RebuyBalance', 'pokerV2RebuyBtn', 'pokerV2RebuyLobbyBtn', 'pokerV2RebuyWatchBtn', 'pokerV2RebuyAccountLink',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
     'pokerV2AllInBtn', 'pokerV2FoldPreactionWrap', 'pokerV2FoldPreaction', 'pokerV2FoldPreactionText',
@@ -137,6 +138,7 @@ function createHarness(options = {}){
   elements.pokerV2AllInPreaction.type = 'checkbox';
   elements.pokerV2LeaveConfirmModal.hidden = true;
   elements.pokerV2ClosedTableModal.hidden = true;
+  elements.pokerV2RebuyPanel.hidden = true;
   elements.pokerMenuPanel.setAttribute('hidden', 'hidden');
 
   const documentEvents = {};
@@ -145,6 +147,7 @@ function createHarness(options = {}){
   const actPayloads = [];
   const startPayloads = [];
   const leavePayloads = [];
+  const rebuyPayloads = [];
   let createOptions = null;
 
   const token = Object.prototype.hasOwnProperty.call(options, 'token')
@@ -169,6 +172,11 @@ function createHarness(options = {}){
     },
     sendAct(payload){ actPayloads.push(payload); return Promise.resolve({ ok: true }); },
     sendStartHand(payload){ startPayloads.push(payload); return Promise.resolve({ ok: true }); },
+    sendRebuy(payload){
+      rebuyPayloads.push(payload);
+      if (typeof options.sendRebuy === 'function') return options.sendRebuy(payload, { attempt: rebuyPayloads.length });
+      return Promise.resolve({ ok: true });
+    },
     sendLeave(payload){
       leavePayloads.push(payload);
       if (typeof options.sendLeave === 'function') return options.sendLeave(payload, { attempt: leavePayloads.length });
@@ -306,6 +314,7 @@ async function flush(){
     actPayloads,
     startPayloads,
     leavePayloads,
+    rebuyPayloads,
     fireDomContentLoaded,
     fireDocumentEvent,
     flush,
@@ -942,6 +951,49 @@ test('poker v2 keeps fold available even when live legalActions omit fold', asyn
   await harness.flush();
 
   assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-fold-always', action: 'FOLD' }));
+});
+
+test('poker v2 renders authoritative out-of-chips state with stable disabled actions and explicit rebuy', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  const snapshot = (playerState) => ({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 40,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
+      public: {
+        seats: [{ userId: 'user-1', seatNo: 1, status: playerState.status }, { userId: 'bot-1', seatNo: 2, status: 'ACTIVE', isBot: true }],
+        stacks: { 'user-1': playerState.stack, 'bot-1': 98 },
+        hand: { handId: 'bot-hand', status: 'PREFLOP', dealerSeatNo: 2 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 3, sidePots: [] },
+        legalActions: { seat: 1, actions: [] }
+      },
+      private: { userId: 'user-1', seat: 1, holeCards: [], playerState },
+      you: { seat: 1 }
+    }
+  });
+  ws.onSnapshot(snapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2TurnText.textContent, 'Out of chips · Sitting out');
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, false);
+  assert.equal(harness.elements.pokerV2RebuyBtn.disabled, false);
+  for (const id of ['pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn', 'pokerV2AllInBtn']) {
+    assert.equal(harness.elements[id].hidden, false);
+    assert.equal(harness.elements[id].disabled, true);
+  }
+  harness.elements.pokerV2RebuyBtn.click();
+  await harness.flush();
+  assert.equal(JSON.stringify(harness.rebuyPayloads), JSON.stringify([{ tableId: 'table-1', amount: 100 }]));
+
+  ws.onSnapshot(snapshot({ status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2TurnText.textContent, 'Funded · Joining next hand');
+  assert.equal(harness.elements.pokerV2RebuyBtn.hidden, true);
 });
 
 test('poker v2 keeps action buttons stable while exposing single-select preactions off-turn', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -976,6 +976,10 @@ test('poker v2 renders authoritative out-of-chips state with stable disabled act
       you: { seat: 1 }
     }
   });
+  ws.onSnapshot(snapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: false }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'non-actionable out-of-chips state must not offer rebuy before rollover');
+
   ws.onSnapshot(snapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
   await harness.flush();
 

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -148,7 +148,7 @@ test('poker ws client bootstraps hello -> auth -> snapshot once', async () => {
 });
 
 
-test('poker ws client sendJoin/sendLeave/sendStartHand/sendAct resolve and reject by commandResult', async () => {
+test('poker ws client gameplay commands including rebuy resolve and reject by commandResult', async () => {
   const h = loadClientHarness();
   h.client.start();
   const ws = h.FakeWebSocket.instances[0];
@@ -168,6 +168,12 @@ test('poker ws client sendJoin/sendLeave/sendStartHand/sendAct resolve and rejec
   ws.message({ type: 'commandResult', requestId: 'leave_req_1', payload: { requestId: 'leave_req_1', status: 'accepted', reason: null } });
   const leaveResult = await leavePromise;
   assert.equal(leaveResult.ok, true);
+
+  const rebuyPromise = h.client.sendRebuy({ tableId: 'table_test_1', amount: 100 }, 'rebuy_req_1');
+  assert.equal(h.sentFrames.at(-1).type, 'rebuy');
+  assert.equal(h.sentFrames.at(-1).payload.amount, 100);
+  ws.message({ type: 'commandResult', requestId: 'rebuy_req_1', payload: { requestId: 'rebuy_req_1', status: 'accepted', reason: null } });
+  assert.equal((await rebuyPromise).ok, true);
 
   const startPromise = h.client.sendStartHand({ tableId: 'table_test_1' }, 'start_req_1');
   ws.message({ type: 'commandResult', requestId: 'start_req_1', payload: { requestId: 'start_req_1', status: 'rejected', reason: 'not_enough_players' } });

--- a/tests/test-all.runner-registration.guard.test.mjs
+++ b/tests/test-all.runner-registration.guard.test.mjs
@@ -34,6 +34,10 @@ assert.match(source, /run\("node", \["ws-server\/poker\/persistence\/inactive-cl
 assert.match(source, /run\("node", \["ws-server\/poker\/runtime\/disconnect-cleanup\.behavior\.test\.mjs"\],/, "runner should include ws disconnect cleanup runtime behavior test");
 assert.match(source, /run\("node", \["ws-server\/poker\/runtime\/accepted-bot-autoplay-adapter\.behavior\.test\.mjs"\],/, "runner should include ws accepted bot autoplay adapter behavior test");
 assert.match(source, /run\("node", \["shared\/poker-domain\/inactive-cleanup\.behavior\.test\.mjs"\],/, "runner should include shared poker-domain inactive cleanup behavior test");
+assert.match(source, /run\("node", \["shared\/poker-domain\/human-stack-accounting\.behavior\.test\.mjs"\],/, "runner should include human stack accounting behavior test");
+assert.match(source, /run\("node", \["shared\/poker-domain\/rebuy\.behavior\.test\.mjs"\],/, "runner should include manual rebuy accounting behavior test");
+assert.match(source, /run\("node", \["ws-server\/poker\/persistence\/authoritative-rebuy-adapter\.behavior\.test\.mjs"\],/, "runner should include authoritative rebuy adapter behavior test");
+assert.match(source, /run\("node", \["ws-server\/poker\/handlers\/rebuy\.behavior\.test\.mjs"\],/, "runner should include rebuy handler behavior test");
 assert.doesNotMatch(source, /poker-heartbeat\.behavior\.test\.mjs/, "runner should not include removed heartbeat behavior tests");
 assert.doesNotMatch(source, /tests\/poker-sweep\.behavior\.test\.mjs/, "runner should not include removed legacy sweep behavior test");
 assert.doesNotMatch(source, /tests\/poker-sweep\..*\.behavior\.test\.mjs/, "runner should not include removed sweep behavior tests");

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -12,7 +12,7 @@ test("adapter maps persisted rows into deterministic ws table/core state", () =>
       { user_id: "user_a", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 120 },
       { user_id: "user_x", seat_no: 3, status: "LEFT", is_bot: false }
     ],
-    stateRow: { version: 12, state: { phase: "PREFLOP", handId: "h1" } }
+    stateRow: { version: 12, state: { phase: "PREFLOP", handId: "h1", stacks: { user_a: 120, user_b: 80 } } }
   });
 
   assert.equal(result.ok, true);
@@ -46,6 +46,7 @@ test("adapter accepts legacy stringified persisted poker state JSON", () => {
       version: 4,
       state: JSON.stringify({
         phase: "PREFLOP",
+        stacks: { user_a: 100 },
         hand: { handId: "h_legacy", pots: JSON.stringify([{ amount: 120 }]) }
       })
     }
@@ -96,6 +97,7 @@ test("adapter drops stale state seats that are no longer ACTIVE in persisted sea
       version: 10,
       state: {
         phase: "HAND_DONE",
+        stacks: { user_a: 120 },
         seats: [
           { userId: "user_a", seatNo: 1, status: "ACTIVE" },
           { userId: "user_b", seatNo: 2, status: "ACTIVE" }
@@ -221,7 +223,7 @@ test("adapter restores replacement bot identity from persisted state when seat r
   assert.equal(result.table.presenceByUserId.has("bot_old_2"), false);
 });
 
-test("adapter keeps public stacks from active seat rows for non-replacement members", () => {
+test("adapter keeps authoritative human stack while retaining bot seat projection", () => {
   const result = adaptPersistedBootstrap({
     tableId: "table_public_stack_restore",
     tableRow: { id: "table_public_stack_restore", max_players: 6, status: "OPEN" },
@@ -250,7 +252,30 @@ test("adapter keeps public stacks from active seat rows for non-replacement memb
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.table.coreState.publicStacks, {
-    user_a: 150,
+    user_a: 149,
     bot_2: 100
   });
+});
+
+test("adapter restores an out-of-chips human at zero despite a stale positive seat projection", () => {
+  const result = adaptPersistedBootstrap({
+    tableId: "table_busted_restore",
+    tableRow: { id: "table_busted_restore", max_players: 6, status: "OPEN" },
+    seatRows: [{ user_id: "user_a", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 }],
+    stateRow: { version: 4, state: { phase: "PREFLOP", handId: "next_hand", handSeats: [], seats: [], stacks: { user_a: 0 } } }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.table.coreState.publicStacks.user_a, 0);
+});
+
+test("adapter fails closed when an active human has no authoritative state stack", () => {
+  const result = adaptPersistedBootstrap({
+    tableId: "table_ambiguous_restore",
+    tableRow: { id: "table_ambiguous_restore", max_players: 6, status: "OPEN" },
+    seatRows: [{ user_id: "user_a", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 }],
+    stateRow: { version: 4, state: { phase: "PREFLOP", handId: "hand" } }
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "invalid_persisted_state");
+  assert.equal(result.message, "human_stack_ambiguous");
 });

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -109,7 +109,7 @@ function normalizeTableMeta(tableRow, maxSeats) {
 
 function normalizePublicStacks(runtimeSeats, pokerState) {
   if (!Array.isArray(runtimeSeats)) {
-    return {};
+    return { ok: false, stacks: {} };
   }
   const stateStacks = asPlainObject(pokerState?.stacks) || {};
   const entries = [];
@@ -117,15 +117,20 @@ function normalizePublicStacks(runtimeSeats, pokerState) {
     const userId = typeof seat?.userId === "string" ? seat.userId.trim() : "";
     const stateStack = Number(stateStacks[userId]);
     const seatStack = Number(seat?.stack);
-    const stack = seat?.preferStatePublicStack === true && Number.isFinite(stateStack) && stateStack >= 0
+    const hasAuthoritativeStateStack = Object.prototype.hasOwnProperty.call(stateStacks, userId)
+      && Number.isSafeInteger(stateStack)
+      && stateStack >= 0;
+    if (!userId) continue;
+    if (seat?.isBot !== true && !hasAuthoritativeStateStack) {
+      return { ok: false, stacks: {} };
+    }
+    const stack = seat?.isBot !== true || seat?.preferStatePublicStack === true || !Number.isFinite(seatStack)
       ? stateStack
       : seatStack;
-    if (!userId || !Number.isFinite(stack)) {
-      continue;
-    }
+    if (!Number.isFinite(stack) || stack < 0) continue;
     entries.push([userId, stack]);
   }
-  return Object.fromEntries(entries);
+  return { ok: true, stacks: Object.fromEntries(entries) };
 }
 
 function normalizeSeatRows(seatRows, maxSeats) {
@@ -300,7 +305,11 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
   const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(pokerState, seats);
   const runtimeSeats = buildRuntimeSeats({ seatRows: seats, stateSeats, replacementSeatNos, leftTableByUserId });
   const members = runtimeSeats.map((seat) => ({ userId: seat.userId, seat: seat.seat }));
-  const publicStacks = normalizePublicStacks(runtimeSeats, pokerState);
+  const publicStackResult = normalizePublicStacks(runtimeSeats, pokerState);
+  if (!publicStackResult.ok) {
+    return { ok: false, code: "invalid_persisted_state", message: "human_stack_ambiguous" };
+  }
+  const publicStacks = publicStackResult.stacks;
   const normalizedPokerState = { ...pokerState, seats: stateSeats };
   const derivedRuntimeHandState = deriveDeterministicRuntimeHandState(normalizedPokerState);
   const seatDetailsByUserId = {};

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -131,6 +131,32 @@ test("human with one chip remains eligible and posts a partial blind", () => {
   assert.equal(next.contributionsByUserId.human, 1);
 });
 
+test("rollover preserves an authoritative stack awaiting cleanup after runtime presence is pruned", () => {
+  const coreState = {
+    roomId: "table_disconnected_human",
+    version: 8,
+    members: [{ userId: "bot_a", seat: 2 }, { userId: "bot_b", seat: 3 }],
+    seats: { bot_a: 2, bot_b: 3 },
+    seatDetailsByUserId: { bot_a: { isBot: true }, bot_b: { isBot: true } },
+    pokerState: null
+  };
+  const next = buildNextHandStateFromSettled({
+    tableId: "table_disconnected_human",
+    coreState,
+    settledState: {
+      handId: "settled_disconnected_human",
+      phase: "SETTLED",
+      dealerSeatNo: 2,
+      stacks: { disconnected_human: 318, bot_a: 400, bot_b: 3282 }
+    },
+    nextVersion: 9
+  });
+
+  assert.ok(next);
+  assert.equal(next.handSeats.some((seat) => seat.userId === "disconnected_human"), false);
+  assert.equal(next.stacks.disconnected_human, 318);
+});
+
 test("rollover does not bootstrap a live hand when fewer than two stack-eligible players remain", () => {
   const baseCore = {
     roomId: "table_engine_roll_no_start",

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -105,7 +105,30 @@ test("fold settlement carryover preserves stack-eligible members and determinist
     { userId: "user_b", seatNo: 2 },
     { userId: "user_c", seatNo: 3 }
   ]);
+  assert.equal(next.stacks.user_a, 0);
+  assert.equal(next.handSeats.some((seat) => seat.userId === "user_a"), false);
   assert.equal(next.turnUserId, "user_b");
+});
+
+test("human with one chip remains eligible and posts a partial blind", () => {
+  const coreState = {
+    roomId: "table_one_chip",
+    version: 4,
+    members: [{ userId: "human", seat: 1 }, { userId: "bot", seat: 2 }],
+    seats: { human: 1, bot: 2 },
+    seatDetailsByUserId: { human: { isBot: false }, bot: { isBot: true } },
+    pokerState: null
+  };
+  const next = buildNextHandStateFromSettled({
+    tableId: "table_one_chip",
+    coreState,
+    settledState: { handId: "settled_one_chip", phase: "SETTLED", dealerSeatNo: 2, stacks: { human: 1, bot: 100 } },
+    nextVersion: 5
+  });
+  assert.ok(next);
+  assert.equal(next.handSeats.some((seat) => seat.userId === "human"), true);
+  assert.equal(next.stacks.human, 0);
+  assert.equal(next.contributionsByUserId.human, 1);
 });
 
 test("rollover does not bootstrap a live hand when fewer than two stack-eligible players remain", () => {

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -216,11 +216,13 @@ export function buildNextHandStateFromSettled({ tableId, coreState, settledState
   });
   if (!nextHandState) return null;
   const durableStacks = { ...nextHandState.stacks };
-  const nextHandUserIds = new Set(nextHandState.handSeats.map((seat) => seat.userId));
-  for (const member of orderedSeatMembers(coreState)) {
-    if (nextHandUserIds.has(member.userId)) continue;
-    const stack = Number(settledState?.stacks?.[member.userId]);
-    if (Number.isInteger(stack) && stack >= 0) durableStacks[member.userId] = stack;
+  const settledStacks = settledState?.stacks && typeof settledState.stacks === "object" && !Array.isArray(settledState.stacks)
+    ? settledState.stacks
+    : {};
+  for (const [userId, rawStack] of Object.entries(settledStacks)) {
+    if (Object.prototype.hasOwnProperty.call(durableStacks, userId)) continue;
+    const stack = Number(rawStack);
+    if (Number.isInteger(stack) && stack >= 0) durableStacks[userId] = stack;
   }
   const waitingForNextHandByUserId = settledState?.waitingForNextHandByUserId && typeof settledState.waitingForNextHandByUserId === "object" && !Array.isArray(settledState.waitingForNextHandByUserId)
     ? { ...settledState.waitingForNextHandByUserId }

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -84,9 +84,10 @@ function orderedSeatMembers(coreState) {
     .sort((a, b) => a.seat - b.seat || a.userId.localeCompare(b.userId));
 }
 
-export function isContinuationEligibleByStack(userId, stacksByUserId) {
+export function isContinuationEligibleByStack(userId, stacksByUserId, { isBot = false } = {}) {
   const stack = Number(stacksByUserId?.[userId] ?? 0);
-  return Number.isFinite(stack) && stack >= MIN_STACK_TO_JOIN_HAND;
+  const minimumStack = isBot ? MIN_STACK_TO_JOIN_HAND : 1;
+  return Number.isFinite(stack) && stack >= minimumStack;
 }
 
 export function orderedEligibleSeatMembers(coreState, stacksByUserId = null) {
@@ -94,7 +95,9 @@ export function orderedEligibleSeatMembers(coreState, stacksByUserId = null) {
   if (!stacksByUserId || typeof stacksByUserId !== "object" || Array.isArray(stacksByUserId)) {
     return members;
   }
-  return members.filter((member) => isContinuationEligibleByStack(member.userId, stacksByUserId));
+  return members.filter((member) => isContinuationEligibleByStack(member.userId, stacksByUserId, {
+    isBot: coreState?.seatDetailsByUserId?.[member.userId]?.isBot === true
+  }));
 }
 
 export function buildBootstrappedPokerState({ tableId, coreState, dealerSeatNo = null, startingStacks = null, handVersion = null }) {
@@ -179,12 +182,14 @@ export function buildBootstrappedPokerState({ tableId, coreState, dealerSeatNo =
   };
 }
 
-export function resolveNextDealerSeatNo({ members, settledState }) {
+export function resolveNextDealerSeatNo({ members, settledState, coreState = null }) {
   if (!Array.isArray(members) || members.length === 0) {
     return null;
   }
 
-  const eligibleMembers = members.filter((member) => isContinuationEligibleByStack(member.userId, settledState?.stacks));
+  const eligibleMembers = members.filter((member) => isContinuationEligibleByStack(member.userId, settledState?.stacks, {
+    isBot: coreState?.seatDetailsByUserId?.[member.userId]?.isBot === true
+  }));
   if (eligibleMembers.length === 0) {
     return null;
   }
@@ -201,14 +206,27 @@ export function resolveNextDealerSeatNo({ members, settledState }) {
 
 export function buildNextHandStateFromSettled({ tableId, coreState, settledState, nextVersion }) {
   const members = orderedEligibleSeatMembers(coreState, settledState?.stacks);
-  const nextDealerSeatNo = resolveNextDealerSeatNo({ members, settledState });
-  return buildBootstrappedPokerState({
+  const nextDealerSeatNo = resolveNextDealerSeatNo({ members, settledState, coreState });
+  const nextHandState = buildBootstrappedPokerState({
     tableId,
     coreState,
     dealerSeatNo: nextDealerSeatNo,
     startingStacks: settledState?.stacks,
     handVersion: nextVersion
   });
+  if (!nextHandState) return null;
+  const durableStacks = { ...nextHandState.stacks };
+  const nextHandUserIds = new Set(nextHandState.handSeats.map((seat) => seat.userId));
+  for (const member of orderedSeatMembers(coreState)) {
+    if (nextHandUserIds.has(member.userId)) continue;
+    const stack = Number(settledState?.stacks?.[member.userId]);
+    if (Number.isInteger(stack) && stack >= 0) durableStacks[member.userId] = stack;
+  }
+  const waitingForNextHandByUserId = settledState?.waitingForNextHandByUserId && typeof settledState.waitingForNextHandByUserId === "object" && !Array.isArray(settledState.waitingForNextHandByUserId)
+    ? { ...settledState.waitingForNextHandByUserId }
+    : {};
+  for (const seat of nextHandState.handSeats) delete waitingForNextHandByUserId[seat.userId];
+  return { ...nextHandState, stacks: durableStacks, waitingForNextHandByUserId };
 }
 
 function nextBotReplacementUserId({ tableId, seatNo, version, existingUserIds }) {

--- a/ws-server/poker/handlers/join.behavior.test.mjs
+++ b/ws-server/poker/handlers/join.behavior.test.mjs
@@ -116,6 +116,22 @@ test('handleJoinCommand forwards join intent to authoritative executor when enab
   assert.equal(calls.joinArgs.authoritativeSeatNo, 2);
 });
 
+test('handleJoinCommand does not reapply the original buy-in during authoritative rejoin attach', async () => {
+  const { ctx, calls } = baseCtx({ seatNo: 2, buyIn: 100 });
+  ctx.authoritativeJoinEnabled = true;
+  ctx.persistedBootstrapEnabled = true;
+  ctx.loadAuthoritativeJoinExecutor = async () => async (args) => {
+    calls.authoritativeArgs = args;
+    return { ok: true, seatNo: 2, stack: 99, rejoin: true };
+  };
+
+  await handleJoinCommand(ctx);
+
+  assert.equal(calls.authoritativeArgs.buyIn, 100);
+  assert.equal(calls.joinArgs.authoritativeSeatNo, 2);
+  assert.equal(calls.joinArgs.buyIn, null);
+});
+
 test('handleJoinCommand rejects instead of degrading when authoritative join is required but unavailable', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 100 });
   ctx.authoritativeJoinEnabled = true;

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -236,7 +236,9 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     seatNo: joinIntent.seatNo,
     autoSeat: joinIntent.autoSeat,
     preferredSeatNo: joinIntent.preferredSeatNo,
-    buyIn: joinIntent.buyIn,
+    buyIn: authoritativeJoinResult?.rejoin === true
+      ? null
+      : (authoritativeJoinResult?.stack ?? joinIntent.buyIn),
     authoritativeSeatNo: authoritativeJoinResult?.seatNo ?? null
   });
   klog("ws_join_attach_result", {

--- a/ws-server/poker/handlers/rebuy.behavior.test.mjs
+++ b/ws-server/poker/handlers/rebuy.behavior.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handleRebuyCommand } from "./rebuy.mjs";
+
+function baseArgs(overrides = {}) {
+  const events = [];
+  return {
+    events,
+    args: {
+      frame: { requestId: "request", ts: "2026-07-14T00:00:00.000Z", payload: { amount: 100 } },
+      ws: {},
+      connState: { session: { userId: "user" } },
+      tableId: "table",
+      loadAuthoritativeRebuyExecutor: async () => async () => ({ ok: true, stateVersion: 9 }),
+      restoreTableFromPersisted: async () => ({ ok: true }),
+      broadcastStateSnapshots: () => events.push("snapshot"),
+      broadcastTableState: () => events.push("table"),
+      broadcastResyncRequired: () => events.push("resync"),
+      sendCommandResult: (_ws, _state, payload) => events.push(payload),
+      scheduleBotStep: () => events.push("bot"),
+      klog: () => {},
+      ...overrides
+    }
+  };
+}
+
+test("rebuy handler restores committed state before broadcasting authoritative snapshot", async () => {
+  const harness = baseArgs();
+  await handleRebuyCommand(harness.args);
+  assert.equal(harness.events[0].status, "accepted");
+  assert.deepEqual(harness.events.slice(1), ["snapshot", "table", "bot"]);
+});
+
+test("rebuy handler rejects domain failure without runtime mutation", async () => {
+  const harness = baseArgs({ loadAuthoritativeRebuyExecutor: async () => async () => ({ ok: false, code: "insufficient_chips" }) });
+  await handleRebuyCommand(harness.args);
+  assert.deepEqual(harness.events, [{ requestId: "request", tableId: "table", status: "rejected", reason: "insufficient_chips" }]);
+});
+
+test("rebuy handler requests resync when commit succeeded but runtime restore fails", async () => {
+  const harness = baseArgs({ restoreTableFromPersisted: async () => ({ ok: false, reason: "restore_error" }) });
+  await handleRebuyCommand(harness.args);
+  assert.equal(harness.events[0].status, "accepted");
+  assert.equal(harness.events[1], "resync");
+  assert.equal(harness.events.includes("snapshot"), false);
+});

--- a/ws-server/poker/handlers/rebuy.mjs
+++ b/ws-server/poker/handlers/rebuy.mjs
@@ -1,0 +1,63 @@
+export async function handleRebuyCommand({
+  frame,
+  ws,
+  connState,
+  tableId,
+  loadAuthoritativeRebuyExecutor,
+  restoreTableFromPersisted,
+  broadcastStateSnapshots,
+  broadcastTableState,
+  broadcastResyncRequired,
+  sendCommandResult,
+  scheduleBotStep = () => {},
+  klog = () => {}
+}) {
+  const amount = frame?.payload?.amount === undefined ? 100 : Number(frame.payload.amount);
+  const executeAuthoritativeRebuy = await loadAuthoritativeRebuyExecutor();
+  const rebuy = await executeAuthoritativeRebuy({
+    tableId,
+    userId: connState.session.userId,
+    requestId: frame.requestId ?? null,
+    amount
+  });
+  if (!rebuy?.ok) {
+    sendCommandResult(ws, connState, {
+      requestId: frame.requestId ?? null,
+      tableId,
+      status: "rejected",
+      reason: rebuy?.code || "authoritative_rebuy_failed"
+    });
+    return;
+  }
+
+  const restored = await restoreTableFromPersisted(tableId);
+  sendCommandResult(ws, connState, {
+    requestId: frame.requestId ?? null,
+    tableId,
+    status: "accepted",
+    reason: rebuy.replayed === true ? "already_applied" : null
+  });
+  if (!restored?.ok) {
+    klog("ws_rebuy_runtime_restore_failed", {
+      tableId,
+      requestId: frame.requestId ?? null,
+      stateVersion: rebuy.stateVersion ?? null,
+      reason: restored?.reason || restored?.code || "restore_failed"
+    });
+    broadcastResyncRequired(tableId, "authoritative_rebuy_restore_failed");
+    return;
+  }
+
+  broadcastStateSnapshots(tableId);
+  broadcastTableState(tableId);
+  try {
+    scheduleBotStep({
+      tableId,
+      trigger: "rebuy",
+      requestId: frame.requestId ?? null,
+      frameTs: frame.ts ?? null
+    });
+  } catch (error) {
+    klog("ws_rebuy_schedule_bot_step_failed", { tableId, requestId: frame.requestId ?? null, message: error?.message || "unknown" });
+  }
+}

--- a/ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAuthoritativeRebuyExecutor } from "./authoritative-rebuy-adapter.mjs";
+
+function dependencies(executePokerRebuyAuthoritative) {
+  return {
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (fn) => fn({ unsafe: async () => [] }),
+    loadRebuyModule: async () => ({ executePokerRebuyAuthoritative }),
+    loadPostTransaction: async () => async () => ({ transaction: { id: "tx" } }),
+    loadLockedStateHelpers: async () => ({
+      loadStateForUpdate: async () => ({ ok: true }),
+      updateStateLocked: async () => ({ ok: true }),
+      validateStateForStorage: () => true
+    }),
+    klog: () => {}
+  };
+}
+
+test("authoritative rebuy adapter forwards the fixed command to shared domain", async () => {
+  let captured = null;
+  const executor = createAuthoritativeRebuyExecutor(dependencies(async (args) => {
+    captured = args;
+    return { ok: true, tableId: args.tableId, userId: args.userId, stack: 100, stateVersion: 9 };
+  }));
+  const result = await executor({ tableId: "table", userId: "user", requestId: "request", amount: 100 });
+  assert.equal(result.ok, true);
+  assert.equal(captured.tableId, "table");
+  assert.equal(captured.amount, 100);
+  assert.equal(typeof captured.postTransactionFn, "function");
+});
+
+test("authoritative rebuy adapter maps insufficient funds and fails closed for file-only runtime", async () => {
+  const insufficient = createAuthoritativeRebuyExecutor(dependencies(async () => {
+    throw Object.assign(new Error("insufficient_funds"), { code: "insufficient_funds" });
+  }));
+  assert.deepEqual(await insufficient({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "insufficient_chips" });
+
+  const fileOnly = createAuthoritativeRebuyExecutor({
+    ...dependencies(async () => ({ ok: true })),
+    env: { WS_PERSISTED_STATE_FILE: "/tmp/poker.json" }
+  });
+  assert.deepEqual(await fileOnly({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "temporarily_unavailable" });
+});

--- a/ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs
@@ -36,9 +36,28 @@ test("authoritative rebuy adapter maps insufficient funds and fails closed for f
   }));
   assert.deepEqual(await insufficient({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "insufficient_chips" });
 
+  const postgresInsufficient = createAuthoritativeRebuyExecutor(dependencies(async () => {
+    throw Object.assign(new Error("insufficient_funds"), { code: "P0001" });
+  }));
+  assert.deepEqual(await postgresInsufficient({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "insufficient_chips" });
+
   const fileOnly = createAuthoritativeRebuyExecutor({
     ...dependencies(async () => ({ ok: true })),
     env: { WS_PERSISTED_STATE_FILE: "/tmp/poker.json" }
   });
   assert.deepEqual(await fileOnly({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "temporarily_unavailable" });
+});
+
+test("authoritative rebuy adapter exposes deadlocks as retryable without leaking raw errors", async () => {
+  const logs = [];
+  const executor = createAuthoritativeRebuyExecutor({
+    ...dependencies(async () => {
+      throw Object.assign(new Error("deadlock details"), { code: "40P01" });
+    }),
+    klog: (event, detail) => logs.push({ event, detail })
+  });
+
+  assert.deepEqual(await executor({ tableId: "table", userId: "user", requestId: "request" }), { ok: false, code: "temporarily_unavailable" });
+  assert.equal(logs.at(-1)?.detail?.sourceCode, "40P01");
+  assert.equal(Object.prototype.hasOwnProperty.call(logs.at(-1)?.detail || {}, "message"), false);
 });

--- a/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
@@ -1,0 +1,118 @@
+async function beginSqlDefault(fn, { env = process.env } = {}) {
+  const bootstrapDb = await import("../bootstrap/persisted-bootstrap-db.mjs");
+  return bootstrapDb.beginSqlWs(fn, { env });
+}
+
+async function loadRebuyModuleDefault() {
+  return import("../../shared/poker-domain/rebuy.mjs");
+}
+
+async function loadPostTransactionDefault() {
+  const ledger = await import("./chips-ledger.mjs");
+  if (typeof ledger?.postTransaction !== "function") throw new Error("missing_post_transaction");
+  return ledger.postTransaction;
+}
+
+const DEFAULT_STORAGE_STATE_OPTIONS = Object.freeze({
+  requireNoDeck: true,
+  requireHandSeed: false,
+  requireCommunityDealt: false
+});
+
+async function loadLockedStateHelpersDefault() {
+  const [locked, stateUtils] = await Promise.all([
+    import("./poker-state-write-locked.mjs"),
+    import("../snapshot-runtime/poker-state-utils.mjs")
+  ]);
+  if (typeof locked?.loadPokerStateForUpdate !== "function" || typeof locked?.updatePokerStateLocked !== "function" || typeof stateUtils?.isStateStorageValid !== "function") {
+    throw new Error("missing_locked_state_helpers");
+  }
+  return {
+    loadStateForUpdate: locked.loadPokerStateForUpdate,
+    updateStateLocked: locked.updatePokerStateLocked,
+    validateStateForStorage: (state) => stateUtils.isStateStorageValid(state, DEFAULT_STORAGE_STATE_OPTIONS)
+  };
+}
+
+function normalizeError(error) {
+  const sourceCode = typeof error?.code === "string" ? error.code : "authoritative_rebuy_failed";
+  const code = sourceCode === "insufficient_funds" ? "insufficient_chips" : sourceCode;
+  const allowed = new Set([
+    "invalid_request",
+    "invalid_rebuy_amount",
+    "request_pending",
+    "request_result_invalid",
+    "table_not_found",
+    "table_not_open",
+    "seat_not_active",
+    "rebuy_not_allowed",
+    "rebuy_not_available",
+    "stack_ambiguous",
+    "state_missing",
+    "state_invalid",
+    "state_conflict",
+    "seat_projection_conflict",
+    "insufficient_chips",
+    "system_account_missing",
+    "system_account_inactive",
+    "chips_apply_failed",
+    "chips_apply_mismatch",
+    "idempotency_mismatch"
+  ]);
+  return { ok: false, code: allowed.has(code) ? code : "authoritative_rebuy_failed" };
+}
+
+function fileStoreOnly(env) {
+  return Boolean(String(env?.WS_PERSISTED_STATE_FILE || "").trim()) && !String(env?.SUPABASE_DB_URL || "").trim();
+}
+
+export function createAuthoritativeRebuyExecutor({
+  env = process.env,
+  klog = () => {},
+  beginSql = beginSqlDefault,
+  loadRebuyModule = loadRebuyModuleDefault,
+  loadPostTransaction = loadPostTransactionDefault,
+  loadLockedStateHelpers = loadLockedStateHelpersDefault
+} = {}) {
+  return async function executeAuthoritativeRebuy({ tableId, userId, requestId, amount = 100 }) {
+    if (fileStoreOnly(env)) return { ok: false, code: "temporarily_unavailable" };
+
+    let rebuyModule;
+    let postTransactionFn;
+    let locked;
+    try {
+      [rebuyModule, postTransactionFn, locked] = await Promise.all([
+        loadRebuyModule(),
+        loadPostTransaction(),
+        loadLockedStateHelpers()
+      ]);
+    } catch (error) {
+      klog("ws_rebuy_authoritative_unavailable", { tableId, requestId: requestId || null, message: error?.message || "unknown" });
+      return { ok: false, code: "temporarily_unavailable" };
+    }
+    if (typeof rebuyModule?.executePokerRebuyAuthoritative !== "function") return { ok: false, code: "temporarily_unavailable" };
+
+    try {
+      return await rebuyModule.executePokerRebuyAuthoritative({
+        beginSql: (fn) => beginSql((tx) => {
+          const txWithKlog = Object.create(tx || null);
+          txWithKlog.klog = klog;
+          return fn(txWithKlog);
+        }, { env }),
+        tableId,
+        userId,
+        requestId,
+        amount,
+        postTransactionFn,
+        loadStateForUpdate: locked.loadStateForUpdate,
+        updateStateLocked: locked.updateStateLocked,
+        validateStateForStorage: locked.validateStateForStorage,
+        klog
+      });
+    } catch (error) {
+      const normalized = normalizeError(error);
+      klog("ws_rebuy_authoritative_failed", { tableId, requestId: requestId || null, code: normalized.code });
+      return normalized;
+    }
+  };
+}

--- a/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
@@ -36,7 +36,12 @@ async function loadLockedStateHelpersDefault() {
 
 function normalizeError(error) {
   const sourceCode = typeof error?.code === "string" ? error.code : "authoritative_rebuy_failed";
-  const code = sourceCode === "insufficient_funds" ? "insufficient_chips" : sourceCode;
+  const sourceMessage = typeof error?.message === "string" ? error.message.trim() : "";
+  const code = sourceCode === "insufficient_funds" || (sourceCode === "P0001" && sourceMessage === "insufficient_funds")
+    ? "insufficient_chips"
+    : sourceCode === "40P01" || sourceCode === "40001"
+      ? "temporarily_unavailable"
+      : sourceCode;
   const allowed = new Set([
     "invalid_request",
     "invalid_rebuy_amount",
@@ -52,6 +57,7 @@ function normalizeError(error) {
     "state_invalid",
     "state_conflict",
     "seat_projection_conflict",
+    "temporarily_unavailable",
     "insufficient_chips",
     "system_account_missing",
     "system_account_inactive",
@@ -111,7 +117,8 @@ export function createAuthoritativeRebuyExecutor({
       });
     } catch (error) {
       const normalized = normalizeError(error);
-      klog("ws_rebuy_authoritative_failed", { tableId, requestId: requestId || null, code: normalized.code });
+      const sourceCode = typeof error?.code === "string" && /^[A-Za-z0-9_]{2,64}$/.test(error.code) ? error.code : null;
+      klog("ws_rebuy_authoritative_failed", { tableId, requestId: requestId || null, code: normalized.code, sourceCode });
       return normalized;
     }
   };

--- a/ws-server/poker/persistence/persisted-state-file-store.mjs
+++ b/ws-server/poker/persistence/persisted-state-file-store.mjs
@@ -44,7 +44,7 @@ export async function loadPersistedTableFromFile({ filePath, tableId }) {
   };
 }
 
-export async function writePersistedTableToFile({ filePath, tableId, expectedVersion, nextState }) {
+export async function writePersistedTableToFile({ filePath, tableId, expectedVersion, nextState, humanStackUpdates = [] }) {
   if (!filePath || !tableId || !Number.isInteger(expectedVersion) || expectedVersion < 0) {
     return { ok: false, reason: "invalid" };
   }
@@ -61,9 +61,30 @@ export async function writePersistedTableToFile({ filePath, tableId, expectedVer
     return { ok: false, reason: "conflict", currentVersion };
   }
   const nextVersion = currentVersion + 1;
+  const projectedHumanStacks = [];
+  for (const update of humanStackUpdates) {
+    const matches = (Array.isArray(row.seatRows) ? row.seatRows : []).filter((seat) => (
+      seat?.user_id === update.userId
+      && Number(seat?.seat_no) === update.seatNo
+      && String(seat?.status || "ACTIVE").toUpperCase() === "ACTIVE"
+      && seat?.is_bot !== true
+    ));
+    if (matches.length !== 1) return { ok: false, reason: "human_stack_projection_conflict" };
+    matches[0].stack = update.stack;
+    projectedHumanStacks.push({ userId: update.userId, seatNo: update.seatNo, stack: update.stack });
+  }
   row.stateRow = { version: nextVersion, state: nextState };
   row.lastActivityAt = new Date().toISOString();
   store.tables[tableId] = row;
   await writeStore(filePath, store);
-  return { ok: true, newVersion: nextVersion };
+  return {
+    ok: true,
+    newVersion: nextVersion,
+    ...(humanStackUpdates.length > 0 ? {
+      tableId,
+      expectedVersion,
+      humanStackProjectionCommitted: true,
+      projectedHumanStacks
+    } : {})
+  };
 }

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -779,6 +779,57 @@ test("persisted state writer logs settlement audit failures without private hole
   assert.equal(serializedLogs.includes("AD"), false);
 });
 
+test("persisted state writer atomically projects authoritative human stack after successful state CAS", async () => {
+  const tableId = "00000000-0000-4000-8000-0000000007a1";
+  const userId = "00000000-0000-4000-8000-0000000007b1";
+  const queries = [];
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (fn) => fn({ unsafe: async (query) => {
+      const text = String(query);
+      queries.push(text);
+      if (text.startsWith("update public.poker_state set version = version + 1")) return [{ version: 9 }];
+      if (text.includes("update public.poker_seats") && text.includes("returning user_id")) return [{ user_id: userId, seat_no: 1, stack: 0 }];
+      return [];
+    } }),
+    klog: () => {}
+  });
+  const result = await writer.writeMutation({
+    tableId,
+    expectedVersion: 8,
+    nextState: { tableId, handId: "next", phase: "PREFLOP", seats: [], stacks: { [userId]: 0 } },
+    humanStackUpdates: [{ userId, seatNo: 1, stack: 0, settledHandId: "settled", fromStateVersion: 8, toStateVersion: 9 }]
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.humanStackProjectionCommitted, true);
+  assert.deepEqual(result.projectedHumanStacks, [{ userId, seatNo: 1, stack: 0 }]);
+  assert.equal(queries.findIndex((query) => query.includes("update public.poker_seats")) > queries.findIndex((query) => query.startsWith("update public.poker_state")), true);
+});
+
+test("persisted state writer never projects human stack when state CAS conflicts", async () => {
+  const queries = [];
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (fn) => fn({ unsafe: async (query) => {
+      const text = String(query);
+      queries.push(text);
+      if (text.startsWith("update public.poker_state set version = version + 1")) return [];
+      if (text.startsWith("select version, state from public.poker_state")) return [{ version: 8, state: { handId: "different" } }];
+      return [];
+    } }),
+    klog: () => {}
+  });
+  const result = await writer.writeMutation({
+    tableId: "00000000-0000-4000-8000-0000000007a2",
+    expectedVersion: 8,
+    nextState: { handId: "next", phase: "PREFLOP", stacks: { human: 0 } },
+    humanStackUpdates: [{ userId: "human", seatNo: 1, stack: 0, settledHandId: "settled", fromStateVersion: 8, toStateVersion: 9 }]
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "conflict");
+  assert.equal(queries.some((query) => query.includes("update public.poker_seats")), false);
+});
+
 function createReplacementFundingDbHarness({ tableId, version = 7, state, treasuryBalance = 1_000, escrowBalance = 50 } = {}) {
   const sourceAccount = { id: "10000000-0000-4000-8000-000000000001", system_key: "TREASURY", account_type: "SYSTEM", status: "active", balance: treasuryBalance };
   const escrowAccount = { id: "10000000-0000-4000-8000-000000000002", system_key: `POKER_TABLE:${tableId}`, account_type: "ESCROW", status: "active", balance: escrowBalance };

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -7,6 +7,7 @@ const SETTLEMENT_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
 const MAX_REPLACEMENT_FUNDINGS = 10;
+const MAX_HUMAN_STACK_UPDATES = 10;
 
 function normalizeJsonState(value) {
   if (!value) return {};
@@ -401,6 +402,50 @@ function normalizeReplacementFundings({ replacementFundings, tableId, expectedVe
   return { ok: true, supplied: true, fundings };
 }
 
+function normalizeHumanStackUpdates({ humanStackUpdates, expectedVersion }) {
+  if (humanStackUpdates === undefined) return { ok: true, supplied: false, updates: [] };
+  if (!Array.isArray(humanStackUpdates) || humanStackUpdates.length > MAX_HUMAN_STACK_UPDATES) {
+    return { ok: false, reason: "invalid_human_stack_updates" };
+  }
+  const seenUsers = new Set();
+  const seenSeats = new Set();
+  const updates = [];
+  for (const value of humanStackUpdates) {
+    const userId = typeof value?.userId === "string" ? value.userId.trim() : "";
+    const seatNo = Number(value?.seatNo);
+    const stack = Number(value?.stack);
+    const fromStateVersion = Number(value?.fromStateVersion);
+    const toStateVersion = Number(value?.toStateVersion);
+    const settledHandId = typeof value?.settledHandId === "string" ? value.settledHandId.trim() : "";
+    if (!userId || seenUsers.has(userId) || !Number.isInteger(seatNo) || seatNo < 1 || seatNo > MAX_HUMAN_STACK_UPDATES || seenSeats.has(seatNo)
+      || !Number.isInteger(stack) || stack < 0 || fromStateVersion !== expectedVersion || toStateVersion !== expectedVersion + 1 || !settledHandId) {
+      return { ok: false, reason: "invalid_human_stack_updates" };
+    }
+    seenUsers.add(userId);
+    seenSeats.add(seatNo);
+    updates.push({ userId, seatNo, stack, settledHandId, fromStateVersion, toStateVersion });
+  }
+  updates.sort((left, right) => left.seatNo - right.seatNo || left.userId.localeCompare(right.userId));
+  return { ok: true, supplied: true, updates };
+}
+
+async function writeHumanStackUpdates({ tx, tableId, updates }) {
+  const projectedHumanStacks = [];
+  for (const update of updates) {
+    const rows = await tx.unsafe(
+      "update public.poker_seats set stack = $4 where table_id = $1 and user_id = $2 and seat_no = $3 and status = 'ACTIVE' and is_bot = false returning user_id, seat_no, stack;",
+      [tableId, update.userId, update.seatNo, update.stack]
+    );
+    if (!Array.isArray(rows) || rows.length !== 1 || Number(rows[0]?.stack) !== update.stack) {
+      const error = new Error("human_stack_projection_conflict");
+      error.code = "human_stack_projection_conflict";
+      throw error;
+    }
+    projectedHumanStacks.push({ userId: update.userId, seatNo: update.seatNo, stack: update.stack });
+  }
+  return projectedHumanStacks;
+}
+
 async function writeReplacementFundings({ tx, tableId, fundings, botFundingSystemKey }) {
   if (fundings.length === 0) {
     return [];
@@ -478,6 +523,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     privateStateForHoleCards = null,
     acceptedActionAudit = null,
     replacementFundingPlan,
+    humanStackUpdatePlan,
     botFundingSystemKey = null
   }) {
     return beginSql(async (tx) => {
@@ -490,6 +536,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
       );
       const newVersion = Number(rows?.[0]?.version);
       if (Number.isInteger(newVersion) && newVersion >= 0) {
+        const projectedHumanStacks = await writeHumanStackUpdates({ tx, tableId, updates: humanStackUpdatePlan.updates });
         const fundedReplacements = await writeReplacementFundings({
           tx,
           tableId,
@@ -537,6 +584,12 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
             expectedVersion,
             replacementFundingCommitted: true,
             fundedReplacements
+          } : {}),
+          ...(humanStackUpdatePlan.supplied ? {
+            tableId,
+            expectedVersion,
+            humanStackProjectionCommitted: true,
+            projectedHumanStacks
           } : {})
         };
       }
@@ -596,6 +649,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     meta = null,
     acceptedActionAudit = null,
     replacementFundings = undefined,
+    humanStackUpdates = undefined,
     botFundingSystemKey = null
   }) {
     if (!tableId || !Number.isInteger(expectedVersion) || expectedVersion < 0) {
@@ -617,6 +671,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     if (!replacementFundingPlan.ok) {
       return { ok: false, reason: replacementFundingPlan.reason };
     }
+    const humanStackUpdatePlan = normalizeHumanStackUpdates({ humanStackUpdates, expectedVersion });
+    if (!humanStackUpdatePlan.ok) return { ok: false, reason: humanStackUpdatePlan.reason };
     if (replacementFundingPlan.fundings.length > 0) {
       const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
       if (!sourceSystemKey) {
@@ -637,7 +693,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
           filePath: env.WS_PERSISTED_STATE_FILE,
           tableId,
           expectedVersion,
-          nextState: persistedState
+          nextState: persistedState,
+          humanStackUpdates: humanStackUpdatePlan.updates
         });
       }
       if (!env.SUPABASE_DB_URL && !supabaseUrl && !supabaseServiceRoleKey) {
@@ -650,6 +707,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         privateStateForHoleCards: holeCardPrivateState,
         acceptedActionAudit,
         replacementFundingPlan,
+        humanStackUpdatePlan,
         botFundingSystemKey
       });
     } catch (error) {

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -595,6 +595,17 @@ test("projectRoomCoreSnapshot derives OUT_OF_CHIPS, canRebuy, and WAITING_NEXT_H
   assert.deepEqual(busted.private.playerState, { status: "OUT_OF_CHIPS", stack: 0, canRebuy: true });
   assert.deepEqual(busted.legalActions.actions, []);
 
+  const allInCore = {
+    ...coreState,
+    pokerState: {
+      ...coreState.pokerState,
+      handSeats: [{ userId: "human", seatNo: 1 }, { userId: "bot", seatNo: 2, isBot: true }]
+    }
+  };
+  const allIn = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState: allInCore, members: allInCore.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
+  assert.equal(allIn.seats.find((seat) => seat.userId === "human")?.status, "ACTIVE");
+  assert.deepEqual(allIn.private.playerState, { status: "ACTIVE", stack: 0, canRebuy: false });
+
   const settledCore = {
     ...coreState,
     pokerState: {
@@ -604,7 +615,8 @@ test("projectRoomCoreSnapshot derives OUT_OF_CHIPS, canRebuy, and WAITING_NEXT_H
     }
   };
   const settled = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState: settledCore, members: settledCore.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
-  assert.equal(settled.private.playerState.canRebuy, false);
+  assert.equal(settled.seats.find((seat) => seat.userId === "human")?.status, "ACTIVE");
+  assert.deepEqual(settled.private.playerState, { status: "ACTIVE", stack: 0, canRebuy: false });
 
   const waitingCore = {
     ...coreState,

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -248,7 +248,7 @@ test("projectRoomCoreSnapshot reuses poker legal-actions/public stripping semant
   assert.deepEqual(seated.committedByUserId, { seated_user: 40, other_user: 35 });
   assert.deepEqual(seated.legalActions.actions, ["FOLD", "CHECK", "BET"]);
   assert.deepEqual(seated.lastBettingRoundActionByUserId, {});
-  assert.deepEqual(seated.private, { userId: "seated_user", seat: 2, holeCards: ["AH", "AD"] });
+  assert.deepEqual(seated.private, { userId: "seated_user", seat: 2, holeCards: ["AH", "AD"], playerState: { status: "ACTIVE", stack: 150, canRebuy: false } });
   assert.deepEqual(observer.hand, seated.hand);
   assert.deepEqual(observer.board, seated.board);
   assert.deepEqual(observer.turn, seated.turn);
@@ -438,7 +438,7 @@ test("projectRoomCoreSnapshot omits terminal fields for fresh next-hand PREFLOP 
   assert.deepEqual(snapshot.board.cards, []);
   assert.equal("showdown" in snapshot, false);
   assert.equal("handSettlement" in snapshot, false);
-  assert.deepEqual(snapshot.private, { userId: "seated_user", seat: 1, holeCards: ["AS", "KD"] });
+  assert.deepEqual(snapshot.private, { userId: "seated_user", seat: 1, holeCards: ["AS", "KD"], playerState: { status: "ACTIVE", stack: 99, canRebuy: false } });
 });
 
 
@@ -573,4 +573,49 @@ test("projectRoomCoreSnapshot adds only minimal profiles to current non-bot seat
   assert.equal("bio" in snapshot.seats[0].profile, false);
   assert.equal("xp" in snapshot.seats[0].profile, false);
   assert.equal("profile" in snapshot.seats[1], false);
+});
+
+test("projectRoomCoreSnapshot derives OUT_OF_CHIPS, canRebuy, and WAITING_NEXT_HAND from authoritative state", () => {
+  const coreState = {
+    seats: { human: 1, bot: 2 },
+    members: [{ userId: "human", seat: 1 }, { userId: "bot", seat: 2 }],
+    publicStacks: { human: 0, bot: 98 },
+    seatDetailsByUserId: { human: { isBot: false }, bot: { isBot: true } },
+    pokerState: {
+      roomId: "table_busted",
+      handId: "bot_hand",
+      phase: "PREFLOP",
+      seats: [{ userId: "bot", seatNo: 2, isBot: true }],
+      handSeats: [{ userId: "bot", seatNo: 2, isBot: true }],
+      stacks: { human: 0, bot: 98 }
+    }
+  };
+  const busted = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState, members: coreState.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
+  assert.equal(busted.seats.find((seat) => seat.userId === "human")?.status, "OUT_OF_CHIPS");
+  assert.deepEqual(busted.private.playerState, { status: "OUT_OF_CHIPS", stack: 0, canRebuy: true });
+  assert.deepEqual(busted.legalActions.actions, []);
+
+  const settledCore = {
+    ...coreState,
+    pokerState: {
+      ...coreState.pokerState,
+      phase: "SETTLED",
+      handSeats: [{ userId: "human", seatNo: 1 }, { userId: "bot", seatNo: 2, isBot: true }]
+    }
+  };
+  const settled = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState: settledCore, members: settledCore.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
+  assert.equal(settled.private.playerState.canRebuy, false);
+
+  const waitingCore = {
+    ...coreState,
+    publicStacks: { human: 100, bot: 98 },
+    pokerState: {
+      ...coreState.pokerState,
+      stacks: { human: 100, bot: 98 },
+      waitingForNextHandByUserId: { human: true }
+    }
+  };
+  const waiting = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState: waitingCore, members: waitingCore.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
+  assert.equal(waiting.seats.find((seat) => seat.userId === "human")?.status, "WAITING_NEXT_HAND");
+  assert.deepEqual(waiting.private.playerState, { status: "WAITING_NEXT_HAND", stack: 100, canRebuy: false });
 });

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -99,10 +99,13 @@ function normalizeMemberSeatRows(value) {
 
 function resolvePublicSeats({ statePublic, members, coreState, publicProfilesByUserId, publicProfileStorageBaseUrl }) {
   const stateSeats = normalizeSeatRows(statePublic?.seats);
+  const memberSeats = normalizeMemberSeatRows(members);
   const seatDetailsByUserId = normalizeSeatDetails(coreState?.seatDetailsByUserId);
   const foldedByUserId = asObject(statePublic?.foldedByUserId) || {};
   const leftTableByUserId = asObject(statePublic?.leftTableByUserId) || {};
-  const baseSeats = stateSeats.length > 0 ? stateSeats : normalizeMemberSeatRows(members);
+  const byUserId = new Map(memberSeats.map((seat) => [seat.userId, seat]));
+  for (const seat of stateSeats) byUserId.set(seat.userId, { ...(byUserId.get(seat.userId) || {}), ...seat });
+  const baseSeats = [...byUserId.values()].sort((left, right) => left.seatNo - right.seatNo || left.userId.localeCompare(right.userId));
   return baseSeats.filter((seat) => leftTableByUserId[seat.userId] !== true).map((seat) => {
     const details = seatDetailsByUserId[seat.userId] || null;
     const merged = { ...seat };
@@ -122,7 +125,7 @@ function resolvePublicSeats({ statePublic, members, coreState, publicProfilesByU
 
 function resolvePublicStacks({ statePublic, coreState, seats }) {
   const stateStacks = normalizeStacks(statePublic?.stacks);
-  const fallbackStacks = Object.keys(stateStacks).length > 0 ? stateStacks : normalizeStacks(coreState?.publicStacks);
+  const fallbackStacks = { ...normalizeStacks(coreState?.publicStacks), ...stateStacks };
   if (Object.keys(fallbackStacks).length <= 0) {
     return {};
   }
@@ -223,17 +226,29 @@ function normalizeHandSettlement(handSettlement) {
   };
 }
 
-function resolvePrivateBranch({ state, userId, youSeat }) {
+function resolvePrivateBranch({ state, statePublic, userId, youSeat, stack, isBot, tableStatus }) {
   if (!Number.isInteger(youSeat)) {
     return null;
   }
 
   const holeCards = normalizeCards(state?.holeCardsByUserId?.[userId]);
-  return {
+  const handSeats = Array.isArray(statePublic?.handSeats) ? statePublic.handSeats : Array.isArray(statePublic?.seats) ? statePublic.seats : [];
+  const inCurrentHand = handSeats.some((seat) => seat?.userId === userId);
+  const waiting = statePublic?.waitingForNextHandByUserId?.[userId] === true;
+  const status = waiting ? "WAITING_NEXT_HAND" : stack === 0 ? "OUT_OF_CHIPS" : "ACTIVE";
+  const branch = {
     userId,
     seat: youSeat,
     holeCards
   };
+  if (Number.isInteger(stack) && stack >= 0) {
+    branch.playerState = {
+      status,
+      stack,
+      canRebuy: isBot !== true && tableStatus === "OPEN" && stack === 0 && !inCurrentHand && !waiting
+    };
+  }
+  return branch;
 }
 
 function hasLeftTable(statePublic, userId) {
@@ -284,11 +299,18 @@ function resolveRevealedShowdownParticipants({ statePublic, state }) {
     .filter((entry) => entry.holeCards.length === 2);
 }
 
-export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, userId, youSeat, publicProfilesByUserId = {}, publicProfileStorageBaseUrl = "" }) {
+export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, userId, youSeat, tableStatus = "OPEN", publicProfilesByUserId = {}, publicProfileStorageBaseUrl = "" }) {
   const state = asObject(coreState?.pokerState) || asObject(coreState?.state);
   const statePublic = state ? withoutPrivateState(state) : null;
-  const publicSeats = resolvePublicSeats({ statePublic, members, coreState, publicProfilesByUserId, publicProfileStorageBaseUrl });
+  let publicSeats = resolvePublicSeats({ statePublic, members, coreState, publicProfilesByUserId, publicProfileStorageBaseUrl });
   const publicStacks = resolvePublicStacks({ statePublic, coreState, seats: publicSeats });
+  publicSeats = publicSeats.map((seat) => {
+    if (seat.isBot === true) return seat;
+    const stack = Number(publicStacks[seat.userId]);
+    if (statePublic?.waitingForNextHandByUserId?.[seat.userId] === true) return { ...seat, status: "WAITING_NEXT_HAND" };
+    if (Number.isInteger(stack) && stack === 0) return { ...seat, status: "OUT_OF_CHIPS" };
+    return seat;
+  });
   const effectiveYouSeat = hasLeftTable(statePublic, userId) ? null : youSeat;
 
   if (!statePublic) {
@@ -376,7 +398,15 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
     betThisRoundByUserId: normalizeNumericUserMap(statePublic.betThisRoundByUserId),
     committedByUserId: normalizeNumericUserMap(statePublic.committedByUserId),
     lastBettingRoundActionByUserId: normalizeLastBettingRoundActionByUserId(statePublic.lastBettingRoundActionByUserId),
-    private: resolvePrivateBranch({ state, userId, youSeat: effectiveYouSeat })
+    private: resolvePrivateBranch({
+      state,
+      statePublic,
+      userId,
+      youSeat: effectiveYouSeat,
+      stack: Number.isInteger(Number(publicStacks[userId])) ? Number(publicStacks[userId]) : null,
+      isBot: coreState?.seatDetailsByUserId?.[userId]?.isBot === true,
+      tableStatus
+    })
   };
 
   const showdown = normalizeShowdown(statePublic.showdown);

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -235,7 +235,7 @@ function resolvePrivateBranch({ state, statePublic, userId, youSeat, stack, isBo
   const handSeats = Array.isArray(statePublic?.handSeats) ? statePublic.handSeats : Array.isArray(statePublic?.seats) ? statePublic.seats : [];
   const inCurrentHand = handSeats.some((seat) => seat?.userId === userId);
   const waiting = statePublic?.waitingForNextHandByUserId?.[userId] === true;
-  const status = waiting ? "WAITING_NEXT_HAND" : stack === 0 ? "OUT_OF_CHIPS" : "ACTIVE";
+  const status = waiting ? "WAITING_NEXT_HAND" : stack === 0 && !inCurrentHand ? "OUT_OF_CHIPS" : "ACTIVE";
   const branch = {
     userId,
     seat: youSeat,
@@ -304,11 +304,13 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
   const statePublic = state ? withoutPrivateState(state) : null;
   let publicSeats = resolvePublicSeats({ statePublic, members, coreState, publicProfilesByUserId, publicProfileStorageBaseUrl });
   const publicStacks = resolvePublicStacks({ statePublic, coreState, seats: publicSeats });
+  const handSeats = Array.isArray(statePublic?.handSeats) ? statePublic.handSeats : Array.isArray(statePublic?.seats) ? statePublic.seats : [];
+  const currentHandUserIds = new Set(handSeats.map((seat) => seat?.userId).filter((seatUserId) => typeof seatUserId === "string" && seatUserId));
   publicSeats = publicSeats.map((seat) => {
     if (seat.isBot === true) return seat;
     const stack = Number(publicStacks[seat.userId]);
     if (statePublic?.waitingForNextHandByUserId?.[seat.userId] === true) return { ...seat, status: "WAITING_NEXT_HAND" };
-    if (Number.isInteger(stack) && stack === 0) return { ...seat, status: "OUT_OF_CHIPS" };
+    if (Number.isInteger(stack) && stack === 0 && !currentHandUserIds.has(seat.userId)) return { ...seat, status: "OUT_OF_CHIPS" };
     return seat;
   });
   const effectiveYouSeat = hasLeftTable(statePublic, userId) ? null : youSeat;

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -99,6 +99,54 @@ test("buildStateSnapshotPayload for observer never exposes private branch", () =
   assert.equal(payload.public.turn.userId, "user_a");
 });
 
+test("buildStateSnapshotPayload preserves the validated private out-of-chips rebuy state", () => {
+  const payload = buildStateSnapshotPayload({
+    userId: "user_a",
+    tableSnapshot: {
+      tableId: "table_busted",
+      roomId: "table_busted",
+      stateVersion: 41,
+      members: [
+        { userId: "user_a", seat: 1 },
+        { userId: "bot_a", seat: 2 }
+      ],
+      memberCount: 2,
+      maxSeats: 6,
+      youSeat: 1,
+      status: "OPEN",
+      seats: [
+        { userId: "user_a", seatNo: 1, status: "OUT_OF_CHIPS" },
+        { userId: "bot_a", seatNo: 2, status: "ACTIVE", isBot: true }
+      ],
+      stacks: { user_a: 0, bot_a: 200 },
+      hand: { handId: "bot_hand", status: "PREFLOP", round: "PREFLOP", dealerSeatNo: 2 },
+      board: { cards: [] },
+      pot: { total: 3, sidePots: [] },
+      turn: { userId: "bot_a", seat: 2, startedAt: null, deadlineAt: null },
+      legalActions: { seat: 1, actions: [] },
+      private: {
+        userId: "user_a",
+        seat: 1,
+        holeCards: [],
+        playerState: {
+          status: "OUT_OF_CHIPS",
+          stack: 0,
+          canRebuy: true,
+          internalLedgerBalance: 999
+        }
+      }
+    }
+  });
+
+  assert.deepEqual(payload.private, {
+    userId: "user_a",
+    seat: 1,
+    holeCards: [],
+    playerState: { status: "OUT_OF_CHIPS", stack: 0, canRebuy: true }
+  });
+  assert.equal("internalLedgerBalance" in payload.private.playerState, false);
+});
+
 test("buildStateSnapshotPayload missing table snapshot returns canonical empty room-core shape", () => {
   const tableManager = createTableManager({ maxSeats: 6 });
 

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -141,6 +141,22 @@ function normalizeHandSettlement(handSettlement) {
   };
 }
 
+function normalizePlayerState(playerState) {
+  if (!playerState || typeof playerState !== "object" || Array.isArray(playerState)) {
+    return null;
+  }
+  const allowedStatuses = new Set(["ACTIVE", "OUT_OF_CHIPS", "WAITING_NEXT_HAND"]);
+  const status = typeof playerState.status === "string" ? playerState.status.trim().toUpperCase() : "";
+  if (!allowedStatuses.has(status) || !Number.isInteger(playerState.stack) || playerState.stack < 0) {
+    return null;
+  }
+  return {
+    status,
+    stack: playerState.stack,
+    canRebuy: playerState.canRebuy === true
+  };
+}
+
 function normalizePrivateBranch(privateBranch, { userId, youSeat }) {
   const base = { userId, seat: youSeat };
   if (!privateBranch || typeof privateBranch !== "object" || Array.isArray(privateBranch)) {
@@ -148,9 +164,11 @@ function normalizePrivateBranch(privateBranch, { userId, youSeat }) {
   }
 
   const holeCards = normalizeCards(privateBranch.holeCards);
+  const playerState = normalizePlayerState(privateBranch.playerState);
   return {
     ...base,
-    holeCards
+    holeCards,
+    ...(playerState ? { playerState } : {})
   };
 }
 

--- a/ws-server/poker/reconnect/resync.behavior.test.mjs
+++ b/ws-server/poker/reconnect/resync.behavior.test.mjs
@@ -177,7 +177,10 @@ function sendFrame(ws, frame) {
 async function writePersistedFile(fixture) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ws-resync-persist-"));
   const filePath = path.join(dir, "persisted-state.json");
-  await fs.writeFile(filePath, `${JSON.stringify(fixture)}
+  const coherentFixture = fixture?.tables && typeof fixture.tables === "object" && !Array.isArray(fixture.tables)
+    ? { ...fixture, tables: coherentPersistedBootstrapFixtures(fixture.tables) }
+    : fixture;
+  await fs.writeFile(filePath, `${JSON.stringify(coherentFixture)}
 `, "utf8");
   return { dir, filePath };
 }
@@ -252,10 +255,51 @@ function nextMessageForRequest(ws, type, requestId, { timeoutMs = 5000 } = {}) {
 }
 
 
+function coherentPersistedBootstrapFixtures(fixtures) {
+  return Object.fromEntries(Object.entries(fixtures || {}).map(([tableId, fixture]) => {
+    const stateValue = fixture?.stateRow?.state;
+    let state = null;
+    let stringified = false;
+    if (stateValue && typeof stateValue === "object" && !Array.isArray(stateValue)) {
+      state = { ...stateValue };
+    } else if (typeof stateValue === "string") {
+      try {
+        const parsed = JSON.parse(stateValue);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          state = { ...parsed };
+          stringified = true;
+        }
+      } catch {
+        return [tableId, fixture];
+      }
+    }
+    if (!state) return [tableId, fixture];
+
+    const stacks = state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
+      ? { ...state.stacks }
+      : {};
+    for (const seat of Array.isArray(fixture?.seatRows) ? fixture.seatRows : []) {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
+      const seatStack = Number(seat?.stack);
+      stacks[userId] = Number.isSafeInteger(seatStack) && seatStack >= 0 ? seatStack : 100;
+    }
+    const coherentState = { ...state, stacks };
+    return [tableId, {
+      ...fixture,
+      stateRow: fixture?.stateRow
+        ? { ...fixture.stateRow, state: stringified ? JSON.stringify(coherentState) : coherentState }
+        : fixture?.stateRow
+    }];
+  }));
+}
+
 function persistedBootstrapFixturesEnv(fixtures) {
+  const coherentFixtures = coherentPersistedBootstrapFixtures(fixtures);
   return {
     SUPABASE_DB_URL: "",
-    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(coherentFixtures)
   };
 }
 

--- a/ws-server/poker/reconnect/resync.behavior.test.mjs
+++ b/ws-server/poker/reconnect/resync.behavior.test.mjs
@@ -278,16 +278,27 @@ function coherentPersistedBootstrapFixtures(fixtures) {
     const stacks = state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
       ? { ...state.stacks }
       : {};
-    for (const seat of Array.isArray(fixture?.seatRows) ? fixture.seatRows : []) {
+    const fixtureSeatRows = Array.isArray(fixture?.seatRows) ? fixture.seatRows : [];
+    for (const seat of fixtureSeatRows) {
       if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
       const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
       if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
       const seatStack = Number(seat?.stack);
-      stacks[userId] = Number.isSafeInteger(seatStack) && seatStack >= 0 ? seatStack : 100;
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      stacks[userId] = hasSeatStack ? seatStack : 100;
     }
+    const coherentSeatRows = fixtureSeatRows.map((seat) => {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") return seat;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      const seatStack = Number(seat?.stack);
+      const stateStack = Number(stacks[userId]);
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      return !hasSeatStack && userId && Number.isSafeInteger(stateStack) && stateStack >= 0 ? { ...seat, stack: stateStack } : seat;
+    });
     const coherentState = { ...state, stacks };
     return [tableId, {
       ...fixture,
+      seatRows: coherentSeatRows,
       stateRow: fixture?.stateRow
         ? { ...fixture.stateRow, state: stringified ? JSON.stringify(coherentState) : coherentState }
         : fixture?.stateRow

--- a/ws-server/poker/runtime/table-command-queue.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-command-queue.behavior.test.mjs
@@ -144,3 +144,48 @@ test("table command queue runs non-deduped bot-step cascade commands even while 
     "bot_step:second:end"
   ]);
 });
+
+test("table command queue retains serialization while an older queued command becomes active", async () => {
+  const queue = createTableCommandQueue();
+  const order = [];
+  let releaseFirst;
+  let releaseSecond;
+  let markSecondStarted;
+  const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+  const secondGate = new Promise((resolve) => { releaseSecond = resolve; });
+  const secondStarted = new Promise((resolve) => { markSecondStarted = resolve; });
+
+  const first = queue.enqueue({
+    tableId: "cleanup-race-table",
+    run: async () => {
+      order.push("first:start");
+      await firstGate;
+      order.push("first:end");
+    }
+  });
+  const second = queue.enqueue({
+    tableId: "cleanup-race-table",
+    run: async () => {
+      order.push("second:start");
+      markSecondStarted();
+      await secondGate;
+      order.push("second:end");
+    }
+  });
+
+  releaseFirst();
+  await secondStarted;
+  const third = queue.enqueue({
+    tableId: "cleanup-race-table",
+    run: async () => {
+      order.push("third:start");
+      order.push("third:end");
+    }
+  });
+  await Promise.resolve();
+  assert.deepEqual(order, ["first:start", "first:end", "second:start"]);
+
+  releaseSecond();
+  await Promise.all([first, second, third]);
+  assert.deepEqual(order, ["first:start", "first:end", "second:start", "second:end", "third:start", "third:end"]);
+});

--- a/ws-server/poker/runtime/table-command-queue.mjs
+++ b/ws-server/poker/runtime/table-command-queue.mjs
@@ -8,7 +8,7 @@ export function createTableCommandQueue({ onError = noop } = {}) {
       queueStateByTableId.set(tableId, {
         tail: Promise.resolve(),
         pendingByKey: new Map(),
-        activeCount: 0
+        pendingCount: 0
       });
     }
     return queueStateByTableId.get(tableId);
@@ -16,7 +16,7 @@ export function createTableCommandQueue({ onError = noop } = {}) {
 
   function cleanupQueueState(tableId, state) {
     if (!state) return;
-    if (state.activeCount !== 0) return;
+    if (state.pendingCount !== 0) return;
     if (state.pendingByKey.size !== 0) return;
     queueStateByTableId.delete(tableId);
   }
@@ -37,12 +37,12 @@ export function createTableCommandQueue({ onError = noop } = {}) {
       return state.pendingByKey.get(normalizedDedupeKey);
     }
 
+    state.pendingCount += 1;
     const execute = async () => {
-      state.activeCount += 1;
       try {
         return await run();
       } finally {
-        state.activeCount = Math.max(0, state.activeCount - 1);
+        state.pendingCount = Math.max(0, state.pendingCount - 1);
         if (normalizedDedupeKey) {
           state.pendingByKey.delete(normalizedDedupeKey);
         }

--- a/ws-server/poker/snapshot-runtime/poker-reducer.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-reducer.mjs
@@ -732,7 +732,7 @@ const applyLeaveTable = (state, { userId, requestId } = {}) => {
   const stackMap = copyMap(state.stacks);
   const hasStackEntry = Object.prototype.hasOwnProperty.call(stackMap, userId);
   const alreadyLeft = !!state.leftTableByUserId?.[userId];
-  if (!userInHandSeats && !userInTableSeats && !alreadyLeft) {
+  if (!userInHandSeats && !userInTableSeats && !hasStackEntry && !alreadyLeft) {
     throw new Error("invalid_player");
   }
   if (alreadyLeft && !userInHandSeats && !userInTableSeats && !hasStackEntry) {

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -263,6 +263,8 @@ test("persistent bot replacement commits runtime only with matching funding rece
       tableId,
       expectedVersion: prepared.expectedVersion,
       newVersion: prepared.stateVersion,
+      humanStackProjectionCommitted: true,
+      projectedHumanStacks: prepared.humanStackUpdates.map(({ userId, seatNo, stack }) => ({ userId, seatNo, stack })),
       replacementFundingCommitted: true,
       fundedReplacements: [{
         seatNo: funding.seatNo,

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -731,6 +731,7 @@ export function createTableManager({
       members,
       userId,
       youSeat,
+      tableStatus,
       publicProfilesByUserId: table ? publicProfilesForSnapshot(table) : {},
       publicProfileStorageBaseUrl
     });
@@ -1015,6 +1016,33 @@ export function createTableManager({
     });
   }
 
+  function normalizedHumanStackUpdates({ coreState, settledState, fromStateVersion, toStateVersion }) {
+    const members = Array.isArray(coreState?.members) ? coreState.members : [];
+    const humanMembers = members.filter((member) => !isCoreStateBotUser(coreState, member?.userId));
+    const updates = humanMembers.map((member) => ({
+        userId: member.userId,
+        seatNo: member.seat,
+        stack: Number(settledState?.stacks?.[member.userId]),
+        settledHandId: typeof settledState?.handId === "string" ? settledState.handId : null,
+        fromStateVersion,
+        toStateVersion
+      }));
+    if (updates.some((entry) => !entry.userId || !Number.isInteger(entry.seatNo) || !Number.isInteger(entry.stack) || entry.stack < 0 || !entry.settledHandId)) {
+      return null;
+    }
+    return updates.sort((left, right) => left.seatNo - right.seatNo || left.userId.localeCompare(right.userId));
+  }
+
+  function humanStackReceiptMatches({ tableId, expectedVersion, stateVersion, humanStackUpdates, persistenceReceipt }) {
+    if (!persistenceReceipt || persistenceReceipt.ok !== true
+      || persistenceReceipt.tableId !== tableId
+      || persistenceReceipt.expectedVersion !== expectedVersion
+      || persistenceReceipt.newVersion !== stateVersion
+      || persistenceReceipt.humanStackProjectionCommitted !== true) return false;
+    const projected = Array.isArray(persistenceReceipt.projectedHumanStacks) ? persistenceReceipt.projectedHumanStacks : [];
+    return JSON.stringify(projected) === JSON.stringify(humanStackUpdates.map(({ userId, seatNo, stack }) => ({ userId, seatNo, stack })));
+  }
+
   function isEconomyFreeRollover({ tableId, economyMode }) {
     return typeof tableBootstrapLoader !== "function"
       || (economyMode === "none" && typeof tableId === "string" && tableId.startsWith("guest_table_"));
@@ -1072,9 +1100,21 @@ export function createTableManager({
       };
     }
 
+    const humanStackUpdates = normalizedHumanStackUpdates({
+      coreState: recycled.coreState,
+      settledState: recycled.settledState,
+      fromStateVersion: Number(table.coreState.version),
+      toStateVersion: nextVersion
+    });
+    if (!humanStackUpdates) {
+      return { ok: false, changed: false, reason: "human_stack_ambiguous", stateVersion: table.coreState.version };
+    }
+    const projectedPublicStacks = { ...(recycled.coreState.publicStacks || {}) };
+    for (const update of humanStackUpdates) projectedPublicStacks[update.userId] = update.stack;
     const nextCoreState = {
       ...recycled.coreState,
       version: nextVersion,
+      publicStacks: projectedPublicStacks,
       pokerState: stampTurnDeadline(nextHandState, resolveNowMs({ nowMs }))
     };
 
@@ -1086,7 +1126,8 @@ export function createTableManager({
       stateVersion: nextVersion,
       nextCoreState,
       handId: nextCoreState?.pokerState?.handId ?? null,
-      replacementFundings: normalizedReplacementFundingShape(recycled.replacementFundings)
+      replacementFundings: normalizedReplacementFundingShape(recycled.replacementFundings),
+      humanStackUpdates
     };
   }
 
@@ -1095,6 +1136,7 @@ export function createTableManager({
     expectedVersion,
     nextCoreState,
     replacementFundings = [],
+    humanStackUpdates = [],
     persistenceReceipt = null,
     economyMode = null,
     nowMs = Date.now()
@@ -1131,6 +1173,24 @@ export function createTableManager({
       persistenceReceipt
     })) {
       return { ok: false, changed: false, reason: "replacement_funding_unconfirmed", stateVersion: currentVersion };
+    }
+    const expectedHumanUpdates = normalizedHumanStackUpdates({
+      coreState: recalculated.coreState,
+      settledState: recalculated.settledState,
+      fromStateVersion: expectedVersion,
+      toStateVersion: nextVersion
+    });
+    if (!expectedHumanUpdates || JSON.stringify(expectedHumanUpdates) !== JSON.stringify(humanStackUpdates)) {
+      return { ok: false, changed: false, reason: "human_stack_projection_mismatch", stateVersion: currentVersion };
+    }
+    if (!economyFree && !humanStackReceiptMatches({
+      tableId,
+      expectedVersion,
+      stateVersion: nextVersion,
+      humanStackUpdates,
+      persistenceReceipt
+    })) {
+      return { ok: false, changed: false, reason: "human_stack_projection_unconfirmed", stateVersion: currentVersion };
     }
 
     table.coreState = nextCoreState;

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1601,12 +1601,15 @@ test("table_leave rejects when authoritative success state still contains actor 
     await auth(actor, actorToken, "auth-leave-still-present-actor");
     await auth(other, keepToken, "auth-leave-still-present-keep");
 
+    const actorJoinAck = nextCommandResultForRequest(actor, "join-leave-still-present-actor");
+    const actorJoinState = nextJoinTableState(actor, { requestId: "join-leave-still-present-actor", tableId });
     sendFrame(actor, { version: "1.0", type: "table_join", requestId: "join-leave-still-present-actor", ts: "2026-02-28T00:00:01Z", payload: { tableId } });
-    await nextCommandResultForRequest(actor, "join-leave-still-present-actor");
-    await nextJoinTableState(actor, { requestId: "join-leave-still-present-actor", tableId });
+    await Promise.all([actorJoinAck, actorJoinState]);
+
+    const otherJoinAckPromise = nextCommandResultForRequest(other, "join-leave-still-present-keep");
+    const otherJoinState = nextJoinTableState(other, { requestId: "join-leave-still-present-keep", tableId });
     sendFrame(other, { version: "1.0", type: "table_join", requestId: "join-leave-still-present-keep", ts: "2026-02-28T00:00:02Z", payload: { tableId } });
-    const otherJoinAck = await nextCommandResultForRequest(other, "join-leave-still-present-keep");
-    await nextJoinTableState(other, { requestId: "join-leave-still-present-keep", tableId });
+    const [otherJoinAck] = await Promise.all([otherJoinAckPromise, otherJoinState]);
     assert.equal(otherJoinAck.payload.status, "accepted");
 
     const leaveResult = nextCommandResultForRequest(actor, "leave-still-present");

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -264,7 +264,10 @@ function sendFrame(ws, frame) {
 async function writePersistedFile(fixture) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ws-persist-"));
   const filePath = path.join(dir, "persisted-state.json");
-  await fs.writeFile(filePath, `${JSON.stringify(fixture)}
+  const coherentFixture = fixture?.tables && typeof fixture.tables === "object" && !Array.isArray(fixture.tables)
+    ? { ...fixture, tables: coherentPersistedBootstrapFixtures(fixture.tables) }
+    : fixture;
+  await fs.writeFile(filePath, `${JSON.stringify(coherentFixture)}
 `, "utf8");
   return { dir, filePath };
 }
@@ -2291,9 +2294,50 @@ test("resume continuity for session A is not invalidated by high-traffic session
   }
 });
 
+function coherentPersistedBootstrapFixtures(fixtures) {
+  return Object.fromEntries(Object.entries(fixtures || {}).map(([tableId, fixture]) => {
+    const stateValue = fixture?.stateRow?.state;
+    let state = null;
+    let stringified = false;
+    if (stateValue && typeof stateValue === "object" && !Array.isArray(stateValue)) {
+      state = { ...stateValue };
+    } else if (typeof stateValue === "string") {
+      try {
+        const parsed = JSON.parse(stateValue);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          state = { ...parsed };
+          stringified = true;
+        }
+      } catch {
+        return [tableId, fixture];
+      }
+    }
+    if (!state) return [tableId, fixture];
+
+    const stacks = state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
+      ? { ...state.stacks }
+      : {};
+    for (const seat of Array.isArray(fixture?.seatRows) ? fixture.seatRows : []) {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
+      const seatStack = Number(seat?.stack);
+      stacks[userId] = Number.isSafeInteger(seatStack) && seatStack >= 0 ? seatStack : 100;
+    }
+    const coherentState = { ...state, stacks };
+    return [tableId, {
+      ...fixture,
+      stateRow: fixture?.stateRow
+        ? { ...fixture.stateRow, state: stringified ? JSON.stringify(coherentState) : coherentState }
+        : fixture?.stateRow
+    }];
+  }));
+}
+
 function persistedBootstrapFixturesEnv(fixtures) {
+  const coherentFixtures = coherentPersistedBootstrapFixtures(fixtures);
   return {
-    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(coherentFixtures)
   };
 }
 

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2317,16 +2317,27 @@ function coherentPersistedBootstrapFixtures(fixtures) {
     const stacks = state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
       ? { ...state.stacks }
       : {};
-    for (const seat of Array.isArray(fixture?.seatRows) ? fixture.seatRows : []) {
+    const fixtureSeatRows = Array.isArray(fixture?.seatRows) ? fixture.seatRows : [];
+    for (const seat of fixtureSeatRows) {
       if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
       const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
       if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
       const seatStack = Number(seat?.stack);
-      stacks[userId] = Number.isSafeInteger(seatStack) && seatStack >= 0 ? seatStack : 100;
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      stacks[userId] = hasSeatStack ? seatStack : 100;
     }
+    const coherentSeatRows = fixtureSeatRows.map((seat) => {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") return seat;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      const seatStack = Number(seat?.stack);
+      const stateStack = Number(stacks[userId]);
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      return !hasSeatStack && userId && Number.isSafeInteger(stateStack) && stateStack >= 0 ? { ...seat, stack: stateStack } : seat;
+    });
     const coherentState = { ...state, stacks };
     return [tableId, {
       ...fixture,
+      seatRows: coherentSeatRows,
       stateRow: fixture?.stateRow
         ? { ...fixture.stateRow, state: stringified ? JSON.stringify(coherentState) : coherentState }
         : fixture?.stateRow

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -27,6 +27,7 @@ import { handleStartHandCommand } from "./poker/handlers/start-hand.mjs";
 import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import { handleBotStepCommand } from "./poker/handlers/bot-autoplay.mjs";
 import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
+import { handleRebuyCommand } from "./poker/handlers/rebuy.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
@@ -39,6 +40,8 @@ const PROTECTED_MESSAGE_TYPES = new Set([
   "leave",
   "table_join",
   "table_leave",
+  "rebuy",
+  "table_rebuy",
   "lobby_subscribe",
   "table_state_sub",
   "table_snapshot",
@@ -48,7 +51,7 @@ const PROTECTED_MESSAGE_TYPES = new Set([
   "resume",
   "ack"
 ]);
-const REQUEST_ID_REQUIRED_TYPES = new Set(["join", "leave", "table_join", "table_leave", "lobby_subscribe", "table_state_sub", "table_snapshot", "act", "start_hand", "resync", "resume"]);
+const REQUEST_ID_REQUIRED_TYPES = new Set(["join", "leave", "table_join", "table_leave", "rebuy", "table_rebuy", "lobby_subscribe", "table_state_sub", "table_snapshot", "act", "start_hand", "resync", "resume"]);
 const TABLE_SNAPSHOT_KNOWN_FAILURE_CODES = new Set([
   "invalid_table_id",
   "table_not_found",
@@ -269,6 +272,7 @@ function snapshotCacheKey(sessionId, tableId) {
 
 let authoritativeLeaveExecutorPromise = null;
 let authoritativeJoinExecutorPromise = null;
+let authoritativeRebuyExecutorPromise = null;
 let inactiveCleanupExecutorPromise = null;
 let acceptedBotAutoplayExecutorPromise = null;
 let beginSqlWsLoaderPromise = null;
@@ -298,6 +302,14 @@ async function loadAuthoritativeJoinExecutor() {
       .then((module) => module.createAuthoritativeJoinExecutor({ env: process.env, klog: klogSafe }));
   }
   return authoritativeJoinExecutorPromise;
+}
+
+async function loadAuthoritativeRebuyExecutor() {
+  if (!authoritativeRebuyExecutorPromise) {
+    authoritativeRebuyExecutorPromise = import("./poker/persistence/authoritative-rebuy-adapter.mjs")
+      .then((module) => module.createAuthoritativeRebuyExecutor({ env: process.env, klog: klogSafe }));
+  }
+  return authoritativeRebuyExecutorPromise;
 }
 
 async function loadInactiveCleanupExecutor() {
@@ -1157,6 +1169,7 @@ async function persistMutatedState({
   nextStateOverride = null,
   privateStateForHoleCardsOverride = null,
   replacementFundings = undefined,
+  humanStackUpdates = undefined,
   replacementFundingSystemKey = null,
   deferRuntimeVersionUpdate = false
 }) {
@@ -1187,6 +1200,7 @@ async function persistMutatedState({
     meta: { mutationKind },
     acceptedActionAudit,
     replacementFundings,
+    humanStackUpdates,
     botFundingSystemKey: replacementFundingSystemKey
   });
   if (!persisted?.ok) {
@@ -1589,6 +1603,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     nextStateOverride: candidatePokerState,
     privateStateForHoleCardsOverride: candidatePokerState,
     replacementFundings: prepared.replacementFundings,
+    humanStackUpdates: prepared.humanStackUpdates,
     replacementFundingSystemKey: botFundingSystemKey,
     deferRuntimeVersionUpdate: true
   });
@@ -1631,6 +1646,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     expectedVersion: prepared.expectedVersion,
     nextCoreState: prepared.nextCoreState,
     replacementFundings: prepared.replacementFundings,
+    humanStackUpdates: prepared.humanStackUpdates,
     persistenceReceipt: persisted,
     nowMs: Date.now()
   });
@@ -2936,6 +2952,47 @@ wss.on("connection", (ws) => {
         trigger: "resume_replay",
         requestId: frame.requestId ?? null,
         frameTs: frame.ts
+      });
+      return;
+    }
+
+    if (frame.type === "table_rebuy" || frame.type === "rebuy") {
+      const resolvedRoomId = resolveRoomId(frame);
+      if (!resolvedRoomId.ok) {
+        sendError(ws, connState, {
+          code: resolvedRoomId.code,
+          message: resolvedRoomId.message,
+          requestId: frame.requestId ?? null
+        });
+        return;
+      }
+      const tableId = resolvedRoomId.roomId;
+      if (isGuestSession(connState) || isGuestTableId(tableId)) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: "rebuy_not_allowed"
+        });
+        return;
+      }
+      await enqueueTableCommand({
+        tableId,
+        commandName: "rebuy",
+        run: async () => handleRebuyCommand({
+          frame,
+          ws,
+          connState,
+          tableId,
+          loadAuthoritativeRebuyExecutor,
+          restoreTableFromPersisted,
+          broadcastStateSnapshots,
+          broadcastTableState,
+          broadcastResyncRequired,
+          sendCommandResult,
+          scheduleBotStep,
+          klog: klogSafe
+        })
       });
       return;
     }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1180,6 +1180,18 @@ async function persistMutatedState({
     if (Array.isArray(replacementFundings) && replacementFundings.length > 0) {
       return { ok: false, reason: "persistence_required" };
     }
+    if (process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON && Array.isArray(humanStackUpdates)) {
+      return {
+        ok: true,
+        skipped: true,
+        fixture: true,
+        tableId,
+        expectedVersion,
+        newVersion: expectedVersion + 1,
+        humanStackProjectionCommitted: true,
+        projectedHumanStacks: humanStackUpdates.map(({ userId, seatNo, stack }) => ({ userId, seatNo, stack }))
+      };
+    }
     return { ok: true, skipped: true };
   }
   const nextState = nextStateOverride || tableManager.persistedPokerState(tableId);

--- a/ws-server/shared/poker-domain/rebuy.mjs
+++ b/ws-server/shared/poker-domain/rebuy.mjs
@@ -1,0 +1,1 @@
+export * from "../../../shared/poker-domain/rebuy.mjs";

--- a/ws-tests/ws-poker-protocol-compliance.test.mjs
+++ b/ws-tests/ws-poker-protocol-compliance.test.mjs
@@ -57,10 +57,62 @@ function observeOnlyJoinEnv() {
   return { WS_OBSERVE_ONLY_JOIN: "1" };
 }
 
+function coherentPersistedBootstrapFixtures(fixtures) {
+  return Object.fromEntries(Object.entries(fixtures || {}).map(([tableId, fixture]) => {
+    const stateValue = fixture?.stateRow?.state;
+    let state = null;
+    let stringified = false;
+    if (stateValue && typeof stateValue === "object" && !Array.isArray(stateValue)) {
+      state = { ...stateValue };
+    } else if (typeof stateValue === "string") {
+      try {
+        const parsed = JSON.parse(stateValue);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          state = { ...parsed };
+          stringified = true;
+        }
+      } catch {
+        return [tableId, fixture];
+      }
+    }
+    if (!state) return [tableId, fixture];
+
+    const stacks = state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
+      ? { ...state.stacks }
+      : {};
+    const fixtureSeatRows = Array.isArray(fixture?.seatRows) ? fixture.seatRows : [];
+    for (const seat of fixtureSeatRows) {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
+      const seatStack = Number(seat?.stack);
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      stacks[userId] = hasSeatStack ? seatStack : 100;
+    }
+    const coherentSeatRows = fixtureSeatRows.map((seat) => {
+      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") return seat;
+      const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
+      const seatStack = Number(seat?.stack);
+      const stateStack = Number(stacks[userId]);
+      const hasSeatStack = seat?.stack !== null && seat?.stack !== undefined && Number.isSafeInteger(seatStack) && seatStack >= 0;
+      return !hasSeatStack && userId && Number.isSafeInteger(stateStack) && stateStack >= 0 ? { ...seat, stack: stateStack } : seat;
+    });
+    const coherentState = { ...state, stacks };
+    return [tableId, {
+      ...fixture,
+      seatRows: coherentSeatRows,
+      stateRow: fixture?.stateRow
+        ? { ...fixture.stateRow, state: stringified ? JSON.stringify(coherentState) : coherentState }
+        : fixture?.stateRow
+    }];
+  }));
+}
+
 function persistedBootstrapFixturesEnv(fixtures) {
+  const coherentFixtures = coherentPersistedBootstrapFixtures(fixtures);
   return {
     SUPABASE_DB_URL: "",
-    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+    WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(coherentFixtures)
   };
 }
 
@@ -69,7 +121,7 @@ async function writePersistedStateFile(fixtures) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "ws-protocol-persist-"));
   const filePath = path.join(dir, "persisted-state.json");
   const tables = {};
-  for (const [tableId, fixture] of Object.entries(fixtures || {})) {
+  for (const [tableId, fixture] of Object.entries(coherentPersistedBootstrapFixtures(fixtures))) {
     tables[tableId] = {
       tableRow: fixture.tableRow,
       seatRows: fixture.seatRows || [],
@@ -766,8 +818,7 @@ test("observe-only mode keeps seated persisted user table_leave authoritative", 
       WS_AUTH_REQUIRED: "1",
       WS_AUTH_TEST_SECRET: secret,
       ...observeOnlyJoinEnv(),
-      SUPABASE_DB_URL: "",
-      WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+      ...persistedBootstrapFixturesEnv(fixtures)
     }
   });
 
@@ -879,8 +930,7 @@ test("observe-only runtime keeps seated act accepted and observer act rejected",
       WS_AUTH_REQUIRED: "1",
       WS_AUTH_TEST_SECRET: secret,
       ...observeOnlyJoinEnv(),
-      SUPABASE_DB_URL: "",
-      WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+      ...persistedBootstrapFixturesEnv(fixtures)
     }
   });
 
@@ -952,8 +1002,7 @@ test("duplicate act requestId does not emit additional advancing state frame", a
       WS_AUTH_TEST_SECRET: secret,
       WS_POKER_SETTLED_REVEAL_MS: "60000",
       ...observeOnlyJoinEnv(),
-      SUPABASE_DB_URL: "",
-      WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+      ...persistedBootstrapFixturesEnv(fixtures)
     }
   });
 
@@ -1033,8 +1082,7 @@ test("timeout sweep emits at most one immediate transition for a single due turn
       WS_AUTH_TEST_SECRET: secret,
       WS_POKER_TURN_MS: "600",
       WS_TIMEOUT_SWEEP_MS: "20",
-      SUPABASE_DB_URL: "",
-      WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON: JSON.stringify(fixtures)
+      ...persistedBootstrapFixturesEnv(fixtures)
     }
   });
 


### PR DESCRIPTION
## Summary

- preserves authoritative human stack 0 through rollover, restore, leave, and inactive cleanup without falling back to stale seat projections
- atomically projects human stacks with the persisted state CAS and fails closed on ambiguous historical state
- keeps busted humans seated as OUT_OF_CHIPS / SITTING_OUT while bots continue and action controls remain visible but disabled
- adds explicit fixed 100 CH manual rebuy with one atomic USER → table ESCROW ledger transfer, durable request idempotency, and WAITING_NEXT_HAND state
- adds the rebuy UI, controlled insufficient-balance handling, read-only discrepancy audit, and WS protocol documentation
- keeps automatic rebuy out of scope in issue #712

## Accounting guarantees

- poker_state.state.stacks is the active-lifecycle cash-out source of truth, including zero
- missing or invalid authoritative human stack fails closed as stack_ambiguous
- state CAS, human seat projection, and existing bot replacement funding commit in one DB transaction
- failed or duplicate rebuy cannot create a second debit or client-only stack
- rebuy never inserts the player into a hand already in progress

## Validation

- npm test
- npm run syntax
- npm run check:all
- npm run ci:guards
- git diff --check

All local suites and guards pass.

## Deployment and manual verification

Both Netlify Deploy Preview and WS Preview Deploy are required. Verify in order:

1. bust to 0, rollover, disconnect/reconnect, leave, and zero cash-out
2. OUT_OF_CHIPS UI, stable disabled actions, and continued bot play
3. one 100 CH rebuy debit/escrow credit, WAITING_NEXT_HAND, next-hand admission, duplicate request, insufficient balance, and leave before next hand

Production rollout must deploy the merged WS server before the web client can send table_rebuy.

## Impact

- additive WS private.playerState and table_rebuy/rebuy command
- no DB migration
- no new ENV or secret
- no CSP change or new script
- no change to hand ranking, settlement, bot strategy, or auto-rebuy