### PR TITLE
fix: block unfunded poker create and join flows

### DIFF
--- a/docs/poker-insufficient-chips-flow-plan.md
+++ b/docs/poker-insufficient-chips-flow-plan.md
@@ -1,0 +1,171 @@
+# Poker insufficient chips flow — implementation plan
+
+Status: accepted for implementation in the same PR.
+
+Issue: #722
+
+## Goal
+
+Keep a signed-in player in the poker lobby when their confirmed CH balance is below the buy-in required by the current cash-table flow. Cover both create-table and quick-seat without weakening the authoritative `USER -> ESCROW` validation performed by Poker WS.
+
+## Current root cause
+
+- `poker-create-table.mjs` creates an empty table and its escrow account without checking whether the creator can fund a seat.
+- `poker-quick-seat.mjs` recommends or creates a table without checking whether a new seat can be funded.
+- The actual debit occurs later in the authoritative WS join. An insufficient player has therefore already navigated into the table UI before receiving `insufficient_funds`.
+- Rejoining an already funded seat must not require another 100 CH in the USER account.
+
+## Scope and decisions
+
+- Add `shared/poker-domain/table-economy.mjs` containing only `DEFAULT_CASH_TABLE_BUY_IN_CHIPS = 100`.
+- The constant names the default of the current cash-table flow. It is not a global poker rule and does not model tournament entry fees or starting stacks.
+- Add a generic `readPokerBuyInEligibility(tx, { userId, requiredBuyIn })` helper. It must not contain a default amount.
+- Keep `createPokerTableWithState()` unchanged.
+- Keep current quick-seat matchmaking. Do not globally search for an old seat at a different table or different stakes.
+- Keep the authoritative WS join and ledger debit unchanged as the final concurrency-safe guard.
+- Do not add a database migration, ENV, feature flag, or new protocol field.
+
+## Task 1 — cash-flow constant and generic eligibility helper
+
+Files:
+
+- `shared/poker-domain/table-economy.mjs`
+- `netlify/functions/_shared/poker-buy-in-eligibility.mjs`
+
+Properties and functions:
+
+- `DEFAULT_CASH_TABLE_BUY_IN_CHIPS = 100`
+- `readPokerBuyInEligibility(tx, { userId, requiredBuyIn })`
+
+Eligibility rules:
+
+- `requiredBuyIn` must be a positive safe integer.
+- Read the player's `chips_accounts` row with `account_type = 'USER'`.
+- A missing USER account is a valid zero balance.
+- Return `{ eligible, balance, requiredBuyIn }` without creating or locking an account.
+- A SQL failure or malformed, negative, fractional, or unsafe stored balance is an integrity failure and must become `500 server_error`, not a false insufficient-balance response.
+
+## Task 2 — create-table guard
+
+File:
+
+- `netlify/functions/poker-create-table.mjs`
+
+Changes:
+
+1. Pass `DEFAULT_CASH_TABLE_BUY_IN_CHIPS` to the generic eligibility helper inside the existing transaction.
+2. Return a discriminated transaction result:
+   - `{ kind: 'created', tableId }`; or
+   - `{ kind: 'insufficient_chips', balance, requiredBuyIn }`.
+3. Invoke `createPokerTableWithState()` only for an eligible player.
+4. Map insufficient funds to HTTP `409` with `{ error, balance, requiredBuyIn }`.
+5. Only a created result may construct the escrow key, log success, or call `notifyWsLobbyMaterialize()`.
+6. Do not represent insufficient funds with an exception that the existing catch would turn into `500`.
+
+## Task 3 — quick-seat guard
+
+File:
+
+- `netlify/functions/poker-quick-seat.mjs`
+
+Changes:
+
+- Preserve the existing candidate order and advisory lock.
+- `recommendSeatAtTable()` must first check for the current user's seat in the selected table. An existing funded seat remains reconnectable even when the USER balance is zero.
+- Before recommending a new seat, call the eligibility helper with `DEFAULT_CASH_TABLE_BUY_IN_CHIPS`.
+- Before the fallback create path, perform the same eligibility check.
+- Use explicit results:
+  - `{ kind: 'recommended', tableId, seatNo }`;
+  - `{ kind: 'insufficient_chips', balance, requiredBuyIn }`;
+  - `{ kind: 'unavailable' }`.
+- Every caller must immediately propagate `insufficient_chips`. It must never be treated as `null`, followed by another candidate, or followed by fallback table creation.
+- Rejection must not update table activity or call WS materialization.
+
+## Task 4 — lobby UX and room fallback
+
+Files:
+
+- `poker/index.html`
+- `poker/poker.js`
+- `poker/poker-v2.js`
+- `js/i18n.js`
+
+Changes:
+
+- Expose the current lobby cash-flow amount as page/form configuration rather than a global poker invariant.
+- Immediately before create-table, call the existing `ChipsClient.fetchBalance()`.
+- For create-table, block the API call and navigation only for a fresh, valid response below the configured amount.
+- If the balance lookup fails, continue to the guarded endpoint; a transient read error must not falsely block an eligible player.
+- Quick-seat must reach its guarded endpoint because only the backend can distinguish a new buy-in from an already funded seat in the selected table. The endpoint still keeps an insufficient new player in the lobby and returns controlled UI data.
+- Existing loading state prevents parallel clicks.
+- Preserve structured API error properties (`balance`, `requiredBuyIn`) and render a localized message using the backend value.
+- Keep the table-list `Open` action available because it is observer navigation, not a buy-in.
+- Map the existing WS `insufficient_funds` rejection to a controlled message. It is already non-retryable, so do not alter auto-join retry logic.
+
+## API contract
+
+Both Netlify endpoints return:
+
+```json
+{
+  "error": "insufficient_chips",
+  "requiredBuyIn": 100,
+  "balance": 99
+}
+```
+
+with HTTP `409`.
+
+## Verification
+
+Extend existing suites only:
+
+- `tests/poker-create-table.stakes.test.mjs`
+- `tests/poker-quick-seat.behavior.test.mjs`
+- `tests/poker-ui.behavior.test.mjs` where the existing lobby harness is sufficient
+- `tests/poker-v2-live.behavior.test.mjs` only if its current harness covers the controlled WS copy without new infrastructure
+
+Critical cases:
+
+- create at 99 is rejected without table/state/escrow writes or WS notification;
+- create at 100 succeeds;
+- a missing USER account is reported as balance 0;
+- quick-seat at 99 does not continue to another candidate or fallback create;
+- quick-seat at 100 succeeds;
+- an existing seat in the selected table works with USER balance 0;
+- a SQL/integrity failure returns 500;
+- a confirmed insufficient lobby balance suppresses create-table API and navigation;
+- a quick-seat `409` remains in the lobby and renders the structured backend error;
+- a failed lobby balance lookup falls through to the guarded backend.
+
+Manual Netlify Deploy Preview smoke:
+
+1. Test create and Play now with 0 and 99 CH: remain in lobby with controlled copy.
+2. Test both paths with 100 CH: proceed normally.
+3. Reconnect an already funded seat while the USER balance is zero.
+4. Confirm `Open` still permits observing a table.
+5. Confirm authoritative WS join still rejects a balance race safely.
+
+## Deployment and dependency graph
+
+- Netlify Deploy Preview is required.
+- The new file under `shared/**` may trigger WS checks or deployment through path filters.
+- Before handoff, verify that `table-economy.mjs` is imported only by the two Netlify endpoints and is not present in the WS runtime import graph or a shared barrel loaded by WS.
+- If that remains true, a manual WS Preview Deploy is not required even if a path-based WS workflow runs automatically.
+- If implementation introduces a WS import, WS Preview Deploy becomes required and must be declared in the PR.
+
+## Breaking impact
+
+Intended behavior change:
+
+- create-table and quick-seat can now return `409 insufficient_chips` before navigation;
+- an insufficient player no longer creates an empty table;
+- the lobby blocks a confirmed invalid flow early.
+
+Unchanged:
+
+- current matchmaking and stakes selection;
+- reconnect to an already funded seat;
+- authoritative join, ledger, poker rules, settlement, and protocol;
+- database schema, ENV, CSP, and CSS;
+- future ability to add persisted per-table economy when a second buy-in or game format exists.

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -330,6 +330,7 @@ homeBonusLoadError: { en: 'Could not load available bonuses.', pl: 'Nie udało s
     pokerErrMissingTableId: { en: 'No tableId provided', pl: 'Nie podano ID stołu' },
     pokerErrLoadTable: { en: 'Failed to load table', pl: 'Nie udało się załadować stołu' },
     pokerErrJoin: { en: 'Failed to join', pl: 'Nie udało się dołączyć' },
+    pokerErrInsufficientChips: { en: 'You need at least {amount} CH to join a table.', pl: 'Potrzebujesz co najmniej {amount} CH, aby dołączyć do stołu.' },
     pokerErrLeave: { en: 'Failed to leave', pl: 'Nie udało się opuścić stołu' },
     pokerErrActionNotAllowed: { en: 'Action not allowed right now', pl: 'Akcja jest teraz niedozwolona' },
     pokerErrStateChanged: { en: 'State changed. Refreshing...', pl: 'Stan gry się zmienił. Odświeżam...' },

--- a/netlify/functions/_shared/poker-buy-in-eligibility.mjs
+++ b/netlify/functions/_shared/poker-buy-in-eligibility.mjs
@@ -1,0 +1,37 @@
+function normalizeRequiredBuyIn(value) {
+  const amount = Number(value);
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    throw new Error("invalid_required_buy_in");
+  }
+  return amount;
+}
+
+function normalizeStoredBalance(value) {
+  const balance = Number(value);
+  if (!Number.isSafeInteger(balance) || balance < 0) {
+    throw new Error("chips_balance_integrity_error");
+  }
+  return balance;
+}
+
+export async function readPokerBuyInEligibility(tx, { userId, requiredBuyIn }) {
+  if (!tx || typeof tx.unsafe !== "function") throw new Error("poker_buy_in_tx_required");
+  if (typeof userId !== "string" || !userId.trim()) throw new Error("poker_buy_in_user_required");
+  const normalizedRequiredBuyIn = normalizeRequiredBuyIn(requiredBuyIn);
+  const rows = await tx.unsafe(
+    `
+select balance
+from public.chips_accounts
+where user_id = $1
+  and account_type = 'USER'
+limit 1;
+    `,
+    [userId]
+  );
+  const balance = rows?.[0] ? normalizeStoredBalance(rows[0].balance) : 0;
+  return {
+    eligible: balance >= normalizedRequiredBuyIn,
+    balance,
+    requiredBuyIn: normalizedRequiredBuyIn,
+  };
+}

--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -1,7 +1,9 @@
 import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
 import { formatStakes, parseStakes } from "./_shared/poker-stakes.mjs";
 import { createPokerTableWithState } from "./_shared/poker-table-init.mjs";
+import { readPokerBuyInEligibility } from "./_shared/poker-buy-in-eligibility.mjs";
 import { notifyWsLobbyMaterialize } from "./_shared/poker-ws-runtime-notify.mjs";
+import { DEFAULT_CASH_TABLE_BUY_IN_CHIPS } from "../../shared/poker-domain/table-economy.mjs";
 
 const mergeHeaders = (next) => ({ ...baseHeaders(), ...(next || {}) });
 
@@ -78,14 +80,38 @@ export async function handler(event) {
   }
   const stakesJson = formatStakes(stakesParsed.value);
 
-  let tableId = null;
+  let transactionResult = null;
   try {
-    await beginSql(async (tx) => {
+    transactionResult = await beginSql(async (tx) => {
+      const eligibility = await readPokerBuyInEligibility(tx, {
+        userId: auth.userId,
+        requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+      });
+      if (!eligibility.eligible) {
+        return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
+      }
       const created = await createPokerTableWithState(tx, { userId: auth.userId, maxPlayers, stakesJson });
-      tableId = created.tableId;
+      return { kind: "created", tableId: created.tableId };
     });
   } catch (error) {
     klog("poker_create_table_error", { message: error?.message || "unknown_error" });
+    return { statusCode: 500, headers: mergeHeaders(cors), body: JSON.stringify({ error: "server_error" }) };
+  }
+
+  if (transactionResult?.kind === "insufficient_chips") {
+    return {
+      statusCode: 409,
+      headers: mergeHeaders(cors),
+      body: JSON.stringify({
+        error: "insufficient_chips",
+        requiredBuyIn: transactionResult.requiredBuyIn,
+        balance: transactionResult.balance,
+      }),
+    };
+  }
+  const tableId = transactionResult?.kind === "created" ? transactionResult.tableId : null;
+  if (!tableId) {
+    klog("poker_create_table_error", { message: "invalid_transaction_result" });
     return { statusCode: 500, headers: mergeHeaders(cors), body: JSON.stringify({ error: "server_error" }) };
   }
 

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -214,7 +214,6 @@ export async function handler(event) {
 
       const preferredRows = await selectCandidate(tx, { stakesJson, maxPlayers, requireHuman: true, humanSeatFreshCutoffIso });
       if (preferredRows?.[0]?.id) {
-        klog("poker_quick_seat_selected", { tableId: preferredRows[0].id, strategy: "prefer_humans", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
         const recommendation = await recommendSeatAtTable(tx, {
           tableId: preferredRows[0].id,
           userId: auth.userId,
@@ -223,12 +222,14 @@ export async function handler(event) {
           createPayload,
         });
         if (recommendation.kind === "insufficient_chips") return recommendation;
-        if (recommendation.kind === "recommended") return { ...recommendation, strategy: "prefer_humans" };
+        if (recommendation.kind === "recommended") {
+          klog("poker_quick_seat_selected", { tableId: recommendation.tableId, strategy: "prefer_humans", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
+          return { ...recommendation, strategy: "prefer_humans" };
+        }
       }
 
       const anyRows = await selectCandidate(tx, { stakesJson, maxPlayers, requireHuman: false, humanSeatFreshCutoffIso });
       if (anyRows?.[0]?.id) {
-        klog("poker_quick_seat_selected", { tableId: anyRows[0].id, strategy: "any_open", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
         const recommendation = await recommendSeatAtTable(tx, {
           tableId: anyRows[0].id,
           userId: auth.userId,
@@ -237,15 +238,21 @@ export async function handler(event) {
           createPayload,
         });
         if (recommendation.kind === "insufficient_chips") return recommendation;
-        if (recommendation.kind === "recommended") return { ...recommendation, strategy: "any_open" };
+        if (recommendation.kind === "recommended") {
+          klog("poker_quick_seat_selected", { tableId: recommendation.tableId, strategy: "any_open", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
+          return { ...recommendation, strategy: "any_open" };
+        }
       }
 
       const createdRecommendation = await createAndRecommend(tx, createPayload);
-      klog("poker_quick_seat_selected", { tableId: createdRecommendation.tableId, strategy: "create", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
+      if (createdRecommendation.kind === "recommended") {
+        klog("poker_quick_seat_selected", { tableId: createdRecommendation.tableId, strategy: "create", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
+      }
       return createdRecommendation;
     });
 
     if (result?.kind === "insufficient_chips") {
+      klog("poker_quick_seat_insufficient_chips", { requiredBuyIn: result.requiredBuyIn, maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
       return {
         statusCode: 409,
         headers: mergeHeaders(cors),

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -1,7 +1,9 @@
 import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySupabaseJwt } from "./_shared/supabase-admin.mjs";
 import { formatStakes, parseStakes } from "./_shared/poker-stakes.mjs";
 import { createPokerTableWithState } from "./_shared/poker-table-init.mjs";
+import { readPokerBuyInEligibility } from "./_shared/poker-buy-in-eligibility.mjs";
 import { notifyWsLobbyMaterialize } from "./_shared/poker-ws-runtime-notify.mjs";
+import { DEFAULT_CASH_TABLE_BUY_IN_CHIPS } from "../../shared/poker-domain/table-economy.mjs";
 
 const DEFAULT_MAX_PLAYERS = 6;
 const mergeHeaders = (next) => ({ ...baseHeaders(), ...(next || {}) });
@@ -55,11 +57,18 @@ const toUiSeatNo = (seatNoDb, maxPlayers) => {
 };
 
 const createAndRecommend = async (tx, { userId, maxPlayers, stakesJson }) => {
+  const eligibility = await readPokerBuyInEligibility(tx, {
+    userId,
+    requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+  });
+  if (!eligibility.eligible) {
+    return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
+  }
   const created = await createPokerTableWithState(tx, { userId, maxPlayers, stakesJson });
   const tableId = created.tableId;
   await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
   const seatNoUi = 1;
-  return { tableId, seatNo: seatNoUi, strategy: "create" };
+  return { kind: "recommended", tableId, seatNo: seatNoUi, strategy: "create" };
 };
 
 const triggerWsLobbyMaterialize = ({ tableId, maxPlayers, stakes, klog }) => {
@@ -123,7 +132,15 @@ const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, allowCrea
   const existingSeatNoDb = existingSeatRows?.[0]?.seat_no;
   if (Number.isInteger(existingSeatNoDb)) {
     await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-    return { tableId, seatNo: toUiSeatNo(existingSeatNoDb, maxPlayers) };
+    return { kind: "recommended", tableId, seatNo: toUiSeatNo(existingSeatNoDb, maxPlayers) };
+  }
+
+  const eligibility = await readPokerBuyInEligibility(tx, {
+    userId,
+    requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+  });
+  if (!eligibility.eligible) {
+    return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
   }
 
   const activeSeatRows = await tx.unsafe(
@@ -133,10 +150,10 @@ const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, allowCrea
   const seatNoDb = pickSeatNo(activeSeatRows, maxPlayers);
   if (seatNoDb == null) {
     if (allowCreateFallback) return createAndRecommend(tx, createPayload);
-    return null;
+    return { kind: "unavailable" };
   }
   await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-  return { tableId, seatNo: toUiSeatNo(seatNoDb, maxPlayers) };
+  return { kind: "recommended", tableId, seatNo: toUiSeatNo(seatNoDb, maxPlayers) };
 };
 
 export async function handler(event) {
@@ -205,7 +222,8 @@ export async function handler(event) {
           allowCreateFallback: true,
           createPayload,
         });
-        if (recommendation) return { ...recommendation, strategy: "prefer_humans" };
+        if (recommendation.kind === "insufficient_chips") return recommendation;
+        if (recommendation.kind === "recommended") return { ...recommendation, strategy: "prefer_humans" };
       }
 
       const anyRows = await selectCandidate(tx, { stakesJson, maxPlayers, requireHuman: false, humanSeatFreshCutoffIso });
@@ -218,7 +236,8 @@ export async function handler(event) {
           allowCreateFallback: true,
           createPayload,
         });
-        if (recommendation) return { ...recommendation, strategy: "any_open" };
+        if (recommendation.kind === "insufficient_chips") return recommendation;
+        if (recommendation.kind === "recommended") return { ...recommendation, strategy: "any_open" };
       }
 
       const createdRecommendation = await createAndRecommend(tx, createPayload);
@@ -226,7 +245,18 @@ export async function handler(event) {
       return createdRecommendation;
     });
 
-    if (result?.strategy === "create" && typeof result?.tableId === "string" && result.tableId) {
+    if (result?.kind === "insufficient_chips") {
+      return {
+        statusCode: 409,
+        headers: mergeHeaders(cors),
+        body: JSON.stringify({ error: "insufficient_chips", requiredBuyIn: result.requiredBuyIn, balance: result.balance }),
+      };
+    }
+    if (result?.kind !== "recommended" || typeof result?.tableId !== "string" || !result.tableId) {
+      throw new Error("invalid_quick_seat_result");
+    }
+
+    if (result.strategy === "create") {
       triggerWsLobbyMaterialize({ tableId: result.tableId, maxPlayers, stakes: stakesParsed.value, klog });
     }
 

--- a/poker/index.html
+++ b/poker/index.html
@@ -96,7 +96,7 @@
       </div>
     </div>
 
-    <div id="pokerLobbyContent" hidden>
+    <div id="pokerLobbyContent" data-required-buy-in="100" hidden>
       <div class="poker-header">
         <h2 data-i18n="pokerTables">Poker Tables</h2>
         <div class="poker-form-row">

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -3067,6 +3067,16 @@
     return value.trim().toLowerCase();
   }
 
+  function joinErrorMessage(error){
+    var code = autoJoinErrorCode(error);
+    if (code !== 'insufficient_funds' && code !== 'insufficient_chips') {
+      return error && error.message ? error.message : 'Failed to join';
+    }
+    var buyIn = els.joinBuyIn ? parseInt(els.joinBuyIn.value, 10) : NaN;
+    var amount = Number.isFinite(buyIn) && buyIn > 0 ? Math.trunc(buyIn) : 100;
+    return t('pokerErrInsufficientChips', 'You need at least {amount} CH to join a table.').replace('{amount}', String(amount));
+  }
+
   function isRetryableAutoJoinError(error){
     var code = autoJoinErrorCode(error);
     if (!code) return false;
@@ -3129,7 +3139,7 @@
         retryScheduled: retryScheduled,
         retryCount: autoJoinRetryCount
       });
-      setError(err && err.message ? err.message : 'Failed to auto-join');
+      setError(joinErrorMessage(err));
     });
   }
 
@@ -3294,7 +3304,7 @@
         state.statusText = result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted';
         renderInfoPanel();
       }).catch(function(err){
-        setError(err && err.message ? err.message : 'Failed to join');
+        setError(joinErrorMessage(err));
       });
     });
     if (els.leaveBtn) els.leaveBtn.addEventListener('click', function(){

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -196,6 +196,8 @@
     var err = new Error(body.error || 'request_failed');
     err.status = res.status;
     err.code = body.error || 'request_failed';
+    if (Number.isSafeInteger(body.balance) && body.balance >= 0) err.balance = body.balance;
+    if (Number.isSafeInteger(body.requiredBuyIn) && body.requiredBuyIn > 0) err.requiredBuyIn = body.requiredBuyIn;
     throw err;
   }
 
@@ -1490,6 +1492,41 @@
     var lobbyReconnectAttempt = 0;
     var lobbyWsGeneration = 0;
 
+    function requiredCashBuyIn(){
+      var value = lobbyContent && lobbyContent.dataset ? Number(lobbyContent.dataset.requiredBuyIn) : NaN;
+      return Number.isSafeInteger(value) && value > 0 ? value : null;
+    }
+
+    function insufficientChipsMessage(requiredBuyIn){
+      var amount = Number.isSafeInteger(requiredBuyIn) && requiredBuyIn > 0 ? requiredBuyIn : requiredCashBuyIn();
+      return t('pokerErrInsufficientChips', 'You need at least {amount} CH to join a table.').replace('{amount}', formatChips(amount));
+    }
+
+    async function hasFreshCashBuyInBalance(){
+      var requiredBuyIn = requiredCashBuyIn();
+      if (!requiredBuyIn || !window.ChipsClient || typeof window.ChipsClient.fetchBalance !== 'function') return true;
+      try {
+        var result = await window.ChipsClient.fetchBalance();
+        var balance = result && Number.isSafeInteger(result.balance) && result.balance >= 0 ? result.balance : null;
+        if (balance !== null && balance < requiredBuyIn){
+          setError(errorEl, insufficientChipsMessage(requiredBuyIn));
+          return false;
+        }
+      } catch (err){
+        klog('poker_buy_in_balance_precheck_failed', { reason: err && (err.code || err.message) ? (err.code || err.message) : 'unknown' });
+      }
+      return true;
+    }
+
+    function handleInsufficientChips(error){
+      if (!error || error.code !== 'insufficient_chips') return false;
+      setError(errorEl, insufficientChipsMessage(error.requiredBuyIn));
+      if (window.ChipsClient && typeof window.ChipsClient.fetchBalance === 'function') {
+        window.ChipsClient.fetchBalance().catch(function(){});
+      }
+      return true;
+    }
+
     function stopAuthWatch(){
       if (authTimer){
         clearInterval(authTimer);
@@ -1842,6 +1879,7 @@
         }
         setError(errorEl, t('pokerErrNoTableId', 'Table created but no ID returned'));
       } catch (err){
+        if (handleInsufficientChips(err)) return;
         if (isAuthError(err)){
           handleAuthExpired({
             authMsg: authMsg,
@@ -1871,6 +1909,7 @@
       var maxPlayers = parseInt(maxPlayersInput ? maxPlayersInput.value : 6, 10) || 6;
       setLoading(createBtn, true);
       try {
+        if (!(await hasFreshCashBuyInBalance())) return;
         var data = await apiPost(CREATE_URL, { stakes: { sb: sb, bb: bb }, maxPlayers: maxPlayers });
         if (data.tableId){
           navigateToPokerTable(data.tableId);
@@ -1878,6 +1917,7 @@
           setError(errorEl, t('pokerErrNoTableId', 'Table created but no ID returned'));
         }
       } catch (err){
+        if (handleInsufficientChips(err)) return;
         if (isAuthError(err)){
           handleAuthExpired({
             authMsg: authMsg,

--- a/shared/poker-domain/table-economy.mjs
+++ b/shared/poker-domain/table-economy.mjs
@@ -1,0 +1,1 @@
+export const DEFAULT_CASH_TABLE_BUY_IN_CHIPS = 100;

--- a/tests/helpers/poker-test-helpers.mjs
+++ b/tests/helpers/poker-test-helpers.mjs
@@ -6,6 +6,7 @@ import { formatStakes, parseStakes } from "../../netlify/functions/_shared/poker
 import { clearMissedTurns } from "../../netlify/functions/_shared/poker-missed-turns.mjs";
 import { patchSitOutByUserId } from "../../netlify/functions/_shared/poker-sitout-flag.mjs";
 import { createPokerTableWithState } from "../../netlify/functions/_shared/poker-table-init.mjs";
+import { readPokerBuyInEligibility } from "../../netlify/functions/_shared/poker-buy-in-eligibility.mjs";
 import { shouldHideSeatRowFromReadModel } from "../../netlify/functions/_shared/poker-list-seat-visibility.mjs";
 import { notifyWsLobbyMaterialize } from "../../netlify/functions/_shared/poker-ws-runtime-notify.mjs";
 import {
@@ -29,6 +30,7 @@ import { isHoleCardsTableMissing, loadHoleCardsByUserId } from "../../netlify/fu
 import { deriveCommunityCards, deriveRemainingDeck } from "../../netlify/functions/_shared/poker-deal-deterministic.mjs";
 import { store as upstashStore, isMemoryStore as upstashIsMemoryStore } from "../../netlify/functions/_shared/store-upstash.mjs";
 import { executePokerLeave } from "../../shared/poker-domain/leave.mjs";
+import { DEFAULT_CASH_TABLE_BUY_IN_CHIPS } from "../../shared/poker-domain/table-economy.mjs";
 
 const root = process.cwd();
 const sharedLeavePath = path.join(root, "shared/poker-domain/leave.mjs");
@@ -131,6 +133,8 @@ export const loadPokerHandler = (filePath, mocks) => {
     "upgradeLegacyInitState",
     "upgradeLegacyInitStateWithSeats",
     "createPokerTableWithState",
+    "readPokerBuyInEligibility",
+    "DEFAULT_CASH_TABLE_BUY_IN_CHIPS",
     "notifyWsLobbyMaterialize",
     "PRESENCE_TTL_SEC",
     "HEARTBEAT_INTERVAL_SEC",
@@ -186,6 +190,8 @@ return handler;`
       patchSitOutByUserId,
       shouldHideSeatRowFromReadModel,
       createPokerTableWithState,
+      readPokerBuyInEligibility,
+      DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
       notifyWsLobbyMaterialize,
       computeTargetBotCount,
       getBotAutoplayConfig,

--- a/tests/poker-create-table.stakes.test.mjs
+++ b/tests/poker-create-table.stakes.test.mjs
@@ -1,8 +1,22 @@
 import assert from "node:assert/strict";
 import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
 import { isStateStorageValid, normalizeJsonState } from "../netlify/functions/_shared/poker-state-utils.mjs";
+import { readPokerBuyInEligibility } from "../netlify/functions/_shared/poker-buy-in-eligibility.mjs";
 
 process.env.CHIPS_ENABLED = "1";
+
+const genericEligibility = await readPokerBuyInEligibility(
+  { unsafe: async () => [{ balance: 999 }] },
+  { userId: "user-1", requiredBuyIn: 1000 }
+);
+assert.deepEqual(genericEligibility, { eligible: false, balance: 999, requiredBuyIn: 1000 });
+await assert.rejects(
+  readPokerBuyInEligibility(
+    { unsafe: async () => [{ balance: -1 }] },
+    { userId: "user-1", requiredBuyIn: 100 }
+  ),
+  /chips_balance_integrity_error/
+);
 
 const makeHandler = (queries, options = {}) =>
   loadPokerHandler("netlify/functions/poker-create-table.mjs", {
@@ -17,6 +31,11 @@ const makeHandler = (queries, options = {}) =>
         unsafe: async (query, params) => {
           const text = String(query).toLowerCase();
           queries.push({ query: String(query), params });
+          if (text.includes("account_type = 'user'")) {
+            if (options.balanceError) throw new Error("balance_read_failed");
+            if (options.missingAccount) return [];
+            return [{ balance: options.balance ?? 100 }];
+          }
           if (text.includes("insert into public.poker_tables")) {
             return [{ id: "table-1" }];
           }
@@ -132,8 +151,53 @@ const runMaintenanceGuard = async () => {
   }
 };
 
+const runInsufficientBalance = async () => {
+  const queries = [];
+  const notifications = [];
+  const handler = makeHandler(queries, {
+    balance: 99,
+    notifyWsLobbyMaterialize: async (payload) => { notifications.push(payload); },
+  });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2" }),
+  });
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), { error: "insufficient_chips", requiredBuyIn: 100, balance: 99 });
+  assert.equal(queries.some((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables")), false);
+  assert.equal(notifications.length, 0);
+};
+
+const runMissingAccount = async () => {
+  const queries = [];
+  const handler = makeHandler(queries, { missingAccount: true });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2" }),
+  });
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), { error: "insufficient_chips", requiredBuyIn: 100, balance: 0 });
+};
+
+const runBalanceReadFailure = async () => {
+  const queries = [];
+  const handler = makeHandler(queries, { balanceError: true });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2" }),
+  });
+  assert.equal(response.statusCode, 500);
+  assert.equal(JSON.parse(response.body).error, "server_error");
+};
+
 await runMissingStakes();
 await runInvalidStakes();
 await runSlashStakes();
 await runSlowNotifyDoesNotDelayResponse();
 await runMaintenanceGuard();
+await runInsufficientBalance();
+await runMissingAccount();
+await runBalanceReadFailure();

--- a/tests/poker-quick-seat.behavior.test.mjs
+++ b/tests/poker-quick-seat.behavior.test.mjs
@@ -14,7 +14,7 @@ const callQuickSeat = async (handler, body = {}) => {
   });
 };
 
-const makeHandler = ({ mode, queries, notifications = [] }) =>
+const makeHandler = ({ mode, queries, notifications = [], balance = 100, balanceError = false }) =>
   loadPokerHandler("netlify/functions/poker-quick-seat.mjs", {
     baseHeaders: () => ({}),
     corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
@@ -27,6 +27,11 @@ const makeHandler = ({ mode, queries, notifications = [] }) =>
           const text = String(query).toLowerCase();
 
           if (text.includes("pg_advisory_xact_lock")) return [];
+
+          if (text.includes("account_type = 'user'")) {
+            if (balanceError) throw new Error("balance_read_failed");
+            return [{ balance }];
+          }
 
           if (
             text.includes("from public.poker_tables t") &&
@@ -114,6 +119,37 @@ const run = async () => {
       "quick seat should bump table activity when recommending"
     );
     assert.equal(notifications.length, 0, "quick seat should not materialize runtime for an existing table recommendation");
+  }
+  {
+    const queries = [];
+    const notifications = [];
+    const handler = makeHandler({ mode: "prefer_humans", queries, notifications, balance: 99 });
+    const res = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
+    assert.equal(res.statusCode, 409);
+    assert.deepEqual(JSON.parse(res.body), { error: "insufficient_chips", requiredBuyIn: 100, balance: 99 });
+    assert.equal(queries.some((entry) => entry.query.toLowerCase().includes("update public.poker_tables")), false);
+    assert.equal(queries.some((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables")), false);
+    assert.equal(notifications.length, 0);
+    const candidateCalls = queries.filter((entry) => entry.query.toLowerCase().includes("from public.poker_tables t"));
+    assert.equal(candidateCalls.length, 1, "insufficient result must not continue to another candidate");
+  }
+
+  {
+    const queries = [];
+    const notifications = [];
+    const handler = makeHandler({ mode: "already_seated", queries, notifications, balance: 0 });
+    const res = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).seatNo, 2);
+    assert.equal(queries.some((entry) => entry.query.toLowerCase().includes("account_type = 'user'")), false);
+  }
+
+  {
+    const queries = [];
+    const handler = makeHandler({ mode: "any_open", queries, balanceError: true });
+    const res = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
+    assert.equal(res.statusCode, 500);
+    assert.equal(JSON.parse(res.body).error, "server_error");
   }
 
   {
@@ -228,6 +264,7 @@ const run = async () => {
           const text = String(query).toLowerCase();
           if (text.includes("pg_advisory_xact_lock")) return [];
           if (text.includes("from public.poker_tables t")) return [];
+          if (text.includes("account_type = 'user'")) return [{ balance: 100 }];
           if (text.includes("insert into public.poker_tables")) return [{ id: "table-slow-notify" }];
           if (text.includes("insert into public.poker_state")) return [];
           if (text.includes("from public.chips_accounts")) return [{ id: "escrow-1" }];
@@ -264,6 +301,7 @@ const run = async () => {
             const text = String(query).toLowerCase();
 
             if (text.includes("pg_advisory_xact_lock")) return [];
+            if (text.includes("account_type = 'user'")) return [{ balance: 100 }];
 
             if (
               text.includes("from public.poker_tables t") &&

--- a/tests/poker-quick-seat.behavior.test.mjs
+++ b/tests/poker-quick-seat.behavior.test.mjs
@@ -14,7 +14,7 @@ const callQuickSeat = async (handler, body = {}) => {
   });
 };
 
-const makeHandler = ({ mode, queries, notifications = [], balance = 100, balanceError = false }) =>
+const makeHandler = ({ mode, queries, notifications = [], logs = [], balance = 100, balanceError = false }) =>
   loadPokerHandler("netlify/functions/poker-quick-seat.mjs", {
     baseHeaders: () => ({}),
     corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
@@ -77,7 +77,7 @@ const makeHandler = ({ mode, queries, notifications = [], balance = 100, balance
       notifications.push(payload);
       return { ok: true };
     },
-    klog: () => {},
+    klog: (kind, data) => { logs.push({ kind, data }); },
   });
 
 const findLockCall = (queries) =>
@@ -123,7 +123,8 @@ const run = async () => {
   {
     const queries = [];
     const notifications = [];
-    const handler = makeHandler({ mode: "prefer_humans", queries, notifications, balance: 99 });
+    const logs = [];
+    const handler = makeHandler({ mode: "prefer_humans", queries, notifications, logs, balance: 99 });
     const res = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
     assert.equal(res.statusCode, 409);
     assert.deepEqual(JSON.parse(res.body), { error: "insufficient_chips", requiredBuyIn: 100, balance: 99 });
@@ -132,6 +133,9 @@ const run = async () => {
     assert.equal(notifications.length, 0);
     const candidateCalls = queries.filter((entry) => entry.query.toLowerCase().includes("from public.poker_tables t"));
     assert.equal(candidateCalls.length, 1, "insufficient result must not continue to another candidate");
+    assert.equal(logs.some((entry) => entry.kind === "poker_quick_seat_selected"), false);
+    assert.equal(logs.filter((entry) => entry.kind === "poker_quick_seat_insufficient_chips").length, 1);
+    assert.equal(Object.prototype.hasOwnProperty.call(logs.find((entry) => entry.kind === "poker_quick_seat_insufficient_chips")?.data || {}, "userId"), false);
   }
 
   {

--- a/tests/poker-ui.behavior.test.mjs
+++ b/tests/poker-ui.behavior.test.mjs
@@ -247,6 +247,7 @@ function loadLobbyHarness(options = {}){
   elements.pokerSb.value = '1';
   elements.pokerBb.value = '2';
   elements.pokerMaxPlayers.value = '6';
+  elements.pokerLobbyContent.dataset.requiredBuyIn = '100';
 
   const fetchCalls = [];
   const wsCreates = [];
@@ -287,7 +288,10 @@ function loadLobbyHarness(options = {}){
       removeEventListener: () => {},
       __RUNNING_POKER_UI_TESTS__: false,
       KLog: { log: () => {} },
-        SupabaseAuthBridge: { getAccessToken: options.getAccessToken || (async () => 'token') },
+      ChipsClient: options.balanceError
+        ? { fetchBalance: async () => { throw new Error('balance_failed'); } }
+        : (options.balanceResult ? { fetchBalance: async () => options.balanceResult } : null),
+      SupabaseAuthBridge: { getAccessToken: options.getAccessToken || (async () => 'token') },
       PokerWsClient: {
         create: (options) => {
           const record = {
@@ -336,6 +340,7 @@ function loadLobbyHarness(options = {}){
     localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
     fetch: async (url) => {
       fetchCalls.push(String(url));
+      if (typeof options.fetchResponse === 'function') return options.fetchResponse(String(url));
       return { ok: true, json: async () => ({ ok: true }) };
     },
     atob: (value) => Buffer.from(String(value), 'base64').toString('binary'),
@@ -394,6 +399,47 @@ assert.equal(lobbyHarness.elements.pokerTableList.children[0].children[0].textCo
 lobbyHarness.elements.pokerRefresh.click();
 await new Promise((resolve) => setTimeout(resolve, 0));
 assert.equal(lobbyHarness.getRequestLobbySnapshotCalls(), 1, 'lobby refresh should request a fresh websocket lobby snapshot');
+
+{
+  const insufficientHarness = loadLobbyHarness({ balanceResult: { balance: 99 } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  insufficientHarness.elements.pokerCreate.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(insufficientHarness.fetchCalls.some((url) => url.includes('poker-create-table')), false, 'confirmed insufficient balance should suppress create-table API');
+  assert.equal(insufficientHarness.elements.pokerError.textContent, 'You need at least 100 CH to join a table.');
+  assert.equal(insufficientHarness.elements.pokerCreate.disabled, false, 'create-table should leave loading state after local rejection');
+  assert.equal(insufficientHarness.getLobbyClient().client.isReady(), true, 'local buy-in rejection should keep the lobby active');
+}
+
+{
+  const quickSeatGuardHarness = loadLobbyHarness({
+    fetchResponse: async (url) => url.includes('poker-quick-seat')
+      ? { ok: false, status: 409, json: async () => ({ error: 'insufficient_chips', requiredBuyIn: 100, balance: 99 }) }
+      : { ok: true, status: 200, json: async () => ({ ok: true }) },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  quickSeatGuardHarness.elements.pokerQuickSeat.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(quickSeatGuardHarness.fetchCalls.some((url) => url.includes('poker-quick-seat')), true, 'quick-seat should let backend preserve funded-seat reconnect semantics');
+  assert.equal(quickSeatGuardHarness.elements.pokerError.textContent, 'You need at least 100 CH to join a table.');
+  assert.equal(quickSeatGuardHarness.elements.pokerQuickSeat.disabled, false);
+}
+
+{
+  const fallbackHarness = loadLobbyHarness({
+    balanceError: true,
+    fetchResponse: async (url) => ({
+      ok: true,
+      status: 200,
+      json: async () => url.includes('poker-create-table') ? { tableId: 'table-after-fallback' } : { ok: true },
+    }),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  fallbackHarness.elements.pokerCreate.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(fallbackHarness.fetchCalls.some((url) => url.includes('poker-create-table')), true, 'balance lookup failure should fall through to guarded create endpoint');
+}
 
 {
   const reconnectHarness = loadLobbyHarness();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -1477,6 +1477,26 @@ test('poker v2 retries Play now auto-join after a transient authoritative join f
   assert.equal(harness.logs.some((entry) => entry.kind === 'poker_auto_join_failed' && entry.data.retryScheduled === true), true);
 });
 
+test('poker v2 renders insufficient funds as controlled non-retryable buy-in copy', async () => {
+  const harness = createHarness({
+    search: '?tableId=table-1&seatNo=4&autoJoin=1',
+    sendJoin(){
+      const error = new Error('insufficient_funds');
+      error.code = 'insufficient_funds';
+      return Promise.reject(error);
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  await waitFor(() => harness.joinPayloads.length === 1);
+
+  assert.equal(harness.elements.pokerV2ErrorText.textContent, 'You need at least 100 CH to join a table.');
+  assert.equal(harness.elements.pokerV2ErrorText.hidden, false);
+  harness.advanceTime(5000);
+  await harness.flush();
+  assert.equal(harness.joinPayloads.length, 1, 'insufficient funds must not schedule auto-join retry');
+});
+
 test('poker v2 safely rejoins the same authoritative seat after a socket reconnect', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();


### PR DESCRIPTION
## Summary

Closes #722.

- add a generic USER balance eligibility check for the current cash-table buy-in
- reject create-table and new quick-seat recommendations with a structured 409 before any table mutation
- preserve reconnect to an already funded seat and keep authoritative WS USER to ESCROW validation unchanged
- show localized insufficient-CH feedback in the lobby and poker room
- document the accepted implementation plan

## Root cause

The lobby create and quick-seat endpoints did not check whether a player could fund a new seat. The authoritative debit correctly failed later during WS join, after the player had already navigated into the table UI.

## Validation

- `npm test`
- `npm run check:all`
- `npm run syntax`
- targeted create-table, quick-seat, lobby UI, and poker-v2 behavior suites
- `git diff --check`

## Deployment

Netlify Deploy Preview is required. No migration or ENV change is required.

The new `shared/poker-domain/table-economy.mjs` module is imported only by the two Netlify endpoints and the test helper. It is not in the WS runtime import graph. A path-based WS workflow may still run, but no manual WS Preview Deploy is required for this diff.

## Breaking impact

Create-table and quick-seat can now return HTTP 409 with `insufficient_chips`, `requiredBuyIn`, and `balance`. Matchmaking, funded-seat reconnect, the WS protocol, ledger settlement, database schema, and poker rules are unchanged.