### PR TITLE
perf(poker): coarsen persisted seat touch cadence

### DIFF
--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -506,6 +506,16 @@ export function createTableManager({
     return connStateBySocket.get(ws);
   }
 
+  function connectionTableAssociation(ws) {
+    const conn = connStateBySocket.get(ws);
+    if (!conn) {
+      return null;
+    }
+    const joinedTableId = conn.joinedTableId && tables.has(conn.joinedTableId) ? conn.joinedTableId : null;
+    const subscribedTableId = conn.subscribedTableId && tables.has(conn.subscribedTableId) ? conn.subscribedTableId : null;
+    return { joinedTableId, subscribedTableId };
+  }
+
   function ensureTable(tableId) {
     if (!tables.has(tableId)) {
       const initialCoreState = createInitialCoreState({ roomId: tableId, maxSeats });
@@ -2160,6 +2170,7 @@ export function createTableManager({
     tableMeta,
     materializeLobbyTable,
     materializeGuestTable,
+    connectionTableAssociation,
     resolveImplicitLeaveTableId,
     sweepExpiredPresence,
     persistedPokerState,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -264,7 +264,7 @@ const janitorLiveHandStaleMs = resolvePositiveInt(process.env.POKER_LIVE_HAND_ST
 });
 const persistedSeatTouchThrottleMs = resolvePositiveInt(
   process.env.WS_PERSISTED_SEAT_TOUCH_THROTTLE_MS,
-  Math.max(1_000, Math.trunc(HEARTBEAT_MS / 2)),
+  30_000,
   { min: 1_000, max: 60_000 }
 );
 const streamLog = createStreamLog({ cap: Number(process.env.WS_STREAM_REPLAY_CAP || 128) });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -544,8 +544,9 @@ async function touchPersistedSeatLastSeen({ tableId, userId }) {
   }
 }
 
-function maybeTouchPersistedSeatLastSeen(connState) {
-  const tableId = connState?.joinedTableId || connState?.subscribedTableId || null;
+function maybeTouchPersistedSeatLastSeen(ws, connState) {
+  const association = tableManager.connectionTableAssociation(ws);
+  const tableId = association?.joinedTableId || association?.subscribedTableId || null;
   const userId = connState?.session?.userId || null;
   if (!tableId || !userId) return;
   void touchPersistedSeatLastSeen({ tableId, userId });
@@ -2821,7 +2822,7 @@ wss.on("connection", (ws) => {
       }
 
       sendFrame(ws, response.frame);
-      maybeTouchPersistedSeatLastSeen(connState);
+      maybeTouchPersistedSeatLastSeen(ws, connState);
       return;
     }
 
@@ -3012,7 +3013,7 @@ wss.on("connection", (ws) => {
           klog: klogSafe
         })
       });
-      maybeTouchPersistedSeatLastSeen(connState);
+      maybeTouchPersistedSeatLastSeen(ws, connState);
       return;
     }
 
@@ -3055,7 +3056,7 @@ wss.on("connection", (ws) => {
         const resyncedSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
         sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: resynced.tableState, tableSnapshot: resyncedSnapshot });
         maybeScheduleSettledRollover(tableId);
-        maybeTouchPersistedSeatLastSeen(connState);
+        maybeTouchPersistedSeatLastSeen(ws, connState);
         scheduleObservedBotTurn({
           tableId,
           trigger: "resync",
@@ -3316,7 +3317,7 @@ wss.on("connection", (ws) => {
         const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
         sendStateSnapshot(ws, connState, { requestId: frame.requestId ?? null, tableSnapshot });
         maybeScheduleSettledRollover(tableId);
-        maybeTouchPersistedSeatLastSeen(connState);
+        maybeTouchPersistedSeatLastSeen(ws, connState);
         return;
       }
 
@@ -3350,7 +3351,7 @@ wss.on("connection", (ws) => {
       const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
       sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: subscribed.tableState, tableSnapshot });
       maybeScheduleSettledRollover(tableId);
-      maybeTouchPersistedSeatLastSeen(connState);
+      maybeTouchPersistedSeatLastSeen(ws, connState);
       scheduleObservedBotTurn({
         tableId,
         trigger: "table_state_sub",
@@ -3382,7 +3383,7 @@ wss.on("connection", (ws) => {
         return;
       }
       sendGameplaySnapshot(ws, connState, { requestId: frame.requestId ?? null, tableId, snapshot: loaded.snapshot });
-      maybeTouchPersistedSeatLastSeen(connState);
+      maybeTouchPersistedSeatLastSeen(ws, connState);
       return;
     }
 
@@ -3419,7 +3420,7 @@ wss.on("connection", (ws) => {
           klog: klogSafe
         })
       });
-      maybeTouchPersistedSeatLastSeen(connState);
+      maybeTouchPersistedSeatLastSeen(ws, connState);
       return;
     }
 


### PR DESCRIPTION
## Summary

- change the default `WS_PERSISTED_SEAT_TOUCH_THROTTLE_MS` from 7.5 seconds to 30 seconds;
- fix persisted seat touches so `maybeTouchPersistedSeatLastSeen()` resolves the socket's current table association from the authoritative table-manager connection state;
- retain the existing SQL UPDATE, per-table/user throttle, 1,000–60,000 ms env bounds, immediate retry after failed writes, and guest-table exclusion;
- leave heartbeat, reconnect grace, stale classification, cleanup, persistence recovery, settlement, ledger accounting, and terminal chip conservation unchanged.

Refs #742

## Discovered root cause and implementation

`server.mjs` and `table-manager.mjs` maintain connection state for different purposes. Join, subscribe, resync, leave, socket cleanup, and table eviction update the table manager's private `connStateBySocket`; the server-level authenticated connection object does not own `joinedTableId` or `subscribedTableId`. The original PR D implementation read those fields from the server object, so normal pings could never resolve a persisted table and `last_seen_at` was not touched.

The fix adds the narrow read-only `tableManager.connectionTableAssociation(ws)` method. It reads the existing authoritative socket association without creating state and returns only joined/subscribed IDs whose runtime table is still loaded. `maybeTouchPersistedSeatLastSeen(ws, connState)` uses that association for the table ID and the authenticated server state for the user ID. No second manually synchronized association was introduced.

Lifecycle behavior is preserved:

- join/subscribe/resync establish the association in the table manager;
- leave and authoritative leave clear it;
- close/error delete it through existing connection cleanup;
- evicted/closed tables are rejected by the read method;
- a reconnecting socket uses its own newly established association;
- guest tables still never call Supabase.

## Basis and expected impact

- Branch created from `origin/main` at `6e1d8755076022bac51417211cdacc691e95d7c8`.
- Effective code defaults are a 15-second WS heartbeat, 30-second persisted touch throttle, 120-second active-seat freshness, and 90-second reconnect grace.
- A continuously seated client therefore persists approximately every second heartbeat: about 2,880 UPDATEs/user/day instead of 5,760 at a 15-second write cadence.

## Automated verification

- table-manager and leave/restore suites: 87 passed
- reconnect/resync suite: 20 passed
- janitor/disconnect/inactive/stale-sweep suites: 38 passed
- server behavior suite: 90 passed
- `npm run test:quick`: syntax check passed for 215 files
- `git diff --check`: passed
- no tests were added

## WS Preview runtime verification — scoped PASS

Deployed exact PR SHA `c20ce4a70622304715bac584dd36fefb62d5a925` with successful workflow run `30051088927`. `/healthz` returned `ok`. No temporary preview env overrides were introduced.

For active seated user `999ab09b-70a2-40e4-b0ea-e1c850f80d9c` at table `ec3f4897-c7bb-4d92-b63d-a38401e9a5c4`, observed persisted timestamps were:

- `2026-07-23T22:50:18.994Z`
- `2026-07-23T22:50:49.005Z` (+30,011 ms)
- `2026-07-23T22:51:19.005Z` (+30,000 ms)

Four 15-second pings occurred during the observation, proving persistence did not run every heartbeat. WS Preview was restarted 26 seconds after the last persisted touch. Reconnect/resync restored seat 1 with stack 100 unchanged; the seat remained `ACTIVE` while the replacement socket stayed connected and no stale cleanup occurred.

Therefore PR D's scoped persisted-touch cadence, worst-case restart, reconnect, resync, seat, and stack behavior is runtime-verified: **PASS**.

## Separately tracked pre-existing accounting failure

The later terminal stale-cleanup phase was blocked by a pre-existing accounting invariant failure now tracked separately in #748.

The same affected state and failure were reproduced with the current `origin/main` SHA `6e1d8755076022bac51417211cdacc691e95d7c8`. Its active hand contained 590 chips in stacks plus 10 chips in the pot, matching the 600-chip escrow. The stale-live-hand cleanup path passed only stack claims to terminal close, which correctly rejected `590 !== 600` with `terminal_claims_mismatch`.

PR #747 does not alter, weaken, bypass, or mask this behavior. It contains no changes to inactive cleanup, settlement, ledger, terminal close, or terminal accounting. The accounting fix belongs exclusively to #748.

An initial create/join attempt also returned `authoritative_state_invalid`; retry after restart succeeded. This appears independent of the seat-touch change and remains recorded as an unexpected runtime observation.

## Risk and breaking impact

The connection-state fix is narrow and read-only, but it activates persistence writes that the broken implementation skipped. The intended breaking impact is therefore increased writes relative to the broken branch behavior, at the corrected 30-second cadence. There is no intended protocol, cleanup, accounting, or table lifecycle change.

The cadence remains high risk around process failure: an explicit deployment override that reduces freshness/reconnect margins could falsely classify a recently active player as stale. Rollback is restoring the prior implementation and/or setting `WS_PERSISTED_SEAT_TOUCH_THROTTLE_MS=7500`; no database migration is involved.