### PR TITLE
fix(poker): refund stale live-hand contributions on terminal close

### DIFF
--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { executeInactiveCleanup } from "./inactive-cleanup.mjs";
+import { executeTerminalPokerCloseInTx } from "./terminal-close.mjs";
 
 function createCleanupHarness({
   seatRows,
@@ -9,21 +10,35 @@ function createCleanupHarness({
   createdAt = "2026-03-01T00:00:00.000Z",
   lastActivityAt = null,
   updatedAt = null,
-  nowMs = Date.parse("2026-03-01T00:02:00.000Z")
+  nowMs = Date.parse("2026-03-01T00:02:00.000Z"),
+  useRealTerminalClose = false,
+  escrowBalance = null
 }) {
   const seatState = seatRows.map((row) => ({ ...row }));
   const tableState = {
-    stateRow: { state: { ...state } },
+    stateRow: { version: 7, state: { ...state } },
     tableStatus,
     createdAt,
     lastActivityAt,
     updatedAt
   };
+  const escrowState = {
+    id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    balance: escrowBalance
+  };
   const cashouts = [];
+  const logs = [];
+  let tableCloseCount = 0;
   const originalDateNow = Date.now;
 
   const tx = {
     unsafe: async (sql, params = []) => {
+      if (sql.includes("select id, status from public.poker_tables")) {
+        return [{ id: "table_1", status: tableState.tableStatus }];
+      }
+      if (sql.includes("select version, state from public.poker_state")) {
+        return [{ version: tableState.stateRow.version, state: { ...tableState.stateRow.state } }];
+      }
       if (sql.includes("where table_id = $1 and user_id = $2 limit 1 for update")) {
         const [, userId] = params;
         const seat = seatState.find((row) => row.user_id === userId) || null;
@@ -44,8 +59,28 @@ function createCleanupHarness({
       if (sql.includes("select user_id, seat_no, status, is_bot, stack from public.poker_seats")) {
         return seatState.map((row) => ({ ...row }));
       }
+      if (sql.includes("select id, account_type, system_key, status, balance from public.chips_accounts")) {
+        return [{
+          id: escrowState.id,
+          account_type: "ESCROW",
+          system_key: "POKER_TABLE:table_1",
+          status: "active",
+          balance: escrowState.balance
+        }];
+      }
+      if (sql.includes("select balance from public.chips_accounts where id = $1")) {
+        return [{ balance: escrowState.balance }];
+      }
+      if (sql.includes("update public.poker_state set version = version + 1")) {
+        if (Number(params[1]) !== tableState.stateRow.version) return [];
+        tableState.stateRow = {
+          version: tableState.stateRow.version + 1,
+          state: JSON.parse(params[2])
+        };
+        return [{ version: tableState.stateRow.version }];
+      }
       if (sql.includes("update public.poker_state set state = $2 where table_id = $1")) {
-        tableState.stateRow = { state: JSON.parse(params[1]) };
+        tableState.stateRow = { ...tableState.stateRow, state: JSON.parse(params[1]) };
         return [];
       }
       if (sql.includes("select status, created_at") && sql.includes("from public.poker_tables")) {
@@ -58,7 +93,8 @@ function createCleanupHarness({
       }
       if (sql.includes("update public.poker_tables set status = 'CLOSED'")) {
         tableState.tableStatus = "CLOSED";
-        return [];
+        tableCloseCount += 1;
+        return [{ id: "table_1" }];
       }
       if (sql.includes("delete from public.poker_hole_cards")) {
         return [];
@@ -76,7 +112,12 @@ function createCleanupHarness({
   return {
     seatState,
     tableState,
+    escrowState,
     cashouts,
+    logs,
+    get tableCloseCount() {
+      return tableCloseCount;
+    },
     run: async () => {
       Date.now = () => nowMs;
       try {
@@ -87,14 +128,21 @@ function createCleanupHarness({
           requestId: "req-1",
           postTransaction: async (entry) => {
             cashouts.push(entry);
+            if (useRealTerminalClose) {
+              const escrowDebit = entry.entries?.find((ledgerEntry) => ledgerEntry.accountType === "ESCROW")?.amount;
+              escrowState.balance += Number(escrowDebit || 0);
+            }
             return { ok: true };
           },
-          executeTerminalClose: async () => {
-            tableState.stateRow = { state: { ...tableState.stateRow.state, phase: "HAND_DONE", turnUserId: null, stacks: {} } };
-            tableState.tableStatus = "CLOSED";
-            for (let i = 0; i < seatState.length; i += 1) seatState[i] = { ...seatState[i], status: "INACTIVE", stack: 0 };
-            return { ok: true, changed: true, closed: true, status: "cleaned_closed", retryable: false };
-          }
+          executeTerminalClose: useRealTerminalClose
+            ? executeTerminalPokerCloseInTx
+            : async () => {
+                tableState.stateRow = { ...tableState.stateRow, state: { ...tableState.stateRow.state, phase: "HAND_DONE", turnUserId: null, stacks: {} } };
+                tableState.tableStatus = "CLOSED";
+                for (let i = 0; i < seatState.length; i += 1) seatState[i] = { ...seatState[i], status: "INACTIVE", stack: 0 };
+                return { ok: true, changed: true, closed: true, status: "cleaned_closed", retryable: false };
+              },
+          klog: (event, payload) => logs.push({ event, payload })
         });
       } finally {
         Date.now = originalDateNow;
@@ -303,6 +351,89 @@ test("inactive cleanup closes stale live hand for disconnected human after activ
   assert.equal(harness.tableState.stateRow.state.phase, "HAND_DONE");
   assert.equal(harness.tableState.stateRow.state.turnUserId, null);
   assert.deepEqual(harness.tableState.stateRow.state.stacks, {});
+});
+
+test("inactive cleanup refunds stale live-hand contributions including zero-stack all-in participant", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 590 },
+      { user_id: "human_all_in", seat_no: 2, status: "INACTIVE", is_bot: false, stack: 0 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-stale-live-refund",
+      turnUserId: "human_1",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "human_all_in", seatNo: 2, status: "ACTIVE" }
+      ],
+      stacks: { human_1: 590 },
+      contributionsByUserId: { human_1: 5, human_all_in: 5 },
+      potTotal: 10,
+      sidePots: []
+    },
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastActivityAt: "2026-03-01T00:00:10.000Z",
+    nowMs: Date.parse("2026-03-01T00:02:00.000Z"),
+    useRealTerminalClose: true,
+    escrowBalance: 600
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.closed, true);
+  assert.equal(result.claimPolicy, "live_hand_cancellation_refund");
+  assert.equal(result.contributionTotal, 10);
+  assert.equal(result.escrowBefore, 600);
+  assert.deepEqual(
+    harness.cashouts.map((cashout) => [cashout.userId, -cashout.entries[0].amount]),
+    [["human_1", 595], ["human_all_in", 5]]
+  );
+  assert.equal(harness.escrowState.balance, 0);
+  assert.equal(harness.tableCloseCount, 1);
+  assert.equal(harness.tableState.tableStatus, "CLOSED");
+  assert.equal(harness.logs.filter((entry) => entry.event === "poker_terminal_accounting_closed").length, 1);
+});
+
+test("inactive cleanup keeps inconsistent stale live-hand contributions fail-closed", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 590 },
+      { user_id: "human_all_in", seat_no: 2, status: "INACTIVE", is_bot: false, stack: 0 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-stale-live-invalid-refund",
+      turnUserId: "human_1",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "human_all_in", seatNo: 2, status: "ACTIVE" }
+      ],
+      stacks: { human_1: 590, human_all_in: 0 },
+      contributionsByUserId: { human_1: 5, human_all_in: 4 },
+      potTotal: 10,
+      sidePots: []
+    },
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastActivityAt: "2026-03-01T00:00:10.000Z",
+    nowMs: Date.parse("2026-03-01T00:02:00.000Z"),
+    useRealTerminalClose: true,
+    escrowBalance: 600
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "terminal_accounting_invariant_failed");
+  assert.equal(result.reason, "terminal_contribution_total_mismatch");
+  assert.equal(harness.cashouts.length, 0);
+  assert.equal(harness.escrowState.balance, 600);
+  assert.equal(harness.tableCloseCount, 0);
+  assert.equal(harness.tableState.tableStatus, "OPEN");
+  assert.equal(harness.tableState.stateRow.version, 7);
 });
 
 test("inactive cleanup does not close stale live hand when another active human remains", async () => {

--- a/shared/poker-domain/terminal-close.mjs
+++ b/shared/poker-domain/terminal-close.mjs
@@ -1,5 +1,6 @@
 const TERMINAL_ACCOUNTING_ERROR = "terminal_accounting_invariant_failed";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const LIVE_ACTION_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER"]);
 
 function normalizeJsonObject(value) {
   if (value && typeof value === "object" && !Array.isArray(value)) return value;
@@ -21,6 +22,10 @@ function normalizeNonNegativeInt(value) {
 function normalizePositiveInt(value) {
   const parsed = normalizeNonNegativeInt(value);
   return parsed != null && parsed > 0 ? parsed : null;
+}
+
+function normalizeStateChipAmount(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function normalizeSeatNo(value) {
@@ -50,6 +55,10 @@ function invariantFailure(reason, extra = {}) {
 function addSafe(left, right) {
   const total = left + right;
   return Number.isSafeInteger(total) && total >= 0 ? total : null;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function toClosedInertState(state) {
@@ -293,15 +302,130 @@ export async function postTerminalBotCashout({
   });
 }
 
-function classifyClaims({ state, seatRows }) {
+function projectTerminalClaimAmounts({ state, escrowBefore }) {
   const stacks = normalizeJsonObject(state?.stacks);
   if (!stacks) return invariantFailure("terminal_stack_state_invalid");
+  const normalizedStacks = new Map();
+  let stackTotal = 0;
+  for (const [userIdRaw, amountRaw] of Object.entries(stacks)) {
+    const userId = normalizeString(userIdRaw);
+    const amount = normalizeStateChipAmount(amountRaw);
+    if (!userId || amount == null || normalizedStacks.has(userId)) {
+      return invariantFailure("terminal_stack_state_invalid");
+    }
+    normalizedStacks.set(userId, amount);
+    stackTotal = addSafe(stackTotal, amount);
+    if (stackTotal == null) return invariantFailure("terminal_claims_overflow");
+  }
+
+  const phase = normalizeString(state?.phase).toUpperCase();
+  const liveActionPhase = LIVE_ACTION_PHASES.has(phase);
+  const potPresent = hasOwn(state, "pot");
+  const potTotalPresent = hasOwn(state, "potTotal");
+  const pot = potPresent ? normalizeStateChipAmount(state.pot) : null;
+  const potTotal = potTotalPresent ? normalizeStateChipAmount(state.potTotal) : null;
+  if ((potPresent && pot == null) || (potTotalPresent && potTotal == null)) {
+    return invariantFailure("terminal_pot_state_invalid");
+  }
+  if (potPresent && potTotalPresent && pot !== potTotal) {
+    return invariantFailure("terminal_pot_state_mismatch");
+  }
+  if (liveActionPhase && !potPresent && !potTotalPresent) {
+    return invariantFailure("terminal_pot_state_invalid");
+  }
+  const canonicalPotTotal = potTotalPresent ? potTotal : potPresent ? pot : 0;
+
+  if (!liveActionPhase) {
+    if (canonicalPotTotal !== 0) return invariantFailure("terminal_unresolved_pot");
+    return {
+      ok: true,
+      claimAmounts: normalizedStacks,
+      totalClaims: stackTotal,
+      claimPolicy: "final_stacks",
+      contributionTotal: 0,
+      potTotal: canonicalPotTotal
+    };
+  }
+
+  const contributions = normalizeJsonObject(state?.contributionsByUserId);
+  if (!contributions) return invariantFailure("terminal_contribution_state_invalid");
+  const normalizedContributions = new Map();
+  let contributionTotal = 0;
+  for (const [userIdRaw, amountRaw] of Object.entries(contributions)) {
+    const userId = normalizeString(userIdRaw);
+    const amount = normalizeStateChipAmount(amountRaw);
+    if (!userId || amount == null || normalizedContributions.has(userId)) {
+      return invariantFailure("terminal_contribution_state_invalid");
+    }
+    normalizedContributions.set(userId, amount);
+    contributionTotal = addSafe(contributionTotal, amount);
+    if (contributionTotal == null) return invariantFailure("terminal_claims_overflow");
+  }
+  if (contributionTotal !== canonicalPotTotal) {
+    return invariantFailure("terminal_contribution_total_mismatch");
+  }
+
+  if (hasOwn(state, "sidePots")) {
+    if (!Array.isArray(state.sidePots)) return invariantFailure("terminal_side_pot_state_invalid");
+    if (state.sidePots.length > 0) {
+      let sidePotTotal = 0;
+      for (const sidePot of state.sidePots) {
+        const amount = normalizeStateChipAmount(sidePot?.amount);
+        if (!sidePot || typeof sidePot !== "object" || Array.isArray(sidePot) || amount == null) {
+          return invariantFailure("terminal_side_pot_state_invalid");
+        }
+        sidePotTotal = addSafe(sidePotTotal, amount);
+        if (sidePotTotal == null) return invariantFailure("terminal_claims_overflow");
+      }
+      if (sidePotTotal !== canonicalPotTotal) {
+        return invariantFailure("terminal_side_pot_total_mismatch");
+      }
+    }
+  }
+
+  const settledHandId = normalizeString(state?.handSettlement?.handId);
+  const handId = normalizeString(state?.handId);
+  if (settledHandId && settledHandId !== handId) {
+    return invariantFailure("terminal_settlement_hand_mismatch");
+  }
+
+  const conservedTotal = addSafe(stackTotal, canonicalPotTotal);
+  if (conservedTotal == null) return invariantFailure("terminal_claims_overflow");
+  if (conservedTotal !== escrowBefore) {
+    return invariantFailure("terminal_claims_mismatch", { totalClaims: conservedTotal });
+  }
+
+  const claimUserIds = new Set([...normalizedStacks.keys(), ...normalizedContributions.keys()]);
+  const claimAmounts = new Map();
+  let totalClaims = 0;
+  for (const userId of claimUserIds) {
+    const amount = addSafe(normalizedStacks.get(userId) ?? 0, normalizedContributions.get(userId) ?? 0);
+    if (amount == null) return invariantFailure("terminal_claims_overflow");
+    claimAmounts.set(userId, amount);
+    totalClaims = addSafe(totalClaims, amount);
+    if (totalClaims == null) return invariantFailure("terminal_claims_overflow");
+  }
+  return {
+    ok: true,
+    claimAmounts,
+    totalClaims,
+    claimPolicy: "live_hand_cancellation_refund",
+    contributionTotal,
+    potTotal: canonicalPotTotal
+  };
+}
+
+function classifyClaims({ state, seatRows, escrowBefore }) {
+  const projected = projectTerminalClaimAmounts({ state, escrowBefore });
+  if (!projected.ok) return projected;
   const seatByUserId = new Map();
   const seatByNo = new Map();
   for (const row of Array.isArray(seatRows) ? seatRows : []) {
     const userId = normalizeString(row?.user_id);
     const seatNo = normalizeSeatNo(row?.seat_no);
-    if (!userId || !seatNo || seatByNo.has(seatNo)) return invariantFailure("terminal_seat_state_invalid");
+    if (!userId || !seatNo || seatByUserId.has(userId) || seatByNo.has(seatNo)) {
+      return invariantFailure("terminal_seat_state_invalid");
+    }
     seatByUserId.set(userId, row);
     seatByNo.set(seatNo, row);
   }
@@ -323,22 +447,26 @@ function classifyClaims({ state, seatRows }) {
   const occupiedClaimSeats = new Set();
   const humanClaims = [];
   const botClaims = [];
-  let totalClaims = 0;
-  for (const [userIdRaw, amountRaw] of Object.entries(stacks)) {
-    const userId = normalizeString(userIdRaw);
-    const amount = normalizeNonNegativeInt(amountRaw);
-    if (!userId || amount == null) return invariantFailure("terminal_stack_state_invalid");
+  for (const [userId, amount] of projected.claimAmounts.entries()) {
     if (amount === 0) continue;
     const directSeat = seatByUserId.get(userId) || null;
-    if (directSeat && directSeat?.is_bot !== true) {
+    const stateSeatNo = stateSeatByUserId.get(userId) || null;
+    if (directSeat?.is_bot === false) {
       const seatNo = normalizeSeatNo(directSeat?.seat_no);
-      if (occupiedClaimSeats.has(seatNo)) return invariantFailure("terminal_seat_state_invalid");
+      if (
+        !seatNo
+        || stateSeatNo !== seatNo
+        || stateUserIdBySeatNo.get(seatNo) !== userId
+        || occupiedClaimSeats.has(seatNo)
+      ) {
+        return invariantFailure("terminal_seat_state_invalid");
+      }
       occupiedClaimSeats.add(seatNo);
       humanClaims.push({ userId, seatNo, amount });
     } else {
       const seatNo = directSeat?.is_bot === true
         ? normalizeSeatNo(directSeat?.seat_no)
-        : stateSeatByUserId.get(userId) || null;
+        : stateSeatNo;
       const projectedSeat = seatNo ? seatByNo.get(seatNo) : null;
       if (
         !seatNo
@@ -352,10 +480,16 @@ function classifyClaims({ state, seatRows }) {
       occupiedClaimSeats.add(seatNo);
       botClaims.push({ botUserId: userId, seatNo, amount });
     }
-    totalClaims = addSafe(totalClaims, amount);
-    if (totalClaims == null) return invariantFailure("terminal_claims_overflow");
   }
-  return { ok: true, humanClaims, botClaims, totalClaims };
+  return {
+    ok: true,
+    humanClaims,
+    botClaims,
+    totalClaims: projected.totalClaims,
+    claimPolicy: projected.claimPolicy,
+    contributionTotal: projected.contributionTotal,
+    potTotal: projected.potTotal
+  };
 }
 
 async function postTerminalHumanCashout({ postTransaction, tx, tableId, toStateVersion, claim, createdBy, closeReason }) {
@@ -433,8 +567,6 @@ export async function executeTerminalPokerCloseInTx({
     "select user_id, seat_no, status, is_bot, stack from public.poker_seats where table_id = $1 order by seat_no asc for update;",
     [tableId]
   );
-  const claims = classifyClaims({ state, seatRows });
-  if (!claims.ok) return fail(claims.reason, { stateVersion });
 
   const escrowSystemKey = `POKER_TABLE:${tableId}`;
   const escrowRows = await tx.unsafe(
@@ -452,6 +584,12 @@ export async function executeTerminalPokerCloseInTx({
   ) {
     return fail("escrow_account_missing_or_invalid", { stateVersion });
   }
+  const claims = classifyClaims({ state, seatRows, escrowBefore });
+  if (!claims.ok) return fail(claims.reason, {
+    stateVersion,
+    escrowBefore,
+    totalClaims: claims.totalClaims ?? null
+  });
   if (claims.totalClaims !== escrowBefore) {
     return fail("terminal_claims_mismatch", { stateVersion, escrowBefore, totalClaims: claims.totalClaims });
   }
@@ -548,6 +686,9 @@ export async function executeTerminalPokerCloseInTx({
     retryable: false,
     stateVersion: toStateVersion,
     escrowBefore,
+    claimPolicy: claims.claimPolicy,
+    contributionTotal: claims.contributionTotal,
+    potTotal: claims.potTotal,
     humanSeatCount: claims.humanClaims.length,
     botSeatCount: claims.botClaims.length
   };
@@ -555,6 +696,9 @@ export async function executeTerminalPokerCloseInTx({
     tableId,
     stateVersion: toStateVersion,
     escrowBefore,
+    claimPolicy: result.claimPolicy,
+    contributionTotal: result.contributionTotal,
+    potTotal: result.potTotal,
     humanSeatCount: result.humanSeatCount,
     botSeatCount: result.botSeatCount
   });


### PR DESCRIPTION
## Summary

- add phase-aware terminal claim projection for stale live poker hands;
- build cancellation claims from `stacks ∪ contributionsByUserId` using the existing safe-add overflow guard;
- refund `stack + own contribution`, including an all-in participant with no stack-map entry;
- validate pot/contribution/side-pot totals, escrow conservation, seat identity, and human/bot type before the first ledger movement;
- preserve stack-only terminal claims for `SETTLED` and other non-action phases;
- keep every inconsistency fail-closed;
- add only the two focused regression cases specified by the accepted #748 plan.

## Root cause addressed

A stale live hand can still have chips committed in `potTotal` and `contributionsByUserId`. The previous terminal projection iterated only over positive `state.stacks`, so a conserved state such as `590 stacks + 10 pot = 600 escrow` produced only 590 claims and remained permanently blocked by the correct `terminal_claims_mismatch` guard.

## Behavior after this PR

For `PREFLOP`, `FLOP`, `TURN`, and `RIVER`, terminal cleanup cancels the whole hand and projects each participant's claim as:

```text
claim = authoritative stack + authoritative own contribution
```

This is not showdown or normal poker settlement. Folded/all-in contributions remain owned by the contributor because the entire stale hand is cancelled.

The projection is accepted only when:

- stacks and contributions contain non-negative safe integers;
- contributions sum exactly to the canonical pot;
- `pot` and `potTotal`, when both present, agree;
- non-empty side pots sum to the same pot;
- stacks plus pot equal locked escrow;
- every positive claim maps unambiguously through persisted state seats and locked DB seat rows to one human or bot;
- all safe-add operations remain within integer bounds.

`SETTLED` continues to use final stacks only. Historical contributions are never added again. `terminal_claims_mismatch` remains unchanged and fail-closed.

## Logging and accounting

The existing single success `klog` now includes only aggregate `claimPolicy`, `contributionTotal`, `potTotal`, and escrow values. It does not log user claim maps, private cards, or full state.

Existing cashout idempotency keys, bot funding provenance, escrow-zero check, state CAS, seat cleanup, and table close transaction remain in use.

## Breaking impact

Stale terminal cleanup of a live hand now performs deterministic cancellation/refund instead of remaining blocked forever. This changes only terminal cleanup policy; it does not change normal gameplay, showdown, settlement, reconnect, leave, rebuy, ledger schema, or table-close idempotency. Invalid or ambiguous states still remain open for manual investigation with no ledger movement.

## Validation

- shared poker behavior, leave/rebuy, terminal bot cashout, cleanup adapter, and deferred-leave adapter suites: **59/59 passed**;
- cleanup-focused WS server tests: **6/6 passed**;
- syntax check: **215 files passed**;
- focused regression tests prove:
  - an all-in human present only in `contributionsByUserId` receives its contribution and escrow reaches zero with one close;
  - mismatched contributions fail before cashout, state mutation, or table close;
- `git diff --check`: passed.

## WS Preview verification

This changes the shared terminal-close path used by WS cleanup, so deploy the exact PR SHA through manual **WS Preview Deploy** before merge.

Basic smoke:

1. Create/fund a Preview poker table through existing endpoints.
2. Reach a live action phase with a non-zero pot; include an all-in or zero-stack contributor if practical.
3. Disconnect all humans and allow the configured stale cleanup path to run.
4. Confirm `poker_terminal_accounting_closed` reports `claimPolicy: "live_hand_cancellation_refund"`, correct aggregate pot/contribution totals, and no private state.
5. Confirm each participant receives stack plus its own contribution, escrow reaches zero, seats become inactive, and the table closes exactly once.
6. Trigger/reobserve cleanup and confirm no duplicate cashouts, ledger movements, settlement, or table close.
7. Run a deliberately inconsistent Preview fixture only if a safe existing harness is available; confirm fail-closed with no ledger movement.
8. Confirm `/healthz` and absence of `ws_table_janitor_*failed` or unexpected terminal accounting errors.

Refs #748