### PR TITLE
fix: suppress failed bot autoplay retries

### DIFF
--- a/shared/poker-domain/poker-autoplay.mjs
+++ b/shared/poker-domain/poker-autoplay.mjs
@@ -69,6 +69,7 @@ export const runBotAutoplayLoop = async ({
   let loopSeatUserIdsInOrder = Array.isArray(seatUserIdsInOrder) ? seatUserIdsInOrder.slice() : [];
   let botActionCount = 0;
   let botStopReason = "not_attempted";
+  let botFailureReason = null;
   let lastBotActionSummary = null;
   let responseEvents = [];
   const botsOnlyAtStart = !hasParticipatingHumanInHand(responseFinalState, loopSeatBotMap);
@@ -154,6 +155,9 @@ export const runBotAutoplayLoop = async ({
       botApplied = applyAction(loopPrivateState, botAction);
     } catch (error) {
       botStopReason = "apply_action_failed";
+      botFailureReason = typeof error?.message === "string" && error.message.trim()
+        ? error.message.trim()
+        : "apply_action_failed";
       klog("poker_act_bot_autoplay_step_error", {
         tableId,
         handId: typeof responseFinalState?.handId === "string" && responseFinalState.handId.trim() ? responseFinalState.handId.trim() : null,
@@ -163,7 +167,7 @@ export const runBotAutoplayLoop = async ({
         reason: botStopReason,
         actionType: botAction.type || null,
         actionAmount: botAction.amount ?? null,
-        error: error?.message || "apply_action_failed"
+        error: botFailureReason
       });
       break;
     }
@@ -238,6 +242,7 @@ export const runBotAutoplayLoop = async ({
     loopVersion,
     botActionCount,
     botStopReason,
+    botFailureReason,
     botsOnlyAtStart,
     effectiveMaxBotActions,
     lastBotActionSummary,

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
+  shouldClearBotTimeoutSafetySuppression,
   shouldSuppressBotTimeoutSafetyRetry
 } from "./bot-autoplay.mjs";
 
@@ -26,6 +27,14 @@ test("bot timeout safety suppression matches the complete unchanged turn fingerp
   assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, stateVersion: 13 }), false);
   assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, handId: "h2" }), false);
   assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, turnUserId: "bot_3" }), false);
+});
+
+test("bot timeout safety suppression clears only after autoplay changes state successfully", () => {
+  assert.equal(shouldClearBotTimeoutSafetySuppression({ ok: true, changed: true, reason: "completed" }), true);
+  assert.equal(shouldClearBotTimeoutSafetySuppression({ ok: true, changed: false, reason: "completed" }), false);
+  assert.equal(shouldClearBotTimeoutSafetySuppression({ ok: true, changed: false, reason: "turn_not_bot" }), false);
+  assert.equal(shouldClearBotTimeoutSafetySuppression({ ok: true, changed: false, reason: "non_action_phase" }), false);
+  assert.equal(shouldClearBotTimeoutSafetySuppression({ ok: false, changed: true, reason: "persist_failed" }), false);
 });
 
 test("handleBotStepCommand broadcasts when autoplay changes state", async () => {

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { handleBotStepCommand, shouldSuppressBotTimeoutSafetyRetry } from "./bot-autoplay.mjs";
+import {
+  handleBotStepCommand,
+  matchesBotTimeoutSafetySuppression,
+  shouldSuppressBotTimeoutSafetyRetry
+} from "./bot-autoplay.mjs";
 
 test("bot timeout safety suppresses deterministic same-state invariant retries only", () => {
   assert.equal(shouldSuppressBotTimeoutSafetyRetry({ ok: false, changed: false, reason: "showdown_incomplete_community" }), true);
@@ -8,6 +12,20 @@ test("bot timeout safety suppresses deterministic same-state invariant retries o
   assert.equal(shouldSuppressBotTimeoutSafetyRetry({ ok: false, changed: false, reason: "persist_failed" }), false);
   assert.equal(shouldSuppressBotTimeoutSafetyRetry({ ok: true, changed: false, reason: "turn_not_bot" }), false);
   assert.equal(shouldSuppressBotTimeoutSafetyRetry({ ok: false, changed: true, reason: "state_invalid" }), false);
+});
+
+test("bot timeout safety suppression matches the complete unchanged turn fingerprint", () => {
+  const suppressed = {
+    tableId: "t1",
+    handId: "h1",
+    stateVersion: 12,
+    turnUserId: "bot_2",
+    reason: "showdown_incomplete_community"
+  };
+  assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed }), true);
+  assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, stateVersion: 13 }), false);
+  assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, handId: "h2" }), false);
+  assert.equal(matchesBotTimeoutSafetySuppression(suppressed, { ...suppressed, turnUserId: "bot_3" }), false);
 });
 
 test("handleBotStepCommand broadcasts when autoplay changes state", async () => {
@@ -110,3 +128,20 @@ test("handleBotStepCommand does not broadcast when autoplay is a clean noop", as
   assert.equal(result.ok, true);
   assert.equal(calls.snapshots, 0);
 });
+
+for (const reason of ["completed", "turn_not_bot", "non_action_phase"]) {
+  test(`handleBotStepCommand preserves ${reason} as a successful clean stop`, async () => {
+    const result = await handleBotStepCommand({
+      tableId: "t-clean-stop",
+      trigger: "test",
+      runBotStep: async () => ({ ok: true, changed: false, actionCount: 0, reason }),
+      broadcastStateSnapshots: () => {
+        throw new Error("clean stop must not broadcast");
+      }
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, false);
+    assert.equal(result.reason, reason);
+  });
+}

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -12,6 +12,14 @@ export function shouldSuppressBotTimeoutSafetyRetry(result) {
     && BOT_AUTOPLAY_SAME_STATE_INVARIANT_FAILURES.has(reason);
 }
 
+export function matchesBotTimeoutSafetySuppression(suppressed, current) {
+  if (!suppressed || !current) return false;
+  return suppressed.tableId === current.tableId
+    && suppressed.handId === current.handId
+    && suppressed.stateVersion === current.stateVersion
+    && suppressed.turnUserId === current.turnUserId;
+}
+
 export async function handleBotStepCommand({
   tableId,
   trigger,

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -20,6 +20,10 @@ export function matchesBotTimeoutSafetySuppression(suppressed, current) {
     && suppressed.turnUserId === current.turnUserId;
 }
 
+export function shouldClearBotTimeoutSafetySuppression(result) {
+  return result?.ok === true && result?.changed === true;
+}
+
 export async function handleBotStepCommand({
   tableId,
   trigger,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -6,7 +6,7 @@ import { createBotReactionOverrideStore } from "./bot-reaction-override.mjs";
 import { initHandState, applyAction as applyRuntimeAction, advanceIfNeeded } from "../snapshot-runtime/poker-reducer.mjs";
 import { buildBootstrappedPokerState, applyCoreStateAction } from "../engine/poker-engine.mjs";
 import { computeSharedLegalActions } from "../shared/poker-primitives.mjs";
-import { runAdvanceLoop } from "../../shared/poker-domain/poker-autoplay.mjs";
+import { runAdvanceLoop, runBotAutoplayLoop } from "../../shared/poker-domain/poker-autoplay.mjs";
 import { materializeShowdownAndPayout } from "../snapshot-runtime/poker-materialize-showdown.mjs";
 import { computeShowdown } from "../snapshot-runtime/poker-showdown.mjs";
 import { awardPotsAtShowdown } from "../snapshot-runtime/poker-payout.mjs";
@@ -70,6 +70,44 @@ test("autoplay adapter resolves shared autoplay from neutral shared module path"
 
   const sharedSource = fs.readFileSync(new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url), "utf8");
   assert.doesNotMatch(sharedSource, /netlify\/functions\/_shared/);
+});
+
+test("shared autoplay preserves the concrete apply failure reason", async () => {
+  const state = {
+    handId: "h-shared-contract",
+    phase: "TURN",
+    turnUserId: "bot_2"
+  };
+  const result = await runBotAutoplayLoop({
+    tableId: "t-shared-contract",
+    requestId: "r-shared-contract",
+    initialState: state,
+    initialPrivateState: state,
+    initialVersion: 12,
+    seatBotMap: new Map([["bot_2", true]]),
+    seatUserIdsInOrder: ["bot_2"],
+    maxActions: 1,
+    botsOnlyHandCompletionHardCap: 1,
+    policyVersion: "test",
+    klog: () => {},
+    isActionPhase: () => true,
+    isBotTurn: () => true,
+    computeLegalActions: () => ({ actions: [{ type: "CALL" }] }),
+    chooseBotActionTrivial: () => ({ type: "CALL" }),
+    withoutPrivateState: (value) => value,
+    applyAction: () => {
+      throw new Error("showdown_incomplete_community");
+    },
+    advanceIfNeeded: (value) => ({ state: value, events: [] }),
+    buildPersistedFromPrivateState: (value) => value,
+    persistStep: async () => {
+      throw new Error("failed apply must not persist");
+    }
+  });
+
+  assert.equal(result.botActionCount, 0);
+  assert.equal(result.botStopReason, "apply_action_failed");
+  assert.equal(result.botFailureReason, "showdown_incomplete_community");
 });
 
 test("accepted bot autoplay executes and persists when bot is on turn", async () => {
@@ -799,6 +837,55 @@ test("accepted bot autoplay unavailable shared helper returns safe non-fatal res
   assert.equal(result.reason, "autoplay_unavailable");
   assert.equal(result.changed, false);
   assert.equal(result.noop, true);
+});
+
+test("accepted bot autoplay preserves a concrete shared apply failure as an unchanged error", async () => {
+  const state = {
+    version: 12,
+    tableId: "t-shared-failure",
+    handId: "h-shared-failure",
+    phase: "TURN",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 }
+  };
+  const moduleSource = `
+    export async function runBotAutoplayLoop({ initialState, initialPrivateState, initialVersion }) {
+      return {
+        responseFinalState: initialState,
+        loopPrivateState: initialPrivateState,
+        loopVersion: initialVersion,
+        botActionCount: 0,
+        botStopReason: "apply_action_failed",
+        botFailureReason: "showdown_incomplete_community"
+      };
+    }
+  `;
+  const moduleUrl = `data:text/javascript,${encodeURIComponent(moduleSource)}`;
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager: {
+      persistedPokerState: () => ({ ...state }),
+      persistedStateVersion: () => state.version,
+      tableSnapshot: () => ({ seats: state.seats })
+    },
+    persistMutatedState: async () => {
+      throw new Error("failure without a changed state must not persist");
+    },
+    restoreTableFromPersisted: async () => {
+      throw new Error("PR A must not restore this invariant failure");
+    },
+    broadcastResyncRequired: () => {},
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: state.tableId, trigger: "bot_timeout_safety", requestId: "r-shared-failure" });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.changed, false);
+  assert.equal(result.reason, "showdown_incomplete_community");
+  assert.equal(result.botStopReason, "apply_action_failed");
+  assert.equal(result.botFailureReason, "showdown_incomplete_community");
 });
 
 test("accepted bot autoplay showdown uses trusted private hole cards even for public showdown state", async () => {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -1172,12 +1172,18 @@ export function createAcceptedBotStepExecutor({
       const pendingBotTurn = !!finalPublicState
         && isActionPhase(finalPublicState.phase)
         && isBotTurnAuthoritatively(tableManager, tableId, finalTurnUserId, finalSeatBotMap);
+      const botFailureReason =
+        typeof botLoop?.botFailureReason === "string" && botLoop.botFailureReason.trim()
+          ? botLoop.botFailureReason.trim()
+          : null;
 
       return {
-        ok: true,
+        ok: botFailureReason === null,
         changed: (botLoop?.botActionCount || 0) > 0,
         actionCount: botLoop?.botActionCount || 0,
-        reason: botLoop?.botStopReason || "not_attempted",
+        reason: botFailureReason || botLoop?.botStopReason || "not_attempted",
+        botStopReason: botLoop?.botStopReason || "not_attempted",
+        botFailureReason,
         broadcastedStepCount,
         lastBroadcastStateVersion,
         finalStateVersion,

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -4684,6 +4684,146 @@ test("table_state_sub schedules autoplay for restored live bot turn before timeo
   }
 });
 
+test("bot timeout safety suppresses repeated autoplay for the same failed turn fingerprint", async () => {
+  const secret = "bot-timeout-same-state-suppression-secret";
+  const tableId = "table_bot_timeout_same_state_suppression";
+  const humanUserId = "timeout_suppression_human";
+  const botSeat2 = makeBotUserId(tableId, 2);
+  const botSeat3 = makeBotUserId(tableId, 3);
+  const baseCoreState = {
+    roomId: tableId,
+    version: 12,
+    maxSeats: 6,
+    members: [
+      { userId: humanUserId, seat: 1 },
+      { userId: botSeat2, seat: 2 },
+      { userId: botSeat3, seat: 3 }
+    ],
+    seats: [
+      { userId: humanUserId, seatNo: 1, status: "ACTIVE" },
+      { userId: botSeat2, seatNo: 2, status: "ACTIVE" },
+      { userId: botSeat3, seatNo: 3, status: "ACTIVE" }
+    ],
+    seatDetailsByUserId: {
+      [humanUserId]: { isBot: false, stack: 100 },
+      [botSeat2]: { isBot: true, botProfile: "NORMAL", stack: 100 },
+      [botSeat3]: { isBot: true, botProfile: "NORMAL", stack: 100 }
+    },
+    publicStacks: {
+      [humanUserId]: 100,
+      [botSeat2]: 100,
+      [botSeat3]: 100
+    }
+  };
+  const liveState = {
+    ...buildBootstrappedPokerState({
+      tableId,
+      coreState: baseCoreState,
+      dealerSeatNo: 2,
+      startingStacks: baseCoreState.publicStacks,
+      handVersion: baseCoreState.version
+    }),
+    turnStartedAt: Date.now() - 10_000,
+    turnDeadlineAt: Date.now() - 5_000
+  };
+  assert.equal(liveState.turnUserId, botSeat2);
+
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+          { user_id: botSeat2, seat_no: 2, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" },
+          { user_id: botSeat3, seat_no: 3, status: "ACTIVE", is_bot: true, stack: 100, bot_profile: "NORMAL" }
+        ],
+        stateRow: { version: baseCoreState.version, state: liveState }
+      }
+    }
+  });
+  const invocationFile = path.join(dir, "bot-timeout-invocations.log");
+  const autoplayModule = await writeTestModule(`
+import fs from "node:fs";
+const invocationFile = ${JSON.stringify(invocationFile)};
+export function createAcceptedBotStepExecutor() {
+  return async ({ trigger }) => {
+    if (trigger !== "bot_timeout_safety") {
+      return { ok: true, changed: false, actionCount: 0, reason: "completed" };
+    }
+    fs.appendFileSync(invocationFile, "applyAction\\n", "utf8");
+    return {
+      ok: false,
+      changed: false,
+      actionCount: 0,
+      reason: "showdown_incomplete_community",
+      phase: "PREFLOP"
+    };
+  };
+}
+`, "same-state-bot-timeout-adapter.mjs");
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_ACCEPTED_BOT_AUTOPLAY_ADAPTER_MODULE_PATH: autoplayModule.filePath,
+      WS_TIMEOUT_SWEEP_MS: "50",
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000"
+    }
+  });
+  const serverLogs = [];
+  child.stdout.on("data", (buf) => {
+    serverLogs.push(String(buf));
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(ws, makeHs256Jwt({ secret, sub: humanUserId }), "auth-bot-timeout-suppression");
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "sub-bot-timeout-suppression",
+      ts: "2026-07-23T00:00:00Z",
+      payload: { tableId }
+    });
+    await nextMessageOfType(ws, "table_state");
+
+    const failureDeadline = Date.now() + 3000;
+    let invocationCount = 0;
+    while (Date.now() < failureDeadline) {
+      const raw = await fs.readFile(invocationFile, "utf8").catch(() => "");
+      invocationCount = raw.trim() ? raw.trim().split("\n").length : 0;
+      if (invocationCount >= 1) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(invocationCount, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const finalRaw = await fs.readFile(invocationFile, "utf8");
+    assert.equal(finalRaw.trim().split("\n").length, 1);
+
+    const joinedLogs = serverLogs.join("");
+    const terminalLogs = joinedLogs
+      .split("\n")
+      .filter((line) => line.includes("ws_bot_timeout_safety_same_state_retry_suppressed"));
+    assert.equal(terminalLogs.length, 1, joinedLogs);
+    assert.match(terminalLogs[0], new RegExp(`"tableId":"${tableId}"`));
+    assert.match(terminalLogs[0], new RegExp(`"handId":"${liveState.handId}"`));
+    assert.match(terminalLogs[0], /"stateVersion":12/);
+    assert.match(terminalLogs[0], new RegExp(`"turnUserId":"${botSeat2}"`));
+    assert.match(terminalLogs[0], /"phase":"PREFLOP"/);
+    assert.match(terminalLogs[0], /"reason":"showdown_incomplete_community"/);
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(autoplayModule.dir, { recursive: true, force: true });
+  }
+});
+
 test("resync schedules autoplay for restored live bot turn before timeout sweep", async () => {
   const secret = "restored-bot-turn-resync-secret";
   const tableId = "table_restored_bot_turn_resync_autoplay";

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -4747,10 +4747,7 @@ import fs from "node:fs";
 const invocationFile = ${JSON.stringify(invocationFile)};
 export function createAcceptedBotStepExecutor() {
   return async ({ trigger }) => {
-    if (trigger !== "bot_timeout_safety") {
-      return { ok: true, changed: false, actionCount: 0, reason: "completed" };
-    }
-    fs.appendFileSync(invocationFile, "applyAction\\n", "utf8");
+    fs.appendFileSync(invocationFile, \`\${trigger || "unknown"}\\n\`, "utf8");
     return {
       ok: false,
       changed: false,
@@ -4790,19 +4787,29 @@ export function createAcceptedBotStepExecutor() {
     });
     await nextMessageOfType(ws, "table_state");
 
-    const failureDeadline = Date.now() + 3000;
-    let invocationCount = 0;
-    while (Date.now() < failureDeadline) {
-      const raw = await fs.readFile(invocationFile, "utf8").catch(() => "");
-      invocationCount = raw.trim() ? raw.trim().split("\n").length : 0;
-      if (invocationCount >= 1) break;
+    const suppressionDeadline = Date.now() + 3000;
+    while (Date.now() < suppressionDeadline) {
+      if (serverLogs.join("").includes("ws_bot_timeout_safety_same_state_retry_suppressed")) break;
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
-    assert.equal(invocationCount, 1);
+    assert.match(serverLogs.join(""), /ws_bot_timeout_safety_same_state_retry_suppressed/);
 
     await new Promise((resolve) => setTimeout(resolve, 250));
+    const suppressedRaw = await fs.readFile(invocationFile, "utf8");
+    const suppressedInvocationCount = suppressedRaw.trim().split("\n").length;
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "resync",
+      requestId: "resync-bot-timeout-suppression",
+      ts: "2026-07-23T00:00:01Z",
+      payload: { tableId }
+    });
+    await nextMessageOfType(ws, "table_state");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
     const finalRaw = await fs.readFile(invocationFile, "utf8");
-    assert.equal(finalRaw.trim().split("\n").length, 1);
+    assert.equal(finalRaw.trim().split("\n").length, suppressedInvocationCount);
 
     const joinedLogs = serverLogs.join("");
     const terminalLogs = joinedLogs

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -28,6 +28,7 @@ import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import {
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
+  shouldClearBotTimeoutSafetySuppression,
   shouldSuppressBotTimeoutSafetyRetry
 } from "./poker/handlers/bot-autoplay.mjs";
 import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
@@ -569,7 +570,7 @@ function isBotTimeoutSafetyRetrySuppressed(tableId) {
 }
 
 function clearBotTimeoutSafetySuppressionAfterSuccess(tableId, result) {
-  if (result?.ok === true) {
+  if (shouldClearBotTimeoutSafetySuppression(result)) {
     suppressedBotTimeoutSafetyFailures.delete(tableId);
   }
 }
@@ -589,6 +590,15 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
     tableId,
     commandName: "bot_step",
     run: async () => {
+      if (isBotTimeoutSafetyRetrySuppressed(tableId)) {
+        return {
+          ok: true,
+          changed: false,
+          actionCount: 0,
+          reason: "same_state_retry_suppressed",
+          suppressed: true
+        };
+      }
       const result = await handleBotStepCommand({
         tableId,
         trigger,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -25,7 +25,11 @@ import { handleJoinCommand } from "./poker/handlers/join.mjs";
 import { handleActCommand } from "./poker/handlers/act.mjs";
 import { handleStartHandCommand } from "./poker/handlers/start-hand.mjs";
 import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
-import { handleBotStepCommand, shouldSuppressBotTimeoutSafetyRetry } from "./poker/handlers/bot-autoplay.mjs";
+import {
+  handleBotStepCommand,
+  matchesBotTimeoutSafetySuppression,
+  shouldSuppressBotTimeoutSafetyRetry
+} from "./poker/handlers/bot-autoplay.mjs";
 import { handleLeaveCommand } from "./poker/handlers/leave.mjs";
 import { handleRebuyCommand } from "./poker/handlers/rebuy.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
@@ -541,13 +545,33 @@ async function runBotStep({ tableId, trigger, requestId, frameTs }) {
 const scheduledObservedBotTurnKeys = new Map();
 const suppressedBotTimeoutSafetyFailures = new Map();
 
+function buildBotTimeoutSafetyFingerprint(tableId) {
+  const pokerState = tableManager.persistedPokerState(tableId);
+  if (!pokerState || typeof pokerState !== "object") return null;
+  const stateVersion = Number(tableManager.persistedStateVersion(tableId));
+  if (!Number.isFinite(stateVersion)) return null;
+  return {
+    tableId,
+    handId: typeof pokerState.handId === "string" ? pokerState.handId.trim() : "",
+    stateVersion,
+    turnUserId: typeof pokerState.turnUserId === "string" ? pokerState.turnUserId.trim() : "",
+    phase: typeof pokerState.phase === "string" ? pokerState.phase.trim() : ""
+  };
+}
+
 function isBotTimeoutSafetyRetrySuppressed(tableId) {
   const suppressed = suppressedBotTimeoutSafetyFailures.get(tableId);
   if (!suppressed) return false;
-  const currentStateVersion = Number(tableManager.persistedStateVersion(tableId));
-  if (Number.isFinite(currentStateVersion) && currentStateVersion === suppressed.stateVersion) return true;
+  const current = buildBotTimeoutSafetyFingerprint(tableId);
+  if (matchesBotTimeoutSafetySuppression(suppressed, current)) return true;
   suppressedBotTimeoutSafetyFailures.delete(tableId);
   return false;
+}
+
+function clearBotTimeoutSafetySuppressionAfterSuccess(tableId, result) {
+  if (result?.ok === true) {
+    suppressedBotTimeoutSafetyFailures.delete(tableId);
+  }
 }
 
 function pruneBotTimeoutSafetySuppressions() {
@@ -564,15 +588,19 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
   const enqueueStep = () => enqueueTableCommand({
     tableId,
     commandName: "bot_step",
-    run: async () => handleBotStepCommand({
-      tableId,
-      trigger,
-      requestId,
-      frameTs,
-      runBotStep,
-      broadcastStateSnapshots,
-      klog: klogSafe
-    })
+    run: async () => {
+      const result = await handleBotStepCommand({
+        tableId,
+        trigger,
+        requestId,
+        frameTs,
+        runBotStep,
+        broadcastStateSnapshots,
+        klog: klogSafe
+      });
+      clearBotTimeoutSafetySuppressionAfterSuccess(tableId, result);
+      return result;
+    }
   });
 
   const runCascade = () => {
@@ -2336,17 +2364,19 @@ async function sweepTurnTimeoutsAndBroadcast() {
           klog: klogSafe
         });
         if (shouldSuppressBotTimeoutSafetyRetry(result)) {
-          suppressedBotTimeoutSafetyFailures.set(update.tableId, {
-            stateVersion: Number(update.stateVersion),
-            reason: result.reason,
-          });
-          klogSafe("ws_bot_timeout_safety_same_state_retry_suppressed", {
-            tableId: update.tableId,
-            stateVersion: Number(update.stateVersion),
-            reason: result.reason,
-          });
+          const fingerprint = buildBotTimeoutSafetyFingerprint(update.tableId);
+          if (fingerprint && fingerprint.stateVersion === Number(update.stateVersion)) {
+            suppressedBotTimeoutSafetyFailures.set(update.tableId, {
+              ...fingerprint,
+              reason: result.reason
+            });
+            klogSafe("ws_bot_timeout_safety_same_state_retry_suppressed", {
+              ...fingerprint,
+              reason: result.reason
+            });
+          }
         } else {
-          suppressedBotTimeoutSafetyFailures.delete(update.tableId);
+          clearBotTimeoutSafetySuppressionAfterSuccess(update.tableId, result);
         }
         return result;
       }


### PR DESCRIPTION
## What changed

Implements PR A from the accepted #737 plan:

- preserves the concrete shared autoplay `botFailureReason` instead of reducing it to only `apply_action_failed`;
- returns `ok: false`, the concrete reason, and unchanged state from the WS adapter when apply fails before persistence;
- extends the existing `suppressedBotTimeoutSafetyFailures` map with the full `tableId + handId + stateVersion + turnUserId` fingerprint;
- prevents timeout sweeps and other automatic `scheduleBotStep()` triggers from retrying the identical failed turn;
- clears suppression when the fingerprint changes, the table disappears/closes, or autoplay succeeds with an actual state change;
- preserves suppression across successful noops such as `completed`, `turn_not_bot`, and `non_action_phase`;
- emits one terminal `klog` with table, hand, version, phase, actor, and reason.

## Why

The historical preview loop kept retrying the same bot `CALL` because shared autoplay logged `showdown_incomplete_community` but exposed only `apply_action_failed`, while the adapter reported a successful unchanged result. The scheduler therefore could not activate its existing deterministic-failure suppression.

## Safety and impact

This PR only stops repeated automatic attempts for the same unchanged fingerprint. It does not guess or modify the underlying incomplete-board transition, does not restore from DB, and does not change settlement, stacks, or pots. A suppressed table remains explicit in terminal logs for recovery/manual investigation. Changing the fingerprint permits normal autoplay again. The source-cause work remains separate PR B scope, so this PR does not close #737.

The shared result change is additive for `shared/poker-domain/leave.mjs`; only the WS adapter maps `botFailureReason` to its existing error result contract.

## Validation

- `node --test ws-server/poker/handlers/bot-autoplay.behavior.test.mjs` — 11/11
- `node --test ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs` — 37/37
- `node --test ws-server/server.behavior.test.mjs` — 89/89
- `node --test shared/poker-domain/leave.behavior.test.mjs` — 1/1
- `npm run test:quick` — syntax OK for 215 files
- `git diff --check`

The server regression test exercises repeated timeout sweeps and a later `resync`-scheduled autoplay, verifies no new adapter invocation for the unchanged fingerprint, and requires exactly one terminal suppression log.