### PR TITLE
fix: reject unrecoverable all-in restores

### DIFF
--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -220,6 +220,50 @@ test("adapter rejects a legacy live all-in hand that cannot reconstruct the show
   assert.deepEqual(persistedState, before);
 });
 
+test("adapter rejects an unrecoverable all-in hand with invalid or duplicate private runtime cards", () => {
+  const tableId = "table_invalid_private_runtime_cards";
+  const persistedState = {
+    tableId,
+    handId: "hand_invalid_private_runtime_cards",
+    phase: "TURN",
+    community: ["AS", "KD", "QC", "JH"],
+    communityDealt: 4,
+    deck: ["AS"],
+    holeCardsByUserId: {
+      human: ["2C", "2D"],
+      bot_call: ["not-a-card", "3D"]
+    },
+    turnUserId: "bot_call",
+    seats: [
+      { userId: "human", seatNo: 1, status: "ACTIVE" },
+      { userId: "bot_call", seatNo: 2, status: "ACTIVE", isBot: true }
+    ],
+    handSeats: [
+      { userId: "human", seatNo: 1, status: "ACTIVE" },
+      { userId: "bot_call", seatNo: 2, status: "ACTIVE", isBot: true }
+    ],
+    currentBet: 100,
+    potTotal: 200,
+    stacks: { human: 0, bot_call: 50 },
+    toCallByUserId: { human: 0, bot_call: 50 },
+    foldedByUserId: { human: false, bot_call: false }
+  };
+
+  const result = adaptPersistedBootstrap({
+    tableId,
+    tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+    seatRows: [
+      { user_id: "human", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 0 },
+      { user_id: "bot_call", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 50 }
+    ],
+    stateRow: { version: 333, state: persistedState }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "invalid_persisted_state");
+  assert.equal(result.reason, "live_hand_runtime_unrecoverable");
+});
+
 test("adapter restores replacement bot identity from persisted state when seat rows still reference prior bot id", () => {
   const result = adaptPersistedBootstrap({
     tableId: "table_replacement_bot_restore",

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { adaptPersistedBootstrap } from "./persisted-bootstrap-adapter.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitives.mjs";
+import { applyAction } from "../shared/poker-action-reducer.mjs";
 
 test("adapter maps persisted rows into deterministic ws table/core state", () => {
   const result = adaptPersistedBootstrap({
@@ -163,6 +164,60 @@ test("adapter rehydrates runtime hand data for retained live-hand leaver during 
   assert.deepEqual(result.table.coreState.pokerState.holeCardsByUserId.user_a, toCardCodes(dealt.holeCardsByUserId.user_a));
   assert.deepEqual(result.table.coreState.pokerState.holeCardsByUserId.bot_1, toCardCodes(dealt.holeCardsByUserId.bot_1));
   assert.deepEqual(result.table.coreState.pokerState.holeCardsByUserId.bot_2, toCardCodes(dealt.holeCardsByUserId.bot_2));
+});
+
+test("adapter rejects a legacy live all-in hand that cannot reconstruct the showdown board", () => {
+  const tableId = "table_legacy_all_in_without_seed";
+  const persistedState = {
+    tableId,
+    handId: "hand_legacy_all_in_without_seed",
+    phase: "PREFLOP",
+    community: [],
+    communityDealt: 0,
+    turnUserId: "bot_call",
+    seats: [
+      { userId: "human", seatNo: 1, status: "ACTIVE" },
+      { userId: "bot_fold", seatNo: 2, status: "ACTIVE", isBot: true },
+      { userId: "bot_call", seatNo: 3, status: "ACTIVE", isBot: true }
+    ],
+    handSeats: [
+      { userId: "human", seatNo: 1, status: "ACTIVE" },
+      { userId: "bot_fold", seatNo: 2, status: "ACTIVE", isBot: true },
+      { userId: "bot_call", seatNo: 3, status: "ACTIVE", isBot: true }
+    ],
+    currentBet: 488,
+    lastRaiseSize: 486,
+    potTotal: 491,
+    stacks: { human: 0, bot_fold: 13, bot_call: 96 },
+    toCallByUserId: { human: 0, bot_fold: 487, bot_call: 486 },
+    betThisRoundByUserId: { human: 488, bot_fold: 1, bot_call: 2 },
+    actedThisRoundByUserId: { human: true, bot_fold: true, bot_call: false },
+    foldedByUserId: { human: false, bot_fold: true, bot_call: false },
+    contributionsByUserId: { human: 488, bot_fold: 1, bot_call: 2 }
+  };
+  const before = structuredClone(persistedState);
+
+  assert.throws(
+    () => applyAction({ pokerState: persistedState, userId: "bot_call", action: "CALL", amount: 0 }),
+    { message: "showdown_incomplete_community" }
+  );
+  assert.deepEqual(persistedState, before);
+
+  const result = adaptPersistedBootstrap({
+    tableId,
+    tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+    seatRows: [
+      { user_id: "human", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 0 },
+      { user_id: "bot_fold", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 13 },
+      { user_id: "bot_call", seat_no: 3, status: "ACTIVE", is_bot: true, stack: 96 }
+    ],
+    stateRow: { version: 332, state: persistedState }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "invalid_persisted_state");
+  assert.equal(result.reason, "live_hand_runtime_unrecoverable");
+  assert.deepEqual(persistedState, before);
 });
 
 test("adapter restores replacement bot identity from persisted state when seat rows still reference prior bot id", () => {

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -1,5 +1,61 @@
 import { parseStakes } from "../../shared/poker-domain/bots.mjs";
 import { deriveDeterministicRuntimeHandState } from "../shared/runtime-hand-state.mjs";
+
+const LIVE_HAND_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER"]);
+
+function hasCompleteRuntimePrivateHandState(state) {
+  const handSeats = Array.isArray(state?.handSeats) && state.handSeats.length > 0
+    ? state.handSeats
+    : state?.seats;
+  const seatUserIds = Array.isArray(handSeats)
+    ? handSeats
+        .map((seat) => typeof seat?.userId === "string" ? seat.userId.trim() : "")
+        .filter(Boolean)
+    : [];
+  const communityDealt = Number.isInteger(state?.communityDealt)
+    ? state.communityDealt
+    : (Array.isArray(state?.community) ? state.community.length : -1);
+  if (
+    seatUserIds.length < 2
+    || communityDealt < 0
+    || communityDealt > 5
+    || !Array.isArray(state?.community)
+    || state.community.length !== communityDealt
+    || !Array.isArray(state?.deck)
+    || state.deck.length < 5 - communityDealt
+    || !state?.holeCardsByUserId
+    || typeof state.holeCardsByUserId !== "object"
+    || Array.isArray(state.holeCardsByUserId)
+  ) {
+    return false;
+  }
+  return seatUserIds.every((userId) => Array.isArray(state.holeCardsByUserId[userId])
+    && state.holeCardsByUserId[userId].length === 2);
+}
+
+function isTerminalAllInCallPending(state) {
+  const turnUserId = typeof state?.turnUserId === "string" ? state.turnUserId.trim() : "";
+  const turnStack = Number(state?.stacks?.[turnUserId]);
+  const turnToCall = Number(state?.toCallByUserId?.[turnUserId]);
+  if (!turnUserId || !Number.isFinite(turnStack) || !Number.isFinite(turnToCall)) return false;
+  if (turnStack <= 0 || turnToCall <= 0 || turnStack > turnToCall) return false;
+
+  const handSeats = Array.isArray(state?.handSeats) && state.handSeats.length > 0
+    ? state.handSeats
+    : state?.seats;
+  const eligibleUserIds = Array.isArray(handSeats)
+    ? handSeats
+        .map((seat) => typeof seat?.userId === "string" ? seat.userId.trim() : "")
+        .filter((userId) => userId
+          && !state?.foldedByUserId?.[userId]
+          && !state?.leftTableByUserId?.[userId]
+          && !state?.sitOutByUserId?.[userId])
+    : [];
+  return eligibleUserIds.length > 1 && eligibleUserIds.every((userId) => (
+    userId === turnUserId || Number(state?.stacks?.[userId] ?? 0) <= 0
+  ));
+}
+
 function asPlainObject(value) {
   return value && typeof value === "object" && !Array.isArray(value) ? value : null;
 }
@@ -312,6 +368,19 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
   const publicStacks = publicStackResult.stacks;
   const normalizedPokerState = { ...pokerState, seats: stateSeats };
   const derivedRuntimeHandState = deriveDeterministicRuntimeHandState(normalizedPokerState);
+  if (
+    LIVE_HAND_PHASES.has(normalizedPokerState.phase)
+    && !derivedRuntimeHandState
+    && !hasCompleteRuntimePrivateHandState(normalizedPokerState)
+    && isTerminalAllInCallPending(normalizedPokerState)
+  ) {
+    return {
+      ok: false,
+      code: "invalid_persisted_state",
+      message: "invalid_persisted_state",
+      reason: "live_hand_runtime_unrecoverable"
+    };
+  }
   const seatDetailsByUserId = {};
   for (const seat of runtimeSeats) {
     seatDetailsByUserId[seat.userId] = {

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -1,4 +1,5 @@
 import { parseStakes } from "../../shared/poker-domain/bots.mjs";
+import { areCardsUnique, isValidTwoCards } from "../snapshot-runtime/poker-cards-utils.mjs";
 import { deriveDeterministicRuntimeHandState } from "../shared/runtime-hand-state.mjs";
 
 const LIVE_HAND_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER"]);
@@ -7,16 +8,19 @@ function hasCompleteRuntimePrivateHandState(state) {
   const handSeats = Array.isArray(state?.handSeats) && state.handSeats.length > 0
     ? state.handSeats
     : state?.seats;
-  const seatUserIds = Array.isArray(handSeats)
+  const showdownUserIds = Array.isArray(handSeats)
     ? handSeats
         .map((seat) => typeof seat?.userId === "string" ? seat.userId.trim() : "")
-        .filter(Boolean)
+        .filter((userId) => userId
+          && !state?.foldedByUserId?.[userId]
+          && !state?.leftTableByUserId?.[userId]
+          && !state?.sitOutByUserId?.[userId])
     : [];
   const communityDealt = Number.isInteger(state?.communityDealt)
     ? state.communityDealt
     : (Array.isArray(state?.community) ? state.community.length : -1);
   if (
-    seatUserIds.length < 2
+    showdownUserIds.length < 2
     || communityDealt < 0
     || communityDealt > 5
     || !Array.isArray(state?.community)
@@ -29,8 +33,15 @@ function hasCompleteRuntimePrivateHandState(state) {
   ) {
     return false;
   }
-  return seatUserIds.every((userId) => Array.isArray(state.holeCardsByUserId[userId])
-    && state.holeCardsByUserId[userId].length === 2);
+  const showdownHoleCards = showdownUserIds.map((userId) => state.holeCardsByUserId[userId]);
+  if (!showdownHoleCards.every(isValidTwoCards)) {
+    return false;
+  }
+  return areCardsUnique([
+    ...state.community,
+    ...state.deck,
+    ...showdownHoleCards.flat()
+  ]);
 }
 
 function isTerminalAllInCallPending(state) {

--- a/ws-server/poker/snapshot-runtime/poker-cards-utils.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-cards-utils.mjs
@@ -29,16 +29,19 @@ const normalizeSuit = (value) => {
 };
 
 export const isValidCard = (card) => {
-  if (!card || typeof card !== "object") return false;
-  const rank = normalizeRank(card.r);
-  const suit = normalizeSuit(card.s);
-  if (!rank) return false;
-  if (!SUIT_SET.has(suit)) return false;
-  return true;
+  return normalizeCardForCompare(card) !== null;
 };
 
 
 export const normalizeCardForCompare = (card) => {
+  if (typeof card === "string") {
+    const match = /^(10|[2-9TJQKA])([SHDC])$/i.exec(card.trim());
+    if (!match) return null;
+    return {
+      r: normalizeRank(match[1]),
+      s: normalizeSuit(match[2])
+    };
+  }
   const rank = normalizeRank(card?.r);
   const suit = normalizeSuit(card?.s);
   if (!rank || !SUIT_SET.has(suit)) return null;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -197,12 +197,20 @@ function createPersistedBootstrapLoader({ env = process.env } = {}) {
   return async function loadPersistedTableBootstrap({ tableId }) {
     const repository = await loadRepository();
     const loaded = await repository.load(tableId);
-    return adaptPersistedBootstrap({
+    const adapted = adaptPersistedBootstrap({
       tableId,
       tableRow: loaded?.tableRow,
       seatRows: loaded?.seatRows,
       stateRow: loaded?.stateRow
     });
+    if (adapted?.reason === "live_hand_runtime_unrecoverable") {
+      klogSafe("ws_persisted_bootstrap_live_hand_rejected", {
+        tableId,
+        code: adapted.code,
+        reason: adapted.reason
+      });
+    }
+    return adapted;
   };
 }
 


### PR DESCRIPTION
## Summary

Implements PR B from the plan in #738 for the reproducible incomplete-community path behind #737.

- reject a narrowly identified legacy live hand at the persisted bootstrap boundary when a terminal all-in `CALL` is pending and private runtime hand data cannot be reconstructed or validated
- validate restored `community`, remaining `deck`, and showdown-eligible hole cards using the existing card primitives, including cross-zone duplicate detection
- emit a single `klog` event (`ws_persisted_bootstrap_live_hand_rejected`) for manual investigation
- add deterministic regressions to the existing bootstrap adapter test file

## Analysis

The historical row from #737 is no longer retained in the current staging database or journal, so this PR does not claim recovery of that exact payload. The repository does expose a matching deterministic failure path:

1. persisted poker state intentionally omits `deck` and `holeCardsByUserId`
2. live-hand reconstruction therefore depends on a valid `handSeed`
3. a legacy live state without reconstructable private runtime data can currently pass bootstrap unchanged
4. for a terminal all-in `CALL`, the reducer attempts the full runout and throws `showdown_incomplete_community` because it cannot produce a valid five-card board

The regression fixture reproduces that exact reducer error using the state shape and version reported in #737. A second regression verifies that correctly sized arrays containing invalid or duplicated card codes also fail closed instead of being treated as complete private runtime state.

## Safety and scope

The guard is deliberately narrow. It applies only when all of these are true:

- phase is `PREFLOP`, `FLOP`, `TURN`, or `RIVER`
- deterministic runtime reconstruction failed
- no complete and valid runtime deck/hole-card state is present
- the current action is a terminal all-in call with every other eligible player already all-in

A private runtime state is complete only when the community count is consistent, the remaining deck can finish the board, every showdown-eligible player has two valid cards, all relevant cards are valid, and cards are unique across community, the remaining deck, and eligible hole cards.

The rejected state is not mutated. This PR does not settle the hand, change stacks or pot, add a DB-to-runtime restore path, or broaden observability work planned for PR C. Other live persisted states continue through the existing bootstrap path.

## Validation

- `node --test ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs` — 13/13
- `node --test ws-server/poker/shared/poker-action-reducer.behavior.test.mjs` — 17/17
- `node --test ws-server/server.behavior.test.mjs` — 89/89
- bootstrap repository tests — 4/4
- bootstrap DB tests — 2/2
- `npm run test:quick` — syntax check passed

Refs #737
Plan: #738