### PR TITLE
feat: control poker bot reaction timing on WS Preview

### DIFF
--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -197,6 +197,11 @@ jobs:
             sudo -n grep -Eq '^WS_AUTHORITATIVE_JOIN_ENABLED=1$' "$PREVIEW_ENV_FILE" || { echo "preview env file must define WS_AUTHORITATIVE_JOIN_ENABLED=1"; exit 1; }
             sudo -n grep -Eq '^SUPABASE_DB_URL=.+$' "$PREVIEW_ENV_FILE" || { echo "preview env file must define SUPABASE_DB_URL"; exit 1; }
             sudo -n grep -Eq '^SUPABASE_STAGE_PROJECT_REF=.+$' "$PREVIEW_ENV_FILE" || { echo "preview env file must define SUPABASE_STAGE_PROJECT_REF"; exit 1; }
+            sudo -n grep -Eq '^POKER_WS_INTERNAL_TOKEN=.+$' "$PREVIEW_ENV_FILE" || { echo "preview env file must define POKER_WS_INTERNAL_TOKEN"; exit 1; }
+            if sudo -n grep -Eq '^WS_BOT_REACTION_(MIN|MAX)_MS=' "$PREVIEW_ENV_FILE"; then
+              echo "preview env file must not define legacy WS_BOT_REACTION_MIN_MS or WS_BOT_REACTION_MAX_MS"
+              exit 1
+            fi
             sudo -n bash -c '
               set -Eeuo pipefail
               env_file="$1"

--- a/admin.html
+++ b/admin.html
@@ -664,6 +664,29 @@
                 <div id="adminOpsRuntime"></div>
               </section>
 
+              <section class="xp-card admin-card" aria-labelledby="adminOpsBotReactionTitle">
+                <div class="admin-card__head">
+                  <div>
+                    <h2 class="xp-card__title" id="adminOpsBotReactionTitle">Poker bot reaction</h2>
+                    <p class="admin-card__subtitle">Process-local timing control for manual poker tests.</p>
+                  </div>
+                  <span class="admin-pill admin-pill--info">WS Preview</span>
+                </div>
+                <div id="adminOpsBotReactionSummary"></div>
+                <form class="admin-adjust" id="adminOpsBotReactionForm">
+                  <label class="admin-field">
+                    <span class="admin-field__label">Reaction delay (ms)</span>
+                    <input class="admin-input" id="adminOpsBotReactionDelay" type="number" name="delayMs" min="100" max="10000" step="100" inputmode="numeric" required>
+                    <span class="admin-field__hint">A fixed value applies to the next bot delay calculation.</span>
+                  </label>
+                  <div class="admin-filter-actions">
+                    <button class="admin-btn admin-btn--primary" id="adminOpsBotReactionApply" type="submit">Apply delay</button>
+                    <button class="admin-btn admin-btn--ghost" id="adminOpsBotReactionDefault" type="button">Set default</button>
+                  </div>
+                </form>
+                <div class="admin-note" id="adminOpsBotReactionStatus" aria-live="polite"></div>
+              </section>
+
               <section class="xp-card admin-card" aria-labelledby="adminOpsActionsTitle">
                 <div class="admin-card__head">
                   <div>

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -161,12 +161,26 @@ The preview VPS contract is:
 - Preview port: `3001`
 - Remote upload staging directory: `/tmp/arcadeplatform-ws-preview`
 - Supabase target: `SUPABASE_STAGE_PROJECT_REF` must be set, and `SUPABASE_URL` plus `SUPABASE_DB_URL` must target that same stage project ref
+- Internal admin token: `POKER_WS_INTERNAL_TOKEN` must be a long preview-only secret shared only with the deploy-preview-scoped Netlify Function configuration
 - Optional close grace: `POKER_TABLE_CLOSE_GRACE_MS=60000` keeps newly created empty tables open for 60s before cleanup may close them
 
 Preview deploys unpack into a temporary directory under `/tmp/arcadeplatform-ws-preview` and then sync the extracted files into `/opt/arcade-ws-preview/ws-server`.
 The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n bash -c 'true'` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`. Do not use `sudo -n -v` as the local smoke check here: it can still require a password when the same user has both normal passworded sudo rules and command-specific `NOPASSWD` rules.
-The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, or stage Supabase project-ref match is missing.
-Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks.
+The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, preview-only `POKER_WS_INTERNAL_TOKEN`, or stage Supabase project-ref match is missing. It also rejects retired `WS_BOT_REACTION_MIN_MS` and `WS_BOT_REACTION_MAX_MS` values so runtime changes have one source of truth.
+Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks. Only the preview host exposes the exact `/internal/admin/bot-reaction` reverse-proxy route; the production host must not expose it.
+
+### WS Preview bot reaction control
+
+The Admin Ops card can set a single fixed bot reaction delay for manual poker testing. A value such as `500 ms` creates the in-memory range `500–500 ms`; **Set default** removes the override and restores random `2000–4000 ms` delays. The next bot action reads the current range, while an action already sleeping keeps its original delay.
+
+The control is intentionally process-local and preview-only: it does not use a table, migration, feature-flag service, or timing ENV. A WS Preview restart or deployment restores the default automatically. The deploy-preview Netlify context must define `POKER_WS_INTERNAL_BASE_URL=https://ws-preview.kcswh.pl` and the same preview-only `POKER_WS_INTERNAL_TOKEN` as `/opt/arcade-ws-preview/.env.preview`. Do not copy either setting into production context.
+
+Manual verification after both Netlify Deploy Preview and an explicit WS Preview Deploy:
+
+1. Open Admin → Ops and confirm the card says `WS Preview`, `Default`, and `2000–4000 ms`.
+2. Set `500 ms`, start a poker hand, and confirm subsequent bot decisions occur after about half a second.
+3. Click **Set default**, continue playing, and confirm subsequent bot decisions again vary within approximately `2000–4000 ms`.
+4. Restart or redeploy the preview WS and confirm the card returns to `Default` without database cleanup.
 
 Minimal preview sudoers coverage for `WS_PREVIEW_USER` must include the concrete programs used by the workflow: `systemctl`, `test`, `grep`, `bash`, `rm`, `mkdir`, `tar`, and `rsync`. On Ubuntu, verify the actual binary paths with `command -v systemctl test grep bash rm mkdir tar rsync`, then keep `/etc/sudoers.d/ws-preview-deploy` mode `0440`.
 

--- a/docs/ws-preview-bot-reaction-admin-plan.md
+++ b/docs/ws-preview-bot-reaction-admin-plan.md
@@ -1,0 +1,507 @@
+# WS Preview poker bot reaction control — implementation plan
+
+Status: planning only  
+Date: 2026-07-14  
+Scope: one small preview-tooling PR before poker bust accounting and manual rebuy
+
+## TL;DR
+
+Add one compact card to the existing Admin **Ops** tab. The administrator enters a single fixed delay such as `500 ms`; the UI sends it as `minMs = 500` and `maxMs = 500`. **Set default** clears the in-memory override instead of storing `2000–4000` as an override.
+
+Use the existing protected path:
+
+```text
+admin.html
+  -> same-origin Netlify admin function
+  -> POKER_WS_INTERNAL_TOKEN
+  -> exact WS Preview internal HTTP endpoint
+  -> one process-local override store
+  -> accepted-bot-autoplay-adapter beforeBotActionStep
+```
+
+Do not add a public poker WS command. The Netlify function reuses `requireAdminUser()`, while the WS endpoint reuses the existing internal bearer token pattern. Preview-only behavior is enforced by all of these independent checks:
+
+1. the Netlify function accepts only a verified `deploy-preview` + stage identity;
+2. the proxy target is allowlisted to `https://ws-preview.kcswh.pl`;
+3. Caddy exposes the exact internal path only under the preview host;
+4. the WS process verifies its existing port/stage-project preview identity before every read or mutation;
+5. the WS process requires `POKER_WS_INTERNAL_TOKEN`.
+
+Production therefore cannot read or mutate the override even if a caller knows the route. No DB, migration, feature-flag system, poker-state property, or timing-value ENV is needed.
+
+## Current repository analysis
+
+### Bot reaction timing
+
+`ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs` currently owns:
+
+- `DEFAULT_BOT_REACTION_MIN_MS = 2000`;
+- `DEFAULT_BOT_REACTION_MAX_MS = 4000`;
+- `getBotAutoplayConfig(env)`, which resolves the reaction range and the unrelated bots-only hard cap;
+- `resolveBotReactionDelayMs()`, which samples once and clamps the result to the remaining bot turn window;
+- `beforeBotActionStep`, which calculates the delay, calls the injected `sleep()`, then reloads authoritative state and confirms that the turn still belongs to a bot.
+
+`createAcceptedBotStepExecutor()` is created lazily from `loadAcceptedBotAutoplayExecutor()` in `ws-server/server.mjs`. One accepted executor invocation runs at most one bot action (`maxActions: 1`). The current `cfg` snapshot is resolved before that action's `beforeBotActionStep`.
+
+This gives a clean change boundary: inject one `getBotReactionOverride()` callback into the existing adapter and call it immediately before `resolveBotReactionDelayMs()`. The callback returns either a validated range or `null`; `getBotAutoplayConfig()` remains responsible for the normal static range. The sampled `reactionDelayMs` remains a local immutable value for the already-started `sleep()`. A later admin update affects only the next delay calculation.
+
+Human timing is separate. Human turn deadlines and timeout handling use `TURN_MS`, `poker-turn-timeout.mjs`, and server timeout sweeps. The override must not be passed to, imported by, or read from those paths.
+
+### Admin authentication and UI
+
+`admin.html` already contains an **Ops** tab with runtime identity, health, and manual operational actions. `js/admin-page.js`:
+
+- obtains the current Supabase access token;
+- sends it through the shared `apiFetch()` helper;
+- calls same-origin `/.netlify/functions/admin-*` endpoints;
+- loads Ops data with `Promise.allSettled()`;
+- uses `klog()` and controlled UI errors;
+- is an existing external script, so this feature needs no new script tag.
+
+`netlify/functions/_shared/admin-auth.mjs` already provides `requireAdminUser()` backed by Supabase JWT verification and the `ADMIN_USER_IDS` allowlist. Existing admin handlers consistently apply CORS, method checks, and `adminAuthErrorResponse()`.
+
+`netlify/functions/admin-stage-identity.mjs` already derives a sanitized deployment identity from the generated deploy context and Supabase project configuration. It distinguishes `deploy-preview`, stage, production, and unknown without exposing secrets. The new proxy can reuse `buildStageIdentity()` rather than inventing another Netlify preview detector.
+
+### Existing Netlify-to-WS path
+
+The repository already has a server-to-server pattern:
+
+- Netlify reads `POKER_WS_INTERNAL_BASE_URL` and `POKER_WS_INTERNAL_TOKEN`;
+- `netlify/functions/_shared/poker-ws-runtime-notify.mjs` calls an internal WS HTTP route;
+- `ws-server/server.mjs` checks the same bearer token in `handleInternalLobbyMaterialize()`;
+- `/healthz` and internal HTTP routing already share the WS process's HTTP server.
+
+This is the smallest existing authorization boundary to reuse. The browser never receives the internal token.
+
+### Preview runtime identity
+
+The preview deployment already has a fail-closed identity contract:
+
+- `PORT=3001`;
+- `WS_AUTHORITATIVE_JOIN_ENABLED=1`;
+- a non-empty `SUPABASE_STAGE_PROJECT_REF`;
+- `SUPABASE_URL` and `SUPABASE_DB_URL` matching that stage project ref;
+- preview-specific service, filesystem root, and Caddy host.
+
+`.github/workflows/ws-preview-deploy.yml` verifies these values before replacing or restarting the preview runtime. Production uses port `3000` and the production Caddy host.
+
+The implementation should reuse this conjunction inside the WS runtime. It must not treat `NODE_ENV=production`, a hostname header, or port `3001` alone as sufficient proof of preview.
+
+## Options considered
+
+| Option | Reuse | Security and complexity | Decision |
+| --- | --- | --- | --- |
+| Protected admin WS command | Reuses normal WS auth, but the WS runtime does not currently own the admin allowlist and the admin page does not maintain a poker WS session | Adds a public protocol message, admin authorization to WS, token mint/client lifecycle, request IDs, and production message handling | Reject |
+| Browser-facing preview-only WS HTTP endpoint | Reuses the HTTP server | Requires browser CORS, Supabase JWT verification, admin allowlist configuration, and public endpoint security inside WS | Reject |
+| Netlify admin function proxy to protected WS Preview HTTP endpoint | Reuses `apiFetch()`, `requireAdminUser()`, deployment identity, internal base URL/token, and WS HTTP routing | One narrow same-origin admin API plus one exact internal route; browser never sees service credentials | Select |
+
+The selected design does not change `docs/ws-poker-protocol.md`, `PROTECTED_MESSAGE_TYPES`, the public WebSocket envelope, or the poker browser client.
+
+## Final architecture
+
+### Process-local state
+
+Add one small closure-backed store created exactly once during `ws-server/server.mjs` startup:
+
+```text
+defaults = { minMs: 2000, maxMs: 4000 }
+override = null
+
+override, when set = {
+  minMs,
+  maxMs,
+  updatedAt,
+  updatedBy
+}
+```
+
+Required store operations:
+
+- `read()` returns the mode, default range, active range, and optional override;
+- `setOverride({ minMs, maxMs, updatedBy })` validates and atomically replaces the in-memory object;
+- `clearOverride({ updatedBy })` sets `override = null`;
+- `getOverrideRange()` returns a fresh `{ minMs, maxMs }` copy or `null` for autoplay;
+- every administrative read/write checks the preview runtime guard;
+- creating a new store always starts with `override = null`.
+
+Do not mutate `process.env`, persist the object, attach it to a table, or copy default values into `override`.
+
+### Input contract
+
+Backend validation is authoritative:
+
+- both values are integers;
+- `100 <= minMs <= 10000`;
+- `100 <= maxMs <= 10000`;
+- `minMs <= maxMs`;
+- `updatedBy` comes from the authenticated Netlify function, never from browser JSON;
+- unknown keys/modes are rejected with controlled `invalid_request` or `invalid_range` responses.
+
+The first UI intentionally exposes one numeric **Reaction delay (ms)** field with `min=100`, `max=10000`, and an appropriate integer step. Applying `500` sends `{ minMs: 500, maxMs: 500 }`. The backend and store retain a range-shaped contract so separate min/max controls can be added later without changing autoplay.
+
+### Read response
+
+The sanitized admin response is additive and contains no secret:
+
+```json
+{
+  "ok": true,
+  "environment": "ws-preview",
+  "mode": "default",
+  "defaults": { "minMs": 2000, "maxMs": 4000 },
+  "active": { "minMs": 2000, "maxMs": 4000 },
+  "override": null
+}
+```
+
+Override mode additionally returns the in-memory `updatedAt` and `updatedBy`. The UI needs to display only mode and active range; identity/timestamp are useful for diagnostics but must not be persisted.
+
+### Timing semantics
+
+For each new bot action:
+
+1. `beforeBotActionStep` verifies that the authoritative turn belongs to a bot;
+2. it reads one effective range snapshot;
+3. existing `resolveBotReactionDelayMs()` samples and clamps the value;
+4. existing `sleep(reactionDelayMs)` begins;
+5. changes made after step 2 do not alter that promise;
+6. the next bot action repeats the lookup and sees the latest override.
+
+No timer registry, cancellation token, rescheduling, or mutation of a pending sleep is allowed.
+
+## Implementation phases and exact touchpoints
+
+### Phase 1 — runtime store and autoplay injection
+
+#### New `ws-server/poker/runtime/bot-reaction-override.mjs`
+
+Add pure validation plus `createBotReactionOverrideStore({ env, now })`.
+
+Responsibilities:
+
+- own the `2000–4000 ms` defaults and `100–10000 ms` validation bounds;
+- keep the optional override in a closure;
+- derive preview identity from the existing `PORT`, `WS_AUTHORITATIVE_JOIN_ENABLED`, `SUPABASE_STAGE_PROJECT_REF`, `SUPABASE_URL`, and `SUPABASE_DB_URL` contract;
+- require both configured Supabase targets to match the declared stage project ref;
+- return `preview_only` without state disclosure on production, unknown, or partially configured runtimes;
+- return copies, never the mutable internal object;
+- use injected `now()` for deterministic timestamps;
+- contain no DB, file, Redis, timer, or network access.
+
+Move the two default reaction constants out of `accepted-bot-autoplay-adapter.mjs` into this module and import them into the adapter. There must be one source of truth, not duplicated `2000` and `4000` literals.
+
+Keep the existing startup `WS_BOT_REACTION_MIN_MS/MAX_MS` hooks for current non-preview tests and deployment compatibility. `getBotAutoplayConfig(env, runtimeOverride)` uses a validated runtime override first and otherwise preserves the current ENV-or-constant resolution. WS Preview deployment must reject those legacy timing ENV values, so its default and every process restart are deterministically `2000–4000 ms`. Do not add another timing ENV.
+
+#### `ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs`
+
+Change `createAcceptedBotStepExecutor()` to accept an injected `getBotReactionOverride` callback whose default returns `null`.
+
+Change only the reaction-delay part of `beforeBotActionStep`:
+
+- read the callback immediately before `resolveBotReactionDelayMs()`;
+- call `getBotAutoplayConfig(env, runtimeOverride)` and pass its resolved range into the existing sampler;
+- retain the deadline clamp, authoritative bot-turn checks, sleep, post-sleep refresh, request IDs, persistence, and bot decision logic unchanged.
+
+Do not read the store while handling a human turn and do not modify `TURN_MS` or `turnDeadlineAt`.
+
+#### `ws-server/server.mjs`
+
+Create one store at module startup and pass `() => botReactionOverrideStore.getOverrideRange()` from `loadAcceptedBotAutoplayExecutor()` into the adapter.
+
+Add `handleInternalBotReactionConfig(req, res)` and route only exact `/internal/admin/bot-reaction` requests:
+
+- `GET` reads the sanitized snapshot;
+- `POST` accepts `mode: "override"` with min/max, or `mode: "default"`;
+- reuse `internalRuntimeToken` and the current bearer comparison pattern;
+- reject missing token configuration with `503`;
+- reject an invalid bearer with `401`;
+- reject a non-preview process with `403 { error: "preview_only" }` before reading or changing state;
+- use bounded JSON body parsing and reject invalid JSON/ranges with `400`;
+- pass the trusted `updatedBy` supplied by the Netlify service call;
+- return `cache-control: no-store` for reads, mutations, and errors;
+- use `klogSafe` for successful mutations and controlled failures; never log the bearer token or request body.
+
+The endpoint is operational HTTP, not part of the public poker WS protocol.
+
+### Phase 2 — protected Netlify admin proxy
+
+#### New `netlify/functions/admin-ws-preview-bot-reaction.mjs`
+
+Follow the existing admin handler shape:
+
+- apply `corsHeaders()` and method handling;
+- call `requireAdminUser(event, env)` for both `GET` and `POST`;
+- reuse `buildStageIdentity(env)` and require `environmentContext === "deploy-preview"`, stage DB target, and matching configured stage project refs;
+- resolve `POKER_WS_INTERNAL_BASE_URL` and require the exact allowlisted origin `https://ws-preview.kcswh.pl` with no credentials or unexpected path;
+- require `POKER_WS_INTERNAL_TOKEN` and send it only server-to-server;
+- use an `AbortController` timeout consistent with existing WS runtime notification;
+- forward only the allowlisted mode/min/max fields;
+- set `updatedBy` from `admin.userId` after authentication;
+- map upstream `preview_only`, auth, validation, unavailable, and timeout results into controlled admin errors;
+- return `cache-control: no-store` and call the upstream with cache disabled;
+- never query or write the database;
+- log through `klog` without token, raw body, email, or profile data.
+
+Public Netlify API contract:
+
+- `GET /.netlify/functions/admin-ws-preview-bot-reaction`;
+- `POST /.netlify/functions/admin-ws-preview-bot-reaction` with `{ "mode": "override", "minMs": 500, "maxMs": 500 }`;
+- `POST` with `{ "mode": "default" }` clears the override.
+
+Production and branch-deploy Netlify contexts must return a controlled `preview_only` response without calling any WS target. A non-admin must receive the existing `401/403` admin response.
+
+### Phase 3 — existing Admin Ops UI
+
+#### `admin.html`
+
+Add one card inside `#adminTabOps` using existing admin card, field, pill, action, and status classes.
+
+Required controls and labels:
+
+- title: **WS Preview · Poker bot reaction**;
+- visible **WS Preview** pill;
+- current mode: **Default** or **Override**;
+- active range such as `2000–4000 ms` or `500 ms`;
+- one numeric fixed-delay input;
+- **Apply delay** button;
+- **Set default** button;
+- card-local `aria-live` result/error area.
+
+The card remains visible outside preview and shows a controlled **Available only on WS Preview** state. It must not imply that hiding controls is the security boundary.
+
+#### `js/admin-page.js`
+
+Extend existing structures rather than adding a script:
+
+- `state.ops.botReaction` and `state.ops.botReactionError`;
+- new cached nodes selected in `selectNodes()`;
+- `renderBotReactionControl()`;
+- `loadBotReactionControl()` or a third settled request inside `loadOps()`;
+- `submitBotReactionOverride()`;
+- `clearBotReactionOverride()`;
+- event wiring in `wireStaticEvents()`.
+
+Behavior:
+
+- a read failure must not fail the other Ops cards;
+- `preview_only`, `ws_preview_unavailable`, and `invalid_range` render inside the card;
+- genuine `401` or `admin_required` can continue to use the page-level unauthorized behavior;
+- disable both mutation buttons while a request is pending;
+- re-render from the server response after every mutation;
+- load the current runtime value with `cache: "no-store"`;
+- do not optimistically claim an override is active;
+- use the existing `apiFetch()` and `klog()` helpers;
+- keep the current IIFE/browser style compatible with JSP-served pages.
+
+#### `css/admin.css`
+
+No new CSS is expected: existing Ops grid, card, field, button, pill, and note classes are sufficient. If implementation reveals one unavoidable layout rule, add it to this existing stylesheet with one line per selector. Do not add inline styles.
+
+### Phase 4 — preview routing and deployment guard
+
+#### `infra/vps/Caddyfile`
+
+Under `ws-preview.kcswh.pl` only, proxy the exact `/internal/admin/bot-reaction` path to `127.0.0.1:3001`.
+
+Do not add the route to `ws.kcswh.pl`, do not proxy a wildcard `/internal/*`, and retain the default response for every other unknown path. The endpoint still requires the internal bearer and the in-process preview guard.
+
+#### `.github/workflows/ws-preview-deploy.yml`
+
+Extend the existing remote preflight to require:
+
+- the existing non-empty `POKER_WS_INTERNAL_TOKEN` in `.env.preview`;
+- the existing port/stage identity checks;
+- absence of `WS_BOT_REACTION_MIN_MS` and `WS_BOT_REACTION_MAX_MS` in preview configuration, so a restart returns to the declared `2000–4000 ms` default.
+
+This adds no timing ENV. It makes the already-existing internal token mandatory for this preview control.
+
+#### `infra/vps/ws-preview.env.example`
+
+Document the existing preview identity and internal-token variable names required by the workflow. Do not add min/max values or an enable flag for the override.
+
+#### `docs/poker-deployment.md`
+
+Document:
+
+- the process-local and restart-reset behavior;
+- the exact preview-only internal route;
+- deploy-preview-scoped `POKER_WS_INTERNAL_BASE_URL=https://ws-preview.kcswh.pl` and matching `POKER_WS_INTERNAL_TOKEN` owner configuration;
+- that production Netlify variables must not inherit the preview target;
+- the manual Apply → test → Set default scenario;
+- that this tooling PR must be deployed and verified before beginning bust-accounting implementation.
+
+## Security invariants
+
+1. Browser code never receives `POKER_WS_INTERNAL_TOKEN`.
+2. Netlify authenticates the Supabase user and applies the existing admin allowlist before proxying.
+3. The Netlify function allows only deploy-preview + stage identity and a fixed WS Preview origin.
+4. Caddy exposes only one exact preview-host path, never a general internal prefix and never the production host.
+5. The WS process independently proves preview identity and checks the bearer before returning state or mutating it.
+6. Production/unknown runtime returns no active/default/override payload.
+7. Inputs are integers in `[100, 10000]` and `minMs <= maxMs`.
+8. Logs contain mode/range/timestamp/admin user ID only; never bearer tokens or raw auth data.
+9. Override state cannot cross a process restart and cannot affect another WS instance.
+10. No human deadline, legal action, bot strategy, request ID, persistence, settlement, or ledger path reads this setting.
+
+## Focused test plan
+
+Use existing Node behavior/contract runners. Do not add Playwright.
+
+### `ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs`
+
+Extend the existing suite to cover:
+
+- no override resolves to `2000–4000 ms`;
+- fixed `500–500 ms` is read by the next bot action and calls `sleep(500)` when the turn window permits;
+- clearing the store returns the next action to the normal sampled range;
+- updating the store from inside the injected `sleep()` does not change the already captured sleep duration;
+- a later executor invocation sees the new range;
+- a human turn does not call the bot range provider and retains its normal deadline behavior;
+- a newly created store has no override, proving restart/new-instance reset;
+- invalid integers, negative/NaN/out-of-range values, and `min > max` are rejected without changing the prior state;
+- production and incomplete preview identities reject administrative read/write and reveal no snapshot.
+
+Keep these tests in the already registered adapter suite unless a separate file materially improves clarity; avoid expanding runner registration for a tiny pure module.
+
+### `ws-server/server.behavior.test.mjs`
+
+Add internal HTTP behavior cases:
+
+- valid preview identity + internal bearer can read and set `500–500`;
+- **Set default** returns `mode: default` and `override: null`;
+- missing/wrong bearer is rejected;
+- production runtime is `preview_only` for both GET and POST and cannot read prior values;
+- invalid range returns `400` and leaves the prior value unchanged;
+- a second server process starts in default mode.
+
+### `tests/admin-endpoints.behavior.test.mjs`
+
+Extend the existing admin endpoint suite:
+
+- allowlisted deploy-preview admin can GET and POST through an injected fetch;
+- `updatedBy` forwarded upstream is taken from authenticated admin identity;
+- non-admin is rejected before fetch;
+- production/branch/unknown context is rejected before fetch;
+- a non-allowlisted base URL is rejected before fetch;
+- upstream preview-only/unavailable/invalid-range errors are mapped to controlled responses.
+
+### `tests/admin-page.contract.test.mjs` and `tests/admin-page.behavior.test.mjs`
+
+Add small checks for:
+
+- required card, fixed-delay input, Apply, Set default, and `aria-live` nodes;
+- Default/Override and active-range rendering;
+- fixed input sends equal min/max;
+- pending state disables duplicate mutations;
+- Set default sends only default mode;
+- preview-only error stays local to the card and does not hide the rest of Admin Ops.
+
+### Preview infrastructure guards
+
+Update existing:
+
+- `ws-tests/infra-vps-caddy.guard.test.mjs` to require the exact route only in the preview block and forbid it in production;
+- `ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs` to require internal token preflight and forbid timing ENV overrides;
+- protocol compliance tests only to assert that no public WS admin message was added, if an existing negative guard can express this without brittle source matching.
+
+## Acceptance criteria
+
+- An allowlisted administrator on Netlify Deploy Preview sees **WS Preview**, current mode, and active range.
+- Initial/new-process state is **Default · 2000–4000 ms**.
+- Applying `500` produces **Override · 500 ms** and each subsequently calculated bot reaction uses `500 ms`, subject only to the existing turn-deadline safety clamp.
+- A bot sleep already in progress is not cancelled, shortened, or restarted.
+- **Set default** removes the override and restores random `2000–4000 ms` calculations.
+- Invalid ranges do not mutate the prior state.
+- Non-admin users cannot read or mutate the setting.
+- Production Netlify and production WS cannot read or mutate the setting.
+- Human turn timing is unchanged.
+- Restart/redeployment clears the override without cleanup work.
+- No DB row, migration, timing-value ENV, poker snapshot field, or public WS protocol message is added.
+
+## Manual verification
+
+Both Netlify Deploy Preview and a manual WS Preview Deploy of the implementation branch are required.
+
+Preconditions:
+
+- the implementation ref is deployed to `ws-preview.kcswh.pl`;
+- the Caddy preview-only route is applied;
+- deploy-preview Netlify variables point only to the WS Preview origin and use the matching internal token;
+- the administrator is present in the existing `ADMIN_USER_IDS` allowlist.
+
+Scenario:
+
+1. Open the implementation Netlify Preview and sign in as an administrator.
+2. Open **Admin → Ops** and confirm **Default · 2000–4000 ms · WS Preview**.
+3. Set **Reaction delay** to `500` and apply.
+4. Open a preview poker table and observe several consecutive bot actions at approximately 0.5-second intervals.
+5. Change the override while one bot delay is already sleeping; confirm that action keeps its sampled delay and the following bot action uses the new value.
+6. Return to Admin → Ops and press **Set default**.
+7. Confirm **Default · 2000–4000 ms** and observe varied bot delays in that range.
+8. Restart or redeploy WS Preview and confirm the UI still reports Default with no retained override.
+9. Open production Admin and confirm the card reports preview-only/unavailable without exposing a range or breaking other Ops cards.
+10. Confirm normal human turn deadline behavior before and after override changes.
+
+## Rollout and rollback
+
+Rollout order:
+
+1. merge/apply the preview-only Caddy route;
+2. verify deploy-preview-scoped internal base URL/token configuration;
+3. deploy the implementation branch through WS Preview Deploy;
+4. deploy/open Netlify Preview;
+5. run the manual scenario;
+6. press **Set default** before starting bust-accounting manual tests;
+7. merge only after default and override behavior are both verified.
+
+Rollback is simple:
+
+- restart immediately clears any active override;
+- reverting the UI/function leaves no durable state;
+- reverting the WS code restores the existing `2000–4000 ms` path;
+- the exact Caddy route can be removed independently;
+- no data rollback or migration rollback exists.
+
+## Breaking-impact analysis
+
+No intended product or protocol break:
+
+- no DB migration or production data change;
+- no public WS protocol change;
+- no change to bot decisions, legal actions, request IDs, persistence, settlement, ledger, or human timeouts;
+- no new browser script, inline script, external origin, or CSP SHA;
+- existing admin APIs remain compatible;
+- override state is additive and preview-process-local.
+
+Operational changes requiring attention:
+
+- preview Caddy gains one exact token-protected route; production must not gain it;
+- `POKER_WS_INTERNAL_TOKEN` becomes required on the preview WS process and must match the deploy-preview-scoped Netlify value;
+- preview deployment rejects legacy `WS_BOT_REACTION_MIN_MS/MAX_MS` values to guarantee reset to `2000–4000`;
+- changing the injected adapter factory signature is internally breaking for tests/custom adapters unless the callback has a safe default;
+- a globally shared WS Preview instance means one administrator's override affects all preview poker tables until cleared or restarted.
+
+## Explicitly out of scope
+
+- production timing controls;
+- per-table, per-bot, or per-admin settings;
+- database persistence or audit tables;
+- feature-flag infrastructure;
+- interrupting active sleeps;
+- modifying human deadlines;
+- bot strategy or action-frequency changes;
+- bust accounting, `OUT_OF_CHIPS`, manual rebuy, or auto-rebuy implementation;
+- Playwright coverage.
+
+## Definition of Done
+
+- The selected Netlify admin proxy architecture is implemented without a public WS command.
+- Preview-only reads and writes are enforced by server-side runtime identity and bearer checks.
+- The Admin Ops card accurately shows Default/Override and the active range.
+- `500` becomes `500–500` for the next delay calculation.
+- **Set default** stores `null`, not copied defaults.
+- Restart returns to `2000–4000`.
+- The focused behavior, admin, UI contract, and preview infra guard tests pass.
+- Netlify Preview and WS Preview manual verification pass.
+- Production cannot read or change the override.
+- The override is reset to default before poker bust-accounting work begins.

--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -20,6 +20,11 @@ ws-preview.kcswh.pl {
     reverse_proxy 127.0.0.1:3001
   }
 
+  @botReactionAdmin path /internal/admin/bot-reaction
+  handle @botReactionAdmin {
+    reverse_proxy 127.0.0.1:3001
+  }
+
   @ws path /ws*
   handle @ws {
     reverse_proxy 127.0.0.1:3001

--- a/infra/vps/ws-preview.env.example
+++ b/infra/vps/ws-preview.env.example
@@ -1,3 +1,8 @@
 PORT=3001
 NODE_ENV=production
+WS_AUTHORITATIVE_JOIN_ENABLED=1
+SUPABASE_STAGE_PROJECT_REF=replace-with-stage-project-ref
+SUPABASE_URL=https://replace-with-stage-project-ref.supabase.co
+SUPABASE_DB_URL=postgresql://postgres.replace-with-stage-project-ref:replace-password@replace-pooler.supabase.com:6543/postgres
+POKER_WS_INTERNAL_TOKEN=replace-with-long-random-preview-only-token
 POKER_TABLE_CLOSE_GRACE_MS=60000

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -45,6 +45,10 @@
       summary: null,
       identity: null,
       identityError: null,
+      botReaction: null,
+      botReactionError: null,
+      botReactionMessage: "",
+      botReactionPending: false,
       loaded: false,
     },
     pokerAudit: {
@@ -120,6 +124,12 @@
     nodes.opsStats = doc.getElementById("adminOpsStats");
     nodes.opsIdentity = doc.getElementById("adminOpsIdentity");
     nodes.opsRuntime = doc.getElementById("adminOpsRuntime");
+    nodes.opsBotReactionSummary = doc.getElementById("adminOpsBotReactionSummary");
+    nodes.opsBotReactionForm = doc.getElementById("adminOpsBotReactionForm");
+    nodes.opsBotReactionDelay = doc.getElementById("adminOpsBotReactionDelay");
+    nodes.opsBotReactionApply = doc.getElementById("adminOpsBotReactionApply");
+    nodes.opsBotReactionDefault = doc.getElementById("adminOpsBotReactionDefault");
+    nodes.opsBotReactionStatus = doc.getElementById("adminOpsBotReactionStatus");
     nodes.opsRefresh = doc.getElementById("adminOpsRefresh");
     nodes.opsRunReconciler = doc.getElementById("adminOpsRunReconciler");
     nodes.opsRunStaleSweep = doc.getElementById("adminOpsRunStaleSweep");
@@ -1069,6 +1079,7 @@
   function renderOps(){
     var summary = state.ops.summary;
     var identity = state.ops.identity;
+    renderBotReactionControl();
     if (!summary && !identity){
       if (nodes.opsStats) nodes.opsStats.innerHTML = "";
       if (nodes.opsIdentity) nodes.opsIdentity.innerHTML = "";
@@ -1149,6 +1160,56 @@
           meta: escapeHtml((item.userId || "—") + " · " + reason),
         };
       })) : "";
+    }
+  }
+
+  function formatReactionRange(range){
+    if (!range) return "—";
+    var minMs = Number(range.minMs);
+    var maxMs = Number(range.maxMs);
+    if (!Number.isInteger(minMs) || !Number.isInteger(maxMs)) return "—";
+    return minMs === maxMs ? String(minMs) + " ms" : String(minMs) + "–" + String(maxMs) + " ms";
+  }
+
+  function renderBotReactionControl(){
+    var value = state.ops.botReaction;
+    var errorCode = state.ops.botReactionError;
+    var pending = state.ops.botReactionPending === true;
+    var unavailable = errorCode === "preview_only" || errorCode === "ws_preview_unavailable" || errorCode === "ws_preview_timeout";
+    if (nodes.opsBotReactionSummary){
+      if (value){
+        var mode = value.mode === "override" ? "Override" : "Default";
+        nodes.opsBotReactionSummary.innerHTML = [
+          '<div class="admin-surface">',
+          '<div class="admin-list__title"><span>Active range</span>' + pill(mode, value.mode === "override" ? "success" : "info") + "</div>",
+          '<div class="admin-kv">',
+          renderKvRow("Environment", "WS Preview"),
+          renderKvRow("Range", formatReactionRange(value.active)),
+          "</div>",
+          "</div>"
+        ].join("");
+      } else if (errorCode){
+        var errorText = errorCode === "preview_only"
+          ? "Available only on WS Preview."
+          : errorCode === "ws_preview_timeout"
+            ? "WS Preview did not respond in time."
+            : errorCode === "ws_preview_unavailable"
+              ? "WS Preview control is unavailable."
+              : "Could not load bot reaction timing.";
+        nodes.opsBotReactionSummary.innerHTML = '<p class="admin-empty">' + escapeHtml(errorText) + "</p>";
+      } else {
+        nodes.opsBotReactionSummary.innerHTML = '<p class="admin-empty">Loading WS Preview timing…</p>';
+      }
+    }
+    if (nodes.opsBotReactionDelay && value && !pending){
+      nodes.opsBotReactionDelay.value = String(value.active && value.active.minMs != null ? value.active.minMs : 500);
+    }
+    if (nodes.opsBotReactionDelay) nodes.opsBotReactionDelay.disabled = pending || unavailable;
+    if (nodes.opsBotReactionApply) nodes.opsBotReactionApply.disabled = pending || unavailable;
+    if (nodes.opsBotReactionDefault) nodes.opsBotReactionDefault.disabled = pending || unavailable || !value || value.mode !== "override";
+    if (nodes.opsBotReactionStatus){
+      var localError = errorCode && !unavailable ? errorCode : "";
+      nodes.opsBotReactionStatus.textContent = pending ? "Updating WS Preview…" : state.ops.botReactionMessage || localError;
     }
   }
 
@@ -1596,7 +1657,8 @@
     try {
       var results = await Promise.allSettled([
         apiFetch("/.netlify/functions/admin-stage-identity", { method: "GET" }),
-        apiFetch("/.netlify/functions/admin-ops-summary", { method: "GET" })
+        apiFetch("/.netlify/functions/admin-ops-summary", { method: "GET" }),
+        apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" })
       ]);
       if (results[0].status === "fulfilled"){
         state.ops.identity = results[0].value || null;
@@ -1611,11 +1673,81 @@
       }
       var payload = results[1].value || {};
       state.ops.summary = payload;
+      if (results[2].status === "fulfilled"){
+        state.ops.botReaction = results[2].value || null;
+        state.ops.botReactionError = null;
+        state.ops.botReactionMessage = "";
+      } else {
+        state.ops.botReaction = null;
+        state.ops.botReactionError = results[2].reason && results[2].reason.code ? results[2].reason.code : "request_failed";
+        state.ops.botReactionMessage = "";
+        klog("admin_ws_preview_bot_reaction_load_failed", { code: state.ops.botReactionError });
+      }
       state.ops.loaded = true;
       renderOps();
       setStatus("", "");
     } catch (err){
       handleApiError(err, "Could not load ops summary.");
+    }
+  }
+
+  function handleBotReactionError(err, fallback){
+    if (err && (err.status === 401 || (err.status === 403 && err.code === "admin_required"))){
+      showUnauthorized(getUnauthorizedMessage(err));
+      setStatus("", "");
+      return;
+    }
+    state.ops.botReactionError = err && err.code ? err.code : "request_failed";
+    state.ops.botReactionMessage = fallback || "Could not update WS Preview timing.";
+    klog("admin_ws_preview_bot_reaction_update_failed", { code: state.ops.botReactionError });
+    renderBotReactionControl();
+  }
+
+  async function submitBotReactionOverride(event){
+    event.preventDefault();
+    var delayMs = Number(nodes.opsBotReactionDelay && nodes.opsBotReactionDelay.value);
+    if (!Number.isInteger(delayMs) || delayMs < 100 || delayMs > 10000){
+      state.ops.botReactionError = "invalid_range";
+      state.ops.botReactionMessage = "Enter a whole value from 100 to 10000 ms.";
+      renderBotReactionControl();
+      return;
+    }
+    state.ops.botReactionPending = true;
+    state.ops.botReactionError = null;
+    state.ops.botReactionMessage = "";
+    renderBotReactionControl();
+    try {
+      state.ops.botReaction = await apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", {
+        method: "POST",
+        body: JSON.stringify({ mode: "override", minMs: delayMs, maxMs: delayMs })
+      });
+      state.ops.botReactionError = null;
+      state.ops.botReactionMessage = "Override applied to the next bot action.";
+    } catch (err){
+      handleBotReactionError(err, "Could not apply the override.");
+    } finally {
+      state.ops.botReactionPending = false;
+      renderBotReactionControl();
+    }
+  }
+
+  async function clearBotReactionOverride(){
+    state.ops.botReactionPending = true;
+    state.ops.botReactionError = null;
+    state.ops.botReactionMessage = "";
+    renderBotReactionControl();
+    try {
+      state.ops.botReaction = await apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", {
+        method: "POST",
+        body: JSON.stringify({ mode: "default" })
+      });
+      state.ops.botReactionError = null;
+      state.ops.botReactionMessage = "Default 2000–4000 ms range restored.";
+    } catch (err){
+      handleBotReactionError(err, "Could not restore the default range.");
+    } finally {
+      state.ops.botReactionPending = false;
+      renderBotReactionControl();
     }
   }
 
@@ -1846,6 +1978,8 @@
     if (nodes.bonusCampaignForm) nodes.bonusCampaignForm.addEventListener("submit", saveBonusCampaignDraft);
     if (nodes.bonusCampaignForm) nodes.bonusCampaignForm.addEventListener("change", handleBonusCampaignFormChange);
     if (nodes.pokerAuditFilters) nodes.pokerAuditFilters.addEventListener("submit", handlePokerAuditSubmit);
+    if (nodes.opsBotReactionForm) nodes.opsBotReactionForm.addEventListener("submit", submitBotReactionOverride);
+    if (nodes.opsBotReactionDefault) nodes.opsBotReactionDefault.addEventListener("click", clearBotReactionOverride);
     if (nodes.usersRefresh) nodes.usersRefresh.addEventListener("click", function(){ loadUsers(); });
     if (nodes.tablesRefresh) nodes.tablesRefresh.addEventListener("click", function(){ loadTables(); });
     if (nodes.bonusCampaignsRefresh) nodes.bonusCampaignsRefresh.addEventListener("click", function(){ loadBonusCampaigns(); });

--- a/netlify/functions/admin-ws-preview-bot-reaction.mjs
+++ b/netlify/functions/admin-ws-preview-bot-reaction.mjs
@@ -71,6 +71,14 @@ function resolveTimeoutMs(env) {
   return Math.trunc(parsed);
 }
 
+function isValidBotReactionSnapshot(value) {
+  if (!value || typeof value !== "object" || value.ok !== true || value.environment !== "ws-preview") return false;
+  if (value.mode !== "default" && value.mode !== "override") return false;
+  const minMs = Number(value.active?.minMs);
+  const maxMs = Number(value.active?.maxMs);
+  return Number.isInteger(minMs) && Number.isInteger(maxMs) && minMs >= 100 && maxMs <= 10_000 && minMs <= maxMs;
+}
+
 async function proxyBotReaction({ method, payload, adminUserId, env, fetchImpl }) {
   const baseUrl = resolvePreviewBaseUrl(env);
   const token = typeof env?.POKER_WS_INTERNAL_TOKEN === "string" ? env.POKER_WS_INTERNAL_TOKEN.trim() : "";
@@ -107,6 +115,12 @@ async function proxyBotReaction({ method, payload, adminUserId, env, fetchImpl }
       const error = new Error(exposedCodes.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable");
       error.code = exposedCodes.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable";
       error.status = upstreamCode === "preview_only" ? 403 : response.status === 400 ? 400 : 502;
+      throw error;
+    }
+    if (!isValidBotReactionSnapshot(responseBody)) {
+      const error = new Error("ws_preview_unavailable");
+      error.code = "ws_preview_unavailable";
+      error.status = 502;
       throw error;
     }
     return responseBody;
@@ -181,6 +195,7 @@ const handler = createAdminWsPreviewBotReactionHandler();
 export {
   createAdminWsPreviewBotReactionHandler,
   handler,
+  isValidBotReactionSnapshot,
   parseBody,
   proxyBotReaction,
   resolvePreviewBaseUrl

--- a/netlify/functions/admin-ws-preview-bot-reaction.mjs
+++ b/netlify/functions/admin-ws-preview-bot-reaction.mjs
@@ -1,0 +1,187 @@
+import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.mjs";
+import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
+import { buildStageIdentity } from "./admin-stage-identity.mjs";
+
+const WS_PREVIEW_ORIGIN = "https://ws-preview.kcswh.pl";
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+function jsonResponse(statusCode, headers, body) {
+  return {
+    statusCode,
+    headers: { ...headers, "cache-control": "no-store" },
+    body: JSON.stringify(body)
+  };
+}
+
+function parseBody(body) {
+  let payload;
+  try {
+    payload = body ? JSON.parse(body) : {};
+  } catch (_error) {
+    const error = new Error("invalid_json");
+    error.code = "invalid_json";
+    error.status = 400;
+    throw error;
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    const error = new Error("invalid_request");
+    error.code = "invalid_request";
+    error.status = 400;
+    throw error;
+  }
+  const mode = typeof payload.mode === "string" ? payload.mode.trim() : "";
+  const keys = Object.keys(payload).sort();
+  if (mode === "default" && keys.length === 1 && keys[0] === "mode") return { mode };
+  if (mode === "override") {
+    const expectedKeys = ["maxMs", "minMs", "mode"];
+    if (keys.length === expectedKeys.length && keys.every((key, index) => key === expectedKeys[index])) {
+      return { mode, minMs: payload.minMs, maxMs: payload.maxMs };
+    }
+  }
+  const error = new Error("invalid_request");
+  error.code = "invalid_request";
+  error.status = 400;
+  throw error;
+}
+
+function resolvePreviewBaseUrl(env) {
+  const raw = typeof env?.POKER_WS_INTERNAL_BASE_URL === "string" ? env.POKER_WS_INTERNAL_BASE_URL.trim() : "";
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (
+      url.origin !== WS_PREVIEW_ORIGIN
+      || (url.pathname !== "/" && url.pathname !== "")
+      || url.username
+      || url.password
+      || url.search
+      || url.hash
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function resolveTimeoutMs(env) {
+  const parsed = Number(env?.POKER_WS_INTERNAL_TIMEOUT_MS);
+  if (!Number.isFinite(parsed) || parsed < 250 || parsed > 10_000) return DEFAULT_TIMEOUT_MS;
+  return Math.trunc(parsed);
+}
+
+async function proxyBotReaction({ method, payload, adminUserId, env, fetchImpl }) {
+  const baseUrl = resolvePreviewBaseUrl(env);
+  const token = typeof env?.POKER_WS_INTERNAL_TOKEN === "string" ? env.POKER_WS_INTERNAL_TOKEN.trim() : "";
+  if (!baseUrl || !token || typeof fetchImpl !== "function") {
+    const error = new Error("ws_preview_unavailable");
+    error.code = "ws_preview_unavailable";
+    error.status = 503;
+    throw error;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), resolveTimeoutMs(env));
+  if (typeof timer?.unref === "function") timer.unref();
+  try {
+    const options = {
+      method,
+      cache: "no-store",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json"
+      },
+      signal: controller.signal
+    };
+    if (method === "POST") {
+      options.body = JSON.stringify({ ...payload, updatedBy: adminUserId });
+    }
+    const response = await fetchImpl(`${baseUrl}/internal/admin/bot-reaction`, options);
+    let responseBody = {};
+    try {
+      responseBody = await response.json();
+    } catch (_error) {}
+    if (!response.ok) {
+      const upstreamCode = typeof responseBody?.error === "string" ? responseBody.error : "ws_preview_unavailable";
+      const exposedCodes = new Set(["invalid_request", "invalid_range", "preview_only"]);
+      const error = new Error(exposedCodes.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable");
+      error.code = exposedCodes.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable";
+      error.status = upstreamCode === "preview_only" ? 403 : response.status === 400 ? 400 : 502;
+      throw error;
+    }
+    return responseBody;
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      const timeoutError = new Error("ws_preview_timeout");
+      timeoutError.code = "ws_preview_timeout";
+      timeoutError.status = 504;
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createAdminWsPreviewBotReactionHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const requireAdmin = deps.requireAdminUser || requireAdminUser;
+  const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
+  const fetchImpl = deps.fetchImpl || globalThis.fetch;
+  return async function handler(event) {
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) return jsonResponse(403, baseHeaders(), { error: "forbidden_origin" });
+    if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: { ...cors, "cache-control": "no-store" }, body: "" };
+    if (event.httpMethod !== "GET" && event.httpMethod !== "POST") {
+      return jsonResponse(405, cors, { error: "method_not_allowed" });
+    }
+    try {
+      const admin = await requireAdmin(event, env);
+      const identity = buildIdentity();
+      if (
+        identity?.environmentContext !== "deploy-preview"
+        || identity?.databaseTarget !== "stage"
+        || identity?.stageProjectRefMatches !== true
+        || identity?.databaseMatchesSupabaseProjectRef !== true
+      ) {
+        return jsonResponse(403, cors, { error: "preview_only" });
+      }
+      const payload = event.httpMethod === "POST" ? parseBody(event.body) : null;
+      const result = await proxyBotReaction({
+        method: event.httpMethod,
+        payload,
+        adminUserId: admin.userId,
+        env,
+        fetchImpl
+      });
+      klog("admin_ws_preview_bot_reaction_ok", {
+        adminUserId: admin.userId,
+        method: event.httpMethod,
+        mode: result?.mode || null,
+        minMs: result?.active?.minMs ?? null,
+        maxMs: result?.active?.maxMs ?? null
+      });
+      return jsonResponse(200, cors, result);
+    } catch (error) {
+      if (error?.status === 401 || (error?.status === 403 && error?.code === "admin_required")) {
+        const response = adminAuthErrorResponse(error, cors);
+        return { ...response, headers: { ...response.headers, "cache-control": "no-store" } };
+      }
+      const status = Number(error?.status) || 500;
+      const code = error?.code || "server_error";
+      klog("admin_ws_preview_bot_reaction_failed", { status, code });
+      return jsonResponse(status, cors, { error: code });
+    }
+  };
+}
+
+const handler = createAdminWsPreviewBotReactionHandler();
+
+export {
+  createAdminWsPreviewBotReactionHandler,
+  handler,
+  parseBody,
+  proxyBotReaction,
+  resolvePreviewBaseUrl
+};

--- a/tests/admin-endpoints.behavior.test.mjs
+++ b/tests/admin-endpoints.behavior.test.mjs
@@ -137,6 +137,28 @@ test("admin WS Preview bot reaction body allowlist rejects unexpected fields", (
   assert.throws(() => parseBotReactionBody(JSON.stringify({ mode: "override", minMs: 500, maxMs: 500, updatedBy: "spoofed" })), { code: "invalid_request" });
 });
 
+test("admin WS Preview bot reaction proxy rejects a non-JSON Caddy fallback response", async () => {
+  const handler = createAdminWsPreviewBotReactionHandler({
+    env: {
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
+    },
+    requireAdminUser: async () => ({ userId: "admin-1" }),
+    buildStageIdentity: previewStageIdentity,
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("not_json");
+      },
+    }),
+  });
+  const response = await handler(event("GET"));
+
+  assert.equal(response.statusCode, 502);
+  assert.deepEqual(JSON.parse(response.body), { error: "ws_preview_unavailable" });
+});
+
 test("admin-user-balance returns target user balance", async () => {
   let seenUserId = null;
   const handler = createAdminUserBalanceHandler({

--- a/tests/admin-endpoints.behavior.test.mjs
+++ b/tests/admin-endpoints.behavior.test.mjs
@@ -4,12 +4,23 @@ import test from "node:test";
 const { createAdminMeHandler } = await import("../netlify/functions/admin-me.mjs");
 const { createAdminUserBalanceHandler } = await import("../netlify/functions/admin-user-balance.mjs");
 const { createAdminUserLedgerHandler } = await import("../netlify/functions/admin-user-ledger.mjs");
+const { createAdminWsPreviewBotReactionHandler, parseBody: parseBotReactionBody } = await import("../netlify/functions/admin-ws-preview-bot-reaction.mjs");
 
-function event(method, queryStringParameters = {}) {
+function event(method, queryStringParameters = {}, body = null) {
   return {
     httpMethod: method,
     headers: { origin: "https://arcade.test" },
     queryStringParameters,
+    body,
+  };
+}
+
+function previewStageIdentity() {
+  return {
+    environmentContext: "deploy-preview",
+    databaseTarget: "stage",
+    stageProjectRefMatches: true,
+    databaseMatchesSupabaseProjectRef: true,
   };
 }
 
@@ -43,6 +54,87 @@ test("admin-me fails closed for non-admin callers", async () => {
 
   assert.equal(response.statusCode, 403);
   assert.deepEqual(JSON.parse(response.body), { error: "admin_required" });
+});
+
+test("admin WS Preview bot reaction proxy forwards only a controlled payload with trusted admin identity", async () => {
+  let seen = null;
+  const handler = createAdminWsPreviewBotReactionHandler({
+    env: {
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: previewStageIdentity,
+    fetchImpl: async (url, options) => {
+      seen = { url, options };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          environment: "ws-preview",
+          mode: "override",
+          defaults: { minMs: 2000, maxMs: 4000 },
+          active: { minMs: 500, maxMs: 500 },
+          override: { minMs: 500, maxMs: 500, updatedBy: "00000000-0000-4000-8000-000000000010" },
+        }),
+      };
+    },
+  });
+  const response = await handler(event("POST", {}, JSON.stringify({ mode: "override", minMs: 500, maxMs: 500 })));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(seen.url, "https://ws-preview.kcswh.pl/internal/admin/bot-reaction");
+  assert.equal(seen.options.headers.authorization, "Bearer preview-internal-token");
+  assert.deepEqual(JSON.parse(seen.options.body), {
+    mode: "override",
+    minMs: 500,
+    maxMs: 500,
+    updatedBy: "00000000-0000-4000-8000-000000000010",
+  });
+});
+
+test("admin WS Preview bot reaction proxy rejects non-admin and non-preview requests before contacting WS", async () => {
+  let fetchCalls = 0;
+  const deps = {
+    env: {
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
+    },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error("unexpected_fetch");
+    },
+  };
+  const nonAdminHandler = createAdminWsPreviewBotReactionHandler({
+    ...deps,
+    requireAdminUser: async () => {
+      const error = new Error("admin_required");
+      error.status = 403;
+      error.code = "admin_required";
+      throw error;
+    },
+    buildStageIdentity: previewStageIdentity,
+  });
+  const nonAdminResponse = await nonAdminHandler(event("GET"));
+  assert.equal(nonAdminResponse.statusCode, 403);
+
+  const productionHandler = createAdminWsPreviewBotReactionHandler({
+    ...deps,
+    requireAdminUser: async () => ({ userId: "admin-1" }),
+    buildStageIdentity: () => ({ ...previewStageIdentity(), environmentContext: "production", databaseTarget: "production" }),
+  });
+  const productionResponse = await productionHandler(event("GET"));
+  assert.equal(productionResponse.statusCode, 403);
+  assert.deepEqual(JSON.parse(productionResponse.body), { error: "preview_only" });
+  assert.equal(fetchCalls, 0);
+});
+
+test("admin WS Preview bot reaction body allowlist rejects unexpected fields", () => {
+  assert.deepEqual(parseBotReactionBody(JSON.stringify({ mode: "default" })), { mode: "default" });
+  assert.deepEqual(parseBotReactionBody(JSON.stringify({ mode: "override", minMs: 500, maxMs: 500 })), { mode: "override", minMs: 500, maxMs: 500 });
+  assert.throws(() => parseBotReactionBody(JSON.stringify({ mode: "default", minMs: 500 })), { code: "invalid_request" });
+  assert.throws(() => parseBotReactionBody(JSON.stringify({ mode: "override", minMs: 500, maxMs: 500, updatedBy: "spoofed" })), { code: "invalid_request" });
 });
 
 test("admin-user-balance returns target user balance", async () => {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -275,6 +275,11 @@ function createAdminDom() {
     "adminOpsStats",
     "adminOpsIdentity",
     "adminOpsRuntime",
+    "adminOpsBotReactionSummary",
+    "adminOpsBotReactionDelay",
+    "adminOpsBotReactionApply",
+    "adminOpsBotReactionDefault",
+    "adminOpsBotReactionStatus",
     "adminOpsRefresh",
     "adminOpsRunReconciler",
     "adminOpsRunStaleSweep",
@@ -313,6 +318,7 @@ function createAdminDom() {
   addField(pokerAuditFilters, { name: "tableId", value: "" });
   addField(pokerAuditFilters, { name: "handId", value: "" });
   addField(pokerAuditFilters, { name: "limit", value: "20" });
+  createForm(document, "adminOpsBotReactionForm");
 
   const tabs = ["users", "tables", "ledger", "bonusCampaigns", "pokerAudit", "ops"].map((tab, index) => {
     const button = registerNode(document, createElement("button", `adminTabButton${tab[0].toUpperCase()}${tab.slice(1)}`));
@@ -418,6 +424,16 @@ function buildContext(options = {}) {
         janitor: { openTableCount: 0, staleHumanSeatCount: 0, staleOpenTableCount: 0, flaggedTableCount: 0 },
         runtime: { buildId: "test-build", chipsEnabled: true, adminUserIdsConfigured: true, janitorConfig: {}, healthy: true },
         recentJanitorActivity: { adminActions: [], cleanupTransactions: [] },
+      }) };
+    }
+    if (text.includes("/.netlify/functions/admin-ws-preview-bot-reaction")) {
+      return { ok: true, json: async () => ({
+        ok: true,
+        environment: "ws-preview",
+        mode: "default",
+        defaults: { minMs: 2000, maxMs: 4000 },
+        active: { minMs: 2000, maxMs: 4000 },
+        override: null,
       }) };
     }
     if (text.includes("/.netlify/functions/admin-stage-identity")) {
@@ -659,10 +675,14 @@ test("admin page tabs switch panels on click and keep ARIA state in sync", async
   assert.equal(panels[5].hidden, false);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-stage-identity"), true);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-ops-summary"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-ws-preview-bot-reaction"), true);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Database target/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /stageabc/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Service role stage match/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /stage/);
+  assert.match(document.getElementById("adminOpsBotReactionSummary").innerHTML, /Default/);
+  assert.match(document.getElementById("adminOpsBotReactionSummary").innerHTML, /2000–4000 ms/);
+  assert.equal(document.getElementById("adminOpsBotReactionDelay").value, "2000");
 });
 
 test("admin page still renders ops summary when stage identity request fails", async () => {

--- a/tests/admin-page.contract.test.mjs
+++ b/tests/admin-page.contract.test.mjs
@@ -31,6 +31,15 @@ test("admin page exposes required admin tabs", () => {
   assert.match(adminHtml, /data-admin-panel="ops"/);
 });
 
+test("admin ops exposes the WS Preview bot reaction control", () => {
+  assert.match(adminHtml, /id="adminOpsBotReactionSummary"/);
+  assert.match(adminHtml, /id="adminOpsBotReactionForm"/);
+  assert.match(adminHtml, /id="adminOpsBotReactionDelay"[^>]+min="100"[^>]+max="10000"/);
+  assert.match(adminHtml, /id="adminOpsBotReactionApply"/);
+  assert.match(adminHtml, /id="adminOpsBotReactionDefault"/);
+  assert.match(adminHtml, />WS Preview</);
+});
+
 test("admin bonus campaign form exposes campaign type suggestions", () => {
   assert.match(adminHtml, /name="campaignType"[^>]+list="adminBonusCampaignTypeOptions"/);
   assert.match(adminHtml, /<datalist id="adminBonusCampaignTypeOptions">/);

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { createAcceptedBotAutoplayExecutor as createAcceptedBotAutoplayExecutorBase } from "./accepted-bot-autoplay-adapter.mjs";
+import { createBotReactionOverrideStore } from "./bot-reaction-override.mjs";
 import { initHandState, applyAction as applyRuntimeAction, advanceIfNeeded } from "../snapshot-runtime/poker-reducer.mjs";
 import { buildBootstrappedPokerState, applyCoreStateAction } from "../engine/poker-engine.mjs";
 import { computeSharedLegalActions } from "../shared/poker-primitives.mjs";
@@ -23,6 +24,44 @@ function createAcceptedBotAutoplayExecutor(options = {}) {
     env: mergedEnv
   });
 }
+
+function previewRuntimeEnv() {
+  return {
+    PORT: "3001",
+    WS_AUTHORITATIVE_JOIN_ENABLED: "1",
+    SUPABASE_STAGE_PROJECT_REF: "stage-project-ref",
+    SUPABASE_URL: "https://stage-project-ref.supabase.co",
+    SUPABASE_DB_URL: "postgresql://postgres.stage-project-ref:password@aws-0-eu-central-1.pooler.supabase.com:6543/postgres"
+  };
+}
+
+test("bot reaction override store defaults, validates, clears, and resets with a new process instance", () => {
+  const env = previewRuntimeEnv();
+  const store = createBotReactionOverrideStore({ env, now: () => Date.parse("2026-07-14T12:00:00.000Z") });
+
+  assert.deepEqual(store.read().active, { minMs: 2000, maxMs: 4000 });
+  assert.equal(store.read().mode, "default");
+  assert.deepEqual(store.setOverride({ minMs: 500, maxMs: 500, updatedBy: "admin-1" }).active, { minMs: 500, maxMs: 500 });
+  assert.throws(() => store.setOverride({ minMs: 99, maxMs: 500, updatedBy: "admin-1" }), { code: "invalid_range" });
+  assert.throws(() => store.setOverride({ minMs: 600, maxMs: 500, updatedBy: "admin-1" }), { code: "invalid_range" });
+  assert.deepEqual(store.getOverrideRange(), { minMs: 500, maxMs: 500 });
+  assert.equal(store.clearOverride({ updatedBy: "admin-1" }).mode, "default");
+  assert.equal(store.getOverrideRange(), null);
+  assert.equal(createBotReactionOverrideStore({ env }).read().mode, "default");
+});
+
+test("bot reaction override admin operations fail closed outside the exact WS Preview runtime", () => {
+  const productionStore = createBotReactionOverrideStore({
+    env: { ...previewRuntimeEnv(), PORT: "3000" }
+  });
+  assert.throws(() => productionStore.read(), { code: "preview_only" });
+  assert.throws(() => productionStore.setOverride({ minMs: 500, maxMs: 500, updatedBy: "admin-1" }), { code: "preview_only" });
+
+  const legacyConfiguredStore = createBotReactionOverrideStore({
+    env: { ...previewRuntimeEnv(), WS_BOT_REACTION_MIN_MS: "500" }
+  });
+  assert.throws(() => legacyConfiguredStore.read(), { code: "preview_only" });
+});
 
 test("autoplay adapter resolves shared autoplay from neutral shared module path", () => {
   const source = fs.readFileSync(new URL("./accepted-bot-autoplay-adapter.mjs", import.meta.url), "utf8");
@@ -287,6 +326,53 @@ test("accepted bot autoplay waits a human-like reaction delay before acting", as
   assert.equal(observed.persist, 1);
 });
 
+test("accepted bot autoplay reads the in-memory override for each next action without interrupting an active sleep", async () => {
+  const store = createBotReactionOverrideStore({ env: previewRuntimeEnv() });
+  store.setOverride({ minMs: 2000, maxMs: 2000, updatedBy: "admin-1" });
+  const observedSleepMs = [];
+  const nowMs = Date.now();
+  let version = 2;
+  const state = {
+    version,
+    tableId: "t-live-override",
+    handId: "h-live-override",
+    phase: "PREFLOP",
+    turnUserId: "bot_2",
+    turnDeadlineAt: nowMs + 20_000,
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state, version }),
+    persistedStateVersion: () => version,
+    tableSnapshot: () => ({ seats: state.seats }),
+    applyAction: () => {
+      version += 1;
+      return { accepted: true, changed: true, replayed: false, stateVersion: version };
+    }
+  };
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    getBotReactionOverride: () => store.getOverrideRange(),
+    now: () => nowMs,
+    sleep: async (ms) => {
+      observedSleepMs.push(ms);
+      if (observedSleepMs.length === 1) {
+        store.setOverride({ minMs: 500, maxMs: 500, updatedBy: "admin-1" });
+      }
+    },
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  await run({ tableId: state.tableId, trigger: "act", requestId: "first-action" });
+  await run({ tableId: state.tableId, trigger: "act", requestId: "second-action" });
+
+  assert.deepEqual(observedSleepMs, [2000, 500]);
+});
+
 test("accepted bot autoplay clamps reaction delay to the remaining turn window", async () => {
   const observed = [];
   const nowMs = Date.now();
@@ -545,6 +631,7 @@ test("accepted bot autoplay exposes final state version when a later step broadc
 });
 
 test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
+  let overrideReads = 0;
   const tableManager = {
     persistedPokerState: () => ({
       version: 2,
@@ -564,6 +651,10 @@ test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
 
   const run = createAcceptedBotAutoplayExecutor({
     tableManager,
+    getBotReactionOverride: () => {
+      overrideReads += 1;
+      return { minMs: 500, maxMs: 500 };
+    },
     persistMutatedState: async () => ({ ok: true }),
     restoreTableFromPersisted: async () => ({ ok: true }),
     broadcastResyncRequired: () => {},
@@ -574,6 +665,7 @@ test("accepted bot autoplay no-ops when next turn is not a bot", async () => {
   assert.equal(result.ok, true);
   assert.equal(result.changed, false);
   assert.equal(result.reason, "turn_not_bot");
+  assert.equal(overrideReads, 0);
 });
 
 test("accepted bot autoplay no-ops on non-action phase boundary", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -1,4 +1,5 @@
 import { recoverFromPersistConflict } from "./persist-conflict-recovery.mjs";
+import { DEFAULT_BOT_REACTION_MAX_MS, DEFAULT_BOT_REACTION_MIN_MS } from "./bot-reaction-override.mjs";
 
 import { TURN_MS } from "../shared/poker-turn-timeout.mjs";
 import { applyAction as applySharedAction } from "../shared/poker-action-reducer.mjs";
@@ -16,8 +17,6 @@ import { computeLegalActions as computeLegacyLegalActions } from "../snapshot-ru
 
 const DEFAULT_SHARED_AUTOPLAY_MODULE_URL = new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url).href;
 const sharedAutoplayModulePromiseByUrl = new Map();
-const DEFAULT_BOT_REACTION_MIN_MS = 2_000;
-const DEFAULT_BOT_REACTION_MAX_MS = 4_000;
 
 const isActionPhase = (phase) => phase === "PREFLOP" || phase === "FLOP" || phase === "TURN" || phase === "RIVER";
 const isCurrentHandPhase = (phase) => isActionPhase(phase) || phase === "SHOWDOWN" || phase === "HAND_DONE";
@@ -346,17 +345,27 @@ function buildSeatUserIdsInOrder(state) {
     .map((seat) => seat.userId.trim());
 }
 
-function getBotAutoplayConfig(env = process.env) {
+function getBotAutoplayConfig(env = process.env, runtimeOverride = null) {
   const hardCapRaw = Number(env?.POKER_BOTS_BOTS_ONLY_HAND_HARD_CAP);
   const botsOnlyHandCompletionHardCap = Number.isInteger(hardCapRaw) && hardCapRaw > 0 ? hardCapRaw : 80;
   const configuredMinRaw = Number(env?.WS_BOT_REACTION_MIN_MS);
   const configuredMaxRaw = Number(env?.WS_BOT_REACTION_MAX_MS);
-  const minReactionMs = Number.isFinite(configuredMinRaw) && configuredMinRaw >= 0
-    ? Math.trunc(configuredMinRaw)
-    : DEFAULT_BOT_REACTION_MIN_MS;
-  const maxReactionMs = Number.isFinite(configuredMaxRaw) && configuredMaxRaw >= 0
-    ? Math.trunc(configuredMaxRaw)
-    : DEFAULT_BOT_REACTION_MAX_MS;
+  const overrideMinRaw = Number(runtimeOverride?.minMs);
+  const overrideMaxRaw = Number(runtimeOverride?.maxMs);
+  const hasValidRuntimeOverride = Number.isInteger(overrideMinRaw)
+    && Number.isInteger(overrideMaxRaw)
+    && overrideMinRaw >= 0
+    && overrideMaxRaw >= overrideMinRaw;
+  const minReactionMs = hasValidRuntimeOverride
+    ? overrideMinRaw
+    : Number.isFinite(configuredMinRaw) && configuredMinRaw >= 0
+      ? Math.trunc(configuredMinRaw)
+      : DEFAULT_BOT_REACTION_MIN_MS;
+  const maxReactionMs = hasValidRuntimeOverride
+    ? overrideMaxRaw
+    : Number.isFinite(configuredMaxRaw) && configuredMaxRaw >= 0
+      ? Math.trunc(configuredMaxRaw)
+      : DEFAULT_BOT_REACTION_MAX_MS;
   return {
     botsOnlyHandCompletionHardCap,
     minReactionMs,
@@ -759,6 +768,7 @@ export function createAcceptedBotStepExecutor({
   broadcastResyncRequired,
   onBotStepPersisted = () => {},
   env = process.env,
+  getBotReactionOverride = () => null,
   random = Math.random,
   now = Date.now,
   sleep = sleepMs,
@@ -922,10 +932,11 @@ export function createAcceptedBotStepExecutor({
           if (!isBotTurnAuthoritatively(tableManager, tableId, botTurnUserId, loopSeatBotMap)) {
             return { ok: false, reason: "turn_not_bot" };
           }
+          const reactionConfig = getBotAutoplayConfig(env, getBotReactionOverride());
           const reactionDelayMs = resolveBotReactionDelayMs({
             state: responseFinalState,
-            minReactionMs: cfg.minReactionMs,
-            maxReactionMs: cfg.maxReactionMs,
+            minReactionMs: reactionConfig.minReactionMs,
+            maxReactionMs: reactionConfig.maxReactionMs,
             random,
             now
           });

--- a/ws-server/poker/runtime/bot-reaction-override.mjs
+++ b/ws-server/poker/runtime/bot-reaction-override.mjs
@@ -1,0 +1,153 @@
+export const DEFAULT_BOT_REACTION_MIN_MS = 2_000;
+export const DEFAULT_BOT_REACTION_MAX_MS = 4_000;
+export const BOT_REACTION_OVERRIDE_MIN_MS = 100;
+export const BOT_REACTION_OVERRIDE_MAX_MS = 10_000;
+
+function normalizeText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseProjectRefFromSupabaseUrl(value) {
+  const raw = normalizeText(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const match = /^([a-z0-9-]+)\.supabase\.co$/i.exec(url.hostname || "");
+    return match ? match[1] : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function parseProjectRefFromDbUrl(value) {
+  const raw = normalizeText(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const username = decodeURIComponent(url.username || "");
+    const host = url.hostname || "";
+    const directMatch = /^db\.([a-z0-9-]+)\.supabase\.co$/i.exec(host);
+    if (directMatch) return directMatch[1];
+    if (!/^[a-z0-9-]+\.pooler\.supabase\.com$/i.test(host)) return null;
+    const poolerMatch = /^postgres\.([a-z0-9-]+)$/i.exec(username);
+    return poolerMatch ? poolerMatch[1] : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+function resolveWsPreviewRuntimeIdentity(env = process.env) {
+  const stageProjectRef = normalizeText(env?.SUPABASE_STAGE_PROJECT_REF);
+  const supabaseProjectRef = parseProjectRefFromSupabaseUrl(env?.SUPABASE_URL || env?.SUPABASE_URL_V2);
+  const databaseProjectRef = parseProjectRefFromDbUrl(env?.SUPABASE_DB_URL);
+  const hasLegacyTimingOverride = normalizeText(env?.WS_BOT_REACTION_MIN_MS) !== ""
+    || normalizeText(env?.WS_BOT_REACTION_MAX_MS) !== "";
+  const ok = (
+    normalizeText(env?.PORT) === "3001"
+    && env?.WS_AUTHORITATIVE_JOIN_ENABLED === "1"
+    && !!stageProjectRef
+    && supabaseProjectRef === stageProjectRef
+    && databaseProjectRef === stageProjectRef
+    && !hasLegacyTimingOverride
+  );
+  return {
+    ok,
+    code: ok ? null : "preview_only"
+  };
+}
+
+function previewOnlyError() {
+  const error = new Error("preview_only");
+  error.code = "preview_only";
+  error.status = 403;
+  return error;
+}
+
+function invalidRangeError() {
+  const error = new Error("invalid_range");
+  error.code = "invalid_range";
+  error.status = 400;
+  return error;
+}
+
+function normalizeOverrideRange(minMs, maxMs) {
+  const min = Number(minMs);
+  const max = Number(maxMs);
+  if (
+    !Number.isInteger(min)
+    || !Number.isInteger(max)
+    || min < BOT_REACTION_OVERRIDE_MIN_MS
+    || max > BOT_REACTION_OVERRIDE_MAX_MS
+    || min > max
+  ) {
+    throw invalidRangeError();
+  }
+  return { minMs: min, maxMs: max };
+}
+
+function normalizeUpdatedBy(value) {
+  const updatedBy = normalizeText(value);
+  if (!updatedBy || updatedBy.length > 128) {
+    const error = new Error("invalid_updated_by");
+    error.code = "invalid_updated_by";
+    error.status = 400;
+    throw error;
+  }
+  return updatedBy;
+}
+
+export function createBotReactionOverrideStore({ env = process.env, now = Date.now } = {}) {
+  const runtimeIdentity = resolveWsPreviewRuntimeIdentity(env);
+  let override = null;
+
+  function requirePreviewRuntime() {
+    if (!runtimeIdentity.ok) throw previewOnlyError();
+  }
+
+  function snapshot() {
+    requirePreviewRuntime();
+    const active = override
+      ? { minMs: override.minMs, maxMs: override.maxMs }
+      : { minMs: DEFAULT_BOT_REACTION_MIN_MS, maxMs: DEFAULT_BOT_REACTION_MAX_MS };
+    return {
+      ok: true,
+      environment: "ws-preview",
+      mode: override ? "override" : "default",
+      defaults: { minMs: DEFAULT_BOT_REACTION_MIN_MS, maxMs: DEFAULT_BOT_REACTION_MAX_MS },
+      active,
+      override: override ? { ...override } : null
+    };
+  }
+
+  return {
+    read: snapshot,
+    getOverrideRange() {
+      return override ? { minMs: override.minMs, maxMs: override.maxMs } : null;
+    },
+    setOverride({ minMs, maxMs, updatedBy } = {}) {
+      requirePreviewRuntime();
+      const range = normalizeOverrideRange(minMs, maxMs);
+      const timestampMs = typeof now === "function" ? Number(now()) : Date.now();
+      const updatedAt = new Date(Number.isFinite(timestampMs) ? timestampMs : Date.now()).toISOString();
+      override = {
+        ...range,
+        updatedAt,
+        updatedBy: normalizeUpdatedBy(updatedBy)
+      };
+      return snapshot();
+    },
+    clearOverride({ updatedBy } = {}) {
+      requirePreviewRuntime();
+      normalizeUpdatedBy(updatedBy);
+      override = null;
+      return snapshot();
+    }
+  };
+}
+
+export {
+  normalizeOverrideRange,
+  parseProjectRefFromDbUrl,
+  parseProjectRefFromSupabaseUrl,
+  resolveWsPreviewRuntimeIdentity
+};

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -19,6 +19,34 @@ const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   import.meta.url
 ).href;
 
+test("internal bot reaction admin endpoint requires its token and fails closed outside WS Preview", async () => {
+  const { port, child } = await createServer({
+    env: {
+      POKER_WS_INTERNAL_TOKEN: "internal-preview-token",
+      WS_BOT_REACTION_MIN_MS: "",
+      WS_BOT_REACTION_MAX_MS: "",
+      WS_AUTHORITATIVE_JOIN_ENABLED: "1",
+      SUPABASE_STAGE_PROJECT_REF: "stage-project-ref",
+      SUPABASE_URL: "https://stage-project-ref.supabase.co",
+      SUPABASE_DB_URL: "postgresql://postgres.stage-project-ref:password@aws-0-eu-central-1.pooler.supabase.com:6543/postgres"
+    }
+  });
+  try {
+    await waitForListening(child, 5000);
+    const unauthorized = await fetch(`http://127.0.0.1:${port}/internal/admin/bot-reaction`);
+    assert.equal(unauthorized.status, 401);
+
+    const blocked = await fetch(`http://127.0.0.1:${port}/internal/admin/bot-reaction`, {
+      headers: { authorization: "Bearer internal-preview-token" }
+    });
+    assert.equal(blocked.status, 403);
+    assert.deepEqual(await blocked.json(), { error: "preview_only" });
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 function getFreePort() {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -14,6 +14,7 @@ import { createTableManager } from "./poker/table/table-manager.mjs";
 import { adaptPersistedBootstrap } from "./poker/bootstrap/persisted-bootstrap-adapter.mjs";
 import { createSessionStore } from "./poker/runtime/session-store.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
+import { createBotReactionOverrideStore } from "./poker/runtime/bot-reaction-override.mjs";
 import { evaluateTableHealth, runTableJanitor, selectOpenTableJanitorBatch } from "./poker/runtime/table-janitor.mjs";
 import { buildStateSnapshotPayload } from "./poker/read-model/state-snapshot.mjs";
 import { buildStatePatch } from "./poker/read-model/state-patch.mjs";
@@ -258,6 +259,7 @@ const lobbySubscribers = new Set();
 const activeLobbyTablesById = new Map();
 const lobbyEmptyJoinableGraceMs = resolveEmptyJoinableGraceMs(process.env.POKER_TABLE_CLOSE_GRACE_MS);
 const internalRuntimeToken = typeof process.env.POKER_WS_INTERNAL_TOKEN === "string" ? process.env.POKER_WS_INTERNAL_TOKEN.trim() : "";
+const botReactionOverrideStore = createBotReactionOverrideStore({ env: process.env });
 let openTableJanitorCursor = null;
 
 function snapshotCacheKey(sessionId, tableId) {
@@ -340,6 +342,7 @@ async function loadAcceptedBotAutoplayExecutor() {
           onBotStepPersisted: ({ tableId }) => {
             broadcastStateSnapshots(tableId);
           },
+          getBotReactionOverride: () => botReactionOverrideStore.getOverrideRange(),
           env: process.env,
           klog: klogSafe
         });
@@ -2251,11 +2254,28 @@ async function sweepTurnTimeoutsAndBroadcast() {
   })));
 }
 
-function readJsonBody(req) {
+function readJsonBody(req, { maxBytes = 64 * 1024 } = {}) {
   return new Promise((resolve, reject) => {
     const chunks = [];
-    req.on("data", (chunk) => chunks.push(chunk));
+    let totalBytes = 0;
+    let tooLarge = false;
+    req.on("data", (chunk) => {
+      if (tooLarge) return;
+      totalBytes += chunk.length;
+      if (totalBytes > maxBytes) {
+        tooLarge = true;
+        chunks.length = 0;
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => {
+      if (tooLarge) {
+        const error = new Error("body_too_large");
+        error.code = "body_too_large";
+        reject(error);
+        return;
+      }
       const raw = Buffer.concat(chunks).toString("utf8");
       if (!raw.trim()) {
         resolve({});
@@ -2269,6 +2289,71 @@ function readJsonBody(req) {
     });
     req.on("error", reject);
   });
+}
+
+function sendInternalJson(res, statusCode, body) {
+  res.writeHead(statusCode, {
+    "content-type": "application/json",
+    "cache-control": "no-store"
+  });
+  res.end(JSON.stringify(body));
+}
+
+function hasExactKeys(payload, allowedKeys) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const allowed = new Set(allowedKeys);
+  return Object.keys(payload).every((key) => allowed.has(key));
+}
+
+async function handleInternalBotReactionConfig(req, res) {
+  if (req.method !== "GET" && req.method !== "POST") {
+    sendInternalJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!internalRuntimeToken) {
+    sendInternalJson(res, 503, { error: "internal_runtime_token_missing" });
+    return;
+  }
+  const authHeader = typeof req.headers?.authorization === "string" ? req.headers.authorization.trim() : "";
+  if (authHeader !== `Bearer ${internalRuntimeToken}`) {
+    sendInternalJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  try {
+    if (req.method === "GET") {
+      sendInternalJson(res, 200, botReactionOverrideStore.read());
+      return;
+    }
+    const payload = await readJsonBody(req, { maxBytes: 1_024 });
+    const mode = typeof payload?.mode === "string" ? payload.mode.trim() : "";
+    let result;
+    if (mode === "override" && hasExactKeys(payload, ["mode", "minMs", "maxMs", "updatedBy"])) {
+      result = botReactionOverrideStore.setOverride({
+        minMs: payload.minMs,
+        maxMs: payload.maxMs,
+        updatedBy: payload.updatedBy
+      });
+    } else if (mode === "default" && hasExactKeys(payload, ["mode", "updatedBy"])) {
+      result = botReactionOverrideStore.clearOverride({ updatedBy: payload.updatedBy });
+    } else {
+      sendInternalJson(res, 400, { error: "invalid_request" });
+      return;
+    }
+    klogSafe("ws_preview_bot_reaction_updated", {
+      mode: result.mode,
+      minMs: result.active.minMs,
+      maxMs: result.active.maxMs,
+      updatedBy: typeof payload.updatedBy === "string" ? payload.updatedBy : null
+    });
+    sendInternalJson(res, 200, result);
+  } catch (error) {
+    const code = error?.code || (error instanceof SyntaxError ? "invalid_json" : "internal_server_error");
+    const statusCode = Number(error?.status) || (code === "body_too_large" || code === "invalid_json" ? 400 : 500);
+    if (statusCode >= 500) {
+      klogSafe("ws_preview_bot_reaction_failed", { code });
+    }
+    sendInternalJson(res, statusCode, { error: code });
+  }
 }
 
 async function handleInternalLobbyMaterialize(req, res) {
@@ -2342,6 +2427,11 @@ async function handleHttpRequest(req, res) {
 
   if (req.url === "/internal/lobby/materialize-table") {
     await handleInternalLobbyMaterialize(req, res);
+    return;
+  }
+
+  if (req.url === "/internal/admin/bot-reaction") {
+    await handleInternalBotReactionConfig(req, res);
     return;
   }
 

--- a/ws-tests/infra-vps-caddy.guard.test.mjs
+++ b/ws-tests/infra-vps-caddy.guard.test.mjs
@@ -32,9 +32,11 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
   assert.match(prod, /respond "OK" 200/);
 
   assert.match(preview, /@healthz path \/healthz/);
+  assert.match(preview, /@botReactionAdmin path \/internal\/admin\/bot-reaction/);
   assert.match(preview, /@ws path \/ws\*/);
   assert.match(preview, /reverse_proxy 127\.0\.0\.1:3001/);
   assert.match(preview, /respond "OK" 200/);
+  assert.doesNotMatch(prod, /internal\/admin\/bot-reaction/);
 });
 
 test("WS PR harness runs the unified infra VPS Caddy guard", () => {

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -54,4 +54,6 @@ test("ws preview deploy remote script rejects non-stage Supabase env", () => {
   assert.match(text, /preview env SUPABASE_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /\*"postgres\.\$stage_ref"\*\|\*"\/\/\$stage_ref\."\*\|\*"\.\$stage_ref\."\*/);
   assert.match(text, /preview env SUPABASE_DB_URL must target SUPABASE_STAGE_PROJECT_REF/);
+  assert.match(text, /preview env file must define POKER_WS_INTERNAL_TOKEN/);
+  assert.match(text, /WS_BOT_REACTION_\(MIN\|MAX\)_MS/);
 });

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -41,6 +41,7 @@ test("ws preview deploy workflow keeps the preview-only manual contract", () => 
   assert.match(text, /https:\/\/ws-preview\.kcswh\.pl\/healthz/);
   assert.match(text, /WS_AUTHORITATIVE_JOIN_ENABLED=1/);
   assert.match(text, /SUPABASE_DB_URL/);
+  assert.match(text, /POKER_WS_INTERNAL_TOKEN/);
   assert.match(text, /node --test ws-tests\/ws-preview-deploy\.workflow\.guard\.test\.mjs/);
   assert.match(text, /node --test ws-tests\/ws-preview-deploy\.remote-shape\.guard\.test\.mjs/);
 
@@ -82,6 +83,8 @@ test("ws preview deploy workflow keeps preview runtime contract and does not man
   assert.match(text, /preview env file must define WS_AUTHORITATIVE_JOIN_ENABLED=1/);
   assert.match(text, /preview env file must define SUPABASE_DB_URL/);
   assert.match(text, /preview env file must define SUPABASE_STAGE_PROJECT_REF/);
+  assert.match(text, /preview env file must define POKER_WS_INTERNAL_TOKEN/);
+  assert.match(text, /must not define legacy WS_BOT_REACTION_MIN_MS or WS_BOT_REACTION_MAX_MS/);
   assert.match(text, /preview env SUPABASE_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env SUPABASE_DB_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /sudo -n bash -c 'true'/);
@@ -128,5 +131,7 @@ test("poker deployment doc states the unified preview Caddy ownership model", ()
   assert.match(text, /WS_AUTHORITATIVE_JOIN_ENABLED=1/);
   assert.match(text, /SUPABASE_DB_URL/);
   assert.match(text, /SUPABASE_STAGE_PROJECT_REF/);
+  assert.match(text, /POKER_WS_INTERNAL_TOKEN/);
+  assert.match(text, /internal\/admin\/bot-reaction/);
   assert.doesNotMatch(text, /Caddyfile\.preview\.example/);
 });


### PR DESCRIPTION
## Summary

- adds an Admin Ops control for the process-local WS Preview poker bot reaction delay
- supports a fixed 100–10000 ms override and Set default for the normal 2000–4000 ms range
- reads the current override immediately before each new bot action without interrupting an existing sleep
- resets automatically on WS restart or deployment; no DB table, migration, timing ENV, or feature-flag service
- keeps human action deadlines, bot strategy, persistence, settlement, and the public WS protocol unchanged

## Security

- reuses the existing Supabase admin guard and same-origin Netlify admin API pattern
- Netlify proxy is restricted to deploy-preview + matching stage Supabase identity
- proxy target is allowlisted to exactly https://ws-preview.kcswh.pl
- the WS process independently requires the exact preview runtime identity and internal bearer token
- Caddy exposes the exact internal route only on ws-preview.kcswh.pl; production Caddy does not expose it
- production WS rejects read and mutation attempts fail-closed

## Runtime and UI

- Admin → Ops shows WS Preview, Default or Override, and the active range
- entering 500 ms sends minMs=500 and maxMs=500
- Set default removes the override instead of storing copied default values
- invalid ranges and unavailable/non-preview backends render controlled local errors

## Deployment

Manual validation requires both:

1. Netlify Deploy Preview for the Admin UI and Netlify Function
2. explicit WS Preview Deploy for the in-memory runtime and internal endpoint

Preview configuration must provide the existing POKER_WS_INTERNAL_BASE_URL=https://ws-preview.kcswh.pl and a matching preview-only POKER_WS_INTERNAL_TOKEN on Netlify and WS Preview. The workflow now fails fast if the WS token is absent or retired timing ENV values are present.

No production deploy, DB migration, or CSP SHA change is required for this PR.

## Validation

- npm test
- npm run syntax
- focused autoplay override/store tests
- focused admin proxy, auth, production fail-closed, Admin UI, Caddy, and preview workflow guard tests
- server behavior check for internal-token enforcement and non-preview rejection

## Breaking impact

No public API or gameplay breaking change. Operationally, WS Preview deployment now requires POKER_WS_INTERNAL_TOKEN and rejects legacy WS_BOT_REACTION_MIN_MS / WS_BOT_REACTION_MAX_MS configuration so the in-memory control remains the sole preview timing override.