### PR TITLE
perf(poker): reduce stale-seat sweep cadence

### DIFF
--- a/netlify/functions/_shared/admin-ops.mjs
+++ b/netlify/functions/_shared/admin-ops.mjs
@@ -612,7 +612,7 @@ function resolveEnvVisibility(env = process.env) {
       seatedReconnectGraceMs: resolveJanitorConfig(env).seatedReconnectGraceMs,
       tableCloseGraceMs: resolveJanitorConfig(env).tableCloseGraceMs,
       liveHandStaleMs: resolveJanitorConfig(env).liveHandStaleMs,
-      staleSeatSweepMs: resolvePositiveInt(env.WS_STALE_ACTIVE_SEAT_SWEEP_MS, 5_000, { min: 500, max: 60_000 }),
+      staleSeatSweepMs: resolvePositiveInt(env.WS_STALE_ACTIVE_SEAT_SWEEP_MS, 30_000, { min: 500, max: 60_000 }),
       openTableSweepBatch: resolvePositiveInt(env.WS_OPEN_TABLE_JANITOR_SWEEP_BATCH, 10, { min: 1, max: 100 }),
       zombieSweepBatch: resolvePositiveInt(env.WS_ZOMBIE_TABLE_SWEEP_BATCH, 25, { min: 1, max: 100 }),
     },

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -3544,7 +3544,7 @@ const disconnectCleanupTimer = setInterval(() => {
 }, Number.isFinite(disconnectCleanupSweepMs) && disconnectCleanupSweepMs > 0 ? disconnectCleanupSweepMs : 500);
 disconnectCleanupTimer.unref();
 
-const staleActiveSeatSweepMs = resolvePositiveInt(process.env.WS_STALE_ACTIVE_SEAT_SWEEP_MS, 5_000, { min: 500, max: 60_000 });
+const staleActiveSeatSweepMs = resolvePositiveInt(process.env.WS_STALE_ACTIVE_SEAT_SWEEP_MS, 30_000, { min: 500, max: 60_000 });
 const staleActiveSeatSweepTimer = setInterval(() => {
   void sweepStaleActiveHumanSeatsAndBroadcast();
 }, staleActiveSeatSweepMs);


### PR DESCRIPTION
## Summary

- change the default `WS_STALE_ACTIVE_SEAT_SWEEP_MS` cadence from 5 seconds to 30 seconds;
- keep explicit environment overrides and the existing 500–60,000 ms validation bounds unchanged;
- align admin environment diagnostics with the WS runtime fallback;
- leave stale-seat SQL, batch size, freshness/reconnect thresholds, classification, cashout, cleanup, and accounting behavior unchanged.

Refs #742

## Basis and expected impact

- Branch created from `origin/main` at `55c26a58ad7f1da80c70fc691cc1940afbcfa037`.
- `WS_STALE_ACTIVE_SEAT_SWEEP_MS`, `WS_ACTIVE_SEAT_FRESH_MS`, and `WS_SEATED_RECONNECT_GRACE_MS` are currently unset in both the production and WS Preview service env files, so code fallbacks apply.
- At the default cadence, the fixed listing query rate falls from 17,280 to 2,880 sweeps/day/WS instance: an 83.3% reduction.

## Breaking impact / risk

This intentionally trades cleanup latency for lower fixed SQL traffic. With the default configuration, a newly eligible stale seat can be detected up to approximately 25 seconds later than before. That can temporarily leave a stale seat or lobby occupancy visible longer. It does not change the freshness threshold, reconnect grace, cleanup decision, cashout idempotency, ledger movement, settlement, or terminal chip-conservation behavior.

Rollback is either restoring the 5-second fallback or setting `WS_STALE_ACTIVE_SEAT_SWEEP_MS=5000` without reverting cleanup logic.

## Verification

- `node --test ws-server/server.stale-seat-sweep.behavior.test.mjs tests/poker-inactive-cleanup.behavior.test.mjs shared/poker-domain/join.behavior.test.mjs` — 40 passed
- `node --test ws-server/poker/reconnect/resync.behavior.test.mjs` — 20 passed
- `node --test ws-server/server.behavior.test.mjs` — 90 passed
- `npm run test:quick` — syntax check passed
- `git diff --check` — passed

## Deployment verification

Because this changes `ws-server/**`, deploy the exact PR SHA through the manual **WS Preview Deploy** workflow before merge. Verify the deployed SHA, observe multiple stale-seat sweep intervals, and exercise reconnect inside and outside the grace period plus stale-seat cleanup. Confirm no duplicate cashouts, table closes, ledger movements, or `ws_table_janitor_*failed` errors.