### PR TITLE
Fix poker all-in and chip conservation

### DIFF
--- a/netlify/functions/_shared/poker-payout.mjs
+++ b/netlify/functions/_shared/poker-payout.mjs
@@ -18,6 +18,7 @@ const normalizeSidePots = (sidePots) => {
     return {
       amount: normalizePotAmount(pot.amount),
       eligibleUserIds: pot.eligibleUserIds.slice(),
+      ...(typeof pot.returnUserId === "string" && pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
     };
   });
 };
@@ -68,7 +69,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       participantUserIds: seatUserIdsInOrder,
       eligibleUserIds: showdownUserIds
     })
-      .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
+      .map((pot) => ({
+        amount: normalizePotAmount(pot.amount),
+        eligibleUserIds: pot.eligibleUserIds.slice(),
+        ...(pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
+      }));
     if (pots.length === 0) {
       pots = null;
     }
@@ -80,10 +85,25 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
   const nextStacks = { ...state.stacks };
   const potsAwarded = [];
   const winnersUnion = new Set();
+  const seatUserIdSet = new Set(seatUserIdsInOrder);
   let potAwardedTotal = 0;
 
   for (const pot of pots) {
     const amount = normalizePotAmount(pot.amount);
+    const returnUserId = typeof pot.returnUserId === "string" ? pot.returnUserId : "";
+    if (returnUserId) {
+      if (!seatUserIdSet.has(returnUserId) || pot.eligibleUserIds.length !== 1 || pot.eligibleUserIds[0] !== returnUserId) {
+        throw new Error("showdown_invalid_return");
+      }
+      const baseStack = Number(nextStacks[returnUserId] ?? 0);
+      if (!Number.isFinite(baseStack)) {
+        throw new Error("showdown_invalid_stack");
+      }
+      nextStacks[returnUserId] = baseStack + amount;
+      potAwardedTotal += amount;
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      continue;
+    }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
     if (eligible.length === 0) continue;

--- a/netlify/functions/_shared/poker-payout.mjs
+++ b/netlify/functions/_shared/poker-payout.mjs
@@ -106,7 +106,9 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
-    if (eligible.length === 0) continue;
+    if (eligible.length === 0) {
+      throw new Error("showdown_pot_without_eligible_player");
+    }
 
     const players = eligible.map((userId) => ({ userId, holeCards: ensureHoleCardsPresent({ holeCardsByUserId, userId }) }));
     const result = computeShowdown({ community, players });

--- a/netlify/functions/_shared/poker-payout.mjs
+++ b/netlify/functions/_shared/poker-payout.mjs
@@ -63,7 +63,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
 
   let pots = normalizeSidePots(state.sidePots);
   if (!pots && isPlainObject(state.contributionsByUserId)) {
-    pots = buildSidePots({ contributionsByUserId: state.contributionsByUserId, eligibleUserIds: showdownUserIds })
+    pots = buildSidePots({
+      contributionsByUserId: state.contributionsByUserId,
+      participantUserIds: seatUserIdsInOrder,
+      eligibleUserIds: showdownUserIds
+    })
       .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
     if (pots.length === 0) {
       pots = null;

--- a/netlify/functions/_shared/poker-side-pots.mjs
+++ b/netlify/functions/_shared/poker-side-pots.mjs
@@ -5,20 +5,22 @@ const normalizeContribution = (value) => {
   return Math.floor(num);
 };
 
-const normalizeContributions = ({ contributionsByUserId, eligibleUserIds }) => {
-  if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
+const normalizeContributions = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
+  const userIds = Array.isArray(participantUserIds) ? participantUserIds : eligibleUserIds;
+  if (!Array.isArray(userIds) || userIds.length === 0) return [];
   const source = contributionsByUserId && typeof contributionsByUserId === "object"
     ? contributionsByUserId
     : {};
-  return eligibleUserIds.map((userId) => ({
+  return userIds.map((userId) => ({
     userId,
     contribution: normalizeContribution(source[userId]),
   }));
 };
 
-const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
+const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
-  const normalized = normalizeContributions({ contributionsByUserId, eligibleUserIds });
+  const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
+  const eligibleUserIdSet = new Set(eligibleUserIds);
   const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
   if (levels.length === 0) return [];
@@ -33,7 +35,7 @@ const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
     if (amount > 0) {
       pots.push({
         amount,
-        eligibleUserIds: participants,
+        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
         minContribution: prev,
         maxContribution: level,
       });

--- a/netlify/functions/_shared/poker-side-pots.mjs
+++ b/netlify/functions/_shared/poker-side-pots.mjs
@@ -17,16 +17,30 @@ const normalizeContributions = ({ contributionsByUserId, participantUserIds, eli
   }));
 };
 
+const resolveUncalledReturn = (normalized) => {
+  if (!Array.isArray(normalized) || normalized.length < 2) return null;
+  const ranked = normalized.slice().sort((a, b) => b.contribution - a.contribution);
+  const highest = ranked[0];
+  const secondHighestContribution = ranked[1].contribution;
+  if (highest.contribution <= secondHighestContribution) return null;
+  return {
+    userId: highest.userId,
+    amount: highest.contribution - secondHighestContribution,
+    minContribution: secondHighestContribution,
+    maxContribution: highest.contribution,
+  };
+};
+
 const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
-    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
-  ), 0);
+  const uncalledReturn = resolveUncalledReturn(normalized);
   const contestable = normalized.map(({ userId, contribution }) => ({
     userId,
-    contribution: Math.min(contribution, maxEligibleContribution),
+    contribution: uncalledReturn?.userId === userId
+      ? uncalledReturn.minContribution
+      : contribution,
   }));
   const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
@@ -39,26 +53,39 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
     const delta = level - prev;
     const amount = delta * participants.length;
     if (amount > 0) {
-      pots.push({
-        amount,
-        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
-        minContribution: prev,
-        maxContribution: level,
-      });
+      const eligibleForBand = participants.filter((userId) => eligibleUserIdSet.has(userId));
+      if (eligibleForBand.length > 0) {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleForBand,
+          minContribution: prev,
+          maxContribution: level,
+        });
+      } else if (pots.length > 0) {
+        // Matched folded/left contributions remain dead money in the nearest lower contestable pot.
+        const target = pots[pots.length - 1];
+        target.amount += amount;
+        target.maxContribution = level;
+      } else {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleUserIds.slice(),
+          minContribution: prev,
+          maxContribution: level,
+        });
+      }
     }
     prev = level;
   });
-  normalized.forEach(({ userId, contribution }) => {
-    const amount = contribution - maxEligibleContribution;
-    if (amount <= 0) return;
+  if (uncalledReturn) {
     pots.push({
-      amount,
-      eligibleUserIds: [userId],
-      minContribution: maxEligibleContribution,
-      maxContribution: contribution,
-      returnUserId: userId,
+      amount: uncalledReturn.amount,
+      eligibleUserIds: [uncalledReturn.userId],
+      minContribution: uncalledReturn.minContribution,
+      maxContribution: uncalledReturn.maxContribution,
+      returnUserId: uncalledReturn.userId,
     });
-  });
+  }
   return pots;
 };
 

--- a/netlify/functions/_shared/poker-side-pots.mjs
+++ b/netlify/functions/_shared/poker-side-pots.mjs
@@ -21,13 +21,19 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
+  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
+    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
+  ), 0);
+  const contestable = normalized.map(({ userId, contribution }) => ({
+    userId,
+    contribution: Math.min(contribution, maxEligibleContribution),
+  }));
+  const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
-  if (levels.length === 0) return [];
   const pots = [];
   let prev = 0;
   levels.forEach((level) => {
-    const participants = normalized
+    const participants = contestable
       .filter(({ contribution }) => contribution >= level)
       .map(({ userId }) => userId);
     const delta = level - prev;
@@ -41,6 +47,17 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
       });
     }
     prev = level;
+  });
+  normalized.forEach(({ userId, contribution }) => {
+    const amount = contribution - maxEligibleContribution;
+    if (amount <= 0) return;
+    pots.push({
+      amount,
+      eligibleUserIds: [userId],
+      minContribution: maxEligibleContribution,
+      maxContribution: contribution,
+      returnUserId: userId,
+    });
   });
   return pots;
 };

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -79,6 +79,7 @@ run("node", ["tests/poker-table-list.left-player-filter.behavior.test.mjs"], "po
 run("node", ["shared/poker-domain/inactive-cleanup.behavior.test.mjs"], "poker-domain-inactive-cleanup-behavior");
 run("node", ["tests/poker-inactive-cleanup.behavior.test.mjs"], "poker-inactive-cleanup-behavior");
 run("node", ["tests/poker-materialize-settlement.payouts.test.mjs"], "poker-materialize-settlement-payouts");
+run("node", ["tests/poker-dead-money-settlement.behavior.test.mjs"], "poker-dead-money-settlement-behavior");
 
 run("node", ["tests/poker-ui.behavior.test.mjs"], "poker-ui-behavior");
 run("node", ["tests/poker-settlement-presentation.unit.test.mjs"], "poker-settlement-presentation-unit");

--- a/tests/poker-dead-money-settlement.behavior.test.mjs
+++ b/tests/poker-dead-money-settlement.behavior.test.mjs
@@ -78,4 +78,91 @@ for (const [label, awardPotsAtShowdown] of implementations) {
     assert.deepEqual(nextState.stacks, { folded: 90, player_a: 120, player_b: 90 });
     assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);
   });
+
+  test(`${label} settlement does not return matched folded contributions`, () => {
+    const state = {
+      phase: "RIVER",
+      community: ["2H", "3D", "4S", "9C", "KD"],
+      holeCardsByUserId: {
+        folded_a: ["AS", "AD"],
+        folded_b: ["KS", "KH"],
+        active_c: ["QS", "QH"]
+      },
+      foldedByUserId: { folded_a: true, folded_b: true, active_c: false },
+      leftTableByUserId: { folded_a: true, folded_b: true },
+      stacks: { folded_a: 0, folded_b: 0, active_c: 90 },
+      contributionsByUserId: { folded_a: 100, folded_b: 100, active_c: 10 },
+      pot: 210
+    };
+
+    const { nextState } = awardPotsAtShowdown({
+      state,
+      seatUserIdsInOrder: ["folded_a", "folded_b", "active_c"],
+      computeShowdown: () => ({ winners: ["active_c"] }),
+      nowIso: "2026-07-15T00:00:00.000Z"
+    });
+
+    assert.equal(nextState.showdown.potAwardedTotal, 210);
+    assert.deepEqual(nextState.showdown.potsAwarded, [
+      { amount: 210, winners: ["active_c"], eligibleUserIds: ["active_c"] }
+    ]);
+    assert.deepEqual(nextState.stacks, { folded_a: 0, folded_b: 0, active_c: 300 });
+    assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);
+  });
+
+  test(`${label} settlement returns only a unique unmatched top contribution`, () => {
+    const state = {
+      phase: "RIVER",
+      community: ["2H", "3D", "4S", "9C", "KD"],
+      holeCardsByUserId: {
+        folded_a: ["AS", "AD"],
+        folded_b: ["KS", "KH"],
+        active_c: ["QS", "QH"]
+      },
+      foldedByUserId: { folded_a: true, folded_b: true, active_c: false },
+      leftTableByUserId: { folded_a: true, folded_b: true },
+      stacks: { folded_a: 0, folded_b: 20, active_c: 90 },
+      contributionsByUserId: { folded_a: 100, folded_b: 80, active_c: 10 },
+      pot: 190
+    };
+
+    const { nextState } = awardPotsAtShowdown({
+      state,
+      seatUserIdsInOrder: ["folded_a", "folded_b", "active_c"],
+      computeShowdown: () => ({ winners: ["active_c"] }),
+      nowIso: "2026-07-15T00:00:00.000Z"
+    });
+
+    assert.equal(nextState.showdown.potAwardedTotal, 190);
+    assert.deepEqual(nextState.showdown.winners, ["active_c"]);
+    assert.deepEqual(nextState.showdown.potsAwarded, [
+      { amount: 170, winners: ["active_c"], eligibleUserIds: ["active_c"] },
+      { amount: 20, winners: ["folded_a"], eligibleUserIds: ["folded_a"] }
+    ]);
+    assert.deepEqual(nextState.stacks, { folded_a: 20, folded_b: 20, active_c: 260 });
+    assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);
+  });
+
+  test(`${label} settlement fails closed for a persisted pot without a legal recipient`, () => {
+    const state = {
+      phase: "RIVER",
+      community: ["2H", "3D", "4S", "9C", "KD"],
+      holeCardsByUserId: {
+        player_a: ["AS", "AD"],
+        player_b: ["KS", "KH"],
+        folded_c: ["QS", "QH"]
+      },
+      foldedByUserId: { player_a: false, player_b: false, folded_c: true },
+      stacks: { player_a: 90, player_b: 90, folded_c: 90 },
+      sidePots: [{ amount: 30, eligibleUserIds: ["folded_c"] }],
+      pot: 30
+    };
+
+    assert.throws(() => awardPotsAtShowdown({
+      state,
+      seatUserIdsInOrder: ["player_a", "player_b", "folded_c"],
+      computeShowdown: () => ({ winners: ["player_a"] }),
+      nowIso: "2026-07-15T00:00:00.000Z"
+    }), /showdown_pot_without_eligible_player/);
+  });
 }

--- a/tests/poker-dead-money-settlement.behavior.test.mjs
+++ b/tests/poker-dead-money-settlement.behavior.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { awardPotsAtShowdown as awardNetlifyPots } from "../netlify/functions/_shared/poker-payout.mjs";
+import { awardPotsAtShowdown as awardSharedPots } from "../ws-server/poker/shared/settlement/poker-payout.mjs";
+import { awardPotsAtShowdown as awardSnapshotPots } from "../ws-server/poker/snapshot-runtime/poker-payout.mjs";
+
+const implementations = [
+  ["netlify", awardNetlifyPots],
+  ["shared WS", awardSharedPots],
+  ["snapshot WS", awardSnapshotPots]
+];
+
+for (const [label, awardPotsAtShowdown] of implementations) {
+  test(`${label} settlement keeps folded and left contributions as dead money`, () => {
+    const state = {
+      phase: "RIVER",
+      community: ["2H", "3D", "4S", "9C", "KD"],
+      holeCardsByUserId: {
+        folded: ["AS", "AD"],
+        player_b: ["KS", "KH"],
+        player_c: ["QS", "QH"]
+      },
+      foldedByUserId: { folded: true, player_b: false, player_c: false },
+      leftTableByUserId: { folded: true },
+      stacks: { folded: 382, player_b: 10, player_c: 20 },
+      contributionsByUserId: { folded: 1, player_b: 16, player_c: 17 },
+      pot: 34
+    };
+    const computeShowdown = ({ players }) => ({
+      winners: [players.length === 1 ? players[0].userId : "player_b"]
+    });
+
+    const { nextState } = awardPotsAtShowdown({
+      state,
+      seatUserIdsInOrder: ["folded", "player_b", "player_c"],
+      computeShowdown,
+      nowIso: "2026-07-15T00:00:00.000Z"
+    });
+
+    assert.equal(nextState.showdown.potAwardedTotal, 34);
+    assert.equal(nextState.showdown.potsAwarded.reduce((total, pot) => total + pot.amount, 0), 34);
+    assert.equal(nextState.stacks.folded, 382);
+    assert.equal(nextState.stacks.player_b, 43);
+    assert.equal(nextState.stacks.player_c, 21);
+    assert.equal(nextState.showdown.potsAwarded.some((pot) => pot.eligibleUserIds.includes("folded")), false);
+  });
+}

--- a/tests/poker-dead-money-settlement.behavior.test.mjs
+++ b/tests/poker-dead-money-settlement.behavior.test.mjs
@@ -44,4 +44,38 @@ for (const [label, awardPotsAtShowdown] of implementations) {
     assert.equal(nextState.stacks.player_c, 21);
     assert.equal(nextState.showdown.potsAwarded.some((pot) => pot.eligibleUserIds.includes("folded")), false);
   });
+
+  test(`${label} settlement returns a folded player's uncalled excess`, () => {
+    const state = {
+      phase: "RIVER",
+      community: ["2H", "3D", "4S", "9C", "KD"],
+      holeCardsByUserId: {
+        folded: ["AS", "AD"],
+        player_a: ["KS", "KH"],
+        player_b: ["QS", "QH"]
+      },
+      foldedByUserId: { folded: true, player_a: false, player_b: false },
+      leftTableByUserId: { folded: true },
+      stacks: { folded: 0, player_a: 90, player_b: 90 },
+      contributionsByUserId: { folded: 100, player_a: 10, player_b: 10 },
+      pot: 120
+    };
+    const computeShowdown = () => ({ winners: ["player_a"] });
+
+    const { nextState } = awardPotsAtShowdown({
+      state,
+      seatUserIdsInOrder: ["folded", "player_a", "player_b"],
+      computeShowdown,
+      nowIso: "2026-07-15T00:00:00.000Z"
+    });
+
+    assert.equal(nextState.showdown.potAwardedTotal, 120);
+    assert.deepEqual(nextState.showdown.winners, ["player_a"]);
+    assert.deepEqual(nextState.showdown.potsAwarded, [
+      { amount: 30, winners: ["player_a"], eligibleUserIds: ["player_a", "player_b"] },
+      { amount: 90, winners: ["folded"], eligibleUserIds: ["folded"] }
+    ]);
+    assert.deepEqual(nextState.stacks, { folded: 90, player_a: 120, player_b: 90 });
+    assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);
+  });
 }

--- a/tests/poker-side-pots.test.mjs
+++ b/tests/poker-side-pots.test.mjs
@@ -55,6 +55,7 @@ const runTypicalSidePotsTest = () => {
       eligibleUserIds: ["A"],
       minContribution: 50,
       maxContribution: 100,
+      returnUserId: "A",
     },
   ]);
 };
@@ -76,6 +77,7 @@ const runIgnoreNonEligibleTest = () => {
       eligibleUserIds: ["A"],
       minContribution: 10,
       maxContribution: 40,
+      returnUserId: "A",
     },
   ]);
 };
@@ -103,6 +105,7 @@ const runStableOrderingTest = () => {
       eligibleUserIds: ["A"],
       minContribution: 50,
       maxContribution: 100,
+      returnUserId: "A",
     },
   ]);
 };
@@ -124,6 +127,44 @@ const runInvalidContributionsTest = () => {
       eligibleUserIds: ["A"],
       minContribution: 4,
       maxContribution: 10,
+      returnUserId: "A",
+    },
+  ]);
+};
+
+const runMatchedFoldedContributionsTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { folded_a: 100, folded_b: 100, active_c: 10 },
+    participantUserIds: ["folded_a", "folded_b", "active_c"],
+    eligibleUserIds: ["active_c"],
+  });
+  assert.deepEqual(pots, [{
+    amount: 210,
+    eligibleUserIds: ["active_c"],
+    minContribution: 0,
+    maxContribution: 100,
+  }]);
+};
+
+const runUniqueUncalledExcessTest = () => {
+  const pots = buildSidePots({
+    contributionsByUserId: { folded_a: 100, folded_b: 80, active_c: 10 },
+    participantUserIds: ["folded_a", "folded_b", "active_c"],
+    eligibleUserIds: ["active_c"],
+  });
+  assert.deepEqual(pots, [
+    {
+      amount: 170,
+      eligibleUserIds: ["active_c"],
+      minContribution: 0,
+      maxContribution: 80,
+    },
+    {
+      amount: 20,
+      eligibleUserIds: ["folded_a"],
+      minContribution: 80,
+      maxContribution: 100,
+      returnUserId: "folded_a",
     },
   ]);
 };
@@ -135,3 +176,5 @@ runTypicalSidePotsTest();
 runIgnoreNonEligibleTest();
 runStableOrderingTest();
 runInvalidContributionsTest();
+runMatchedFoldedContributionsTest();
+runUniqueUncalledExcessTest();

--- a/ws-server/poker/engine/engine-act.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-act.behavior.test.mjs
@@ -179,8 +179,12 @@ test("engine accepts short-stack CALL as all-in contribution", () => {
 
   assert.equal(shortCall.accepted, true);
   assert.equal(shortCall.reason, null);
-  assert.equal(shortCall.coreState.pokerState.stacks.user_b, 0);
+  assert.equal(shortCall.coreState.pokerState.phase, "SETTLED");
   assert.equal(shortCall.coreState.pokerState.contributionsByUserId.user_b, 5);
+  assert.equal(
+    Object.values(shortCall.coreState.pokerState.handSettlement.payouts).reduce((total, amount) => total + amount, 0),
+    11
+  );
 });
 
 test("engine accepts out-of-turn fold when a seated player wants to leave the hand immediately", () => {

--- a/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
@@ -69,6 +69,32 @@ test("bootstrap maps dealer/SB/BB/UTG deterministically for 2-player and 3-playe
   assert.equal(threePlayer.coreState.pokerState.betThisRoundByUserId.user_c, 2);
 });
 
+test("bootstrap preserves authoritative funded stacks from the public projection", () => {
+  const fundedCore = {
+    ...coreStateBase(),
+    publicStacks: { user_a: 100, user_b: 200, user_c: 200 },
+    seatDetailsByUserId: {
+      user_a: { isBot: false },
+      user_b: { isBot: true },
+      user_c: { isBot: true }
+    }
+  };
+
+  const result = bootstrapCoreStateHand({ tableId: "table_engine", coreState: fundedCore, nowMs: 1_000 });
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.coreState.pokerState.stacks, {
+    user_a: 100,
+    user_b: 199,
+    user_c: 198
+  });
+  assert.equal(
+    Object.values(result.coreState.pokerState.stacks).reduce((total, stack) => total + stack, 0)
+      + result.coreState.pokerState.potTotal,
+    500
+  );
+});
+
 test("bootstrap no-op paths preserve stable result shape", () => {
   const insufficientPlayers = {
     roomId: "table_engine_short",

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -383,7 +383,11 @@ export function bootstrapCoreStateHand({ tableId, coreState, nowMs = Date.now() 
     };
   }
 
-  const bootstrappedState = buildBootstrappedPokerState({ tableId, coreState });
+  const bootstrappedState = buildBootstrappedPokerState({
+    tableId,
+    coreState,
+    startingStacks: coreState?.publicStacks
+  });
   if (!bootstrappedState) {
     return { ok: true, changed: false, bootstrap: "not_eligible", stateVersion: coreState.version, coreState };
   }

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -364,6 +364,54 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.deepEqual(seated.private, { userId: "seated_user", seat: 1, holeCards: ["AH", "AD"] });
 });
 
+test("projectRoomCoreSnapshot does not reveal a folded player's cards for an uncalled return", () => {
+  const snapshot = projectRoomCoreSnapshot({
+    tableId: "table_settled_return",
+    roomId: "table_settled_return",
+    coreState: {
+      seats: { folded_user: 1, player_a: 2, player_b: 3 },
+      pokerState: {
+        roomId: "table_settled_return",
+        handId: "hand_settled_return",
+        phase: "SETTLED",
+        showdown: {
+          handId: "hand_settled_return",
+          winners: ["player_a"],
+          potsAwarded: [
+            { amount: 30, winners: ["player_a"], eligibleUserIds: ["player_a", "player_b"] },
+            { amount: 90, winners: ["folded_user"], eligibleUserIds: ["folded_user"] }
+          ],
+          potAwardedTotal: 120,
+          reason: "computed"
+        },
+        handSettlement: {
+          handId: "hand_settled_return",
+          settledAt: "2026-03-01T00:00:00.000Z",
+          payouts: { folded_user: 90, player_a: 30 }
+        },
+        foldedByUserId: { folded_user: true, player_a: false, player_b: false },
+        holeCardsByUserId: {
+          folded_user: ["AS", "KH"],
+          player_a: ["AH", "AD"],
+          player_b: ["2C", "2D"]
+        }
+      }
+    },
+    members: [
+      { userId: "folded_user", seat: 1 },
+      { userId: "player_a", seat: 2 },
+      { userId: "player_b", seat: 3 }
+    ],
+    userId: "observer",
+    youSeat: null
+  });
+
+  assert.deepEqual(snapshot.showdown.revealedShowdownParticipants, [
+    { userId: "player_a", holeCards: ["AH", "AD"] },
+    { userId: "player_b", holeCards: ["2C", "2D"] }
+  ]);
+});
+
 test("projectRoomCoreSnapshot does not reveal showdown participant cards when hand ends by folds", () => {
   const snapshot = projectRoomCoreSnapshot({
     tableId: "table_settled_folded",

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -270,7 +270,7 @@ function resolveRevealedShowdownParticipants({ statePublic, state }) {
   const comparedUserIds = [];
   const comparedUserIdSet = new Set();
   potsAwarded.forEach((pot) => {
-    if (!pot || typeof pot !== "object" || !Array.isArray(pot.eligibleUserIds)) return;
+    if (!pot || typeof pot !== "object" || !Array.isArray(pot.eligibleUserIds) || pot.eligibleUserIds.length < 2) return;
     pot.eligibleUserIds.forEach((userId) => {
       if (typeof userId !== "string" || !userId || comparedUserIdSet.has(userId)) return;
       comparedUserIdSet.add(userId);

--- a/ws-server/poker/shared/poker-action-reducer.behavior.test.mjs
+++ b/ws-server/poker/shared/poker-action-reducer.behavior.test.mjs
@@ -415,6 +415,51 @@ test("applyAction showdown side-pot payout remains deterministic", () => {
   assert.deepEqual(settled.state.handSettlement.payouts, { u1: 50, u2: 150 });
 });
 
+test("all-in keeps the sole funded opponent on preflop until it calls or folds", () => {
+  const allInPending = stateFixture({
+    seats: [
+      { userId: "human", seatNo: 1 },
+      { userId: "bot_fold", seatNo: 2 },
+      { userId: "bot_call", seatNo: 3 }
+    ],
+    handSeats: [
+      { userId: "human", seatNo: 1 },
+      { userId: "bot_fold", seatNo: 2 },
+      { userId: "bot_call", seatNo: 3 }
+    ],
+    turnUserId: "bot_fold",
+    currentBet: 488,
+    lastRaiseSize: 486,
+    potTotal: 491,
+    stacks: { human: 0, bot_fold: 13, bot_call: 96 },
+    toCallByUserId: { human: 0, bot_fold: 487, bot_call: 486 },
+    betThisRoundByUserId: { human: 488, bot_fold: 1, bot_call: 2 },
+    actedThisRoundByUserId: { human: true, bot_fold: false, bot_call: false },
+    foldedByUserId: { human: false, bot_fold: false, bot_call: false },
+    contributionsByUserId: { human: 488, bot_fold: 1, bot_call: 2 },
+    holeCardsByUserId: {
+      human: ["AS", "AD"],
+      bot_fold: ["KS", "KD"],
+      bot_call: ["QS", "QD"]
+    }
+  });
+
+  const folded = applyAction({ pokerState: allInPending, userId: "bot_fold", action: "FOLD", amount: 0 });
+
+  assert.equal(folded.ok, true);
+  assert.equal(folded.state.phase, "PREFLOP");
+  assert.equal(folded.state.turnUserId, "bot_call");
+  assert.equal(folded.state.toCallByUserId.bot_call, 486);
+
+  const called = applyAction({ pokerState: folded.state, userId: "bot_call", action: "CALL", amount: 0 });
+
+  assert.equal(called.ok, true);
+  assert.equal(called.state.phase, "SETTLED");
+  assert.equal(called.state.contributionsByUserId.bot_call, 98);
+  assert.equal(called.state.showdown.potAwardedTotal, 587);
+  assert.equal(Object.values(called.state.handSettlement.payouts).reduce((total, amount) => total + amount, 0), 587);
+});
+
 test("applyAction terminal-closing replay remains deterministic", () => {
   const riverPending = stateFixture({
     phase: "RIVER",

--- a/ws-server/poker/shared/poker-action-reducer.mjs
+++ b/ws-server/poker/shared/poker-action-reducer.mjs
@@ -201,8 +201,12 @@ function resolveNextTurnUserId(state, currentUserId) {
   }
 
   const activeUserIds = seats.map((seat) => seat.userId).filter((userId) => isSelectableActor(state, userId));
-  if (activeUserIds.length <= 1) {
+  if (activeUserIds.length === 0) {
     return null;
+  }
+  if (activeUserIds.length === 1) {
+    const onlyUserId = activeUserIds[0];
+    return Number(state.toCallByUserId?.[onlyUserId] ?? 0) > 0 ? onlyUserId : null;
   }
 
   const currentIndex = seats.findIndex((seat) => seat.userId === currentUserId);
@@ -232,8 +236,11 @@ function recomputeToCall(state) {
 function isBettingClosed(state) {
   const seats = orderedSeats(state);
   const active = seats.filter((seat) => isSelectableActor(state, seat.userId));
-  if (active.length <= 1) {
+  if (active.length === 0) {
     return true;
+  }
+  if (active.length === 1) {
+    return Number(state.toCallByUserId?.[active[0].userId] ?? 0) === 0;
   }
 
   const allMatched = active.every((seat) => Number(state.toCallByUserId?.[seat.userId] ?? 0) === 0);
@@ -349,6 +356,20 @@ function advanceStreetIfClosed(state) {
   return true;
 }
 
+function advanceClosedStreets(state, nowIso) {
+  let advanced = false;
+  while (isBettingClosed(state)) {
+    if (state.phase === "RIVER") {
+      return { advanced: true, settled: true, state: settleHandState(state, nowIso) };
+    }
+    if (!advanceStreetIfClosed(state)) {
+      break;
+    }
+    advanced = true;
+  }
+  return { advanced, settled: false, state };
+}
+
 export function applyAction({ pokerState, userId, action, amount, nowIso = "1970-01-01T00:00:00.000Z" }) {
   if (!pokerState || typeof pokerState !== "object" || Array.isArray(pokerState)) {
     return { ok: false, reason: "invalid_state" };
@@ -454,8 +475,15 @@ export function applyAction({ pokerState, userId, action, amount, nowIso = "1970
     };
   }
 
-  const closedRound = advanceStreetIfClosed(nextState);
-  if (!closedRound) {
+  const progression = advanceClosedStreets(nextState, nowIso);
+  if (progression.settled) {
+    return {
+      ok: true,
+      action: normalizedAction,
+      state: progression.state
+    };
+  }
+  if (!progression.advanced) {
     nextState.turnUserId = resolveNextTurnUserId(nextState, userId);
   }
 

--- a/ws-server/poker/shared/settlement/poker-payout.mjs
+++ b/ws-server/poker/shared/settlement/poker-payout.mjs
@@ -18,6 +18,7 @@ const normalizeSidePots = (sidePots) => {
     return {
       amount: normalizePotAmount(pot.amount),
       eligibleUserIds: pot.eligibleUserIds.slice(),
+      ...(typeof pot.returnUserId === "string" && pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
     };
   });
 };
@@ -74,7 +75,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       participantUserIds: seatUserIdsInOrder,
       eligibleUserIds: showdownUserIds
     })
-      .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
+      .map((pot) => ({
+        amount: normalizePotAmount(pot.amount),
+        eligibleUserIds: pot.eligibleUserIds.slice(),
+        ...(pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
+      }));
     if (pots.length === 0) {
       pots = null;
     }
@@ -87,10 +92,25 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
   const potsAwarded = [];
   const handsByUserId = {};
   const winnersUnion = new Set();
+  const seatUserIdSet = new Set(seatUserIdsInOrder);
   let potAwardedTotal = 0;
 
   for (const pot of pots) {
     const amount = normalizePotAmount(pot.amount);
+    const returnUserId = typeof pot.returnUserId === "string" ? pot.returnUserId : "";
+    if (returnUserId) {
+      if (!seatUserIdSet.has(returnUserId) || pot.eligibleUserIds.length !== 1 || pot.eligibleUserIds[0] !== returnUserId) {
+        throw new Error("showdown_invalid_return");
+      }
+      const baseStack = Number(nextStacks[returnUserId] ?? 0);
+      if (!Number.isFinite(baseStack)) {
+        throw new Error("showdown_invalid_stack");
+      }
+      nextStacks[returnUserId] = baseStack + amount;
+      potAwardedTotal += amount;
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      continue;
+    }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
     if (eligible.length === 0) continue;

--- a/ws-server/poker/shared/settlement/poker-payout.mjs
+++ b/ws-server/poker/shared/settlement/poker-payout.mjs
@@ -113,7 +113,9 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
-    if (eligible.length === 0) continue;
+    if (eligible.length === 0) {
+      throw new Error("showdown_pot_without_eligible_player");
+    }
 
     const players = eligible.map((userId) => ({ userId, holeCards: ensureHoleCardsPresent({ holeCardsByUserId, userId }) }));
     const result = computeShowdown({ community, players });

--- a/ws-server/poker/shared/settlement/poker-payout.mjs
+++ b/ws-server/poker/shared/settlement/poker-payout.mjs
@@ -69,7 +69,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
 
   let pots = normalizeSidePots(state.sidePots);
   if (!pots && isPlainObject(state.contributionsByUserId)) {
-    pots = buildSidePots({ contributionsByUserId: state.contributionsByUserId, eligibleUserIds: showdownUserIds })
+    pots = buildSidePots({
+      contributionsByUserId: state.contributionsByUserId,
+      participantUserIds: seatUserIdsInOrder,
+      eligibleUserIds: showdownUserIds
+    })
       .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
     if (pots.length === 0) {
       pots = null;

--- a/ws-server/poker/shared/settlement/poker-side-pots.mjs
+++ b/ws-server/poker/shared/settlement/poker-side-pots.mjs
@@ -5,20 +5,22 @@ const normalizeContribution = (value) => {
   return Math.floor(num);
 };
 
-const normalizeContributions = ({ contributionsByUserId, eligibleUserIds }) => {
-  if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
+const normalizeContributions = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
+  const userIds = Array.isArray(participantUserIds) ? participantUserIds : eligibleUserIds;
+  if (!Array.isArray(userIds) || userIds.length === 0) return [];
   const source = contributionsByUserId && typeof contributionsByUserId === "object"
     ? contributionsByUserId
     : {};
-  return eligibleUserIds.map((userId) => ({
+  return userIds.map((userId) => ({
     userId,
     contribution: normalizeContribution(source[userId]),
   }));
 };
 
-const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
+const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
-  const normalized = normalizeContributions({ contributionsByUserId, eligibleUserIds });
+  const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
+  const eligibleUserIdSet = new Set(eligibleUserIds);
   const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
   if (levels.length === 0) return [];
@@ -33,7 +35,7 @@ const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
     if (amount > 0) {
       pots.push({
         amount,
-        eligibleUserIds: participants,
+        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
         minContribution: prev,
         maxContribution: level,
       });

--- a/ws-server/poker/shared/settlement/poker-side-pots.mjs
+++ b/ws-server/poker/shared/settlement/poker-side-pots.mjs
@@ -17,16 +17,30 @@ const normalizeContributions = ({ contributionsByUserId, participantUserIds, eli
   }));
 };
 
+const resolveUncalledReturn = (normalized) => {
+  if (!Array.isArray(normalized) || normalized.length < 2) return null;
+  const ranked = normalized.slice().sort((a, b) => b.contribution - a.contribution);
+  const highest = ranked[0];
+  const secondHighestContribution = ranked[1].contribution;
+  if (highest.contribution <= secondHighestContribution) return null;
+  return {
+    userId: highest.userId,
+    amount: highest.contribution - secondHighestContribution,
+    minContribution: secondHighestContribution,
+    maxContribution: highest.contribution,
+  };
+};
+
 const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
-    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
-  ), 0);
+  const uncalledReturn = resolveUncalledReturn(normalized);
   const contestable = normalized.map(({ userId, contribution }) => ({
     userId,
-    contribution: Math.min(contribution, maxEligibleContribution),
+    contribution: uncalledReturn?.userId === userId
+      ? uncalledReturn.minContribution
+      : contribution,
   }));
   const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
@@ -39,26 +53,39 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
     const delta = level - prev;
     const amount = delta * participants.length;
     if (amount > 0) {
-      pots.push({
-        amount,
-        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
-        minContribution: prev,
-        maxContribution: level,
-      });
+      const eligibleForBand = participants.filter((userId) => eligibleUserIdSet.has(userId));
+      if (eligibleForBand.length > 0) {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleForBand,
+          minContribution: prev,
+          maxContribution: level,
+        });
+      } else if (pots.length > 0) {
+        // Matched folded/left contributions remain dead money in the nearest lower contestable pot.
+        const target = pots[pots.length - 1];
+        target.amount += amount;
+        target.maxContribution = level;
+      } else {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleUserIds.slice(),
+          minContribution: prev,
+          maxContribution: level,
+        });
+      }
     }
     prev = level;
   });
-  normalized.forEach(({ userId, contribution }) => {
-    const amount = contribution - maxEligibleContribution;
-    if (amount <= 0) return;
+  if (uncalledReturn) {
     pots.push({
-      amount,
-      eligibleUserIds: [userId],
-      minContribution: maxEligibleContribution,
-      maxContribution: contribution,
-      returnUserId: userId,
+      amount: uncalledReturn.amount,
+      eligibleUserIds: [uncalledReturn.userId],
+      minContribution: uncalledReturn.minContribution,
+      maxContribution: uncalledReturn.maxContribution,
+      returnUserId: uncalledReturn.userId,
     });
-  });
+  }
   return pots;
 };
 

--- a/ws-server/poker/shared/settlement/poker-side-pots.mjs
+++ b/ws-server/poker/shared/settlement/poker-side-pots.mjs
@@ -21,13 +21,19 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
+  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
+    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
+  ), 0);
+  const contestable = normalized.map(({ userId, contribution }) => ({
+    userId,
+    contribution: Math.min(contribution, maxEligibleContribution),
+  }));
+  const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
-  if (levels.length === 0) return [];
   const pots = [];
   let prev = 0;
   levels.forEach((level) => {
-    const participants = normalized
+    const participants = contestable
       .filter(({ contribution }) => contribution >= level)
       .map(({ userId }) => userId);
     const delta = level - prev;
@@ -41,6 +47,17 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
       });
     }
     prev = level;
+  });
+  normalized.forEach(({ userId, contribution }) => {
+    const amount = contribution - maxEligibleContribution;
+    if (amount <= 0) return;
+    pots.push({
+      amount,
+      eligibleUserIds: [userId],
+      minContribution: maxEligibleContribution,
+      maxContribution: contribution,
+      returnUserId: userId,
+    });
   });
   return pots;
 };

--- a/ws-server/poker/snapshot-runtime/poker-payout.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-payout.mjs
@@ -18,6 +18,7 @@ const normalizeSidePots = (sidePots) => {
     return {
       amount: normalizePotAmount(pot.amount),
       eligibleUserIds: pot.eligibleUserIds.slice(),
+      ...(typeof pot.returnUserId === "string" && pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
     };
   });
 };
@@ -74,7 +75,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       participantUserIds: seatUserIdsInOrder,
       eligibleUserIds: showdownUserIds
     })
-      .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
+      .map((pot) => ({
+        amount: normalizePotAmount(pot.amount),
+        eligibleUserIds: pot.eligibleUserIds.slice(),
+        ...(pot.returnUserId ? { returnUserId: pot.returnUserId } : {}),
+      }));
     if (pots.length === 0) {
       pots = null;
     }
@@ -87,10 +92,25 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
   const potsAwarded = [];
   const handsByUserId = {};
   const winnersUnion = new Set();
+  const seatUserIdSet = new Set(seatUserIdsInOrder);
   let potAwardedTotal = 0;
 
   for (const pot of pots) {
     const amount = normalizePotAmount(pot.amount);
+    const returnUserId = typeof pot.returnUserId === "string" ? pot.returnUserId : "";
+    if (returnUserId) {
+      if (!seatUserIdSet.has(returnUserId) || pot.eligibleUserIds.length !== 1 || pot.eligibleUserIds[0] !== returnUserId) {
+        throw new Error("showdown_invalid_return");
+      }
+      const baseStack = Number(nextStacks[returnUserId] ?? 0);
+      if (!Number.isFinite(baseStack)) {
+        throw new Error("showdown_invalid_stack");
+      }
+      nextStacks[returnUserId] = baseStack + amount;
+      potAwardedTotal += amount;
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      continue;
+    }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
     if (eligible.length === 0) continue;

--- a/ws-server/poker/snapshot-runtime/poker-payout.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-payout.mjs
@@ -113,7 +113,9 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);
     const eligible = seatUserIdsInOrder.filter((userId) => showdownUserIdSet.has(userId) && eligibleSet.has(userId));
-    if (eligible.length === 0) continue;
+    if (eligible.length === 0) {
+      throw new Error("showdown_pot_without_eligible_player");
+    }
 
     const players = eligible.map((userId) => ({ userId, holeCards: ensureHoleCardsPresent({ holeCardsByUserId, userId }) }));
     const result = computeShowdown({ community, players });

--- a/ws-server/poker/snapshot-runtime/poker-payout.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-payout.mjs
@@ -69,7 +69,11 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
 
   let pots = normalizeSidePots(state.sidePots);
   if (!pots && isPlainObject(state.contributionsByUserId)) {
-    pots = buildSidePots({ contributionsByUserId: state.contributionsByUserId, eligibleUserIds: showdownUserIds })
+    pots = buildSidePots({
+      contributionsByUserId: state.contributionsByUserId,
+      participantUserIds: seatUserIdsInOrder,
+      eligibleUserIds: showdownUserIds
+    })
       .map((pot) => ({ amount: normalizePotAmount(pot.amount), eligibleUserIds: pot.eligibleUserIds.slice() }));
     if (pots.length === 0) {
       pots = null;

--- a/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
@@ -5,20 +5,22 @@ const normalizeContribution = (value) => {
   return Math.floor(num);
 };
 
-const normalizeContributions = ({ contributionsByUserId, eligibleUserIds }) => {
-  if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
+const normalizeContributions = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
+  const userIds = Array.isArray(participantUserIds) ? participantUserIds : eligibleUserIds;
+  if (!Array.isArray(userIds) || userIds.length === 0) return [];
   const source = contributionsByUserId && typeof contributionsByUserId === "object"
     ? contributionsByUserId
     : {};
-  return eligibleUserIds.map((userId) => ({
+  return userIds.map((userId) => ({
     userId,
     contribution: normalizeContribution(source[userId]),
   }));
 };
 
-const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
+const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
-  const normalized = normalizeContributions({ contributionsByUserId, eligibleUserIds });
+  const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
+  const eligibleUserIdSet = new Set(eligibleUserIds);
   const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
   if (levels.length === 0) return [];
@@ -33,7 +35,7 @@ const buildSidePots = ({ contributionsByUserId, eligibleUserIds }) => {
     if (amount > 0) {
       pots.push({
         amount,
-        eligibleUserIds: participants,
+        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
         minContribution: prev,
         maxContribution: level,
       });

--- a/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
@@ -17,16 +17,30 @@ const normalizeContributions = ({ contributionsByUserId, participantUserIds, eli
   }));
 };
 
+const resolveUncalledReturn = (normalized) => {
+  if (!Array.isArray(normalized) || normalized.length < 2) return null;
+  const ranked = normalized.slice().sort((a, b) => b.contribution - a.contribution);
+  const highest = ranked[0];
+  const secondHighestContribution = ranked[1].contribution;
+  if (highest.contribution <= secondHighestContribution) return null;
+  return {
+    userId: highest.userId,
+    amount: highest.contribution - secondHighestContribution,
+    minContribution: secondHighestContribution,
+    maxContribution: highest.contribution,
+  };
+};
+
 const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUserIds }) => {
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
-    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
-  ), 0);
+  const uncalledReturn = resolveUncalledReturn(normalized);
   const contestable = normalized.map(({ userId, contribution }) => ({
     userId,
-    contribution: Math.min(contribution, maxEligibleContribution),
+    contribution: uncalledReturn?.userId === userId
+      ? uncalledReturn.minContribution
+      : contribution,
   }));
   const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
@@ -39,26 +53,39 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
     const delta = level - prev;
     const amount = delta * participants.length;
     if (amount > 0) {
-      pots.push({
-        amount,
-        eligibleUserIds: participants.filter((userId) => eligibleUserIdSet.has(userId)),
-        minContribution: prev,
-        maxContribution: level,
-      });
+      const eligibleForBand = participants.filter((userId) => eligibleUserIdSet.has(userId));
+      if (eligibleForBand.length > 0) {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleForBand,
+          minContribution: prev,
+          maxContribution: level,
+        });
+      } else if (pots.length > 0) {
+        // Matched folded/left contributions remain dead money in the nearest lower contestable pot.
+        const target = pots[pots.length - 1];
+        target.amount += amount;
+        target.maxContribution = level;
+      } else {
+        pots.push({
+          amount,
+          eligibleUserIds: eligibleUserIds.slice(),
+          minContribution: prev,
+          maxContribution: level,
+        });
+      }
     }
     prev = level;
   });
-  normalized.forEach(({ userId, contribution }) => {
-    const amount = contribution - maxEligibleContribution;
-    if (amount <= 0) return;
+  if (uncalledReturn) {
     pots.push({
-      amount,
-      eligibleUserIds: [userId],
-      minContribution: maxEligibleContribution,
-      maxContribution: contribution,
-      returnUserId: userId,
+      amount: uncalledReturn.amount,
+      eligibleUserIds: [uncalledReturn.userId],
+      minContribution: uncalledReturn.minContribution,
+      maxContribution: uncalledReturn.maxContribution,
+      returnUserId: uncalledReturn.userId,
     });
-  });
+  }
   return pots;
 };
 

--- a/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-side-pots.mjs
@@ -21,13 +21,19 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
   if (!Array.isArray(eligibleUserIds) || eligibleUserIds.length === 0) return [];
   const normalized = normalizeContributions({ contributionsByUserId, participantUserIds, eligibleUserIds });
   const eligibleUserIdSet = new Set(eligibleUserIds);
-  const levels = [...new Set(normalized.map(({ contribution }) => contribution).filter((value) => value > 0))]
+  const maxEligibleContribution = normalized.reduce((max, { userId, contribution }) => (
+    eligibleUserIdSet.has(userId) ? Math.max(max, contribution) : max
+  ), 0);
+  const contestable = normalized.map(({ userId, contribution }) => ({
+    userId,
+    contribution: Math.min(contribution, maxEligibleContribution),
+  }));
+  const levels = [...new Set(contestable.map(({ contribution }) => contribution).filter((value) => value > 0))]
     .sort((a, b) => a - b);
-  if (levels.length === 0) return [];
   const pots = [];
   let prev = 0;
   levels.forEach((level) => {
-    const participants = normalized
+    const participants = contestable
       .filter(({ contribution }) => contribution >= level)
       .map(({ userId }) => userId);
     const delta = level - prev;
@@ -41,6 +47,17 @@ const buildSidePots = ({ contributionsByUserId, participantUserIds, eligibleUser
       });
     }
     prev = level;
+  });
+  normalized.forEach(({ userId, contribution }) => {
+    const amount = contribution - maxEligibleContribution;
+    if (amount <= 0) return;
+    pots.push({
+      amount,
+      eligibleUserIds: [userId],
+      minContribution: maxEligibleContribution,
+      maxContribution: contribution,
+      returnUserId: userId,
+    });
   });
   return pots;
 };

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2322,7 +2322,7 @@ function coherentPersistedBootstrapFixtures(fixtures) {
       : {};
     const fixtureSeatRows = Array.isArray(fixture?.seatRows) ? fixture.seatRows : [];
     for (const seat of fixtureSeatRows) {
-      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
+      if (String(seat?.status || "").toUpperCase() !== "ACTIVE") continue;
       const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
       if (!userId || Object.prototype.hasOwnProperty.call(stacks, userId)) continue;
       const seatStack = Number(seat?.stack);
@@ -2330,7 +2330,7 @@ function coherentPersistedBootstrapFixtures(fixtures) {
       stacks[userId] = hasSeatStack ? seatStack : 100;
     }
     const coherentSeatRows = fixtureSeatRows.map((seat) => {
-      if (seat?.is_bot === true || String(seat?.status || "").toUpperCase() !== "ACTIVE") return seat;
+      if (String(seat?.status || "").toUpperCase() !== "ACTIVE") return seat;
       const userId = typeof seat?.user_id === "string" ? seat.user_id.trim() : "";
       const seatStack = Number(seat?.stack);
       const stateStack = Number(stacks[userId]);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2006,7 +2006,7 @@ async function listStaleActiveHumanSeatCandidates({ limit = 25 } = {}) {
   const cutoffIso = new Date(Date.now() - activeSeatFreshMs).toISOString();
   try {
     const beginSqlWs = await loadBeginSqlWs();
-    return beginSqlWs(async (tx) => {
+    return await beginSqlWs(async (tx) => {
       const rows = await tx.unsafe(
         `select s.table_id, s.user_id
          from public.poker_seats s


### PR DESCRIPTION
## Summary

- preserve authoritative funded stacks when the first poker hand is bootstrapped, so bots funded with 200 CH do not enter the engine with 100 CH
- keep folded and departed players matched contributions in main and side pots while excluding those players from winner eligibility
- return only the unique highest contribution above the second-highest contribution as uncalled chips
- merge matched folded-only bands into the nearest lower contestable pot instead of refunding covered bets or creating a pot without a legal recipient
- keep a funded opponent on the current betting street after another player goes all-in until the opponent calls or folds
- automatically run out the remaining board and settle once no funded player can take another action

## Root causes

Production evidence from table fd4f7cbb showed that the reducer treated a betting round as closed whenever only one funded player remained, even when that player still owed a call. The engine advanced to later streets, where the bot could check or make small 1–2 CH bets instead of answering the all-in.

Two related chip-conservation issues were also confirmed during the previous smoke test: bootstrap ignored the ledger-backed publicStacks, and side-pot construction used showdown eligibility as the contributor list, dropping folded or left dead money.

Review then exposed a broader leave-during-hand accounting edge. Comparing every folded contribution only with the largest eligible contribution could refund a covered bet. For example, 100 / 100 / 10 must not refund either 100 contributor, while 100 / 80 / 10 has only one true uncalled amount of 20. The implementation now derives at most one return from the unique highest contribution over the second-highest contribution across all participants. Any remaining matched band with no eligible contributor stays dead money and is folded into the nearest lower pot with legal recipients.

## Accounting invariants

- sum of awarded pots and explicit returns equals the sum of normalized contributions
- at most one uncalled return exists, owned by the unique highest contributor
- tied highest contributions never produce a return
- covered folded or left contributions are never refunded
- generated contestable pots always have at least one legal recipient
- persisted invalid pots without a legal recipient fail closed instead of silently losing chips

## Validation

- full npm test
- WS server behavior suite: 88 of 88 passed
- reducer, engine action, timeout, autoplay, table-manager, bootstrap, side-pot, payout, settlement, snapshot, and UI behavior suites
- regression coverage across all three payout implementations for 100 / 100 / 10, 100 / 80 / 10, and 100 / 10 / 10 contribution shapes
- exhaustive local invariant check across 9,375 contribution and eligibility combinations
- return recipients remain excluded from global showdown winners, and one-person return bands cannot reveal folded hole cards

## Manual verification

WS Preview Deploy is required because the PR changes ws-server.

1. Start a new persistent table and confirm bot stacks match their funded buy-ins.
2. Go all-in while two bots remain; after one folds, the other must call or fold before the board advances.
3. If the remaining bot short-calls, confirm the board runs out automatically and the hand settles without later 1–2 CH betting.
4. Confirm folded matched contributions remain included in the final awarded amount.
5. Confirm only a unique unmatched top excess is displayed and accounted as Returned.

## Deployment and breaking impact

- no database migration
- no new environment variable
- no CSP change
- additive settlement behavior: a true uncalled excess uses the existing one-recipient return shape
- intended economic behavior change: new hands use actual funded bot stacks, covered folded contributions stay in the pot, and every contributed chip is either contested or explicitly returned
