### PR TITLE
feat: add durable Poker WS action idempotency

### DIFF
--- a/docs/poker-durable-action-idempotency-plan.md
+++ b/docs/poker-durable-action-idempotency-plan.md
@@ -2,7 +2,7 @@
 
 Issue: [#377](https://github.com/krzysztofcal/arcadePlatform/issues/377)
 
-Status: planning only. This document does not implement runtime, database, protocol, or client changes.
+Status: implemented by PR #725. This document is retained as the design and deployment contract for the runtime and additive database migration in that PR.
 
 ## 1. Goal and scope
 
@@ -382,13 +382,17 @@ Rollback to the previous WS version is safe because the schema change is additiv
 
 ## 13. Breaking impact
 
-The sole intentional behavioral change is that a previously accepted `requestId` reused with a different normalized payload returns `idempotency_conflict` instead of being re-evaluated or receiving an unrelated cached result.
+Intentional behavioral changes:
+
+- a previously accepted `requestId` reused with a different normalized payload returns `idempotency_conflict` instead of being re-evaluated or receiving an unrelated cached result;
+- `BET` and `RAISE` amounts must be integer CH values at the handler boundary; fractional amounts that previously passed the preliminary finite-number check are rejected before the reducer.
 
 Operational impact:
 
 - an additive database migration must precede the WS deployment;
-- persistent human actions require the durable DB capability;
-- file-store or misconfigured persistent runtime cannot silently claim the durable guarantee.
+- DB-backed persistent human actions require the durable DB capability;
+- the additive migration must be applied on stage before WS Preview deployment and smoke verification;
+- fixture and file-store test modes retain the legacy in-memory replay cache and do not claim the durable guarantee.
 
 No breaking change applies to poker rules, WS frame shape, guest tables, timeout actions, bots, client retry, ledger, settlement, JSP, CSS, or CSP.
 

--- a/docs/poker-durable-action-idempotency-plan.md
+++ b/docs/poker-durable-action-idempotency-plan.md
@@ -257,6 +257,20 @@ payload_hash
 
 If CAS or another already-required persistence step fails, the reservation disappears with transaction rollback.
 
+### Durable ACT must bypass the equal-state fallback
+
+`persisted-state-writer.mjs::writeViaDb()` currently handles a failed CAS by loading the authoritative row and comparing it with `nextState`. For existing mutation kinds, equal state may return `alreadyApplied: true` to tolerate an ambiguous persistence result.
+
+That fallback is not proof that a particular ACT request caused the state transition. For a mutation carrying `durableActionRequest`, it must therefore be disabled locally:
+
+- only a successful CAS performed after this transaction reserved a new ACT row may return `committed`;
+- a failed CAS must roll back the newly reserved ACT row and return `failure`/state conflict;
+- equal authoritative state must not convert that failure into `committed` or `durable_replay`;
+- `durable_replay` may come only from an ACT row that already existed, has the same payload hash, and contains a valid final `result_json`;
+- the existing equal-state/`alreadyApplied` behavior remains unchanged for mutation kinds without `durableActionRequest`.
+
+This is a conditional branch in the existing writer, not a global removal or refactor of the fallback.
+
 ### Writer outcomes
 
 `writeMutation()` must return an explicit `outcome` rather than making every successful return look like a fresh commit:
@@ -316,6 +330,9 @@ Use existing Node and WS test patterns; do not create a new framework.
 
 - ACT reservation, state CAS, and final result commit atomically.
 - CAS failure or rollback leaves no durable success row.
+- For durable ACT, a failed CAS followed by equal authoritative state still returns failure and rolls back the reservation.
+- Equal-state fallback remains available for existing non-durable mutation kinds.
+- Durable replay is returned only from a pre-existing, valid ACT row, never inferred from state equality.
 - Final result update must affect exactly one matching row.
 - Same key/hash after a new writer instance returns durable replay.
 - Same key with another hash returns conflict.
@@ -356,6 +373,7 @@ Rollback to the previous WS version is safe because the schema change is additiv
 - A committed persistent human action replays after reconnect, restore, eviction, and WS restart without another mutation.
 - Same scoped key with a different payload returns `idempotency_conflict`.
 - State CAS and durable ACT result are atomic.
+- A failed durable ACT CAS cannot become `committed` or `durable_replay` through the writer's equal-state/`alreadyApplied` fallback.
 - A two-worker race produces one state commit.
 - Race loser restores authoritative state without gameplay broadcast or side effects.
 - Only `outcome: "committed"` triggers broadcast, bot scheduling, and rollover.

--- a/docs/poker-durable-action-idempotency-plan.md
+++ b/docs/poker-durable-action-idempotency-plan.md
@@ -1,0 +1,379 @@
+# Poker WS durable action idempotency — implementation plan
+
+Issue: [#377](https://github.com/krzysztofcal/arcadePlatform/issues/377)
+
+Status: planning only. This document does not implement runtime, database, protocol, or client changes.
+
+## 1. Goal and scope
+
+Guarantee that one accepted human `ACT` command on a persistent poker table can produce at most one authoritative state transition, even when the response is lost and the same command is submitted after table eviction, authoritative restore, WS restart, or a race between WS workers.
+
+The first implementation PR is deliberately server-only. It adds durable replay for accepted persistent human actions and preserves all current behavior for guest tables, bots, timeouts, rejected actions, and the browser client.
+
+### In scope
+
+- Store accepted persistent human `ACT` outcomes in `public.poker_requests`.
+- Detect same-key/same-payload replay and same-key/different-payload conflict.
+- Commit the durable result atomically with the `public.poker_state` compare-and-swap update.
+- Restore speculative runtime state for a worker that loses the durable-request race.
+- Keep the existing in-memory action cache unchanged for flows that still use it.
+
+### Out of scope
+
+- Automatic client retry after timeout or reconnect.
+- Client, JSP, HTML, CSS, localization, or CSP changes.
+- Durable idempotency for join, rebuy, leave, start-hand, bot, or timeout commands.
+- Retention jobs, opportunistic cleanup, new timestamps, new indexes, or monitoring for `poker_requests`.
+- Changes to poker rules, ledger, settlement, bot policy, or the WS frame schema.
+- Making `poker_actions` audit writes mandatory.
+
+## 2. Current architecture and gap
+
+### Browser and protocol
+
+- `poker/poker-v2.js::handleAction()` builds `{ handId, action, amount? }` and calls `sendCommand("sendAct", payload)`.
+- `poker/poker-ws-client.js::sendCommand()` creates a `requestId`, stores a pending Promise in memory, and rejects it after timeout or socket close.
+- The client does not automatically retransmit `act`; this remains unchanged.
+
+### WS action flow
+
+- `ws-server/poker/handlers/act.mjs::handleActCommand()` validates the command and calls `tableManager.applyAction()`.
+- `ws-server/poker/table/table-manager.mjs::applyAction()` currently reads and writes `table.actionResultsByRequestId` using `userId + requestId`.
+- The manager mutates runtime state before `ws-server/server.mjs::persistMutatedState()` calls `persisted-state-writer.mjs::writeMutation()`.
+- `writeViaDb()` performs a version CAS on `public.poker_state`, persists required projections, and attempts action audit writes.
+- Broadcast, settled rollover, and bot autoplay run only after persistence reports success.
+
+### Residual gap
+
+`actionResultsByRequestId` is process memory. `restoreTableFromPersisted()` clears it, eviction deletes it, and a WS restart loses it. A previously accepted request can therefore be evaluated again against a later state. The cache also has no payload-hash conflict contract.
+
+### Existing durable table
+
+`public.poker_requests` already provides:
+
+- `table_id`, `user_id`, `request_id`, and `kind`;
+- `result_json` and `created_at`;
+- uniqueness on `(table_id, kind, request_id, user_id)`;
+- `poker_requests_created_at_idx`;
+- `ON DELETE CASCADE` from `public.poker_tables`.
+
+It lacks only the payload hash required to distinguish replay from conflicting reuse. No retention work is justified in this PR.
+
+## 3. Target contract
+
+For one scoped identity `(tableId, kind="ACT", requestId, userId)`:
+
+- no record means the handler may attempt a fresh action;
+- the same normalized payload returns the previously committed result;
+- a different normalized payload returns `idempotency_conflict`;
+- an invalid durable record fails closed;
+- the state CAS and final durable result commit together or both roll back;
+- only a writer outcome of `committed` triggers gameplay side effects;
+- `durable_replay`, `idempotency_conflict`, `invalid`, and `failure` never trigger gameplay side effects.
+
+The durable result allowlist is:
+
+```text
+status
+reason
+handId
+stateVersion
+```
+
+No snapshot, cards, session data, token, raw frame, or arbitrary reducer object is stored.
+
+## 4. Task 1 — normalize and hash the action payload
+
+### Files
+
+- Add `ws-server/poker/idempotency/action-command.mjs`.
+- Add a small colocated behavior/unit test using the existing Node test runner.
+
+### Functions
+
+- `normalizeActionCommand({ tableId, userId, handId, action, amount })`
+- `hashActionCommand(normalizedCommand)`
+- Optionally `projectDurableActionResult(result)` if it is used as the single allowlist boundary for `result_json`; otherwise keep this four-field projection local to the handler/writer.
+
+### Normalized payload
+
+The payload hash contains:
+
+```text
+kind = ACT
+tableId
+userId
+handId
+action
+amount
+```
+
+`requestId` is deliberately excluded. It identifies the idempotency record and is already part of the unique key; it is not command payload.
+
+Normalization rules:
+
+- trim table, user, and hand identifiers;
+- uppercase the action;
+- require the currently supported human actions;
+- use an integer amount only for `BET` and `RAISE`;
+- normalize amount to `null` for `FOLD`, `CHECK`, and `CALL`;
+- use stable field order and `node:crypto` SHA-256;
+- do not include frame timestamps.
+
+No new package is required.
+
+## 5. Task 2 — minimal schema migration
+
+### File
+
+- Add one timestamped migration under `supabase/migrations/`, named for poker action request payload hashing.
+
+### Change
+
+```sql
+alter table public.poker_requests
+add column if not exists payload_hash text;
+```
+
+The column remains nullable so existing request kinds and historical rows remain compatible. Runtime code requires a non-empty hash for newly created `kind = 'ACT'` records.
+
+Do not add:
+
+- `completed_at` or `expires_at`;
+- indexes;
+- retention or deletion logic;
+- changes to the current unique index.
+
+## 6. Task 3 — durable request API and explicit outcomes
+
+### Files and methods
+
+- Extend `ws-server/poker/persistence/persisted-state-writer.mjs`.
+- Wire the capability through `ws-server/server.mjs` into `handleActCommand()`.
+
+### Read capability
+
+Expose a DB-backed function such as:
+
+```text
+readDurableActionRequest({ tableId, userId, requestId, payloadHash })
+```
+
+It performs one point lookup by the existing unique key and returns exactly one outcome:
+
+- `missing` — no row;
+- `durable_replay` — matching hash and valid allowlisted `result_json`;
+- `idempotency_conflict` — row exists with a different hash;
+- `invalid` — malformed/missing hash, missing result, or invalid result shape;
+- `failure` — DB/capability error.
+
+`result_json = null` is not a separately exposed domain state. During a new writer transaction it is only a private reservation step and is invisible until commit. A visible ACT row without a final result is invalid and fails closed.
+
+### Capability boundary
+
+The handler must not infer durable support from `tableId` alone. `server.mjs` supplies an explicit capability, for example:
+
+- `durableActionRequestsEnabled`, plus read/write functions; or
+- presence of the read capability and writer support.
+
+Rules:
+
+- production persistent DB table without durable capability: fail closed before reducer mutation;
+- guest table: use the existing in-memory flow;
+- persisted file store, fixtures, or missing DB: never claim durable support; persistent human ACT fails closed when the durable contract is required;
+- bots and timeout actions retain their existing flow.
+
+## 7. Task 4 — handler and table-manager integration
+
+### Table manager
+
+Extend `ws-server/poker/table/table-manager.mjs::applyAction()` with one simple option, for example:
+
+```text
+useActionReplayCache: false
+```
+
+When false, `applyAction()` skips both the read and write of `actionResultsByRequestId`. It otherwise uses the current reducer unchanged.
+
+Do not change the cache representation or add speculative-cache finalization. Guest tables, timeout actions, and all other current in-memory users keep the existing cache behavior.
+
+### Handler
+
+Update `ws-server/poker/handlers/act.mjs::handleActCommand()`:
+
+1. Perform current frame validation.
+2. Determine durable capability explicitly.
+3. For persistent human ACT, normalize the payload and compute its hash without `requestId`.
+4. Execute the point lookup before `tableManager.applyAction()`.
+5. Return stored result for `durable_replay` without reducer or persistence.
+6. Return `idempotency_conflict` or controlled invalid/failure result without reducer.
+7. For `missing`, call `applyAction(..., useActionReplayCache: false)`.
+8. For an accepted reducer result, pass a closed `durableActionRequest` object to persistence.
+9. Run broadcast, rollover, and bot scheduling only when persistence returns `outcome: "committed"`.
+
+Rejected domain actions remain non-durable. Protocol errors, illegal actions, hand mismatch, not-seated results, CAS conflicts, DB failures, and rollbacks do not reserve a lasting request identity.
+
+## 8. Task 5 — atomic reserve, CAS, and finalization
+
+### Signatures
+
+Extend:
+
+- `ws-server/server.mjs::persistMutatedState()`;
+- `persisted-state-writer.mjs::writeMutation()`;
+- `persisted-state-writer.mjs::writeViaDb()`.
+
+Add the optional closed property:
+
+```text
+durableActionRequest:
+  userId
+  requestId
+  payloadHash
+  result
+```
+
+### Transaction flow
+
+Within the existing `beginSql()` transaction:
+
+1. Attempt to insert the scoped ACT row with `payload_hash` and temporary `result_json = null`.
+2. If inserted, perform the existing `poker_state.version` CAS.
+3. On CAS success, perform existing required state projections and ledger-related work for that mutation.
+4. Preserve the current best-effort action-audit behavior: `poker_actions` failure is logged with `klog` and does not become a new rollback condition.
+5. Finalize the ACT row with the allowlisted `result_json` using all identity fields and `payload_hash` in the `WHERE` clause.
+6. Require exactly one updated row; otherwise throw and roll back.
+7. Commit the state and durable ACT together.
+
+The final update must be scoped by:
+
+```text
+table_id
+kind = ACT
+request_id
+user_id
+payload_hash
+```
+
+If CAS or another already-required persistence step fails, the reservation disappears with transaction rollback.
+
+### Writer outcomes
+
+`writeMutation()` must return an explicit `outcome` rather than making every successful return look like a fresh commit:
+
+- `committed` — this invocation committed the new state and durable result;
+- `durable_replay` — an existing matching request won the race;
+- `idempotency_conflict` — the scoped key exists with another payload;
+- `invalid` — durable evidence is malformed;
+- `failure` — CAS, configuration, or persistence failed.
+
+Only `committed` may be treated as permission for gameplay side effects.
+
+## 9. Task 6 — race loser and authoritative restore
+
+Two workers may both observe `missing` before either transaction commits. The unique key and transaction serialize the winner:
+
+- winner reserves ACT, performs CAS, finalizes result, and returns `committed`;
+- loser observes the committed row and returns `durable_replay` or `idempotency_conflict` without CAS.
+
+The loser may already have applied a speculative reducer mutation locally. In that post-reducer race path, `handleActCommand()` must:
+
+1. call `restoreTableFromPersisted(tableId)` directly;
+2. avoid `recoverFromPersistConflict()`, because it broadcasts after successful restore;
+3. perform no gameplay broadcast, bot scheduling, rollover, ledger action, or second audit;
+4. return the stored result only after restore succeeds.
+
+If restore fails:
+
+- do not return `accepted`, even if durable evidence says accepted;
+- send a controlled error/resync-required response;
+- leave all gameplay side effects disabled;
+- do not present speculative local runtime as authoritative.
+
+## 10. Verification
+
+Use existing Node and WS test patterns; do not create a new framework.
+
+### Hash/normalization
+
+- Same normalized payload produces the same hash.
+- Changing hand, action, or amount changes the hash.
+- Changing only `requestId` does not change the hash.
+- Non-amount actions normalize amount to `null`.
+- Invalid amounts/actions fail validation.
+
+### Handler and manager
+
+- Pre-lookup replay bypasses reducer and persistence.
+- Payload conflict returns `idempotency_conflict`.
+- Persistent human ACT calls `applyAction()` with runtime replay cache disabled.
+- Guest and timeout flows retain current cache behavior.
+- Only `committed` triggers broadcast, bots, and rollover.
+- Race replay/conflict restores without broadcast or side effects.
+- Restore failure is fail-closed and never returns accepted.
+
+### Writer/transaction integration
+
+- ACT reservation, state CAS, and final result commit atomically.
+- CAS failure or rollback leaves no durable success row.
+- Final result update must affect exactly one matching row.
+- Same key/hash after a new writer instance returns durable replay.
+- Same key with another hash returns conflict.
+- Two concurrent transactions produce one committed mutation and one replay/conflict outcome.
+- Normal successful flow writes at most one action audit.
+- An injected audit failure retains existing best-effort semantics: committed state and ACT remain valid.
+
+### Restore wiring
+
+- After table restore, the handler reads the DB result and bypasses reducer.
+- This wiring test complements rather than duplicates the writer-restart durability test.
+
+No client test is added or modified because client code and retry behavior are unchanged. The full existing suite still runs in CI.
+
+## 11. Deployment and manual verification
+
+### Stage
+
+1. Apply the additive migration to stage.
+2. Deploy WS Preview; Netlify Deploy Preview is not required for this server-only change.
+3. Submit a valid human action with a captured request ID.
+4. Repeat the same ID and payload; verify the original accepted outcome and no second state transition/audit/side effects.
+5. Restart WS Preview or evict/restore the table and repeat again.
+6. Submit the same ID with a different action or amount; verify `idempotency_conflict`.
+7. Exercise a normal guest table and bot/timeout flow to confirm unchanged behavior.
+
+### Production
+
+1. Apply the migration before deploying the new WS code.
+2. Deploy production WS.
+3. Smoke one fresh action and controlled replay without enabling browser auto-retry.
+4. Monitor `klog` persistence, restore, conflict, and invalid-record events.
+
+Rollback to the previous WS version is safe because the schema change is additive. Do not roll back the nullable column during an application rollback.
+
+## 12. Acceptance criteria
+
+- A committed persistent human action replays after reconnect, restore, eviction, and WS restart without another mutation.
+- Same scoped key with a different payload returns `idempotency_conflict`.
+- State CAS and durable ACT result are atomic.
+- A two-worker race produces one state commit.
+- Race loser restores authoritative state without gameplay broadcast or side effects.
+- Only `outcome: "committed"` triggers broadcast, bot scheduling, and rollover.
+- Persistent DB tables fail closed when durable capability is unavailable.
+- Guest, bot, timeout, ledger, settlement, and client retry behavior remain unchanged.
+
+## 13. Breaking impact
+
+The sole intentional behavioral change is that a previously accepted `requestId` reused with a different normalized payload returns `idempotency_conflict` instead of being re-evaluated or receiving an unrelated cached result.
+
+Operational impact:
+
+- an additive database migration must precede the WS deployment;
+- persistent human actions require the durable DB capability;
+- file-store or misconfigured persistent runtime cannot silently claim the durable guarantee.
+
+No breaking change applies to poker rules, WS frame shape, guest tables, timeout actions, bots, client retry, ledger, settlement, JSP, CSS, or CSP.
+
+## 14. Future follow-up
+
+After the durable server contract is deployed and production-verified, a separate issue/PR may preserve one pending action request across response loss and perform a controlled browser retry. Retention or cleanup of `poker_requests` should be considered only if measured table growth becomes an operational problem.

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -78,6 +78,7 @@ run("node", ["tests/poker-settlement-presentation.unit.test.mjs"], "poker-settle
 run("node", ["tests/poker-v2-live.behavior.test.mjs"], "poker-v2-live-behavior");
 run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs"], "ws-inactive-cleanup-adapter-behavior");
 run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");
+run("node", ["ws-server/poker/idempotency/action-command.behavior.test.mjs"], "ws-action-command-idempotency-behavior");
 run("node", ["ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs"], "ws-authoritative-rebuy-adapter-behavior");
 run("node", ["ws-server/poker/handlers/rebuy.behavior.test.mjs"], "ws-rebuy-handler-behavior");
 run("node", ["ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs"], "ws-disconnect-cleanup-runtime-behavior");

--- a/supabase/migrations/20260718090000_poker_requests_action_payload_hash.sql
+++ b/supabase/migrations/20260718090000_poker_requests_action_payload_hash.sql
@@ -1,0 +1,2 @@
+alter table public.poker_requests
+add column if not exists payload_hash text;

--- a/ws-server/poker/handlers/act.behavior.test.mjs
+++ b/ws-server/poker/handlers/act.behavior.test.mjs
@@ -175,3 +175,114 @@ test('handleActCommand rejects ensureTableLoaded failure with mapped stable code
   assert.equal(calls[0].status, 'rejected');
   assert.equal(calls[0].reason, 'table_not_found');
 });
+
+test('durable pre-lookup replay bypasses reducer, persistence, and gameplay side effects', async () => {
+  const calls = { results: [], apply: 0, persist: 0, snapshots: 0, autoplay: 0, rollover: 0 };
+  await handleActCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'durable-r1', ts: new Date().toISOString(), payload: { handId: 'h1', action: 'CHECK' } },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: {
+      ensureTableLoaded: async () => ({ ok: true }),
+      applyAction: () => { calls.apply += 1; return { accepted: true }; }
+    },
+    durableActionRequired: true,
+    durableActionStore: { readDurableActionRequest: async () => ({ outcome: 'durable_replay', durableResult: { status: 'accepted', reason: null, handId: 'h1', stateVersion: 2 } }) },
+    ensureTableLoadedErrorMapper: (value) => value,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _state, payload) => calls.results.push(payload),
+    persistMutatedState: async () => { calls.persist += 1; return { ok: true, outcome: 'committed' }; },
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    broadcastStateSnapshots: () => { calls.snapshots += 1; },
+    scheduleBotStep: () => { calls.autoplay += 1; },
+    scheduleSettledRollover: () => { calls.rollover += 1; }
+  });
+
+  assert.equal(calls.results[0].status, 'accepted');
+  assert.equal(calls.results[0].stateVersion, 2);
+  assert.deepEqual({ apply: calls.apply, persist: calls.persist, snapshots: calls.snapshots, autoplay: calls.autoplay, rollover: calls.rollover }, { apply: 0, persist: 0, snapshots: 0, autoplay: 0, rollover: 0 });
+});
+
+test('durable fresh commit bypasses runtime cache and alone triggers side effects', async () => {
+  const calls = { results: [], applyArgs: null, persistArgs: null, snapshots: 0, autoplay: 0, rollover: 0 };
+  await handleActCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'durable-r2', ts: new Date().toISOString(), payload: { handId: 'h1', action: 'RAISE', amount: 20 } },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: {
+      ensureTableLoaded: async () => ({ ok: true }),
+      applyAction: (args) => {
+        calls.applyArgs = args;
+        return { accepted: true, replayed: false, changed: true, stateVersion: 2, handId: 'h1', reason: null, acceptedActionAudit: { action: 'RAISE' } };
+      }
+    },
+    durableActionRequired: true,
+    durableActionStore: { readDurableActionRequest: async () => ({ outcome: 'missing' }) },
+    ensureTableLoadedErrorMapper: (value) => value,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _state, payload) => calls.results.push(payload),
+    persistMutatedState: async (args) => { calls.persistArgs = args; return { ok: true, outcome: 'committed', newVersion: 2 }; },
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    broadcastStateSnapshots: () => { calls.snapshots += 1; },
+    scheduleBotStep: () => { calls.autoplay += 1; },
+    scheduleSettledRollover: () => { calls.rollover += 1; }
+  });
+
+  assert.equal(calls.applyArgs.useActionReplayCache, false);
+  assert.equal(calls.persistArgs.durableActionRequest.requestId, 'durable-r2');
+  assert.equal(calls.persistArgs.durableActionRequest.payloadHash.length, 64);
+  assert.deepEqual(calls.persistArgs.durableActionRequest.result, { status: 'accepted', reason: null, handId: 'h1', stateVersion: 2 });
+  assert.equal(calls.results[0].status, 'accepted');
+  assert.deepEqual({ snapshots: calls.snapshots, autoplay: calls.autoplay, rollover: calls.rollover }, { snapshots: 1, autoplay: 1, rollover: 1 });
+});
+
+test('durable race loser restores without gameplay broadcast or side effects', async () => {
+  const calls = { results: [], restores: 0, snapshots: 0, autoplay: 0, rollover: 0, resync: 0 };
+  await handleActCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'durable-r3', ts: new Date().toISOString(), payload: { handId: 'h1', action: 'CHECK' } },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: {
+      ensureTableLoaded: async () => ({ ok: true }),
+      applyAction: () => ({ accepted: true, replayed: false, changed: true, stateVersion: 2, handId: 'h1', reason: null })
+    },
+    durableActionRequired: true,
+    durableActionStore: { readDurableActionRequest: async () => ({ outcome: 'missing' }) },
+    ensureTableLoadedErrorMapper: (value) => value,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _state, payload) => calls.results.push(payload),
+    persistMutatedState: async () => ({ ok: true, outcome: 'durable_replay', durableResult: { status: 'accepted', reason: null, handId: 'h1', stateVersion: 2 } }),
+    restoreTableFromPersisted: async () => { calls.restores += 1; return { ok: true }; },
+    broadcastResyncRequired: () => { calls.resync += 1; },
+    broadcastStateSnapshots: () => { calls.snapshots += 1; },
+    scheduleBotStep: () => { calls.autoplay += 1; },
+    scheduleSettledRollover: () => { calls.rollover += 1; }
+  });
+
+  assert.equal(calls.results[0].status, 'accepted');
+  assert.deepEqual({ restores: calls.restores, snapshots: calls.snapshots, autoplay: calls.autoplay, rollover: calls.rollover, resync: calls.resync }, { restores: 1, snapshots: 0, autoplay: 0, rollover: 0, resync: 0 });
+});
+
+test('persistent human action fails closed when durable capability is unavailable', async () => {
+  const results = [];
+  let applyCalls = 0;
+  await handleActCommand({
+    frame: { __resolvedTableId: 't1', requestId: 'durable-r4', ts: new Date().toISOString(), payload: { handId: 'h1', action: 'CHECK' } },
+    ws: {},
+    connState: { session: { userId: 'u1' } },
+    tableManager: { ensureTableLoaded: async () => ({ ok: true }), applyAction: () => { applyCalls += 1; } },
+    durableActionRequired: true,
+    durableActionStore: null,
+    ensureTableLoadedErrorMapper: (value) => value,
+    sendError: () => assert.fail('unexpected sendError'),
+    sendCommandResult: (_ws, _state, payload) => results.push(payload),
+    persistMutatedState: async () => assert.fail('unexpected persistence'),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    broadcastStateSnapshots: () => {}
+  });
+  assert.equal(applyCalls, 0);
+  assert.equal(results[0].reason, 'durable_action_store_unavailable');
+});

--- a/ws-server/poker/handlers/act.behavior.test.mjs
+++ b/ws-server/poker/handlers/act.behavior.test.mjs
@@ -265,6 +265,50 @@ test('durable race loser restores without gameplay broadcast or side effects', a
   assert.deepEqual({ restores: calls.restores, snapshots: calls.snapshots, autoplay: calls.autoplay, rollover: calls.rollover, resync: calls.resync }, { restores: 1, snapshots: 0, autoplay: 0, rollover: 0, resync: 0 });
 });
 
+for (const scenario of [
+  {
+    name: 'invalid projected durable result',
+    applyResult: { accepted: true, replayed: false, changed: true, stateVersion: null, handId: 'h1', reason: null },
+    persistResult: null
+  },
+  {
+    name: 'unexpected successful writer outcome',
+    applyResult: { accepted: true, replayed: false, changed: true, stateVersion: 2, handId: 'h1', reason: null },
+    persistResult: { ok: true, outcome: 'unexpected' }
+  }
+]) {
+  test(`durable ${scenario.name} fails closed when authoritative restore fails`, async () => {
+    const calls = { results: [], persist: 0, resync: 0, snapshots: 0, autoplay: 0, rollover: 0 };
+    await handleActCommand({
+      frame: { __resolvedTableId: 't1', requestId: `restore-${scenario.name}`, ts: new Date().toISOString(), payload: { handId: 'h1', action: 'CHECK' } },
+      ws: {},
+      connState: { session: { userId: 'u1' } },
+      tableManager: {
+        ensureTableLoaded: async () => ({ ok: true }),
+        applyAction: () => scenario.applyResult
+      },
+      durableActionRequired: true,
+      durableActionStore: { readDurableActionRequest: async () => ({ outcome: 'missing' }) },
+      ensureTableLoadedErrorMapper: (value) => value,
+      sendError: () => assert.fail('unexpected sendError'),
+      sendCommandResult: (_ws, _state, payload) => calls.results.push(payload),
+      persistMutatedState: async () => { calls.persist += 1; return scenario.persistResult; },
+      restoreTableFromPersisted: async () => ({ ok: false, reason: 'restore_failed' }),
+      broadcastResyncRequired: () => { calls.resync += 1; },
+      broadcastStateSnapshots: () => { calls.snapshots += 1; },
+      scheduleBotStep: () => { calls.autoplay += 1; },
+      scheduleSettledRollover: () => { calls.rollover += 1; }
+    });
+
+    assert.equal(calls.results.length, 1);
+    assert.equal(calls.results[0].status, 'rejected');
+    assert.equal(calls.results[0].reason, 'durable_action_restore_failed');
+    assert.equal(calls.resync, 1);
+    assert.deepEqual({ snapshots: calls.snapshots, autoplay: calls.autoplay, rollover: calls.rollover }, { snapshots: 0, autoplay: 0, rollover: 0 });
+    assert.equal(calls.persist, scenario.persistResult ? 1 : 0);
+  });
+}
+
 test('persistent human action fails closed when durable capability is unavailable', async () => {
   const results = [];
   let applyCalls = 0;

--- a/ws-server/poker/handlers/act.mjs
+++ b/ws-server/poker/handlers/act.mjs
@@ -8,6 +8,21 @@ function mapActReason(reason) {
   return reason;
 }
 
+async function restoreDurableRuntimeOrReject({ tableId, requestId, ws, connState, restoreTableFromPersisted, broadcastResyncRequired, sendCommandResult }) {
+  const restored = await restoreTableFromPersisted(tableId);
+  if (restored?.ok) return true;
+  if (typeof broadcastResyncRequired === "function") {
+    broadcastResyncRequired(tableId, "durable_action_restore_failed");
+  }
+  sendCommandResult(ws, connState, {
+    requestId: requestId ?? null,
+    tableId,
+    status: "rejected",
+    reason: "durable_action_restore_failed"
+  });
+  return false;
+}
+
 export async function handleActCommand({ frame, ws, connState, tableManager, ensureTableLoadedErrorMapper, sendError, sendCommandResult, persistMutatedState, restoreTableFromPersisted, broadcastResyncRequired, broadcastStateSnapshots, durableActionRequired = false, durableActionStore = null, scheduleSettledRollover = () => {}, scheduleBotStep = () => {}, klog = () => {} }) {
   const tableId = frame.__resolvedTableId;
   const handId = typeof frame.payload?.handId === "string" ? frame.payload.handId.trim() : "";
@@ -98,7 +113,8 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
       ? projectDurableActionResult({ status: "accepted", reason: mapActReason(result.reason), handId: result.handId || handId, stateVersion: result.stateVersion })
       : null;
     if (durableActionRequired && !durableResult) {
-      await restoreTableFromPersisted(tableId);
+      const restored = await restoreDurableRuntimeOrReject({ tableId, requestId: frame.requestId, ws, connState, restoreTableFromPersisted, broadcastResyncRequired, sendCommandResult });
+      if (!restored) return;
       sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_result_invalid" });
       return;
     }
@@ -114,12 +130,8 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
         : null
     });
     if (durableActionRequired && ["durable_replay", "idempotency_conflict", "invalid"].includes(persisted?.outcome)) {
-      const restored = await restoreTableFromPersisted(tableId);
-      if (!restored?.ok) {
-        if (typeof broadcastResyncRequired === "function") broadcastResyncRequired(tableId, "durable_action_restore_failed");
-        sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_restore_failed" });
-        return;
-      }
+      const restored = await restoreDurableRuntimeOrReject({ tableId, requestId: frame.requestId, ws, connState, restoreTableFromPersisted, broadcastResyncRequired, sendCommandResult });
+      if (!restored) return;
       const replay = persisted.outcome === "durable_replay" ? persisted.durableResult : null;
       sendCommandResult(ws, connState, {
         requestId: frame.requestId ?? null,
@@ -144,7 +156,8 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
       return;
     }
     if (durableActionRequired && persisted.outcome !== "committed") {
-      await restoreTableFromPersisted(tableId);
+      const restored = await restoreDurableRuntimeOrReject({ tableId, requestId: frame.requestId, ws, connState, restoreTableFromPersisted, broadcastResyncRequired, sendCommandResult });
+      if (!restored) return;
       sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_outcome_invalid" });
       return;
     }

--- a/ws-server/poker/handlers/act.mjs
+++ b/ws-server/poker/handlers/act.mjs
@@ -1,4 +1,5 @@
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
+import { hashActionCommand, normalizeActionCommand, projectDurableActionResult } from "../idempotency/action-command.mjs";
 
 function mapActReason(reason) {
   if (reason === "illegal_action") return "action_not_allowed";
@@ -7,7 +8,7 @@ function mapActReason(reason) {
   return reason;
 }
 
-export async function handleActCommand({ frame, ws, connState, tableManager, ensureTableLoadedErrorMapper, sendError, sendCommandResult, persistMutatedState, restoreTableFromPersisted, broadcastResyncRequired, broadcastStateSnapshots, scheduleSettledRollover = () => {}, scheduleBotStep = () => {}, klog = () => {} }) {
+export async function handleActCommand({ frame, ws, connState, tableManager, ensureTableLoadedErrorMapper, sendError, sendCommandResult, persistMutatedState, restoreTableFromPersisted, broadcastResyncRequired, broadcastStateSnapshots, durableActionRequired = false, durableActionStore = null, scheduleSettledRollover = () => {}, scheduleBotStep = () => {}, klog = () => {} }) {
   const tableId = frame.__resolvedTableId;
   const handId = typeof frame.payload?.handId === "string" ? frame.payload.handId.trim() : "";
   const action = typeof frame.payload?.action === "string" ? frame.payload.action.trim().toUpperCase() : "";
@@ -31,7 +32,7 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
     return;
   }
 
-  if ((action === "BET" || action === "RAISE") && !Number.isFinite(amount)) {
+  if ((action === "BET" || action === "RAISE") && !Number.isInteger(amount)) {
     sendError(ws, connState, {
       code: "INVALID_COMMAND",
       message: "act requires numeric payload.amount for bet/raise",
@@ -52,25 +53,81 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
     return;
   }
 
+  const userId = connState.session.userId;
+  let payloadHash = null;
+  if (durableActionRequired) {
+    if (!durableActionStore || typeof durableActionStore.readDurableActionRequest !== "function") {
+      sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_store_unavailable" });
+      return;
+    }
+    const normalizedCommand = normalizeActionCommand({ tableId, userId, handId, action, amount });
+    payloadHash = normalizedCommand ? hashActionCommand(normalizedCommand) : null;
+    if (!payloadHash) {
+      sendError(ws, connState, { code: "INVALID_COMMAND", message: "act payload cannot be normalized", requestId: frame.requestId ?? null });
+      return;
+    }
+    const durableLookup = await durableActionStore.readDurableActionRequest({ tableId, userId, requestId: frame.requestId, payloadHash });
+    if (durableLookup?.outcome === "durable_replay") {
+      sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, ...durableLookup.durableResult });
+      return;
+    }
+    if (durableLookup?.outcome !== "missing") {
+      sendCommandResult(ws, connState, {
+        requestId: frame.requestId ?? null,
+        tableId,
+        status: "rejected",
+        reason: durableLookup?.reason || durableLookup?.outcome || "durable_action_read_failed"
+      });
+      return;
+    }
+  }
+
   const result = tableManager.applyAction({
     tableId,
     handId,
-    userId: connState.session.userId,
+    userId,
     requestId: frame.requestId,
     action,
     amount,
-    nowIso: frame.ts
+    nowIso: frame.ts,
+    useActionReplayCache: !durableActionRequired
   });
 
   if (result.accepted && !result.replayed && result.changed) {
+    const durableResult = durableActionRequired
+      ? projectDurableActionResult({ status: "accepted", reason: mapActReason(result.reason), handId: result.handId || handId, stateVersion: result.stateVersion })
+      : null;
+    if (durableActionRequired && !durableResult) {
+      await restoreTableFromPersisted(tableId);
+      sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_result_invalid" });
+      return;
+    }
     const persisted = await persistMutatedState({
       tableId,
       expectedVersion: Number(result.stateVersion) - 1,
       mutationKind: "act",
       acceptedActionAudit: result.acceptedActionAudit
         ? { ...result.acceptedActionAudit, source: "human" }
+        : null,
+      durableActionRequest: durableActionRequired
+        ? { userId, requestId: frame.requestId, payloadHash, result: durableResult }
         : null
     });
+    if (durableActionRequired && ["durable_replay", "idempotency_conflict", "invalid"].includes(persisted?.outcome)) {
+      const restored = await restoreTableFromPersisted(tableId);
+      if (!restored?.ok) {
+        if (typeof broadcastResyncRequired === "function") broadcastResyncRequired(tableId, "durable_action_restore_failed");
+        sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_restore_failed" });
+        return;
+      }
+      const replay = persisted.outcome === "durable_replay" ? persisted.durableResult : null;
+      sendCommandResult(ws, connState, {
+        requestId: frame.requestId ?? null,
+        tableId,
+        ...(replay || { status: "rejected", reason: persisted.reason || persisted.outcome })
+      });
+      return;
+    }
     if (!persisted?.ok) {
       await recoverFromPersistConflict({
         tableId,
@@ -84,6 +141,11 @@ export async function handleActCommand({ frame, ws, connState, tableManager, ens
         status: "rejected",
         reason: persisted?.reason || "persist_failed"
       });
+      return;
+    }
+    if (durableActionRequired && persisted.outcome !== "committed") {
+      await restoreTableFromPersisted(tableId);
+      sendCommandResult(ws, connState, { requestId: frame.requestId ?? null, tableId, status: "rejected", reason: "durable_action_outcome_invalid" });
       return;
     }
   }

--- a/ws-server/poker/idempotency/action-command.behavior.test.mjs
+++ b/ws-server/poker/idempotency/action-command.behavior.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { hashActionCommand, normalizeActionCommand, projectDurableActionResult } from "./action-command.mjs";
+
+const base = { tableId: " table-1 ", userId: " user-1 ", handId: " hand-1 ", action: "raise", amount: 20 };
+
+test("action payload hash excludes request identity and changes with command payload", () => {
+  const hash = hashActionCommand(base);
+  assert.equal(hash.length, 64);
+  assert.equal(hashActionCommand({ ...base, requestId: "request-a" }), hashActionCommand({ ...base, requestId: "request-b" }));
+  assert.notEqual(hashActionCommand({ ...base, amount: 21 }), hash);
+  assert.notEqual(hashActionCommand({ ...base, action: "BET" }), hash);
+  assert.notEqual(hashActionCommand({ ...base, handId: "hand-2" }), hash);
+});
+
+test("action normalization removes irrelevant amounts and rejects invalid amount actions", () => {
+  assert.deepEqual(normalizeActionCommand({ ...base, action: "CHECK", amount: 999 }), {
+    kind: "ACT",
+    tableId: "table-1",
+    userId: "user-1",
+    handId: "hand-1",
+    action: "CHECK",
+    amount: null
+  });
+  assert.equal(normalizeActionCommand({ ...base, amount: 1.5 }), null);
+  assert.equal(normalizeActionCommand({ ...base, action: "ALL_IN" }), null);
+});
+
+test("durable result projection keeps only the accepted result allowlist", () => {
+  assert.deepEqual(projectDurableActionResult({ status: "accepted", handId: "h1", stateVersion: 4, ignored: "secret" }), {
+    status: "accepted",
+    reason: null,
+    handId: "h1",
+    stateVersion: 4
+  });
+  assert.equal(projectDurableActionResult({ status: "rejected", handId: "h1", stateVersion: 4 }), null);
+});

--- a/ws-server/poker/idempotency/action-command.mjs
+++ b/ws-server/poker/idempotency/action-command.mjs
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+
+const HUMAN_ACTIONS = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE"]);
+const AMOUNT_ACTIONS = new Set(["BET", "RAISE"]);
+
+function normalizeRequiredString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function normalizeActionCommand({ tableId, userId, handId, action, amount } = {}) {
+  const normalizedTableId = normalizeRequiredString(tableId);
+  const normalizedUserId = normalizeRequiredString(userId);
+  const normalizedHandId = normalizeRequiredString(handId);
+  const normalizedAction = typeof action === "string" ? action.trim().toUpperCase() : "";
+  if (!normalizedTableId || !normalizedUserId || !normalizedHandId || !HUMAN_ACTIONS.has(normalizedAction)) {
+    return null;
+  }
+  let normalizedAmount = null;
+  if (AMOUNT_ACTIONS.has(normalizedAction)) {
+    if (!Number.isInteger(amount)) return null;
+    normalizedAmount = amount;
+  }
+  return {
+    kind: "ACT",
+    tableId: normalizedTableId,
+    userId: normalizedUserId,
+    handId: normalizedHandId,
+    action: normalizedAction,
+    amount: normalizedAmount
+  };
+}
+
+export function hashActionCommand(command) {
+  const normalized = normalizeActionCommand(command);
+  if (!normalized) return null;
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+}
+
+export function projectDurableActionResult({ status, reason = null, handId, stateVersion } = {}) {
+  const normalizedHandId = normalizeRequiredString(handId);
+  const normalizedReason = reason === null || reason === undefined
+    ? null
+    : normalizeRequiredString(reason);
+  if (status !== "accepted" || !normalizedHandId || !Number.isInteger(stateVersion) || stateVersion < 0) {
+    return null;
+  }
+  if (reason !== null && reason !== undefined && !normalizedReason) return null;
+  return { status: "accepted", reason: normalizedReason, handId: normalizedHandId, stateVersion };
+}

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -1017,3 +1017,133 @@ test("replacement funding failure rolls back persisted state and escrow", async 
   assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore);
   assert.equal(harness.durable.ledgerInsertCount, 0);
 });
+
+function createDurableActionDbHarness({ tableId, version = 1, state = { tableId, handId: "h1", phase: "PREFLOP" } } = {}) {
+  const durable = { version, state: structuredClone(state), requests: new Map(), casCount: 0, failAudit: false };
+  const requestKey = (userId, requestId) => `${tableId}:ACT:${requestId}:${userId}`;
+
+  async function beginSql(fn) {
+    const working = {
+      version: durable.version,
+      state: structuredClone(durable.state),
+      requests: new Map([...durable.requests].map(([key, value]) => [key, structuredClone(value)])),
+      casCount: durable.casCount,
+      failAudit: durable.failAudit
+    };
+    const tx = {
+      unsafe: async (query, params = []) => {
+        const text = String(query).replace(/\s+/g, " ").trim();
+        if (text.startsWith("insert into public.poker_requests")) {
+          const key = requestKey(params[1], params[2]);
+          if (working.requests.has(key)) return [];
+          working.requests.set(key, { payload_hash: params[4], result_json: null });
+          return [{ request_id: params[2] }];
+        }
+        if (text.startsWith("select payload_hash, result_json from public.poker_requests")) {
+          const row = working.requests.get(requestKey(params[3], params[2]));
+          return row ? [structuredClone(row)] : [];
+        }
+        if (text.startsWith("update public.poker_requests set result_json")) {
+          const key = requestKey(params[3], params[2]);
+          const row = working.requests.get(key);
+          if (!row || row.payload_hash !== params[4]) return [];
+          row.result_json = JSON.parse(params[5]);
+          return [{ request_id: params[2] }];
+        }
+        if (text.startsWith("update public.poker_state set version = version + 1")) {
+          if (working.version !== Number(params[1])) return [];
+          working.version += 1;
+          working.state = JSON.parse(params[2]);
+          working.casCount += 1;
+          return [{ version: working.version }];
+        }
+        if (text.startsWith("select id from public.poker_actions") || text.startsWith("update public.poker_tables set last_activity_at")) return [];
+        if (text.startsWith("insert into public.poker_actions")) {
+          if (working.failAudit) throw new Error("audit_failed");
+          return [];
+        }
+        if (text.startsWith("select version, state from public.poker_state")) return [{ version: working.version, state: structuredClone(working.state) }];
+        return [];
+      }
+    };
+    const result = await fn(tx);
+    durable.version = working.version;
+    durable.state = working.state;
+    durable.requests = working.requests;
+    durable.casCount = working.casCount;
+    return result;
+  }
+
+  return { beginSql, durable, requestKey };
+}
+
+function durableActionRequestFixture({ requestId = "action-1", payloadHash = "a".repeat(64), stateVersion = 2 } = {}) {
+  return {
+    userId: "00000000-0000-4000-8000-000000000001",
+    requestId,
+    payloadHash,
+    result: { status: "accepted", reason: null, handId: "h1", stateVersion }
+  };
+}
+
+test("durable ACT commits with state CAS and replays after writer restart", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000377";
+  const harness = createDurableActionDbHarness({ tableId });
+  const options = { env: { SUPABASE_DB_URL: "postgres://example.invalid/db" }, beginSql: harness.beginSql, klog: () => {} };
+  const writer = createPersistedStateWriter(options);
+  const request = durableActionRequestFixture();
+  const nextState = { tableId, handId: "h1", phase: "FLOP" };
+
+  assert.deepEqual(await writer.readDurableActionRequest({ tableId, userId: request.userId, requestId: request.requestId, payloadHash: request.payloadHash }), { outcome: "missing" });
+  const committed = await writer.writeMutation({ tableId, expectedVersion: 1, nextState, durableActionRequest: request });
+  assert.equal(committed.ok, true);
+  assert.equal(committed.outcome, "committed");
+  assert.deepEqual(committed.durableResult, request.result);
+  assert.equal(harness.durable.version, 2);
+  assert.equal(harness.durable.casCount, 1);
+
+  const restartedWriter = createPersistedStateWriter(options);
+  const lookup = await restartedWriter.readDurableActionRequest({ tableId, userId: request.userId, requestId: request.requestId, payloadHash: request.payloadHash });
+  assert.deepEqual(lookup, { outcome: "durable_replay", durableResult: request.result });
+  const raceReplay = await restartedWriter.writeMutation({ tableId, expectedVersion: 1, nextState, durableActionRequest: request });
+  assert.equal(raceReplay.outcome, "durable_replay");
+  assert.equal(harness.durable.casCount, 1);
+
+  const conflict = await restartedWriter.readDurableActionRequest({ tableId, userId: request.userId, requestId: request.requestId, payloadHash: "b".repeat(64) });
+  assert.equal(conflict.outcome, "idempotency_conflict");
+});
+
+test("durable ACT failed CAS rolls back reservation and cannot use equal-state fallback", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000378";
+  const equalState = { tableId, handId: "h1", phase: "FLOP" };
+  const harness = createDurableActionDbHarness({ tableId, version: 2, state: equalState });
+  const writer = createPersistedStateWriter({ env: { SUPABASE_DB_URL: "postgres://example.invalid/db" }, beginSql: harness.beginSql, klog: () => {} });
+  const request = durableActionRequestFixture({ requestId: "cas-loser" });
+
+  const result = await writer.writeMutation({ tableId, expectedVersion: 1, nextState: equalState, durableActionRequest: request });
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, "failure");
+  assert.equal(result.reason, "conflict");
+  assert.equal(harness.durable.requests.has(harness.requestKey(request.userId, request.requestId)), false);
+  assert.equal(harness.durable.casCount, 0);
+});
+
+test("durable ACT keeps accepted action audit best-effort", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000379";
+  const harness = createDurableActionDbHarness({ tableId });
+  harness.durable.failAudit = true;
+  const logs = [];
+  const writer = createPersistedStateWriter({ env: { SUPABASE_DB_URL: "postgres://example.invalid/db" }, beginSql: harness.beginSql, klog: (event) => logs.push(event) });
+  const request = durableActionRequestFixture({ requestId: "audit-best-effort" });
+  const result = await writer.writeMutation({
+    tableId,
+    expectedVersion: 1,
+    nextState: { tableId, handId: "h1", phase: "FLOP" },
+    durableActionRequest: request,
+    acceptedActionAudit: { handId: "h1", actorUserId: request.userId, action: "CHECK", requestId: request.requestId }
+  });
+
+  assert.equal(result.outcome, "committed");
+  assert.equal(harness.durable.requests.get(harness.requestKey(request.userId, request.requestId)).result_json.status, "accepted");
+  assert.equal(logs.includes("ws_accepted_action_audit_failed"), true);
+});

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -1,6 +1,7 @@
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 import { writePersistedTableToFile } from "./persisted-state-file-store.mjs";
+import { projectDurableActionResult } from "../idempotency/action-command.mjs";
 
 const HAND_SETTLED_ACTION_TYPE = "HAND_SETTLED";
 const SETTLEMENT_AUDIT_VERSION = 1;
@@ -8,6 +9,8 @@ const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
 const MAX_REPLACEMENT_FUNDINGS = 10;
 const MAX_HUMAN_STACK_UPDATES = 10;
+const DURABLE_ACTION_KIND = "ACT";
+const PAYLOAD_HASH_PATTERN = /^[a-f0-9]{64}$/;
 
 function normalizeJsonState(value) {
   if (!value) return {};
@@ -29,6 +32,89 @@ function sanitizePersistedState(value) {
   const state = normalizeJsonState(value);
   const { deck: _ignoredDeck, holeCardsByUserId: _ignoredHoleCards, ...persistedState } = state;
   return persistedState;
+}
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function normalizeDurableActionRequest(value, { expectedVersion = null } = {}) {
+  if (value === undefined || value === null) return { ok: true, supplied: false, request: null };
+  const identity = normalizeDurableActionIdentity(value);
+  if (!identity) {
+    return { ok: false, supplied: true, reason: "invalid_durable_action_request" };
+  }
+  const result = projectDurableActionResult(value?.result);
+  if (!result) {
+    return { ok: false, supplied: true, reason: "invalid_durable_action_request" };
+  }
+  if (Number.isInteger(expectedVersion) && result.stateVersion !== expectedVersion + 1) {
+    return { ok: false, supplied: true, reason: "invalid_durable_action_request" };
+  }
+  return { ok: true, supplied: true, request: { ...identity, result } };
+}
+
+function normalizeDurableActionIdentity(value) {
+  const userId = typeof value?.userId === "string" ? value.userId.trim() : "";
+  const requestId = typeof value?.requestId === "string" ? value.requestId.trim() : "";
+  const payloadHash = typeof value?.payloadHash === "string" ? value.payloadHash.trim().toLowerCase() : "";
+  if (!userId || !requestId || requestId.length > 200 || !PAYLOAD_HASH_PATTERN.test(payloadHash)) return null;
+  return { userId, requestId, payloadHash };
+}
+
+function classifyDurableActionRow(row, payloadHash) {
+  if (!row) return { outcome: "missing" };
+  const storedHash = typeof row?.payload_hash === "string" ? row.payload_hash.trim().toLowerCase() : "";
+  if (!PAYLOAD_HASH_PATTERN.test(storedHash)) return { outcome: "invalid", reason: "idempotency_record_invalid" };
+  if (storedHash !== payloadHash) return { outcome: "idempotency_conflict", reason: "idempotency_conflict" };
+  const durableResult = projectDurableActionResult(parseJsonObject(row?.result_json));
+  if (!durableResult) return { outcome: "invalid", reason: "idempotency_record_invalid" };
+  return { outcome: "durable_replay", durableResult };
+}
+
+async function readDurableActionRow(tx, { tableId, userId, requestId, lock = false }) {
+  const lockClause = lock ? " for update" : "";
+  const rows = await tx.unsafe(
+    `select payload_hash, result_json from public.poker_requests where table_id = $1 and kind = $2 and request_id = $3 and user_id = $4 limit 1${lockClause};`,
+    [tableId, DURABLE_ACTION_KIND, requestId, userId]
+  );
+  return rows?.[0] || null;
+}
+
+async function reserveDurableActionRequest(tx, { tableId, request }) {
+  const insertedRows = await tx.unsafe(
+    `insert into public.poker_requests (table_id, user_id, request_id, kind, payload_hash, result_json)
+     values ($1, $2, $3, $4, $5, null)
+     on conflict (table_id, kind, request_id, user_id) do nothing
+     returning request_id;`,
+    [tableId, request.userId, request.requestId, DURABLE_ACTION_KIND, request.payloadHash]
+  );
+  if (insertedRows?.[0]?.request_id) return { outcome: "reserved" };
+  const existingRow = await readDurableActionRow(tx, { tableId, userId: request.userId, requestId: request.requestId, lock: true });
+  return classifyDurableActionRow(existingRow, request.payloadHash);
+}
+
+async function finalizeDurableActionRequest(tx, { tableId, request }) {
+  const rows = await tx.unsafe(
+    `update public.poker_requests set result_json = $6::jsonb
+     where table_id = $1 and kind = $2 and request_id = $3 and user_id = $4 and payload_hash = $5
+     returning request_id;`,
+    [tableId, DURABLE_ACTION_KIND, request.requestId, request.userId, request.payloadHash, JSON.stringify(request.result)]
+  );
+  if (!Array.isArray(rows) || rows.length !== 1 || rows[0]?.request_id !== request.requestId) {
+    const error = new Error("durable_action_finalize_conflict");
+    error.code = "durable_action_finalize_conflict";
+    throw error;
+  }
 }
 
 const stableStringify = (value) =>
@@ -524,12 +610,22 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     acceptedActionAudit = null,
     replacementFundingPlan,
     humanStackUpdatePlan,
-    botFundingSystemKey = null
+    botFundingSystemKey = null,
+    durableActionPlan
   }) {
     return beginSql(async (tx) => {
       const persistedState = sanitizePersistedState(nextState);
       const holeCardState = normalizeJsonState(privateStateForHoleCards) || {};
       const payload = JSON.stringify(persistedState);
+      if (durableActionPlan.supplied) {
+        const reservation = await reserveDurableActionRequest(tx, { tableId, request: durableActionPlan.request });
+        if (reservation.outcome !== "reserved") {
+          return {
+            ok: reservation.outcome === "durable_replay",
+            ...reservation
+          };
+        }
+      }
       const rows = await tx.unsafe(
         "update public.poker_state set version = version + 1, state = $3::jsonb, updated_at = now() where table_id = $1 and version = $2 returning version;",
         [tableId, expectedVersion, payload]
@@ -576,9 +672,16 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
             reason: error?.message || "unknown"
           });
         }
+        if (durableActionPlan.supplied) {
+          await finalizeDurableActionRequest(tx, { tableId, request: durableActionPlan.request });
+        }
         return {
           ok: true,
           newVersion,
+          ...(durableActionPlan.supplied ? {
+            outcome: "committed",
+            durableResult: durableActionPlan.request.result
+          } : {}),
           ...(replacementFundingPlan.supplied ? {
             tableId,
             expectedVersion,
@@ -592,6 +695,12 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
             projectedHumanStacks
           } : {})
         };
+      }
+
+      if (durableActionPlan.supplied) {
+        const error = new Error("durable_action_state_conflict");
+        error.code = "durable_action_state_conflict";
+        throw error;
       }
 
       const stateRows = await tx.unsafe("select version, state from public.poker_state where table_id = $1 limit 1;", [tableId]);
@@ -650,7 +759,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     acceptedActionAudit = null,
     replacementFundings = undefined,
     humanStackUpdates = undefined,
-    botFundingSystemKey = null
+    botFundingSystemKey = null,
+    durableActionRequest = null
   }) {
     if (!tableId || !Number.isInteger(expectedVersion) || expectedVersion < 0) {
       return { ok: false, reason: "invalid" };
@@ -673,6 +783,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     }
     const humanStackUpdatePlan = normalizeHumanStackUpdates({ humanStackUpdates, expectedVersion });
     if (!humanStackUpdatePlan.ok) return { ok: false, reason: humanStackUpdatePlan.reason };
+    const durableActionPlan = normalizeDurableActionRequest(durableActionRequest, { expectedVersion });
+    if (!durableActionPlan.ok) return { ok: false, outcome: "invalid", reason: durableActionPlan.reason };
     if (replacementFundingPlan.fundings.length > 0) {
       const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
       if (!sourceSystemKey) {
@@ -686,6 +798,9 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         return { ok: false, reason: "conflict" };
       }
       if (env.WS_PERSISTED_STATE_FILE) {
+        if (durableActionPlan.supplied) {
+          return { ok: false, outcome: "failure", reason: "durable_action_store_unavailable" };
+        }
         if (replacementFundingPlan.fundings.length > 0) {
           return { ok: false, reason: "ledger_unavailable" };
         }
@@ -708,7 +823,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         acceptedActionAudit,
         replacementFundingPlan,
         humanStackUpdatePlan,
-        botFundingSystemKey
+        botFundingSystemKey,
+        durableActionPlan
       });
     } catch (error) {
       klog("ws_persisted_state_write_error", {
@@ -718,9 +834,34 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         message: error?.message || "unknown",
         ...(meta && typeof meta === "object" ? meta : {})
       });
-      return { ok: false, reason: "db_error", message: error?.message || "unknown" };
+      const stateConflict = error?.code === "durable_action_state_conflict";
+      return {
+        ok: false,
+        ...(durableActionPlan.supplied ? { outcome: "failure" } : {}),
+        reason: stateConflict ? "conflict" : "db_error",
+        message: error?.message || "unknown"
+      };
     }
   }
 
-  return { writeMutation };
+  async function readDurableActionRequest({ tableId, userId, requestId, payloadHash }) {
+    const identity = normalizeDurableActionIdentity({ userId, requestId, payloadHash });
+    if (!tableId || !identity) {
+      return { outcome: "invalid", reason: "invalid_durable_action_request" };
+    }
+    if (!env.SUPABASE_DB_URL || env.WS_PERSISTED_STATE_FILE) {
+      return { outcome: "failure", reason: "durable_action_store_unavailable" };
+    }
+    try {
+      return await beginSql(async (tx) => {
+        const row = await readDurableActionRow(tx, { tableId, userId: identity.userId, requestId: identity.requestId });
+        return classifyDurableActionRow(row, identity.payloadHash);
+      }, { env });
+    } catch (error) {
+      klog("ws_durable_action_read_error", { tableId, reason: "db_error", message: error?.message || "unknown" });
+      return { outcome: "failure", reason: "db_error" };
+    }
+  }
+
+  return { writeMutation, readDurableActionRequest };
 }

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -1856,6 +1856,43 @@ test("applyAction is idempotent for requestId and does not double-apply", () => 
   assert.deepEqual(after, mid);
 });
 
+test("applyAction can bypass the in-memory replay cache for durable human actions", () => {
+  const tableManager = createTableManager({ maxSeats: 4, enableDebugCore: true });
+  const wsA = fakeWs("durable-a");
+  const wsB = fakeWs("durable-b");
+  const tableId = "table_apply_durable_cache_bypass";
+
+  assert.equal(tableManager.join({ ws: wsA, userId: "user_a", tableId, requestId: "join-a", nowTs: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: wsB, userId: "user_b", tableId, requestId: "join-b", nowTs: 1 }).ok, true);
+  assert.equal(tableManager.bootstrapHand(tableId).ok, true);
+
+  const before = tableManager.tableSnapshot(tableId, "user_a");
+  const first = tableManager.applyAction({
+    tableId,
+    handId: before.hand.handId,
+    userId: "user_a",
+    requestId: "req-durable",
+    action: "CALL",
+    amount: 0,
+    useActionReplayCache: false
+  });
+  const second = tableManager.applyAction({
+    tableId,
+    handId: before.hand.handId,
+    userId: "user_a",
+    requestId: "req-durable",
+    action: "CALL",
+    amount: 0,
+    useActionReplayCache: false
+  });
+
+  assert.equal(first.accepted, true);
+  assert.equal(first.replayed, false);
+  assert.equal(second.accepted, false);
+  assert.equal(second.replayed, false);
+  assert.equal(tableManager.__debugCore(tableId).actionResultsCacheSize, 0);
+});
+
 test("applyAction same requestId from different users does not collide", () => {
   const tableManager = createTableManager({ maxSeats: 4, actionResultCacheMax: 8 });
   const wsA = fakeWs("scope-a");

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -803,14 +803,14 @@ export function createTableManager({
     };
   }
 
-  function applyAction({ tableId, handId, userId, requestId, action, amount, nowIso, nowMs }) {
+  function applyAction({ tableId, handId, userId, requestId, action, amount, nowIso, nowMs, useActionReplayCache = true }) {
     const table = tables.get(tableId);
     if (!table) {
       return rejectAction({ reason: "table_not_found", stateVersion: 0 });
     }
 
     const replayKey = makeActionReplayKey({ userId, requestId });
-    if (replayKey && table.actionResultsByRequestId.has(replayKey)) {
+    if (useActionReplayCache && replayKey && table.actionResultsByRequestId.has(replayKey)) {
       return asReplayedResult(table.actionResultsByRequestId.get(replayKey));
     }
 
@@ -829,7 +829,7 @@ export function createTableManager({
 
     if (!applied.accepted) {
       const rejected = rejectAction({ reason: applied.reason || "action_rejected", stateVersion: applied.stateVersion });
-      rememberActionResult(table, requestId, { ...rejected, userId });
+      if (useActionReplayCache) rememberActionResult(table, requestId, { ...rejected, userId });
       return rejected;
     }
 
@@ -857,7 +857,7 @@ export function createTableManager({
       })
     };
 
-    rememberActionResult(table, requestId, { ...accepted, userId });
+    if (useActionReplayCache) rememberActionResult(table, requestId, { ...accepted, userId });
 
     return accepted;
   }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -255,6 +255,9 @@ const persistedSeatTouchThrottleMs = resolvePositiveInt(
 const streamLog = createStreamLog({ cap: Number(process.env.WS_STREAM_REPLAY_CAP || 128) });
 const tableSnapshotLoader = createTableSnapshotLoader({ env: process.env });
 const persistedStateWriter = persistedStateWriteEnabled ? createPersistedStateWriter({ env: process.env, klog: klogSafe }) : null;
+const durableActionStore = hasSupabaseDbUrl && persistedStateWriter?.readDurableActionRequest
+  ? persistedStateWriter
+  : null;
 const botFundingSystemKey = getBotConfig(process.env).bankrollSystemKey;
 const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
@@ -1191,6 +1194,7 @@ async function persistMutatedState({
   replacementFundings = undefined,
   humanStackUpdates = undefined,
   replacementFundingSystemKey = null,
+  durableActionRequest = null,
   deferRuntimeVersionUpdate = false
 }) {
   if (isGuestTableId(tableId)) {
@@ -1233,14 +1237,15 @@ async function persistMutatedState({
     acceptedActionAudit,
     replacementFundings,
     humanStackUpdates,
-    botFundingSystemKey: replacementFundingSystemKey
+    botFundingSystemKey: replacementFundingSystemKey,
+    durableActionRequest
   });
   if (!persisted?.ok) {
     klogSafe("ws_state_persist_failed", { tableId, expectedVersion, mutationKind, reason: persisted?.reason || "unknown" });
     return persisted;
   }
   klogSafe("ws_state_persist_result", { ok: true, newVersion: persisted.newVersion ?? null });
-  if (!deferRuntimeVersionUpdate) {
+  if (!deferRuntimeVersionUpdate && persisted.outcome !== "durable_replay") {
     tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
   }
   return persisted;
@@ -3229,6 +3234,8 @@ wss.on("connection", (ws) => {
           restoreTableFromPersisted,
           broadcastResyncRequired,
           broadcastStateSnapshots,
+          durableActionRequired: !isGuestTableId(frame.__resolvedTableId),
+          durableActionStore,
           scheduleSettledRollover: maybeScheduleSettledRollover,
           scheduleBotStep,
           klog: klogSafe

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -169,7 +169,6 @@ function resolveAuthoritativeJoinEnabled(rawValue, { hasSupabaseDbUrl = false, o
 }
 
 const hasSupabaseDbUrl = Boolean(process.env.SUPABASE_DB_URL);
-const hasPersistedStateFile = Boolean(process.env.WS_PERSISTED_STATE_FILE);
 const publicProfileStorageBaseUrl = process.env.SUPABASE_URL || process.env.SUPABASE_URL_V2 || "";
 const persistedBootstrapEnabled = Boolean(hasSupabaseDbUrl || process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON || process.env.WS_PERSISTED_STATE_FILE);
 const persistedStateWriteEnabled = Boolean(process.env.SUPABASE_DB_URL || process.env.WS_PERSISTED_STATE_FILE);
@@ -3235,7 +3234,7 @@ wss.on("connection", (ws) => {
           restoreTableFromPersisted,
           broadcastResyncRequired,
           broadcastStateSnapshots,
-          durableActionRequired: !isGuestTableId(frame.__resolvedTableId) && !hasPersistedStateFile,
+          durableActionRequired: hasSupabaseDbUrl && !isGuestTableId(frame.__resolvedTableId),
           durableActionStore,
           scheduleSettledRollover: maybeScheduleSettledRollover,
           scheduleBotStep,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -169,6 +169,7 @@ function resolveAuthoritativeJoinEnabled(rawValue, { hasSupabaseDbUrl = false, o
 }
 
 const hasSupabaseDbUrl = Boolean(process.env.SUPABASE_DB_URL);
+const hasPersistedStateFile = Boolean(process.env.WS_PERSISTED_STATE_FILE);
 const publicProfileStorageBaseUrl = process.env.SUPABASE_URL || process.env.SUPABASE_URL_V2 || "";
 const persistedBootstrapEnabled = Boolean(hasSupabaseDbUrl || process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON || process.env.WS_PERSISTED_STATE_FILE);
 const persistedStateWriteEnabled = Boolean(process.env.SUPABASE_DB_URL || process.env.WS_PERSISTED_STATE_FILE);
@@ -3234,7 +3235,7 @@ wss.on("connection", (ws) => {
           restoreTableFromPersisted,
           broadcastResyncRequired,
           broadcastStateSnapshots,
-          durableActionRequired: !isGuestTableId(frame.__resolvedTableId),
+          durableActionRequired: !isGuestTableId(frame.__resolvedTableId) && !hasPersistedStateFile,
           durableActionStore,
           scheduleSettledRollover: maybeScheduleSettledRollover,
           scheduleBotStep,


### PR DESCRIPTION
## Summary

Implements durable idempotency for accepted human poker `ACT` commands on DB-backed persistent tables (#377).

- reuses `public.poker_requests` and adds only nullable `payload_hash`
- hashes normalized action payload without `requestId`
- checks durable replay/conflict before running the reducer
- reserves and finalizes the ACT record atomically with the authoritative `poker_state` CAS
- distinguishes fresh `committed` from `durable_replay`; only a fresh commit broadcasts state or schedules bots/rollover
- restores speculative race/failure state from authoritative persistence and fails closed when restore fails
- disables equal-state `alreadyApplied` fallback only for durable ACT
- bypasses the RAM replay cache only for DB-backed persistent human ACT; guest, fixture/file-store, bot and timeout flows retain existing behavior

## Persistence contract

The durable ACT reservation, state CAS and final `result_json` are one transaction. Failed CAS rolls back the reservation. Existing same-payload rows replay; conflicting payloads return `idempotency_conflict`. The existing `poker_actions` audit remains best-effort.

## Deployment order

1. Apply migration `20260718090000_poker_requests_action_payload_hash.sql` on stage.
2. Deploy WS Preview from this PR.
3. Smoke a fresh action and controlled same-request replay.
4. After stage verification, merge and deploy production WS.

The migration must precede the matching WS runtime.

## Breaking impact

- Additive nullable database column.
- DB-backed persistent human actions fail closed when durable DB capability or authoritative restore is unavailable.
- Reusing an accepted request ID with a different normalized payload returns `idempotency_conflict`.
- `BET` and `RAISE` amounts must be integer CH; fractional values are rejected at the handler boundary.
- No WS frame, client retry, poker rules, guest, bot, timeout, ledger, settlement, JSP, CSS or CSP changes.

## Validation

- `npm test`
- `npm run syntax`
- focused handler/writer/cache/hash tests
- WS runtime and server behavior suites
- `git diff --check`
