### PR TITLE
perf(poker): coalesce concurrent janitor evaluations

### DIFF
--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -278,6 +278,7 @@ const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
 const lobbySubscribers = new Set();
 const activeLobbyTablesById = new Map();
+const pendingTableJanitorEvaluationByTableId = new Map();
 const lobbyEmptyJoinableGraceMs = resolveEmptyJoinableGraceMs(process.env.POKER_TABLE_CLOSE_GRACE_MS);
 const internalRuntimeToken = typeof process.env.POKER_WS_INTERNAL_TOKEN === "string" ? process.env.POKER_WS_INTERNAL_TOKEN.trim() : "";
 const botReactionOverrideStore = createBotReactionOverrideStore({ env: process.env });
@@ -2258,30 +2259,58 @@ function buildTableJanitorRuntimeContext(tableId, persistedSeats = []) {
   };
 }
 
-async function runEvaluatedTableJanitor({ tableId, trigger, requestId }) {
+async function evaluateTableForJanitor(tableId) {
   const persistedHealth = await loadPersistedTableHealthSnapshot(tableId);
   if (!persistedHealth?.table) {
     return {
-      ok: true,
-      changed: false,
-      skipped: true,
-      status: "table_missing"
+      result: {
+        ok: true,
+        changed: false,
+        skipped: true,
+        status: "table_missing"
+      }
     };
   }
-  const classification = evaluateTableHealth({
-    tableId,
-    persistedTable: persistedHealth.table,
-    persistedSeats: persistedHealth.seats,
-    persistedState: persistedHealth.state,
-    runtime: buildTableJanitorRuntimeContext(tableId, persistedHealth.seats),
-    nowMs: Date.now(),
-    activeSeatFreshMs,
-    seatedReconnectGraceMs,
-    tableCloseGraceMs: lobbyEmptyJoinableGraceMs,
-    liveHandStaleMs: janitorLiveHandStaleMs
-  });
+  return {
+    classification: evaluateTableHealth({
+      tableId,
+      persistedTable: persistedHealth.table,
+      persistedSeats: persistedHealth.seats,
+      persistedState: persistedHealth.state,
+      runtime: buildTableJanitorRuntimeContext(tableId, persistedHealth.seats),
+      nowMs: Date.now(),
+      activeSeatFreshMs,
+      seatedReconnectGraceMs,
+      tableCloseGraceMs: lobbyEmptyJoinableGraceMs,
+      liveHandStaleMs: janitorLiveHandStaleMs
+    })
+  };
+}
+
+async function runEvaluatedTableJanitor({ tableId, trigger, requestId }) {
+  let pendingEvaluation = pendingTableJanitorEvaluationByTableId.get(tableId);
+  if (pendingEvaluation) {
+    klogSafe("ws_table_janitor_evaluation_coalesced", {
+      tableId,
+      trigger,
+      requestId: requestId || null
+    });
+  } else {
+    const evaluation = evaluateTableForJanitor(tableId);
+    pendingEvaluation = evaluation.finally(() => {
+      if (pendingTableJanitorEvaluationByTableId.get(tableId) === pendingEvaluation) {
+        pendingTableJanitorEvaluationByTableId.delete(tableId);
+      }
+    });
+    pendingTableJanitorEvaluationByTableId.set(tableId, pendingEvaluation);
+  }
+
+  const evaluated = await pendingEvaluation;
+  if (evaluated?.result) {
+    return evaluated.result;
+  }
   return runTableJanitor({
-    classification,
+    classification: evaluated?.classification,
     trigger,
     requestId,
     primitives: tableJanitorPrimitives,


### PR DESCRIPTION
## Summary

Implements PR B from the accepted #742 optimization plan.

- coalesces only concurrent persisted snapshot loading and health classification for the same `tableId`;
- avoids three duplicate SELECTs for each overlapping evaluation;
- keeps `runTableJanitor()` caller-specific, preserving each caller's original `trigger`, `requestId`, diagnostics, primitive routing, idempotency, and result;
- removes the in-flight entry in `finally` on success or failure, so every later invocation reevaluates;
- emits bounded `ws_table_janitor_evaluation_coalesced` metadata without poker state or cards.

No completed result is cached and no new cleanup path is introduced.

## Mandatory caller audit

Current `runEvaluatedTableJanitor()` callers on analyzed `main` (`d352dbb2e71b2ed60309fd8cde15a5d8bee97b37`):

1. `sweepStaleActiveHumanSeatsAndBroadcast()` — `stale_active_seat_sweep`, `ws-stale-active-seat-cleanup:<tableId>`;
2. `sweepZombieTablesAndBroadcast()` — `zombie_table_sweep`, `ws-zombie-cleanup:<tableId>`;
3. `sweepOpenTableJanitorAndBroadcast()` — `open_table_reconciler`, `ws-open-table-janitor:<tableId>`.

All three callers consume only promise settlement through `Promise.allSettled`; they do not branch, broadcast, or retry based on the result.

`trigger` and `requestId` do not affect persisted snapshot reads, runtime context construction, or `evaluateTableHealth()`. They do affect `runTableJanitor()` diagnostics, and `requestId` is forwarded through cleanup primitives into the existing command/cleanup path. Therefore full-operation coalescing by `tableId` was rejected as unsafe.

The implementation follows the plan's fallback: only snapshot plus classification is shared. Every caller still invokes `runTableJanitor()` with its own parameters. Existing command dedupe and cleanup behavior remain authoritative after classification.

## Expected impact

For each overlapping evaluation of the same table, one table metadata SELECT, one seats SELECT, and one state SELECT are avoided. Exact percentage savings require runtime overlap evidence.

## Verification

Passed locally:

- `git diff --check`
- `node --check ws-server/server.mjs`
- `node --test ws-server/poker/runtime/table-janitor.behavior.test.mjs ws-server/server.stale-seat-sweep.behavior.test.mjs ws-server/server.leave-race.behavior.test.mjs`
- `npm run test:quick`
- `node --test ws-server/server.behavior.test.mjs` — 90/90 passed

## Breaking impact

No breaking impact intended. Classification, cleanup primitive selection, request idempotency, ledger calls, broadcasts, timers, retry behavior, and caller-visible results remain unchanged.

The only new structured event is `ws_table_janitor_evaluation_coalesced`, containing `tableId`, `trigger`, and `requestId` only.

## Deployment

This changes `ws-server/**`; manual `WS Preview Deploy` for the exact PR head ref/SHA is required before full preview verification.

Refs #742