### PR TITLE
feat: add WS autoplay observability

### DIFF
--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -82,6 +82,10 @@ jobs:
           node-version: 20
 
       - name: Build and package preview ws-server artifact
+        env:
+          RELEASE_SHA: ${{ steps.selected_ref.outputs.sha }}
+          DEPLOY_REF: ${{ inputs.ref }}
+          RELEASE_ENVIRONMENT: preview
         run: |
           set -euo pipefail
 
@@ -106,6 +110,7 @@ jobs:
           if [ -f ws-server/server.mjs ]; then
             cp ws-server/server.mjs "$PREVIEW_STAGE_WS_DIR"/
           fi
+          node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({ releaseSha: process.env.RELEASE_SHA, deployRef: process.env.DEPLOY_REF, environment: process.env.RELEASE_ENVIRONMENT }) + "\n")' "$PREVIEW_STAGE_WS_DIR/release-metadata.json"
 
           if [ -d ws-server/poker ]; then
             cp -R ws-server/poker "$PREVIEW_STAGE_WS_DIR"/poker
@@ -137,6 +142,7 @@ jobs:
           fi
 
           test -f "$PREVIEW_STAGE_DIR/netlify/functions/_shared/chips-ledger.mjs"
+          test -f "$PREVIEW_STAGE_WS_DIR/release-metadata.json"
           test -f "$PREVIEW_STAGE_DIR/netlify/functions/_shared/api-cors.mjs"
           test -f "$PREVIEW_STAGE_DIR/netlify/functions/_generated/deploy-context.mjs"
           (

--- a/.github/workflows/ws-server-deploy.yml
+++ b/.github/workflows/ws-server-deploy.yml
@@ -78,6 +78,10 @@ jobs:
           node-version: 20
 
       - name: Build and package ws-server deploy artifact
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          DEPLOY_REF: ${{ github.ref_name }}
+          RELEASE_ENVIRONMENT: production
         run: |
           set -euo pipefail
           ARTIFACT_DIR="$GITHUB_WORKSPACE/.artifacts/ws-server"
@@ -106,6 +110,7 @@ jobs:
           if [ -f ws-server/server.mjs ]; then
             cp ws-server/server.mjs "$STAGE_WS_DIR"/
           fi
+          node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({ releaseSha: process.env.RELEASE_SHA, deployRef: process.env.DEPLOY_REF, environment: process.env.RELEASE_ENVIRONMENT }) + "\n")' "$STAGE_WS_DIR/release-metadata.json"
 
           if [ -d ws-server/poker ]; then
             cp -R ws-server/poker "$STAGE_WS_DIR"/poker
@@ -130,6 +135,7 @@ jobs:
           fi
 
           test -f "$STAGE_WS_DIR/server.mjs"
+          test -f "$STAGE_WS_DIR/release-metadata.json"
           test -f "$STAGE_ROOT/shared/profile-avatar-projection.mjs"
           test -f "$STAGE_ROOT/netlify/functions/_shared/chips-ledger.mjs"
           test -f "$STAGE_ROOT/netlify/functions/_shared/api-cors.mjs"

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -1,11 +1,51 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  createBotAutoplayObservability,
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
   shouldClearBotTimeoutSafetySuppression,
   shouldSuppressBotTimeoutSafetyRetry
 } from "./bot-autoplay.mjs";
+
+test("bot autoplay observability preserves first and terminal events while aggregating repeated failures", () => {
+  const logs = [];
+  let nowMs = 1_000;
+  const observer = createBotAutoplayObservability({
+    klog: (kind, data) => logs.push({ kind, data }),
+    now: () => nowMs,
+    summaryIntervalMs: 60_000
+  });
+  const failure = {
+    tableId: "t1",
+    handId: "h1",
+    stateVersion: 12,
+    turnUserId: "bot_2",
+    reason: "apply_action_failed",
+    error: "showdown_incomplete_community"
+  };
+
+  assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), true);
+  assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), false);
+  assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), false);
+  nowMs += 25;
+  assert.equal(observer.log("ws_bot_timeout_safety_same_state_retry_suppressed", {
+    tableId: "t1",
+    handId: "h1",
+    stateVersion: 12,
+    turnUserId: "bot_2",
+    reason: "showdown_incomplete_community"
+  }), true);
+
+  assert.deepEqual(logs.map((entry) => entry.kind), [
+    "poker_act_bot_autoplay_step_error",
+    "ws_bot_timeout_safety_same_state_retry_suppressed",
+    "ws_bot_autoplay_failure_summary"
+  ]);
+  assert.deepEqual(logs[2].data.countsByReason, {
+    showdown_incomplete_community: { total: 3, logged: 1, suppressed: 2 }
+  });
+});
 
 test("bot timeout safety suppresses deterministic same-state invariant retries only", () => {
   assert.equal(shouldSuppressBotTimeoutSafetyRetry({ ok: false, changed: false, reason: "showdown_incomplete_community" }), true);

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -26,8 +26,9 @@ test("bot autoplay observability preserves first and terminal events while aggre
   };
 
   assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), true);
+  assert.equal(observer.log("ws_bot_autoplay_failed", failure), true);
   assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), false);
-  assert.equal(observer.log("poker_act_bot_autoplay_step_error", failure), false);
+  assert.equal(observer.log("ws_bot_autoplay_failed", failure), false);
   nowMs += 25;
   assert.equal(observer.log("ws_bot_timeout_safety_same_state_retry_suppressed", {
     tableId: "t1",
@@ -39,11 +40,12 @@ test("bot autoplay observability preserves first and terminal events while aggre
 
   assert.deepEqual(logs.map((entry) => entry.kind), [
     "poker_act_bot_autoplay_step_error",
+    "ws_bot_autoplay_failed",
     "ws_bot_timeout_safety_same_state_retry_suppressed",
     "ws_bot_autoplay_failure_summary"
   ]);
-  assert.deepEqual(logs[2].data.countsByReason, {
-    showdown_incomplete_community: { total: 3, logged: 1, suppressed: 2 }
+  assert.deepEqual(logs[3].data.countsByReason, {
+    showdown_incomplete_community: { total: 4, logged: 2, suppressed: 2 }
   });
 });
 

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -18,8 +18,9 @@ function failureReason(data) {
   return asLogValue(data?.error) || asLogValue(data?.reason) || "unknown";
 }
 
-function failureFingerprint(data) {
+function failureFingerprint(kind, data) {
   return [
+    kind,
     asLogValue(data?.tableId),
     asLogValue(data?.handId),
     Number.isFinite(Number(data?.stateVersion ?? data?.lastKnownStateVersion))
@@ -84,7 +85,7 @@ export function createBotAutoplayObservability({
     }
 
     const reason = failureReason(data);
-    const fingerprint = failureFingerprint(data);
+    const fingerprint = failureFingerprint(kind, data);
     const alreadySeen = seenFingerprints.has(fingerprint);
     if (!alreadySeen && seenFingerprints.size >= maxFingerprints) {
       flush("capacity");

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -4,6 +4,107 @@ const BOT_AUTOPLAY_SAME_STATE_INVARIANT_FAILURES = new Set([
   "not_enough_cards",
   "state_invalid",
 ]);
+const BOT_AUTOPLAY_DEDUPED_FAILURE_LOG_KINDS = new Set([
+  "poker_act_bot_autoplay_step_error",
+  "ws_bot_autoplay_failed"
+]);
+const BOT_AUTOPLAY_TERMINAL_LOG_KIND = "ws_bot_timeout_safety_same_state_retry_suppressed";
+
+function asLogValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+function failureReason(data) {
+  return asLogValue(data?.error) || asLogValue(data?.reason) || "unknown";
+}
+
+function failureFingerprint(data) {
+  return [
+    asLogValue(data?.tableId),
+    asLogValue(data?.handId),
+    Number.isFinite(Number(data?.stateVersion ?? data?.lastKnownStateVersion))
+      ? Number(data?.stateVersion ?? data?.lastKnownStateVersion)
+      : "",
+    asLogValue(data?.turnUserId ?? data?.lastKnownTurnUserId),
+    failureReason(data)
+  ].join(":");
+}
+
+export function createBotAutoplayObservability({
+  klog = () => {},
+  now = Date.now,
+  summaryIntervalMs = 60_000,
+  maxFingerprints = 1_000
+} = {}) {
+  const seenFingerprints = new Set();
+  const countsByReason = new Map();
+  let windowStartedAt = now();
+
+  const flush = (trigger = "interval") => {
+    if (countsByReason.size === 0) return false;
+    const counts = {};
+    let total = 0;
+    let logged = 0;
+    let suppressed = 0;
+    for (const reason of [...countsByReason.keys()].sort()) {
+      const entry = countsByReason.get(reason);
+      counts[reason] = { ...entry };
+      total += entry.total;
+      logged += entry.logged;
+      suppressed += entry.suppressed;
+    }
+    const endedAt = now();
+    klog("ws_bot_autoplay_failure_summary", {
+      trigger,
+      windowMs: Math.max(0, endedAt - windowStartedAt),
+      total,
+      logged,
+      suppressed,
+      countsByReason: counts
+    });
+    countsByReason.clear();
+    seenFingerprints.clear();
+    windowStartedAt = endedAt;
+    return true;
+  };
+
+  const log = (kind, data) => {
+    const nowMs = now();
+    if (nowMs - windowStartedAt >= summaryIntervalMs) {
+      flush("interval");
+    }
+    if (kind === BOT_AUTOPLAY_TERMINAL_LOG_KIND) {
+      klog(kind, data);
+      flush("terminal");
+      return true;
+    }
+    if (!BOT_AUTOPLAY_DEDUPED_FAILURE_LOG_KINDS.has(kind)) {
+      klog(kind, data);
+      return true;
+    }
+
+    const reason = failureReason(data);
+    const fingerprint = failureFingerprint(data);
+    const alreadySeen = seenFingerprints.has(fingerprint);
+    if (!alreadySeen && seenFingerprints.size >= maxFingerprints) {
+      flush("capacity");
+    }
+    const previous = countsByReason.get(reason) || { total: 0, logged: 0, suppressed: 0 };
+    previous.total += 1;
+    if (!alreadySeen) {
+      seenFingerprints.add(fingerprint);
+      previous.logged += 1;
+      countsByReason.set(reason, previous);
+      klog(kind, data);
+      return true;
+    }
+    previous.suppressed += 1;
+    countsByReason.set(reason, previous);
+    return false;
+  };
+
+  return { flush, log };
+}
 
 export function shouldSuppressBotTimeoutSafetyRetry(result) {
   const reason = typeof result?.reason === "string" ? result.reason.trim() : "";

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1204,6 +1204,30 @@ test("server supports healthz and hello/helloAck smoke flow", async () => {
   }
 });
 
+test("server logs deploy identity at artifact startup", async () => {
+  const { child } = await createServer({
+    env: {
+      WS_RELEASE_SHA: "test-release-sha",
+      WS_DEPLOY_REF: "agent/test-release-ref",
+      WS_DEPLOY_ENVIRONMENT: "preview"
+    }
+  });
+  const logs = [];
+  child.stdout.on("data", (chunk) => logs.push(String(chunk)));
+
+  try {
+    await waitForListening(child, 5000);
+    const joined = logs.join("");
+    assert.match(joined, /ws_artifact_start/);
+    assert.match(joined, /"releaseSha":"test-release-sha"/);
+    assert.match(joined, /"deployRef":"agent\/test-release-ref"/);
+    assert.match(joined, /"environment":"preview"/);
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 
 
 test("server boots with leave handler wired in default env without override", async () => {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1,4 +1,5 @@
 import http from "http";
+import fs from "node:fs";
 import WebSocket, { WebSocketServer } from "ws";
 import { MAX_FRAME_BYTES } from "./poker/protocol/constants.mjs";
 import { makeErrorFrame, parseFrame, validateEnvelope } from "./poker/protocol/envelope.mjs";
@@ -26,6 +27,7 @@ import { handleActCommand } from "./poker/handlers/act.mjs";
 import { handleStartHandCommand } from "./poker/handlers/start-hand.mjs";
 import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import {
+  createBotAutoplayObservability,
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
   shouldClearBotTimeoutSafetySuppression,
@@ -381,7 +383,7 @@ async function loadAcceptedBotAutoplayExecutor() {
           },
           getBotReactionOverride: () => botReactionOverrideStore.getOverrideRange(),
           env: process.env,
-          klog: klogSafe
+          klog: botAutoplayObservability.log
         });
       } catch (error) {
         klogSafe("ws_bot_autoplay_executor_unavailable", {
@@ -435,6 +437,45 @@ function klogSafe(kind, data) {
     klog(kind, data);
   } catch {
     // Logging must never break request handling.
+  }
+}
+
+const botAutoplayLogSummaryMs = resolvePositiveInt(process.env.WS_BOT_AUTOPLAY_LOG_SUMMARY_MS, 60_000, {
+  min: 10_000,
+  max: 3_600_000
+});
+const botAutoplayObservability = createBotAutoplayObservability({
+  klog: klogSafe,
+  summaryIntervalMs: botAutoplayLogSummaryMs
+});
+const botAutoplaySummaryTimer = setInterval(() => {
+  botAutoplayObservability.flush("interval");
+}, botAutoplayLogSummaryMs);
+botAutoplaySummaryTimer.unref();
+
+function loadReleaseMetadata() {
+  const fallback = {
+    releaseSha: typeof process.env.WS_RELEASE_SHA === "string" ? process.env.WS_RELEASE_SHA.trim() : "",
+    deployRef: typeof process.env.WS_DEPLOY_REF === "string" ? process.env.WS_DEPLOY_REF.trim() : "",
+    environment: typeof process.env.WS_DEPLOY_ENVIRONMENT === "string"
+      ? process.env.WS_DEPLOY_ENVIRONMENT.trim()
+      : (process.env.NODE_ENV || "unknown")
+  };
+  try {
+    const parsed = JSON.parse(fs.readFileSync(new URL("./release-metadata.json", import.meta.url), "utf8"));
+    return {
+      releaseSha: typeof parsed?.releaseSha === "string" && parsed.releaseSha.trim()
+        ? parsed.releaseSha.trim()
+        : fallback.releaseSha,
+      deployRef: typeof parsed?.deployRef === "string" && parsed.deployRef.trim()
+        ? parsed.deployRef.trim()
+        : fallback.deployRef,
+      environment: typeof parsed?.environment === "string" && parsed.environment.trim()
+        ? parsed.environment.trim()
+        : fallback.environment
+    };
+  } catch {
+    return fallback;
   }
 }
 
@@ -614,7 +655,7 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
         frameTs,
         runBotStep,
         broadcastStateSnapshots,
-        klog: klogSafe
+        klog: botAutoplayObservability.log
       });
       clearBotTimeoutSafetySuppressionAfterSuccess(tableId, result);
       return result;
@@ -2379,7 +2420,7 @@ async function sweepTurnTimeoutsAndBroadcast() {
           frameTs: null,
           runBotStep,
           broadcastStateSnapshots,
-          klog: klogSafe
+          klog: botAutoplayObservability.log
         });
         if (shouldSuppressBotTimeoutSafetyRetry(result)) {
           const fingerprint = buildBotTimeoutSafetyFingerprint(update.tableId);
@@ -2388,7 +2429,7 @@ async function sweepTurnTimeoutsAndBroadcast() {
               ...fingerprint,
               reason: result.reason
             });
-            klogSafe("ws_bot_timeout_safety_same_state_retry_suppressed", {
+            botAutoplayObservability.log("ws_bot_timeout_safety_same_state_retry_suppressed", {
               ...fingerprint,
               reason: result.reason
             });
@@ -3490,6 +3531,12 @@ const lobbyVisibilitySweepTimer = setInterval(() => {
 lobbyVisibilitySweepTimer.unref();
 
 async function startServer() {
+  const release = loadReleaseMetadata();
+  klogSafe("ws_artifact_start", {
+    releaseSha: release.releaseSha || null,
+    deployRef: release.deployRef || null,
+    environment: release.environment || "unknown"
+  });
   server.listen(PORT, "0.0.0.0", () => {
     klogSafe("ws_listening", { message: `WS listening on ${PORT}`, port: PORT });
   });

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -102,12 +102,17 @@ test("ws preview deploy workflow packages and validates shared runtime files", (
   assert.match(text, /cp -R ws-server\/poker "\$PREVIEW_STAGE_WS_DIR"\/poker/);
   assert.match(text, /cp -R ws-server\/shared\/poker-domain "\$PREVIEW_STAGE_WS_DIR"\/shared\/poker-domain/);
   assert.match(text, /cp -R ws-server\/node_modules "\$PREVIEW_STAGE_WS_DIR"\/node_modules/);
+  assert.match(text, /RELEASE_ENVIRONMENT: preview/);
+  assert.match(text, /release-metadata\.json/);
+  assert.match(text, /releaseSha: process\.env\.RELEASE_SHA/);
+  assert.match(text, /deployRef: process\.env\.DEPLOY_REF/);
   assert.match(text, /cp -R ws-server\/node_modules "\$PREVIEW_STAGE_DIR"\/node_modules/);
   assert.match(text, /cp -R shared "\$PREVIEW_STAGE_DIR"\/shared/);
   assert.match(text, /cp netlify\/functions\/_shared\/chips-ledger\.mjs "\$PREVIEW_STAGE_DIR"\/netlify\/functions\/_shared\//);
   assert.match(text, /node --input-type=module -e "await import\('\.\/ws-server\/shared\/poker-domain\/inactive-cleanup-deps\.mjs'\)"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/shared\/poker-domain\/join\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/server\.mjs"/);
+  assert.match(text, /test -f "\$PREVIEW_STAGE_WS_DIR\/release-metadata\.json"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/shared\/poker-domain\/inactive-cleanup-deps\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/chips-ledger\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/deploy-context\.mjs"/);

--- a/ws-tests/ws-server-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-server-deploy.workflow.guard.test.mjs
@@ -16,6 +16,10 @@ test("ws-server deploy workflow has guarded triggers, secrets and concurrency", 
   assert.match(text, /"netlify\/functions\/_shared\/supabase-admin\.mjs"/);
   assert.match(text, /concurrency:\n\s+group: ws-server-\$\{\{ github\.ref \}\}/);
   assert.match(text, /permissions:\n\s+contents: read/);
+  assert.match(text, /RELEASE_ENVIRONMENT: production/);
+  assert.match(text, /release-metadata\.json/);
+  assert.match(text, /releaseSha: process\.env\.RELEASE_SHA/);
+  assert.match(text, /deployRef: process\.env\.DEPLOY_REF/);
 
   assert.match(text, /host: \$\{\{ secrets\.WS_HOST \}\}/);
   assert.match(text, /username: \$\{\{ secrets\.WS_USER \}\}/);


### PR DESCRIPTION
## Summary

Implements PR C from the approved plan in #738, independently from poker game logic.

- logs the deployed artifact SHA, ref, and environment once at WS startup through `klog`
- embeds release metadata in both preview and production WS artifacts
- limits repeated autoplay failure logs for the same `kind + tableId + handId + stateVersion + turnUserId + reason` fingerprint within a bounded window
- preserves the first occurrence of each detailed event kind and the terminal same-state suppression event
- emits aggregated `ws_bot_autoplay_failure_summary` counters grouped by concrete reason

## Behavior

Detailed failure events `poker_act_bot_autoplay_step_error` and `ws_bot_autoplay_failed` are each emitted once per fingerprint in the aggregation window. Because `kind` is part of the fingerprint, the lower-level event cannot hide the first higher-level event and its trigger/request context. Repeats of the same kind increment `total` and `suppressed` counters instead of writing another detailed event.

The terminal `ws_bot_timeout_safety_same_state_retry_suppressed` event is always written and flushes the current summary immediately. Remaining summaries flush every 60 seconds by default or when the bounded fingerprint capacity is reached.

The counters are intentionally best-effort process-local telemetry. The server has no existing controlled SIGTERM shutdown lifecycle, so a final partial aggregation window may be lost during deploy/restart. The first detailed failure remains present in `klog`; this PR does not add a new signal-handling lifecycle solely to flush counters.

The startup event is:

- `ws_artifact_start`
- fields: `releaseSha`, `deployRef`, `environment`

Release metadata is generated by the existing WS Preview Deploy and WS Server Deploy packaging steps. Generated artifact metadata is not maintained as a second source file.

## Scope and safety

This PR changes observability only. It does not change reducers, autoplay decisions, settlement, recovery, stacks, pots, or suppression semantics. Logs contain identifiers and reasons only; they do not include private cards, full poker state, credentials, or secrets.

## Validation

- `node --test ws-server/poker/handlers/bot-autoplay.behavior.test.mjs` — 12/12
- `node --test ws-server/server.behavior.test.mjs` — 90/90
- `node --test ws-tests/*deploy*.test.mjs` — 32/32
- `npm run test:quick` — syntax check passed

## WS Preview rollout

- deployed immutable SHA: `b602dd520d5d76fb48c19cd51d45048109e6ee03`
- successful run: https://github.com/krzysztofcal/arcadePlatform/actions/runs/30021893583
- validate, artifact build/upload, preview restart, and health gates passed
- the earlier run `30021672606` failed before build because the branch-name input collided with GitHub secret masking; dispatching the immutable SHA avoided that runner/input limitation

Plan: #738
Related: #737