### PR TITLE
Preserve Admin observability during CH maintenance

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -128,7 +128,13 @@
           </div>
         </section>
 
+        <section class="xp-card" id="adminUnavailable" hidden aria-labelledby="adminUnavailableTitle">
+          <h2 class="xp-card__title" id="adminUnavailableTitle">Admin temporarily unavailable</h2>
+          <p class="admin-empty" id="adminUnavailableText">Admin authorization could not be verified. Try again after the service is available.</p>
+        </section>
+
         <section id="adminApp" hidden>
+          <div class="admin-status" id="adminMaintenance" data-tone="error" role="status" hidden>Economy maintenance is active. CH and poker mutations are disabled; only read-only Ops observability is available.</div>
           <section class="xp-card admin-tabbar" aria-labelledby="adminTabBarTitle">
             <h2 class="visually-hidden" id="adminTabBarTitle">Admin sections</h2>
             <div class="admin-tabs" role="tablist" aria-label="Admin panel sections">

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -6,6 +6,7 @@
   var BONUS_CAMPAIGN_CODE_RE = /^[a-z0-9][a-z0-9_-]*$/;
   var state = {
     adminUserId: null,
+    maintenance: false,
     activeTab: "users",
     users: {
       page: 1,
@@ -82,6 +83,9 @@
     nodes.status = doc.getElementById("adminStatus");
     nodes.unauthorized = doc.getElementById("adminUnauthorized");
     nodes.unauthorizedText = doc.getElementById("adminUnauthorizedText");
+    nodes.unavailable = doc.getElementById("adminUnavailable");
+    nodes.unavailableText = doc.getElementById("adminUnavailableText");
+    nodes.maintenance = doc.getElementById("adminMaintenance");
     nodes.app = doc.getElementById("adminApp");
     nodes.tabs = Array.prototype.slice.call(doc.querySelectorAll("[data-admin-tab]"));
     nodes.panels = Array.prototype.slice.call(doc.querySelectorAll("[data-admin-panel]"));
@@ -272,15 +276,29 @@
 
   function showUnauthorized(message){
     setVisible(nodes.app, false);
+    setVisible(nodes.unavailable, false);
     setVisible(nodes.unauthorized, true);
     if (nodes.unauthorizedText){
       nodes.unauthorizedText.textContent = message || t("adminUnauthorized", "This page is available only for allowlisted admin accounts.");
     }
   }
 
+  function showUnavailable(message){
+    setVisible(nodes.app, false);
+    setVisible(nodes.unauthorized, false);
+    setVisible(nodes.unavailable, true);
+    if (nodes.unavailableText){
+      nodes.unavailableText.textContent = message || "Admin authorization could not be verified. Try again after the service is available.";
+    }
+  }
+
   function showApp(){
     setVisible(nodes.unauthorized, false);
+    setVisible(nodes.unavailable, false);
     setVisible(nodes.app, true);
+    setVisible(nodes.maintenance, state.maintenance);
+    if (nodes.opsRunReconciler) nodes.opsRunReconciler.disabled = state.maintenance;
+    if (nodes.opsRunStaleSweep) nodes.opsRunStaleSweep.disabled = state.maintenance;
   }
 
   function buildQuery(params){
@@ -1161,6 +1179,8 @@
         };
       })) : "";
     }
+    if (nodes.opsRunReconciler) nodes.opsRunReconciler.disabled = state.maintenance;
+    if (nodes.opsRunStaleSweep) nodes.opsRunStaleSweep.disabled = state.maintenance;
   }
 
   function formatReactionRange(range){
@@ -1175,7 +1195,7 @@
     var value = state.ops.botReaction;
     var errorCode = state.ops.botReactionError;
     var pending = state.ops.botReactionPending === true;
-    var unavailable = errorCode === "preview_only" || errorCode === "ws_preview_unavailable" || errorCode === "ws_preview_timeout";
+    var unavailable = state.maintenance || errorCode === "maintenance" || errorCode === "preview_only" || errorCode === "ws_preview_unavailable" || errorCode === "ws_preview_timeout";
     if (nodes.opsBotReactionSummary){
       if (value){
         var mode = value.mode === "override" ? "Override" : "Default";
@@ -1189,7 +1209,9 @@
           "</div>"
         ].join("");
       } else if (errorCode){
-        var errorText = errorCode === "preview_only"
+        var errorText = errorCode === "maintenance"
+          ? "Disabled while CHIPS_ENABLED is off."
+          : errorCode === "preview_only"
           ? "Available only on WS Preview."
           : errorCode === "ws_preview_timeout"
             ? "WS Preview did not respond in time."
@@ -1270,7 +1292,11 @@
 
   function renderTabs(){
     (nodes.tabs || []).forEach(function(button){
-      var isActive = button.getAttribute("data-admin-tab") === state.activeTab;
+      var tab = button.getAttribute("data-admin-tab");
+      var maintenanceDisabled = state.maintenance && tab !== "ops";
+      var isActive = tab === state.activeTab;
+      button.disabled = maintenanceDisabled;
+      button.setAttribute("aria-disabled", maintenanceDisabled ? "true" : "false");
       button.classList.toggle("is-active", isActive);
       button.setAttribute("aria-selected", isActive ? "true" : "false");
       button.setAttribute("tabindex", isActive ? "0" : "-1");
@@ -1283,6 +1309,7 @@
   }
 
   function setActiveTab(tab){
+    if (state.maintenance && tab !== "ops") tab = "ops";
     if (!tab || state.activeTab === tab && tab !== "ops") {
       renderTabs();
       return;
@@ -1302,12 +1329,22 @@
     try {
       var me = await apiFetch("/.netlify/functions/admin-me", { method: "GET" });
       state.adminUserId = me.userId || null;
+      state.maintenance = me.maintenance === true || me.chipsEnabled === false;
       showApp();
       setStatus("", "");
-      loadUsers();
+      if (state.maintenance){
+        setActiveTab("ops");
+      } else {
+        loadUsers();
+      }
     } catch (err){
       state.adminUserId = null;
-      showUnauthorized(getUnauthorizedMessage(err));
+      state.maintenance = false;
+      if (err && (err.status === 401 || (err.status === 403 && err.code === "admin_required"))){
+        showUnauthorized(getUnauthorizedMessage(err));
+      } else {
+        showUnavailable("Admin access verification is temporarily unavailable. Try again after the service is available.");
+      }
       setStatus("", "");
     }
   }
@@ -1658,7 +1695,7 @@
       var results = await Promise.allSettled([
         apiFetch("/.netlify/functions/admin-stage-identity", { method: "GET" }),
         apiFetch("/.netlify/functions/admin-ops-summary", { method: "GET" }),
-        apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" })
+        state.maintenance ? Promise.resolve(null) : apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" })
       ]);
       if (results[0].status === "fulfilled"){
         state.ops.identity = results[0].value || null;
@@ -1673,7 +1710,11 @@
       }
       var payload = results[1].value || {};
       state.ops.summary = payload;
-      if (results[2].status === "fulfilled"){
+      if (state.maintenance){
+        state.ops.botReaction = null;
+        state.ops.botReactionError = "maintenance";
+        state.ops.botReactionMessage = "";
+      } else if (results[2].status === "fulfilled"){
         state.ops.botReaction = results[2].value || null;
         state.ops.botReactionError = null;
         state.ops.botReactionMessage = "";
@@ -1705,6 +1746,10 @@
 
   async function submitBotReactionOverride(event){
     event.preventDefault();
+    if (state.maintenance){
+      setStatus("CH and poker mutations are disabled during maintenance.", "error");
+      return;
+    }
     var delayMs = Number(nodes.opsBotReactionDelay && nodes.opsBotReactionDelay.value);
     if (!Number.isInteger(delayMs) || delayMs < 100 || delayMs > 10000){
       state.ops.botReactionError = "invalid_range";
@@ -1732,6 +1777,10 @@
   }
 
   async function clearBotReactionOverride(){
+    if (state.maintenance){
+      setStatus("CH and poker mutations are disabled during maintenance.", "error");
+      return;
+    }
     state.ops.botReactionPending = true;
     state.ops.botReactionError = null;
     state.ops.botReactionMessage = "";
@@ -1752,6 +1801,10 @@
   }
 
   async function runOpsAction(action){
+    if (state.maintenance){
+      setStatus("CH and poker mutations are disabled during maintenance.", "error");
+      return;
+    }
     setStatus(t("loading", "Loading..."), "info");
     try {
       var payload = await apiFetch("/.netlify/functions/admin-ops-actions", {
@@ -1775,7 +1828,7 @@
   }
 
   function handleApiError(err, fallback){
-    if (err && (err.status === 401 || err.status === 403)){
+    if (err && (err.status === 401 || (err.status === 403 && err.code === "admin_required"))){
       showUnauthorized(getUnauthorizedMessage(err));
       setStatus("", "");
       return;

--- a/netlify/functions/admin-me.mjs
+++ b/netlify/functions/admin-me.mjs
@@ -5,10 +5,6 @@ function createAdminMeHandler(deps = {}) {
   const env = deps.env || process.env;
   const requireAdmin = deps.requireAdminUser || requireAdminUser;
   return async function handler(event) {
-    if (env.CHIPS_ENABLED !== "1") {
-      return { statusCode: 404, headers: baseHeaders(), body: JSON.stringify({ error: "not_found" }) };
-    }
-
     const origin = event.headers?.origin || event.headers?.Origin;
     const cors = corsHeaders(origin);
     if (!cors) {
@@ -26,7 +22,13 @@ function createAdminMeHandler(deps = {}) {
       return {
         statusCode: 200,
         headers: cors,
-        body: JSON.stringify({ ok: true, isAdmin: true, userId: admin.userId }),
+        body: JSON.stringify({
+          ok: true,
+          isAdmin: true,
+          userId: admin.userId,
+          chipsEnabled: env.CHIPS_ENABLED === "1",
+          maintenance: env.CHIPS_ENABLED !== "1",
+        }),
       };
     } catch (error) {
       return adminAuthErrorResponse(error, cors);

--- a/netlify/functions/admin-ops-summary.mjs
+++ b/netlify/functions/admin-ops-summary.mjs
@@ -124,9 +124,6 @@ function createAdminOpsSummaryHandler(deps = {}) {
   const requireAdmin = deps.requireAdminUser || requireAdminUser;
   const loadSummary = deps.loadOpsSummary || (() => loadOpsSummary(env));
   return async function handler(event) {
-    if (env.CHIPS_ENABLED !== "1") {
-      return { statusCode: 404, headers: baseHeaders(), body: JSON.stringify({ error: "not_found" }) };
-    }
     const origin = event.headers?.origin || event.headers?.Origin;
     const cors = corsHeaders(origin);
     if (!cors) {

--- a/netlify/functions/admin-ws-preview-bot-reaction.mjs
+++ b/netlify/functions/admin-ws-preview-bot-reaction.mjs
@@ -143,6 +143,9 @@ function createAdminWsPreviewBotReactionHandler(deps = {}) {
   const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
   const fetchImpl = deps.fetchImpl || globalThis.fetch;
   return async function handler(event) {
+    if (env.CHIPS_ENABLED !== "1") {
+      return jsonResponse(404, baseHeaders(), { error: "not_found" });
+    }
     const origin = event.headers?.origin || event.headers?.Origin;
     const cors = corsHeaders(origin);
     if (!cors) return jsonResponse(403, baseHeaders(), { error: "forbidden_origin" });

--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -31,6 +31,9 @@ const parseMaxPlayers = (value) => {
 };
 
 export async function handler(event) {
+  if (process.env.CHIPS_ENABLED !== "1") {
+    return { statusCode: 404, headers: baseHeaders(), body: JSON.stringify({ error: "not_found" }) };
+  }
   const origin = event.headers?.origin || event.headers?.Origin;
   const cors = corsHeaders(origin);
   if (!cors) {

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -140,6 +140,9 @@ const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, allowCrea
 };
 
 export async function handler(event) {
+  if (process.env.CHIPS_ENABLED !== "1") {
+    return { statusCode: 404, headers: baseHeaders(), body: JSON.stringify({ error: "not_found" }) };
+  }
   const origin = event.headers?.origin || event.headers?.Origin;
   const cors = corsHeaders(origin);
   if (!cors) {

--- a/tests/admin-endpoints.behavior.test.mjs
+++ b/tests/admin-endpoints.behavior.test.mjs
@@ -37,12 +37,36 @@ test("admin-me returns admin payload for an allowlisted caller", async () => {
     ok: true,
     isAdmin: true,
     userId: "00000000-0000-4000-8000-000000000010",
+    chipsEnabled: true,
+    maintenance: false,
+  });
+});
+
+test("admin-me preserves allowlisted admin bootstrap during CH maintenance", async () => {
+  let authCalls = 0;
+  const handler = createAdminMeHandler({
+    env: { CHIPS_ENABLED: "0" },
+    requireAdminUser: async () => {
+      authCalls += 1;
+      return { userId: "00000000-0000-4000-8000-000000000010" };
+    },
+  });
+  const response = await handler(event("GET"));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(authCalls, 1);
+  assert.deepEqual(JSON.parse(response.body), {
+    ok: true,
+    isAdmin: true,
+    userId: "00000000-0000-4000-8000-000000000010",
+    chipsEnabled: false,
+    maintenance: true,
   });
 });
 
 test("admin-me fails closed for non-admin callers", async () => {
   const handler = createAdminMeHandler({
-    env: { CHIPS_ENABLED: "1" },
+    env: { CHIPS_ENABLED: "0" },
     requireAdminUser: async () => {
       const error = new Error("admin_required");
       error.status = 403;
@@ -60,6 +84,7 @@ test("admin WS Preview bot reaction proxy forwards only a controlled payload wit
   let seen = null;
   const handler = createAdminWsPreviewBotReactionHandler({
     env: {
+      CHIPS_ENABLED: "1",
       POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
       POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
     },
@@ -98,6 +123,7 @@ test("admin WS Preview bot reaction proxy rejects non-admin and non-preview requ
   let fetchCalls = 0;
   const deps = {
     env: {
+      CHIPS_ENABLED: "1",
       POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
       POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
     },
@@ -137,9 +163,38 @@ test("admin WS Preview bot reaction body allowlist rejects unexpected fields", (
   assert.throws(() => parseBotReactionBody(JSON.stringify({ mode: "override", minMs: 500, maxMs: 500, updatedBy: "spoofed" })), { code: "invalid_request" });
 });
 
+test("admin WS Preview bot reaction endpoint stays unavailable during CH maintenance", async () => {
+  let authCalls = 0;
+  let fetchCalls = 0;
+  const handler = createAdminWsPreviewBotReactionHandler({
+    env: {
+      CHIPS_ENABLED: "0",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
+    },
+    requireAdminUser: async () => {
+      authCalls += 1;
+      return { userId: "admin-1" };
+    },
+    buildStageIdentity: previewStageIdentity,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error("unexpected_fetch");
+    },
+  });
+  for (const method of ["GET", "POST"]) {
+    const response = await handler(event(method, {}, method === "POST" ? JSON.stringify({ mode: "default" }) : undefined));
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), { error: "not_found" });
+  }
+  assert.equal(authCalls, 0);
+  assert.equal(fetchCalls, 0);
+});
+
 test("admin WS Preview bot reaction proxy rejects a non-JSON Caddy fallback response", async () => {
   const handler = createAdminWsPreviewBotReactionHandler({
     env: {
+      CHIPS_ENABLED: "1",
       POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
       POKER_WS_INTERNAL_TOKEN: "preview-internal-token",
     },

--- a/tests/admin-ops-summary.behavior.test.mjs
+++ b/tests/admin-ops-summary.behavior.test.mjs
@@ -13,12 +13,12 @@ function createEvent() {
 
 test("admin-ops-summary returns ops contract", async () => {
   const handler = createAdminOpsSummaryHandler({
-    env: { CHIPS_ENABLED: "1" },
+    env: { CHIPS_ENABLED: "0" },
     requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
     loadOpsSummary: async () => ({
       janitor: { openTableCount: 4, staleHumanSeatCount: 2, staleOpenTableCount: 1, flaggedTableCount: 3, idleThresholdMinutes: 15 },
       recentJanitorActivity: { adminActions: [], cleanupTransactions: [] },
-      runtime: { buildId: "abc123", chipsEnabled: true, adminUserIdsConfigured: true, janitorConfig: {}, wsHealth: { available: true, ok: true, status: 200 }, healthy: true },
+      runtime: { buildId: "abc123", chipsEnabled: false, adminUserIdsConfigured: true, janitorConfig: {}, wsHealth: { available: true, ok: true, status: 200 }, healthy: false },
     }),
   });
   const response = await handler(createEvent());
@@ -27,5 +27,28 @@ test("admin-ops-summary returns ops contract", async () => {
   assert.equal(response.statusCode, 200);
   assert.equal(body.janitor.openTableCount, 4);
   assert.equal(body.runtime.buildId, "abc123");
-  assert.equal(body.runtime.healthy, true);
+  assert.equal(body.runtime.chipsEnabled, false);
+  assert.equal(body.runtime.healthy, false);
+});
+
+test("admin-ops-summary still rejects a non-admin during maintenance", async () => {
+  let loadCalls = 0;
+  const handler = createAdminOpsSummaryHandler({
+    env: { CHIPS_ENABLED: "0" },
+    requireAdminUser: async () => {
+      const error = new Error("admin_required");
+      error.status = 403;
+      error.code = "admin_required";
+      throw error;
+    },
+    loadOpsSummary: async () => {
+      loadCalls += 1;
+      return {};
+    },
+  });
+  const response = await handler(createEvent());
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), { error: "admin_required" });
+  assert.equal(loadCalls, 0);
 });

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -242,6 +242,9 @@ function createAdminDom() {
     "adminStatus",
     "adminUnauthorized",
     "adminUnauthorizedText",
+    "adminUnavailable",
+    "adminUnavailableText",
+    "adminMaintenance",
     "adminApp",
     "adminUsersBody",
     "adminUsersEmpty",
@@ -358,7 +361,19 @@ function buildContext(options = {}) {
     fetchCalls.push(String(url || ""));
     const text = String(url || "");
     if (text.includes("/.netlify/functions/admin-me")) {
-      return { ok: true, json: async () => ({ userId: "admin-1" }) };
+      if (opts.meUnavailable){
+        return { ok: false, status: 503, json: async () => ({ error: "server_error" }) };
+      }
+      if (opts.nonAdmin){
+        return { ok: false, status: 403, json: async () => ({ error: "admin_required" }) };
+      }
+      return { ok: true, json: async () => ({
+        ok: true,
+        isAdmin: true,
+        userId: "admin-1",
+        chipsEnabled: !opts.maintenance,
+        maintenance: opts.maintenance === true,
+      }) };
     }
     if (text.includes("/.netlify/functions/admin-users-list")) {
       return { ok: true, json: async () => ({ items: [], pagination: null }) };
@@ -422,7 +437,7 @@ function buildContext(options = {}) {
       return { ok: true, json: async () => ({
         summary: {},
         janitor: { openTableCount: 0, staleHumanSeatCount: 0, staleOpenTableCount: 0, flaggedTableCount: 0 },
-        runtime: { buildId: "test-build", chipsEnabled: true, adminUserIdsConfigured: true, janitorConfig: {}, healthy: true },
+        runtime: { buildId: "test-build", chipsEnabled: !opts.maintenance, adminUserIdsConfigured: true, janitorConfig: {}, healthy: !opts.maintenance },
         recentJanitorActivity: { adminActions: [], cleanupTransactions: [] },
       }) };
     }
@@ -445,7 +460,7 @@ function buildContext(options = {}) {
         supabaseProjectRef: "stageabc",
         expectedStageProjectRef: "stageabc",
         databaseTarget: "stage",
-        chipsEnabled: true,
+        chipsEnabled: !opts.maintenance,
         stageProjectRefConfigured: true,
         stageProjectRefMatches: true,
         serviceRoleProjectRef: "stageabc",
@@ -701,6 +716,56 @@ test("admin page still renders ops summary when stage identity request fails", a
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Stage identity unavailable/);
   assert.match(document.getElementById("adminOpsStats").innerHTML, /OPEN tables/);
   assert.match(document.getElementById("adminOpsRuntime").innerHTML, /Runtime health/);
+});
+
+test("admin page keeps read-only Ops available during CH maintenance", async () => {
+  const { context, document, tabs, panels, fetchCalls } = buildContext({ maintenance: true });
+  vm.runInContext(source, context, { filename: "js/admin-page.js" });
+
+  await flush();
+  await flush();
+  await flush();
+
+  assert.equal(document.getElementById("adminApp").hidden, false);
+  assert.equal(document.getElementById("adminUnauthorized").hidden, true);
+  assert.equal(document.getElementById("adminUnavailable").hidden, true);
+  assert.equal(document.getElementById("adminMaintenance").hidden, false);
+  assert.equal(tabs[5].getAttribute("aria-selected"), "true");
+  assert.equal(panels[5].hidden, false);
+  assert.equal(tabs.slice(0, 5).every((tab) => tab.disabled === true), true);
+  assert.equal(fetchCalls.some((url) => url.includes("admin-users-list")), false);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-stage-identity"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-ops-summary"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-ws-preview-bot-reaction"), false);
+  assert.match(document.getElementById("adminOpsIdentity").innerHTML, /CHIPS_ENABLED/);
+  assert.match(document.getElementById("adminOpsIdentity").innerHTML, /off/);
+  assert.match(document.getElementById("adminOpsRuntime").innerHTML, /off/);
+  assert.equal(document.getElementById("adminOpsRunReconciler").disabled, true);
+  assert.equal(document.getElementById("adminOpsRunStaleSweep").disabled, true);
+  assert.equal(document.getElementById("adminOpsBotReactionDelay").disabled, true);
+  assert.equal(document.getElementById("adminOpsBotReactionApply").disabled, true);
+  assert.equal(document.getElementById("adminOpsBotReactionDefault").disabled, true);
+});
+
+test("admin page distinguishes unavailable bootstrap from a non-admin account", async () => {
+  const unavailable = buildContext({ meUnavailable: true });
+  vm.runInContext(source, unavailable.context, { filename: "js/admin-page.js" });
+  await flush();
+  await flush();
+
+  assert.equal(unavailable.document.getElementById("adminUnavailable").hidden, false);
+  assert.equal(unavailable.document.getElementById("adminUnauthorized").hidden, true);
+  assert.match(unavailable.document.getElementById("adminUnavailableText").textContent, /temporarily unavailable/i);
+  assert.doesNotMatch(unavailable.document.getElementById("adminUnavailableText").textContent, /not.*allowlist/i);
+
+  const nonAdmin = buildContext({ nonAdmin: true });
+  vm.runInContext(source, nonAdmin.context, { filename: "js/admin-page.js" });
+  await flush();
+  await flush();
+
+  assert.equal(nonAdmin.document.getElementById("adminUnauthorized").hidden, false);
+  assert.equal(nonAdmin.document.getElementById("adminUnavailable").hidden, true);
+  assert.match(nonAdmin.document.getElementById("adminUnauthorizedText").textContent, /allowlisted/i);
 });
 
 test("admin bonus campaign form explains invalid campaign codes before sending a request", async () => {

--- a/tests/admin-stage-identity.behavior.test.mjs
+++ b/tests/admin-stage-identity.behavior.test.mjs
@@ -143,7 +143,7 @@ test("admin-stage-identity endpoint requires admin and returns sanitized payload
   const handler = createAdminStageIdentityHandler({
     env: {
       CONTEXT: "deploy-preview",
-      CHIPS_ENABLED: "1",
+      CHIPS_ENABLED: "0",
       SUPABASE_URL: "https://stageabc.supabase.co",
       SUPABASE_STAGE_PROJECT_REF: "stageabc",
     },
@@ -155,4 +155,5 @@ test("admin-stage-identity endpoint requires admin and returns sanitized payload
   assert.equal(response.statusCode, 200);
   assert.equal(body.databaseTarget, "stage");
   assert.equal(body.supabaseProjectRef, "stageabc");
+  assert.equal(body.chipsEnabled, false);
 });

--- a/tests/poker-create-table.stakes.test.mjs
+++ b/tests/poker-create-table.stakes.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
 import { isStateStorageValid, normalizeJsonState } from "../netlify/functions/_shared/poker-state-utils.mjs";
 
+process.env.CHIPS_ENABLED = "1";
+
 const makeHandler = (queries, options = {}) =>
   loadPokerHandler("netlify/functions/poker-create-table.mjs", {
     baseHeaders: () => ({}),
@@ -112,7 +114,26 @@ const runSlowNotifyDoesNotDelayResponse = async () => {
   resolveNotify({ ok: true });
 };
 
+const runMaintenanceGuard = async () => {
+  const queries = [];
+  const handler = makeHandler(queries);
+  process.env.CHIPS_ENABLED = "0";
+  try {
+    const response = await handler({
+      httpMethod: "POST",
+      headers: { origin: "https://example.test", authorization: "Bearer token" },
+      body: JSON.stringify({ maxPlayers: 6, stakes: "1/2" }),
+    });
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), { error: "not_found" });
+    assert.equal(queries.length, 0);
+  } finally {
+    process.env.CHIPS_ENABLED = "1";
+  }
+};
+
 await runMissingStakes();
 await runInvalidStakes();
 await runSlashStakes();
 await runSlowNotifyDoesNotDelayResponse();
+await runMaintenanceGuard();

--- a/tests/poker-quick-seat.behavior.test.mjs
+++ b/tests/poker-quick-seat.behavior.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
 import { isStateStorageValid, normalizeJsonState } from "../netlify/functions/_shared/poker-state-utils.mjs";
 
+process.env.CHIPS_ENABLED = "1";
+
 const userId = "user-quick";
 
 const callQuickSeat = async (handler, body = {}) => {
@@ -306,6 +308,19 @@ const run = async () => {
     assert.equal(lockCalls.length, 2);
     assert.equal(lockCalls[0]?.params?.[0], "quickseat:6:1:2");
     assert.equal(lockCalls[1]?.params?.[0], "quickseat:6:1:2");
+  }
+  {
+    const queries = [];
+    const handler = makeHandler({ mode: "create", queries });
+    process.env.CHIPS_ENABLED = "0";
+    try {
+      const response = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
+      assert.equal(response.statusCode, 404);
+      assert.deepEqual(JSON.parse(response.body), { error: "not_found" });
+      assert.equal(queries.length, 0);
+    } finally {
+      process.env.CHIPS_ENABLED = "1";
+    }
   }
 
 };


### PR DESCRIPTION
## Summary

- keep the allowlisted Admin bootstrap available when `CHIPS_ENABLED=0`
- preserve only the required read-only Stage Identity and Ops observability during maintenance
- distinguish non-admin access from temporary bootstrap failures in the Admin UI
- show an explicit maintenance banner and restrict the UI to the read-only Ops tab
- keep CH/poker mutations fail-closed, including table creation, quick-seat, Ops actions and WS Preview bot-reaction controls

## Root cause

`admin-me` returned `404` on `CHIPS_ENABLED=0` before calling `requireAdminUser()`. The Admin frontend treated every bootstrap error as a missing allowlist grant. `admin-ops-summary` had the same economy gate despite being read-only.

## Safety boundary

Available to an authenticated allowlisted administrator during maintenance:

- `admin-me`
- `admin-stage-identity`
- `admin-ops-summary`

All mutation paths remain unavailable. No environment, database, WS, backup, reset, or Netlify project operation was performed.

## Validation

- `npm test`
- `npm run syntax`
- `npm run check:all`
- `npm run ci:guards`
- `npm run lint:games`
- targeted Admin maintenance, authorization, poker create-table and quick-seat behavior tests
- `git diff --check`

## Breaking impact

- `admin-me` adds `chipsEnabled` and `maintenance` to its successful response and remains reachable for authenticated admins while CH is disabled.
- `admin-ops-summary` is now readable by authenticated admins while CH is disabled.
- WS Preview bot-reaction reads and writes, poker create-table, and poker quick-seat now return controlled `404` while CH is disabled.
- Other Admin data tabs remain intentionally unavailable during maintenance.
- No migration, new ENV, CSP change, new script, or WS protocol change.

## Manual Deploy Preview verification (not yet executed)

1. Verify Admin works with `CHIPS_ENABLED=1`.
2. Set deploy-preview `CHIPS_ENABLED=0` and trigger a fresh deploy.
3. With the same active session, verify Admin remains visible and opens Ops.
4. Verify the maintenance banner, `CHIPS_ENABLED off`, and the expected stage project ref.
5. Verify `admin-me`, `admin-stage-identity`, and `admin-ops-summary` succeed for the allowlisted admin.
6. Verify mutation endpoints, `poker-create-table`, and `poker-quick-seat` return controlled `404`.
7. Verify a user outside `ADMIN_USER_IDS` still cannot access Admin.
8. Restore `CHIPS_ENABLED=1`, trigger a fresh deploy, and verify normal operations return.

This PR does not continue or execute the economy reset.