### PR TITLE
perf(poker): bound open-table janitor query

### DIFF
--- a/scripts/poker-open-table-janitor-preview-smoke.mjs
+++ b/scripts/poker-open-table-janitor-preview-smoke.mjs
@@ -1,0 +1,150 @@
+import { spawn } from "node:child_process";
+
+const targetCount = Number(process.env.SMOKE_TABLE_COUNT || 25);
+const expectedBatchSize = Number(process.env.SMOKE_EXPECTED_BATCH_SIZE || 10);
+const timeoutMs = Number(process.env.SMOKE_TIMEOUT_MS || 240_000);
+const createTableUrl = String(process.env.POKER_CREATE_TABLE_URL || "").trim();
+const origin = String(process.env.POKER_CREATE_TABLE_ORIGIN || "").trim();
+const bearerToken = String(process.env.SUPABASE_BEARER_TOKEN || "").trim();
+const serviceName = String(process.env.WS_PREVIEW_SERVICE || "ws-server-preview.service").trim();
+const existingTableIds = String(process.env.SMOKE_EXISTING_TABLE_IDS || "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+if (!Number.isInteger(targetCount) || targetCount < 1) throw new Error("invalid_SMOKE_TABLE_COUNT");
+if (!Number.isInteger(expectedBatchSize) || expectedBatchSize < 1) throw new Error("invalid_SMOKE_EXPECTED_BATCH_SIZE");
+if (!Number.isFinite(timeoutMs) || timeoutMs < 1_000) throw new Error("invalid_SMOKE_TIMEOUT_MS");
+if (!createTableUrl || !origin || !bearerToken) throw new Error("missing_create_table_configuration");
+if (existingTableIds.length > targetCount) throw new Error("too_many_existing_table_ids");
+
+const startedAtMs = Date.now();
+const journal = spawn("sudo", [
+  "-n",
+  "journalctl",
+  "-u",
+  serviceName,
+  "--since",
+  `@${Math.floor(startedAtMs / 1000)}`,
+  "--follow",
+  "--no-pager",
+  "-o",
+  "cat"
+], { stdio: ["ignore", "pipe", "pipe"] });
+
+const batches = [];
+let journalBuffer = "";
+let resolveBatch;
+const nextBatch = () => new Promise((resolve) => {
+  resolveBatch = resolve;
+});
+
+journal.stdout.setEncoding("utf8");
+journal.stdout.on("data", (chunk) => {
+  journalBuffer += chunk;
+  const lines = journalBuffer.split("\n");
+  journalBuffer = lines.pop() || "";
+  for (const line of lines) {
+    const marker = "ws_open_table_reconciler_batch_selected ";
+    const markerIndex = line.indexOf(marker);
+    if (markerIndex < 0) continue;
+    try {
+      const payload = JSON.parse(line.slice(markerIndex + marker.length));
+      batches.push(payload);
+      resolveBatch?.();
+      resolveBatch = null;
+    } catch {
+      // Ignore unrelated or incomplete journal lines.
+    }
+  }
+});
+
+let journalError = "";
+journal.stderr.setEncoding("utf8");
+journal.stderr.on("data", (chunk) => {
+  journalError += chunk;
+});
+
+async function createTable() {
+  const response = await fetch(createTableUrl, {
+    method: "POST",
+    headers: {
+      origin,
+      authorization: `Bearer ${bearerToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2" })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || typeof payload?.tableId !== "string" || !payload.tableId) {
+    throw new Error(`create_table_failed:${response.status}:${payload?.error || "invalid_response"}`);
+  }
+  return payload.tableId;
+}
+
+function verifyRotation(tableIds, observedBatches) {
+  const targetSet = new Set(tableIds);
+  const relevantBatches = observedBatches
+    .map((batch) => ({
+      ...batch,
+      tableIds: Array.isArray(batch?.tableIds) ? batch.tableIds : []
+    }))
+    .filter((batch) => batch.tableIds.some((tableId) => targetSet.has(tableId)));
+  const flattened = relevantBatches.flatMap((batch) => batch.tableIds);
+  const requiredVisits = targetCount + Math.min(expectedBatchSize, targetCount);
+  if (flattened.length < requiredVisits) return null;
+
+  const firstCycle = flattened.slice(0, targetCount);
+  const wrappedPrefix = flattened.slice(targetCount, requiredVisits);
+  if (firstCycle.some((tableId) => !targetSet.has(tableId))) {
+    throw new Error(`unexpected_table_in_rotation:${firstCycle.find((tableId) => !targetSet.has(tableId))}`);
+  }
+  if (new Set(firstCycle).size !== targetCount) {
+    throw new Error("table_repeated_before_full_rotation");
+  }
+  if (tableIds.some((tableId) => !firstCycle.includes(tableId))) {
+    throw new Error("created_table_missing_from_full_rotation");
+  }
+  const expectedWrappedPrefix = firstCycle.slice(0, wrappedPrefix.length);
+  if (JSON.stringify(wrappedPrefix) !== JSON.stringify(expectedWrappedPrefix)) {
+    throw new Error("cursor_wrap_order_mismatch");
+  }
+  for (const batch of relevantBatches.slice(0, Math.ceil(requiredVisits / expectedBatchSize))) {
+    if (batch.limit !== expectedBatchSize || batch.returnedOpenTableCount !== expectedBatchSize) {
+      throw new Error("unexpected_bounded_batch_shape");
+    }
+  }
+  return { relevantBatches, firstCycle, wrappedPrefix };
+}
+
+const timeoutAt = startedAtMs + timeoutMs;
+try {
+  const createdTableIds = [...existingTableIds];
+  while (createdTableIds.length < targetCount) {
+    createdTableIds.push(await createTable());
+  }
+  process.stdout.write(`${JSON.stringify({ event: "tables_created", tableIds: createdTableIds })}\n`);
+
+  let verified = null;
+  while (!verified && Date.now() < timeoutAt) {
+    verified = verifyRotation(createdTableIds, batches);
+    if (verified) break;
+    await Promise.race([
+      nextBatch(),
+      new Promise((resolve) => setTimeout(resolve, Math.min(5_000, Math.max(0, timeoutAt - Date.now()))))
+    ]);
+  }
+  if (!verified) throw new Error("rotation_verification_timeout");
+
+  process.stdout.write(`${JSON.stringify({
+    event: "rotation_verified",
+    targetCount,
+    expectedBatchSize,
+    batches: verified.relevantBatches,
+    firstCycle: verified.firstCycle,
+    wrappedPrefix: verified.wrappedPrefix
+  })}\n`);
+} finally {
+  journal.kill("SIGTERM");
+  if (journalError.trim()) process.stderr.write(journalError);
+}

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -16,7 +16,7 @@ import { adaptPersistedBootstrap } from "./poker/bootstrap/persisted-bootstrap-a
 import { createSessionStore } from "./poker/runtime/session-store.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
 import { createBotReactionOverrideStore } from "./poker/runtime/bot-reaction-override.mjs";
-import { evaluateTableHealth, runTableJanitor, selectOpenTableJanitorBatch } from "./poker/runtime/table-janitor.mjs";
+import { evaluateTableHealth, runTableJanitor } from "./poker/runtime/table-janitor.mjs";
 import { buildStateSnapshotPayload } from "./poker/read-model/state-snapshot.mjs";
 import { buildStatePatch } from "./poker/read-model/state-patch.mjs";
 import { createStreamLog } from "./poker/runtime/stream-log.mjs";
@@ -2349,43 +2349,46 @@ async function sweepZombieTablesAndBroadcast() {
 async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
   if (!persistedBootstrapEnabled) return [];
   const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 10;
-  const hasCursor = Boolean(Number.isFinite(openTableJanitorCursor?.updatedAtMs)
+  const hasCursor = Boolean(typeof openTableJanitorCursor?.updatedAt === "string"
+    && openTableJanitorCursor.updatedAt.trim()
     && typeof openTableJanitorCursor?.tableId === "string"
     && openTableJanitorCursor.tableId.trim());
-  const cursorUpdatedAt = hasCursor ? new Date(openTableJanitorCursor.updatedAtMs).toISOString() : null;
+  const cursorUpdatedAt = hasCursor ? openTableJanitorCursor.updatedAt.trim() : null;
   const cursorTableId = hasCursor ? openTableJanitorCursor.tableId.trim() : null;
   try {
     const beginSqlWs = await loadBeginSqlWs();
     return beginSqlWs(async (tx) => {
       const rows = await tx.unsafe(
-        `select t.id, t.updated_at
+        `select
+           t.id,
+           t.updated_at::text as cursor_updated_at,
+           case
+             when $1::timestamptz is null then false
+             when (t.updated_at, t.id) > ($1::timestamptz, $2::uuid) then false
+             else true
+           end as cursor_wrapped
          from public.poker_tables t
          where t.status = 'OPEN'
-         order by
-           case
-             when $1::timestamptz is null then 0
-             when (t.updated_at, t.id) > ($1::timestamptz, $2::uuid) then 0
-             else 1
-           end asc,
-           t.updated_at asc,
-           t.id asc
+         order by cursor_wrapped asc, t.updated_at asc, t.id asc
          limit $3;`,
         [cursorUpdatedAt, cursorTableId, boundedLimit]
       );
-      const selected = selectOpenTableJanitorBatch({
-        tables: Array.isArray(rows) ? rows : [],
-        limit: boundedLimit,
-        cursor: openTableJanitorCursor
-      });
-      openTableJanitorCursor = selected.cursor;
+      const selectedRows = Array.isArray(rows)
+        ? rows.filter((row) => typeof row?.id === "string" && row.id)
+        : [];
+      const tableIds = selectedRows.map((row) => row.id);
+      const lastRow = selectedRows.at(-1) || null;
+      openTableJanitorCursor = lastRow && typeof lastRow?.cursor_updated_at === "string"
+        ? { tableId: lastRow.id, updatedAt: lastRow.cursor_updated_at }
+        : null;
       klogSafe("ws_open_table_reconciler_batch_selected", {
         limit: boundedLimit,
-        returnedOpenTableCount: selected.total,
-        wrapped: selected.wrapped,
-        cursorTableId: selected.cursor?.tableId || null,
-        tableIds: selected.tableIds
+        returnedOpenTableCount: tableIds.length,
+        wrapped: selectedRows.some((row) => row?.cursor_wrapped === true),
+        cursorTableId: openTableJanitorCursor?.tableId || null,
+        tableIds
       });
-      return selected.tableIds;
+      return tableIds;
     }, { env: process.env });
   } catch (error) {
     klogSafe("ws_open_table_reconciler_list_failed", { message: error?.message || "unknown" });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2349,37 +2349,38 @@ async function sweepZombieTablesAndBroadcast() {
 async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
   if (!persistedBootstrapEnabled) return [];
   const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 10;
-  const hasCursor = Boolean(typeof openTableJanitorCursor?.updatedAt === "string"
-    && openTableJanitorCursor.updatedAt.trim()
+  // Keep the cursor on immutable creation order so table activity cannot requeue the boundary row.
+  const hasCursor = Boolean(typeof openTableJanitorCursor?.createdAt === "string"
+    && openTableJanitorCursor.createdAt.trim()
     && typeof openTableJanitorCursor?.tableId === "string"
     && openTableJanitorCursor.tableId.trim());
-  const cursorUpdatedAt = hasCursor ? openTableJanitorCursor.updatedAt.trim() : null;
+  const cursorCreatedAt = hasCursor ? openTableJanitorCursor.createdAt.trim() : null;
   const cursorTableId = hasCursor ? openTableJanitorCursor.tableId.trim() : null;
   try {
     const beginSqlWs = await loadBeginSqlWs();
     return beginSqlWs(async (tx) => {
       const rows = await tx.unsafe(
-        `select
+         `select
            t.id,
-           t.updated_at::text as cursor_updated_at,
+           t.created_at::text as cursor_created_at,
            case
              when $1::timestamptz is null then false
-             when (t.updated_at, t.id) > ($1::timestamptz, $2::uuid) then false
+             when (t.created_at, t.id) > ($1::timestamptz, $2::uuid) then false
              else true
            end as cursor_wrapped
          from public.poker_tables t
          where t.status = 'OPEN'
-         order by cursor_wrapped asc, t.updated_at asc, t.id asc
+         order by cursor_wrapped asc, t.created_at asc, t.id asc
          limit $3;`,
-        [cursorUpdatedAt, cursorTableId, boundedLimit]
+        [cursorCreatedAt, cursorTableId, boundedLimit]
       );
       const selectedRows = Array.isArray(rows)
         ? rows.filter((row) => typeof row?.id === "string" && row.id)
         : [];
       const tableIds = selectedRows.map((row) => row.id);
       const lastRow = selectedRows.at(-1) || null;
-      openTableJanitorCursor = lastRow && typeof lastRow?.cursor_updated_at === "string"
-        ? { tableId: lastRow.id, updatedAt: lastRow.cursor_updated_at }
+      openTableJanitorCursor = lastRow && typeof lastRow?.cursor_created_at === "string"
+        ? { tableId: lastRow.id, createdAt: lastRow.cursor_created_at }
         : null;
       klogSafe("ws_open_table_reconciler_batch_selected", {
         limit: boundedLimit,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2349,6 +2349,11 @@ async function sweepZombieTablesAndBroadcast() {
 async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
   if (!persistedBootstrapEnabled) return [];
   const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 10;
+  const hasCursor = Boolean(Number.isFinite(openTableJanitorCursor?.updatedAtMs)
+    && typeof openTableJanitorCursor?.tableId === "string"
+    && openTableJanitorCursor.tableId.trim());
+  const cursorUpdatedAt = hasCursor ? new Date(openTableJanitorCursor.updatedAtMs).toISOString() : null;
+  const cursorTableId = hasCursor ? openTableJanitorCursor.tableId.trim() : null;
   try {
     const beginSqlWs = await loadBeginSqlWs();
     return beginSqlWs(async (tx) => {
@@ -2356,7 +2361,16 @@ async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
         `select t.id, t.updated_at
          from public.poker_tables t
          where t.status = 'OPEN'
-         order by t.updated_at asc, t.id asc;`
+         order by
+           case
+             when $1::timestamptz is null then 0
+             when (t.updated_at, t.id) > ($1::timestamptz, $2::uuid) then 0
+             else 1
+           end asc,
+           t.updated_at asc,
+           t.id asc
+         limit $3;`,
+        [cursorUpdatedAt, cursorTableId, boundedLimit]
       );
       const selected = selectOpenTableJanitorBatch({
         tables: Array.isArray(rows) ? rows : [],
@@ -2366,7 +2380,7 @@ async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
       openTableJanitorCursor = selected.cursor;
       klogSafe("ws_open_table_reconciler_batch_selected", {
         limit: boundedLimit,
-        totalOpenTables: selected.total,
+        returnedOpenTableCount: selected.total,
         wrapped: selected.wrapped,
         cursorTableId: selected.cursor?.tableId || null,
         tableIds: selected.tableIds

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -2349,12 +2349,9 @@ async function sweepZombieTablesAndBroadcast() {
 async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
   if (!persistedBootstrapEnabled) return [];
   const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 10;
-  // Keep the cursor on immutable creation order so table activity cannot requeue the boundary row.
-  const hasCursor = Boolean(typeof openTableJanitorCursor?.createdAt === "string"
-    && openTableJanitorCursor.createdAt.trim()
-    && typeof openTableJanitorCursor?.tableId === "string"
+  // UUID order is immutable and round-trips exactly, so the boundary row cannot requeue itself.
+  const hasCursor = Boolean(typeof openTableJanitorCursor?.tableId === "string"
     && openTableJanitorCursor.tableId.trim());
-  const cursorCreatedAt = hasCursor ? openTableJanitorCursor.createdAt.trim() : null;
   const cursorTableId = hasCursor ? openTableJanitorCursor.tableId.trim() : null;
   try {
     const beginSqlWs = await loadBeginSqlWs();
@@ -2362,26 +2359,23 @@ async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
       const rows = await tx.unsafe(
          `select
            t.id,
-           t.created_at::text as cursor_created_at,
            case
-             when $1::timestamptz is null then false
-             when (t.created_at, t.id) > ($1::timestamptz, $2::uuid) then false
+             when $1::uuid is null then false
+             when t.id > $1::uuid then false
              else true
            end as cursor_wrapped
          from public.poker_tables t
          where t.status = 'OPEN'
-         order by cursor_wrapped asc, t.created_at asc, t.id asc
-         limit $3;`,
-        [cursorCreatedAt, cursorTableId, boundedLimit]
+         order by cursor_wrapped asc, t.id asc
+         limit $2;`,
+        [cursorTableId, boundedLimit]
       );
       const selectedRows = Array.isArray(rows)
         ? rows.filter((row) => typeof row?.id === "string" && row.id)
         : [];
       const tableIds = selectedRows.map((row) => row.id);
       const lastRow = selectedRows.at(-1) || null;
-      openTableJanitorCursor = lastRow && typeof lastRow?.cursor_created_at === "string"
-        ? { tableId: lastRow.id, createdAt: lastRow.cursor_created_at }
-        : null;
+      openTableJanitorCursor = lastRow ? { tableId: lastRow.id } : null;
       klogSafe("ws_open_table_reconciler_batch_selected", {
         limit: boundedLimit,
         returnedOpenTableCount: tableIds.length,


### PR DESCRIPTION
## Summary

Implements PR A from the accepted #742 optimization plan.

- applies a deterministic immutable UUID cursor in PostgreSQL;
- limits each open-table listing result to `WS_OPEN_TABLE_JANITOR_SWEEP_BATCH` (bounded to 100);
- preserves cyclic coverage and the existing per-table evaluation/cleanup path;
- replaces the misleading `totalOpenTables` diagnostic with `returnedOpenTableCount`, because the bounded query no longer computes the global total;
- adds a repeatable preview smoke harness that creates tables through the existing `poker-create-table` endpoint and verifies journal rotation.

The cursor intentionally uses immutable `poker_tables.id`, not mutable timestamps. Preview smoke testing showed that a timestamp boundary can requeue the boundary table after `updated_at` changes, while timestamptz serialization also risks precision loss. UUID ordering is exact, deterministic, deletion-safe, and prevents starvation without depending on mutable table activity.

The change keeps the number of listing queries per sweep unchanged while bounding rows transferred from Postgres. No timer, cleanup classification, retry, broadcast, persistence, settlement, or accounting behavior is changed.

## Verification

- `node --check ws-server/server.mjs`
- `node --check scripts/poker-open-table-janitor-preview-smoke.mjs`
- `node --test ws-server/poker/runtime/table-janitor.behavior.test.mjs`
- `node --test ws-server/server.stale-seat-sweep.behavior.test.mjs ws-server/server.leave-race.behavior.test.mjs`
- `npm run test:quick`
- `git diff --check`

All passed locally.

### WS Preview smoke

Deployed exact SHA `4694123c423e4b1f8c5f1c62d9dd97c53a1846eb` with successful workflow run `30044859579`.

The smoke harness:

- created 25 open tables through the deploy-preview `poker-create-table` endpoint, never through direct SQL;
- collected `ws_open_table_reconciler_batch_selected` from `ws-server-preview.service`;
- observed a complete cycle of 25 distinct table IDs with no duplicate before full coverage;
- observed the next 10 visits equal the first 10 IDs in the same UUID order;
- verified every observed batch had `limit: 10` and `returnedOpenTableCount: 10`;
- observed `wrapped: true` on the boundary batch;
- restored the normal preview grace configuration after verification.

The initial timestamp-cursor implementation failed this smoke test by repeating the boundary row. That finding is fixed in the current SHA by the immutable UUID cursor.

## Breaking impact

No runtime breaking impact intended. Ordering changes from mutable `updated_at` order to deterministic UUID order. The janitor provides cyclic full coverage rather than age-priority, while cleanup classification and routing remain unchanged.

The structured diagnostic field `totalOpenTables` is renamed to `returnedOpenTableCount`; repository search found no in-repo consumer. The new field accurately represents the bounded result rather than implying a full-table count.

## Deployment

Manual `WS Preview Deploy` and preview smoke verification completed for exact SHA `4694123c423e4b1f8c5f1c62d9dd97c53a1846eb`.

Refs #742