### PR TITLE
fix: suppress repeated poker janitor terminal failures

### DIFF
--- a/docs/poker-janitor-nonretryable-suppression-plan.md
+++ b/docs/poker-janitor-nonretryable-suppression-plan.md
@@ -1,0 +1,359 @@
+# Poker janitor non-retryable terminal failure suppression — analysis and fix plan
+
+## Metadata
+
+- Issue: `#752`
+- Follow-up to: `#748`
+- Repository: `krzysztofcal/arcadePlatform`
+- Analysed `origin/main`: `09dc2c30d0b956da674fb161761b4cd36db2830d`
+- Analysis date: `2026-07-24`
+- Environment inspected: WS Preview / stage
+- Affected table: `7af59a48-5804-4c78-b8c3-d81e5e721d6c`
+- Scope: automatic poker janitor scheduling after a deterministic, non-retryable terminal-accounting failure
+- Runtime code changed by this document: none
+
+## Executive conclusion
+
+The repeated cleanup is caused by a missing scheduler-level contract, not by a failure of the terminal accounting guard.
+
+`executeTerminalPokerCloseInTx()` correctly rejects the historical table with `terminal_claims_mismatch`, returns `changed:false` and `retryable:false`, and performs no cash-out or close. That result propagates through the persistence adapter and `runTableJanitor()`. However, `runEvaluatedTableJanitor()` does not retain or consult it. Each later stale-seat or open-table sweep loads the same authoritative state and schedules the same cleanup again.
+
+The existing `pendingTableJanitorEvaluationByTableId` map solves only overlap while a snapshot evaluation is in flight. Its entry is deleted as soon as the snapshot promise settles. The per-table command queue also deduplicates overlapping calls that resolve to the same cleanup primitive, but deletes its entry after that command completes. Neither mechanism suppresses a later sweep of the same unchanged state.
+
+The minimal fix is a process-local, TTL-bounded suppression map at the automatic janitor boundary. It blocks repeated automatic terminal attempts for the same persisted state version and current janitor classification. It must not weaken the accounting invariant, change the historical table, or block an explicit admin recovery attempt.
+
+## Evidence from WS Preview
+
+### Read-only command
+
+```bash
+sudo journalctl -u ws-server-preview.service --since "2026-07-24 14:00:00" --until "2026-07-24 14:30:00" --no-pager
+```
+
+The filtered 30-minute sample for table `7af59a48-5804-4c78-b8c3-d81e5e721d6c` contained:
+
+| Event | Count |
+|---|---:|
+| `poker_terminal_accounting_invariant_failed` | 60 |
+| `ws_table_janitor_result` | 90 |
+| `ws_table_janitor_evaluation_coalesced` | 30 |
+
+Representative invariant attempts occurred at:
+
+```text
+14:00:21.229
+14:00:51.304
+14:01:21.232
+14:01:51.304
+```
+
+The pattern continues approximately every 30 seconds, matching the stale-active-seat sweep. Approximately every 60 seconds the open-table reconciler overlaps that sweep. At those overlaps the snapshot evaluation is coalesced and both callers receive a result, while the per-table command queue prevents simultaneous execution of the same stale-seat primitive. After completion all transient dedupe state is discarded, so the following sweep starts a fresh terminal attempt.
+
+The invariant log remains stable:
+
+```text
+tableId: 7af59a48-5804-4c78-b8c3-d81e5e721d6c
+stateVersion: 159
+phase: SETTLED
+escrowBefore: 600
+totalClaims: 585
+reason: terminal_claims_mismatch
+```
+
+No evidence indicates that these retries mutate escrow, claims, ledger, table status, or poker state. The noise and repeated locked DB work are nevertheless unbounded while the process and unchanged OPEN table remain present.
+
+## Confirmed call flow
+
+### Automatic stale-seat path
+
+```text
+sweepStaleActiveHumanSeatsAndBroadcast()
+  -> listStaleActiveHumanSeatCandidates()
+  -> runEvaluatedTableJanitor(trigger: "stale_active_seat_sweep")
+  -> evaluateTableForJanitor()
+  -> loadPersistedTableHealthSnapshot()
+  -> evaluateTableHealth()
+  -> runTableJanitor()
+  -> executeStaleSeatCleanupPrimitive()
+  -> executeUserInactiveCleanupPrimitive()
+  -> enqueueTableCommand()
+  -> inactive-cleanup-adapter
+  -> executeInactiveCleanup()
+  -> executeTerminalPokerCloseInTx()
+```
+
+### Automatic open-table path
+
+```text
+sweepOpenTableJanitorAndBroadcast()
+  -> listOpenTableIdsForJanitor()
+  -> runEvaluatedTableJanitor(trigger: "open_table_reconciler")
+  -> the same evaluation and cleanup path
+```
+
+The zombie sweep also calls `runEvaluatedTableJanitor()` and must obey the same automatic suppression contract if it reaches the same terminal failure.
+
+The disconnect cleanup queue is separate. It already removes a candidate when `retryable:false` is returned and must not be rewritten as part of this issue. Admin cleanup calls the shared inactive-cleanup operation through `netlify/functions/_shared/admin-ops.mjs`; it does not pass through the process-local automatic-sweep suppression and must remain available for an explicit, audited attempt.
+
+## Exact root cause
+
+1. `shared/poker-domain/terminal-close.mjs::invariantFailure()` deliberately returns `retryable:false`, `changed:false`, and `closed:false`.
+2. `shared/poker-domain/inactive-cleanup.mjs::executeInactiveCleanup()` returns that result without changing the table.
+3. `ws-server/poker/persistence/inactive-cleanup-adapter.mjs` preserves the concrete terminal failure contract.
+4. `ws-server/poker/runtime/table-janitor.mjs::runTableJanitor()` returns the result to its caller.
+5. `ws-server/server.mjs::runEvaluatedTableJanitor()` returns it but stores no stable failure state and performs no decision based on `retryable:false`.
+6. `pendingTableJanitorEvaluationByTableId` is deleted immediately after `evaluateTableForJanitor()` completes.
+7. `createTableCommandQueue()` removes its `pendingByKey` entry after the queued primitive completes.
+8. The next fixed-cadence sweep therefore evaluates and executes the identical failure again.
+
+The historical 15-chip mismatch is the data condition that triggers the guard, but it is not the cause of the retry loop. Its recovery remains governed by the runbook from #748 and is out of scope here.
+
+## Required safety properties
+
+- `terminal_claims_mismatch` remains fail-closed.
+- Suppression never changes poker state, table status, seat state, escrow, balances, claims, ledger, settlement, or idempotency records.
+- A changed state version, table status, or classification always permits a fresh automatic attempt.
+- An unchanged entry expires after a short TTL and permits one fresh fail-closed attempt.
+- An explicit manual/admin recovery attempt is never blocked by process-local automatic suppression.
+- Conserved tables continue through the existing terminal close path.
+- Concurrent automatic triggers produce no more than one terminal mutation attempt for the same table generation.
+- Process restart may forget process-local suppression and perform one fresh fail-closed attempt; this is intentional and safe.
+- Guest tables remain DB-free.
+- Logs use `klog` only and contain no private cards, complete state, per-user claims, or secrets.
+
+## Proposed implementation
+
+Implement this as one narrow runtime PR. Do not combine it with historical repair, cadence changes, terminal accounting policy, schema work, or general janitor refactoring.
+
+### 1. Build one small suppression key
+
+File: `ws-server/server.mjs`
+
+Methods:
+
+- `loadPersistedTableHealthSnapshot()`
+- `evaluateTableForJanitor()`
+- a small new suppression-key helper next to the existing janitor maps
+
+Change the existing `poker_state` snapshot query to select its persisted `version` alongside `state`. Build one normalized key from values already available after `evaluateTableForJanitor()`:
+
+```text
+tableId + stateVersion + tableStatus + classification + action + reasonCode + targetUserId + terminalCode + terminalReason
+```
+
+The terminal code and reason become known after the first failed attempt and are stored with the current state/classification key. On a later sweep, compare the current state version, status, and classification fields with the stored entry before returning its terminal failure.
+
+Do not add seat hashing, escrow fingerprints, new DB queries, dependencies, or a generic fingerprint abstraction. If state version or a required classification field is unavailable, do not suppress.
+
+This is sufficient for the current call flow:
+
+- authoritative join/rebuy and persisted stack synchronization write poker state and advance its version;
+- refreshed persisted presence or active WS presence changes the current classification;
+- terminal close changes table status;
+- the #748 historical recovery is version-checked and invokes manual terminal close, which bypasses this map;
+- ordinary ledger funding is coupled to authoritative table operations rather than being an invisible automatic repair of this blocked generation.
+
+A direct out-of-band seat or escrow edit that preserves state version, status, and classification could therefore wait until TTL expiry before the next automatic attempt. It cannot cause an incorrect ledger mutation because suppression performs no mutation and terminal close remains fail-closed. The approved manual recovery path remains immediately available.
+
+### 2. Add one bounded process-local suppression registry
+
+File: `ws-server/server.mjs`
+
+Add one map next to `pendingTableJanitorEvaluationByTableId`, keyed by `tableId`. Each value contains only:
+
+```text
+stateVersion, tableStatus, classification, action, reasonCode, targetUserId, code, reason, expiresAt
+```
+
+Name it explicitly for terminal janitor failures, for example `suppressedNonRetryableTerminalJanitorFailuresByTableId`. Do not reuse the bot timeout map and do not create a general cache framework.
+
+Store an entry only when all of these are true:
+
+- the caller is an automatic janitor trigger;
+- `result.ok === false`;
+- `result.changed === false`;
+- `result.closed === false`;
+- `result.retryable === false`;
+- `result.code === "terminal_accounting_invariant_failed"`;
+- `result.reason` is a non-empty concrete reason;
+- state version and the current classification key are complete.
+
+Do not suppress generic `retryable:false` results such as `seat_missing`, `already_closed`, or a missing primitive. The scope is the deterministic terminal-accounting failure contract.
+
+Give each entry a simple fixed TTL of 10 minutes. After expiry, delete it and permit one fresh fail-closed attempt even if the state and classification are unchanged. Let the narrow expiry predicate accept `nowMs`, supplied by `Date.now()` in production, so the existing suite can test expiry deterministically without timers or overrides. Keep the registry bounded using the existing simple map/set patterns: configure a small fixed maximum in code, evict the oldest entry when capacity is reached, and permit one fresh attempt after eviction. Do not add an environment variable, timer, hashing helper, or reusable cache abstraction. Expired entries can be removed lazily when the map is checked and during the existing automatic sweeps.
+
+### 3. Check suppression after snapshot evaluation and before mutation
+
+File: `ws-server/server.mjs`
+
+Method: `runEvaluatedTableJanitor()`
+
+After awaiting the shared `evaluateTableForJanitor()` result:
+
+1. Use the freshly computed `evaluateTableHealth()` classification returned by the shared current snapshot evaluation; do not reuse the classification stored with suppression.
+2. Confirm that state version, table status, classification, action, reason code, and target user still match the stored entry.
+3. Confirm that the stored entry has not expired.
+4. Suppress only if the complete key matches and the stored terminal code/reason are still present.
+5. Return an explicit unchanged result such as:
+
+```text
+ok: false
+changed: false
+closed: false
+retryable: false
+suppressed: true
+code: terminal_accounting_invariant_failed
+reason: <stored concrete reason>
+status: same_state_terminal_failure_suppressed
+```
+
+6. Do not call `runTableJanitor()` or any cleanup primitive for the suppressed attempt.
+7. If the key differs or TTL expired, delete the stale entry before running the normal janitor path.
+8. If the table is missing or persisted status is no longer `OPEN`, delete its entry.
+9. After a normal result, store only a qualifying non-retryable terminal failure. A successful changed/closed result or changed state version, table status, or classification must leave no stale suppression record.
+
+The automatic-trigger allow-list must be explicit:
+
+- `stale_active_seat_sweep`;
+- `zombie_table_sweep`;
+- `open_table_reconciler`.
+
+Do not broaden it to manual/admin calls, disconnect cleanup, join/leave, settlement rollover, or future unknown triggers.
+
+### 4. Preserve concurrency semantics
+
+Files:
+
+- `ws-server/server.mjs`
+- `ws-server/poker/runtime/table-command-queue.mjs` (inspection only; no change expected)
+
+Keep `pendingTableJanitorEvaluationByTableId` and the per-table command queue. They already ensure that overlapping callers share the snapshot and that identical primitive keys share the in-flight command. Suppression is checked using the shared current state/classification key before a new mutation is scheduled.
+
+When two automatic callers overlap on the first failing operation, they may both observe the same shared terminal result, but only one primitive execution is allowed. Both may attempt to record the identical map value; that write must be idempotent. Later matching calls before TTL expiry must not reach the primitive.
+
+Do not serialize all tables globally and do not change trigger-dependent classification, routing, broadcasts, or successful caller results.
+
+### 5. Use bounded observability
+
+Files:
+
+- `ws-server/server.mjs`
+- reuse the existing `klogSafe()` pattern
+
+For the first terminal attempt, retain the existing detailed invariant and janitor result logs. When suppression is first activated for a key, emit one terminal event containing only:
+
+```text
+tableId, stateVersion, status, handId, phase, code, reason
+```
+
+Do not emit one detailed log per suppressed sweep. Maintain aggregate process-local counters by trigger and reason and flush them at a bounded interval using the existing bot-autoplay observability style as a pattern, without coupling the two features. A shutdown flush is optional only if it can reuse existing controlled shutdown handling; do not add signal machinery solely for this issue.
+
+Keep this observability minimal: one activation log and one simple periodic counter are sufficient; do not build a separate observability subsystem. The activation log and summary must not include the classification target, raw seat fields, account identifiers, user IDs, cards, full state, escrow maps, or per-user claims.
+
+## Minimal regression tests
+
+Do not add a framework or a new broad suite.
+
+### `ws-server/server.behavior.test.mjs`
+
+Extend the existing server harness with focused cases:
+
+1. The first automatic sweep for a fixed OPEN state/classification key reaches the cleanup adapter and returns `terminal_accounting_invariant_failed`, `terminal_claims_mismatch`, `retryable:false`.
+2. A second automatic sweep with the same state version, status, and classification before TTL expiry does not invoke the adapter again and returns the explicit suppressed result.
+3. Changing state version invalidates suppression and permits one fresh attempt when the current classification still requires cleanup.
+4. Changing table status, classification/action/reason code, or target user invalidates the old entry and follows the newly evaluated route without returning stale suppression.
+5. TTL expiry permits one fresh attempt for an otherwise unchanged key and installs a new TTL only if the same qualifying failure returns.
+6. A missing state version or classification component does not suppress.
+7. Overlapping stale-seat and open-table triggers for one unchanged operation cause exactly one adapter/terminal attempt.
+8. A normal conserved cleanup still invokes the adapter, closes once, and is not suppressed.
+
+Use the existing injectable inactive-cleanup adapter and persisted-state fixture patterns. Do not reproduce ledger internals in the server test.
+
+### `ws-server/poker/runtime/table-janitor.behavior.test.mjs`
+
+Only if a small pure suppression predicate is placed in this existing module, add direct boundary assertions that:
+
+- only the exact terminal-accounting/non-retryable/unchanged result qualifies;
+- successful, changed, retryable, or unrelated failures do not qualify.
+
+If the predicate remains local to `server.mjs`, keep this coverage in `server.behavior.test.mjs` instead of exporting implementation detail solely for testing.
+
+Run the existing inactive cleanup suite, which exercises the terminal-close dependency, unchanged to prove fail-closed and conserved close behavior:
+
+```bash
+node --test shared/poker-domain/inactive-cleanup.behavior.test.mjs
+```
+
+```bash
+node --test ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs
+```
+
+```bash
+node --test ws-server/poker/runtime/table-janitor.behavior.test.mjs
+```
+
+```bash
+node --test ws-server/server.behavior.test.mjs
+```
+
+## WS Preview verification
+
+Every WS-affecting implementation PR requires a manual `WS Preview Deploy` for the exact PR SHA.
+
+1. Record the workflow run URL, exact requested SHA, completion time, and the matching `ws_artifact_start` SHA.
+2. Confirm local and public `/healthz`.
+3. Observe the known historical table or a safe fixture with the same non-retryable contract through at least two stale-seat intervals and two open-table intervals.
+4. Confirm one initial `poker_terminal_accounting_invariant_failed` for its state/classification key.
+5. Confirm no later terminal-close attempt or repeated detailed result for that key before TTL expiry.
+6. Confirm the bounded suppression summary counts later automatic selections.
+7. Confirm a manual admin attempt remains possible and still fails closed.
+8. Change a safe preview fixture's presence/classification and confirm that the stale suppression is not returned.
+9. Change the fixture's authoritative state version and confirm one fresh automatic attempt.
+10. Verify TTL expiry with an injectable clock in automated coverage; do not wait 10 minutes or add a Preview-only runtime override solely for smoke testing.
+11. Close a conserved stale table through the normal path and confirm exactly one close, correct cash-outs, escrow zero, and no duplicate ledger idempotency keys.
+12. Confirm no unexpected `ws_table_janitor_*failed`, persistence conflict, duplicate settlement, duplicate close, or runtime error.
+
+Do not repair or add chips to the historical table as part of this verification.
+
+Representative one-line log query:
+
+```bash
+sudo journalctl -u ws-server-preview.service --since "<deploy time>" --no-pager | grep -E "ws_artifact_start|poker_terminal_accounting_invariant_failed|ws_table_janitor_result|ws_table_janitor_.*suppressed|ws_table_janitor_.*summary|ws_table_janitor_.*failed"
+```
+
+## Rollback
+
+Revert the runtime commit and redeploy the previous known-good SHA. The registry is process-local, so rollback requires no schema, data, or cache migration. After restart, the old behavior resumes and the terminal guard remains fail-closed.
+
+## Risks and breaking impact
+
+- **Intended breaking diagnostic impact:** automatic janitor callers no longer execute or emit a full detailed result on every unchanged non-retryable terminal failure.
+- **Delayed automatic retry after an out-of-band edit:** a direct seat or escrow change which preserves state version, status, and classification is not detected immediately. In the current application flows, join/rebuy/persistence advances state version, presence changes classification, close changes status, and approved historical recovery invokes the manual path. Any unsupported out-of-band edit is therefore delayed only until the 10-minute TTL; it is not converted into a mutation or accounting success.
+- **Manual recovery risk:** a broad hook could block operator action. Mitigation: use an explicit automatic-trigger allow-list at the WS scheduler boundary; admin operations bypass it.
+- **Memory growth risk:** historical table IDs could remain in a long-lived writer process. Mitigation: one bounded map, deletion on missing/closed/changed state, and oldest-entry eviction.
+- **Concurrent trigger risk:** two first attempts could race before suppression is recorded. Mitigation: retain shared evaluation and per-table command dedupe; add an overlap regression case.
+- **False success risk:** reporting suppression as `ok:true` could make callers believe cleanup completed. Mitigation: return `ok:false`, `changed:false`, `closed:false`, `suppressed:true`, and preserve the terminal code/reason.
+- **Accounting risk:** none of the invariant, claim, settlement, cash-out, or ledger code is changed. Any proposal requiring such a change belongs outside this issue.
+
+## Out of scope
+
+- repairing, deleting, resetting, or closing the historical table;
+- changing `terminal_claims_mismatch` or terminal claim calculation;
+- adding missing chips or bypassing escrow conservation;
+- changing stale-seat, zombie, or open-table sweep cadence;
+- changing reconnect, persistence recovery, settlement, ledger, or terminal close behavior;
+- caching live poker state;
+- schema changes;
+- a general retry, suppression, cache, or observability framework;
+- browser JavaScript, JSP, CSS, and CSP changes.
+
+## Notes
+
+- This concerns critical realtime poker cleanup and accounting. The implementation must remain small and fail closed.
+- WS/runtime remains authoritative for loaded live tables; persisted DB state is the authoritative comparison source for an unloaded historical table generation.
+- Reuse `runEvaluatedTableJanitor()`, `pendingTableJanitorEvaluationByTableId`, `createTableCommandQueue()`, the existing adapter, and `klogSafe()`.
+- Do not create a parallel janitor or terminal-close path.
+- Log only through `klog`; never use `console.log`.
+- Never log private cards, complete state, secrets, or per-user claim maps.
+- JSP, CSS, and CSP are not applicable because no browser code is planned.
+- The implementation PR must explicitly document the intended breaking impact on repeated automatic janitor diagnostics.

--- a/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
@@ -38,10 +38,51 @@ async function beginSqlFileStore(fn, { env = process.env } = {}) {
       const tableId = params?.[0];
       const table = tables?.[tableId] || null;
 
+      if (sql.includes("from public.poker_seats s") && sql.includes("order by s.last_seen_at")) {
+        const cutoffMs = Date.parse(String(params?.[0] || ""));
+        const limit = Number(params?.[1]) || 25;
+        return Object.entries(tables)
+          .filter(([, candidate]) => String(candidate?.tableRow?.status || "OPEN").toUpperCase() === "OPEN")
+          .flatMap(([candidateTableId, candidate]) => (candidate?.seatRows || [])
+            .filter((seat) => (
+              String(seat?.status || "ACTIVE").toUpperCase() === "ACTIVE"
+              && seat?.is_bot !== true
+              && Number.isFinite(Date.parse(String(seat?.last_seen_at || "")))
+              && Date.parse(String(seat.last_seen_at)) < cutoffMs
+            ))
+            .map((seat) => ({ table_id: candidateTableId, user_id: seat.user_id, last_seen_at: seat.last_seen_at })))
+          .sort((left, right) => Date.parse(left.last_seen_at) - Date.parse(right.last_seen_at))
+          .slice(0, limit);
+      }
+
+      if (sql.includes("from public.poker_tables t") && sql.includes("cursor_wrapped")) {
+        const cursorTableId = typeof params?.[0] === "string" ? params[0] : "";
+        const limit = Number(params?.[1]) || 10;
+        const openTableIds = Object.entries(tables)
+          .filter(([, candidate]) => String(candidate?.tableRow?.status || "OPEN").toUpperCase() === "OPEN")
+          .map(([candidateTableId]) => candidateTableId)
+          .sort();
+        const afterCursor = cursorTableId
+          ? [...openTableIds.filter((id) => id > cursorTableId), ...openTableIds.filter((id) => id <= cursorTableId)]
+          : openTableIds;
+        return afterCursor.slice(0, limit).map((id) => ({
+          id,
+          cursor_wrapped: Boolean(cursorTableId && id <= cursorTableId)
+        }));
+      }
+
       if (sql.includes("from public.poker_tables")) {
         if (!table?.tableRow) return [];
         const row = table.tableRow;
-        return [{ id: row.id || tableId, status: row.status || "OPEN", max_players: row.max_players || row.maxPlayers || 6, stakes: row.stakes ?? '{"sb":1,"bb":2}' }];
+        return [{
+          id: row.id || tableId,
+          status: row.status || "OPEN",
+          max_players: row.max_players || row.maxPlayers || 6,
+          stakes: row.stakes ?? '{"sb":1,"bb":2}',
+          created_at: row.created_at ?? null,
+          updated_at: row.updated_at ?? null,
+          last_activity_at: row.last_activity_at ?? null
+        }];
       }
 
       if (sql.includes("from public.poker_seats") && sql.includes("order by seat_no asc;")) {
@@ -58,7 +99,8 @@ async function beginSqlFileStore(fn, { env = process.env } = {}) {
           is_bot: !!r.is_bot,
           bot_profile: r.bot_profile ?? null,
           leave_after_hand: !!r.leave_after_hand,
-          stack: r.stack ?? 0
+          stack: r.stack ?? 0,
+          last_seen_at: r.last_seen_at ?? null
         }));
       }
 

--- a/ws-server/poker/runtime/table-janitor.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-janitor.behavior.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { evaluateTableHealth, runTableJanitor, selectOpenTableJanitorBatch } from "./table-janitor.mjs";
+import {
+  createNonRetryableTerminalJanitorSuppression,
+  evaluateTableHealth,
+  matchesNonRetryableTerminalJanitorSuppression,
+  runTableJanitor,
+  selectOpenTableJanitorBatch
+} from "./table-janitor.mjs";
 
 const NOW_MS = Date.parse("2026-04-23T13:12:00.000Z");
 
@@ -316,4 +322,105 @@ test("runTableJanitor keeps runtime/db mismatch traceable while routing cleanup"
   assert.equal(calls[0].tableId, "t_runtime_mismatch");
   assert.equal(logs[0].kind, "ws_table_janitor_classified");
   assert.equal(logs[0].data.reasonCode, "open_table_without_active_humans");
+});
+
+test("non-retryable terminal janitor suppression matches only the same unexpired state and classification", () => {
+  const classification = {
+    classification: "stale_human_seat",
+    action: "stale_seat_cleanup",
+    reasonCode: "stale_human_last_seen_expired",
+    userId: "user-1"
+  };
+  const suppression = createNonRetryableTerminalJanitorSuppression({
+    tableId: "table-1",
+    stateVersion: 159,
+    tableStatus: "OPEN",
+    classification,
+    result: {
+      ok: false,
+      changed: false,
+      closed: false,
+      retryable: false,
+      code: "terminal_accounting_invariant_failed",
+      reason: "terminal_claims_mismatch"
+    },
+    nowMs: NOW_MS,
+    ttlMs: 600_000
+  });
+
+  assert.equal(suppression?.reason, "terminal_claims_mismatch");
+  assert.equal(matchesNonRetryableTerminalJanitorSuppression(suppression, {
+    tableId: "table-1",
+    stateVersion: 159,
+    tableStatus: "OPEN",
+    classification,
+    nowMs: NOW_MS + 599_999
+  }), true);
+  assert.equal(matchesNonRetryableTerminalJanitorSuppression(suppression, {
+    tableId: "table-1",
+    stateVersion: 160,
+    tableStatus: "OPEN",
+    classification,
+    nowMs: NOW_MS + 1
+  }), false);
+  assert.equal(matchesNonRetryableTerminalJanitorSuppression(suppression, {
+    tableId: "table-1",
+    stateVersion: 159,
+    tableStatus: "OPEN",
+    classification: { ...classification, action: "noop" },
+    nowMs: NOW_MS + 1
+  }), false);
+  assert.equal(matchesNonRetryableTerminalJanitorSuppression(suppression, {
+    tableId: "table-1",
+    stateVersion: 159,
+    tableStatus: "OPEN",
+    classification,
+    nowMs: NOW_MS + 600_000
+  }), false);
+});
+
+test("terminal janitor suppression rejects changed, retryable, and unrelated results", () => {
+  const base = {
+    tableId: "table-1",
+    stateVersion: 159,
+    tableStatus: "OPEN",
+    classification: {
+      classification: "stale_human_seat",
+      action: "stale_seat_cleanup",
+      reasonCode: "stale_human_last_seen_expired",
+      userId: "user-1"
+    },
+    nowMs: NOW_MS,
+    ttlMs: 600_000
+  };
+  const terminalFailure = {
+    ok: false,
+    changed: false,
+    closed: false,
+    retryable: false,
+    code: "terminal_accounting_invariant_failed",
+    reason: "terminal_claims_mismatch"
+  };
+
+  assert.equal(createNonRetryableTerminalJanitorSuppression({
+    ...base,
+    result: { ...terminalFailure, changed: true }
+  }), null);
+  assert.equal(createNonRetryableTerminalJanitorSuppression({
+    ...base,
+    result: { ...terminalFailure, closed: true }
+  }), null);
+  assert.equal(createNonRetryableTerminalJanitorSuppression({
+    ...base,
+    result: { ...terminalFailure, retryable: true }
+  }), null);
+  assert.equal(createNonRetryableTerminalJanitorSuppression({
+    ...base,
+    result: { ...terminalFailure, code: "inactive_cleanup_failed" }
+  }), null);
+  assert.equal(createNonRetryableTerminalJanitorSuppression({
+    ...base,
+    stateVersion: null,
+    result: terminalFailure
+  }), null);
 });

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -4,6 +4,7 @@ const DEFAULT_TABLE_CLOSE_GRACE_MS = 60_000;
 const DEFAULT_LIVE_HAND_STALE_MS = 15_000;
 const LIVE_HAND_PHASES = new Set(["POSTING_BLINDS", "PREFLOP", "FLOP", "TURN", "RIVER", "SHOWDOWN"]);
 const ACTION_HAND_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER"]);
+const TERMINAL_ACCOUNTING_INVARIANT_FAILED = "terminal_accounting_invariant_failed";
 
 function normalizePositiveInt(value, fallback) {
   const parsed = Number(value);
@@ -17,6 +18,80 @@ function normalizeStatus(value, fallback = "OPEN") {
   if (typeof value !== "string") return fallback;
   const normalized = value.trim().toUpperCase();
   return normalized || fallback;
+}
+
+function normalizeRequiredString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "";
+}
+
+export function createNonRetryableTerminalJanitorSuppression({
+  tableId,
+  stateVersion,
+  tableStatus,
+  classification,
+  result,
+  nowMs = Date.now(),
+  ttlMs
+} = {}) {
+  const normalizedTableId = normalizeRequiredString(tableId);
+  const normalizedStateVersion = stateVersion;
+  const normalizedTableStatus = normalizeStatus(tableStatus, "");
+  const normalizedClassification = normalizeRequiredString(classification?.classification);
+  const action = normalizeRequiredString(classification?.action);
+  const reasonCode = normalizeRequiredString(classification?.reasonCode);
+  const targetUserId = normalizeRequiredString(classification?.userId);
+  const code = normalizeRequiredString(result?.code);
+  const reason = normalizeRequiredString(result?.reason);
+  const normalizedNowMs = Number(nowMs);
+  const normalizedTtlMs = Number(ttlMs);
+  if (
+    !normalizedTableId
+    || !Number.isInteger(normalizedStateVersion)
+    || normalizedStateVersion < 0
+    || !normalizedTableStatus
+    || !normalizedClassification
+    || !action
+    || !reasonCode
+    || !Number.isFinite(normalizedNowMs)
+    || !Number.isFinite(normalizedTtlMs)
+    || normalizedTtlMs <= 0
+    || result?.ok !== false
+    || result?.changed !== false
+    || result?.closed !== false
+    || result?.retryable !== false
+    || code !== TERMINAL_ACCOUNTING_INVARIANT_FAILED
+    || !reason
+  ) {
+    return null;
+  }
+  return {
+    tableId: normalizedTableId,
+    stateVersion: normalizedStateVersion,
+    tableStatus: normalizedTableStatus,
+    classification: normalizedClassification,
+    action,
+    reasonCode,
+    targetUserId,
+    code,
+    reason,
+    expiresAt: normalizedNowMs + normalizedTtlMs
+  };
+}
+
+export function matchesNonRetryableTerminalJanitorSuppression(
+  suppression,
+  { tableId, stateVersion, tableStatus, classification, nowMs = Date.now() } = {}
+) {
+  if (!suppression || typeof suppression !== "object") return false;
+  const normalizedNowMs = Number(nowMs);
+  if (!Number.isFinite(normalizedNowMs) || normalizedNowMs >= Number(suppression.expiresAt)) return false;
+  return suppression.tableId === normalizeRequiredString(tableId)
+    && suppression.stateVersion === stateVersion
+    && suppression.tableStatus === normalizeStatus(tableStatus, "")
+    && suppression.classification === normalizeRequiredString(classification?.classification)
+    && suppression.action === normalizeRequiredString(classification?.action)
+    && suppression.reasonCode === normalizeRequiredString(classification?.reasonCode)
+    && suppression.targetUserId === normalizeRequiredString(classification?.userId);
 }
 
 function normalizeState(value) {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -284,6 +284,102 @@ async function writeTestModule(source, filename = "ws-test-module.mjs") {
   return { dir, filePath };
 }
 
+async function waitForJsonCounter(filePath, expected, timeoutMs = 5000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const count = Number(JSON.parse(await fs.readFile(filePath, "utf8"))?.count);
+      if (count >= expected) return count;
+    } catch {
+      // The fixture writer may be between its atomic test steps.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for counter ${expected}`);
+}
+
+async function createTerminalJanitorSuppressionHarness({
+  tableId,
+  cleanupDelayMs = 0,
+  staleSweepMs = "500",
+  openSweepMs = "60000"
+}) {
+  const nowMs = Date.now();
+  const persisted = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: {
+          id: tableId,
+          status: "OPEN",
+          max_players: 6,
+          created_at: new Date(nowMs - 600_000).toISOString(),
+          updated_at: new Date(nowMs - 300_000).toISOString(),
+          last_activity_at: new Date(nowMs - 300_000).toISOString()
+        },
+        seatRows: [{
+          user_id: "11111111-1111-4111-8111-111111111111",
+          seat_no: 1,
+          status: "ACTIVE",
+          is_bot: false,
+          stack: 585,
+          last_seen_at: new Date(nowMs - 300_000).toISOString()
+        }],
+        stateRow: {
+          version: 159,
+          state: {
+            tableId,
+            handId: "hand-terminal-suppression",
+            phase: "SETTLED",
+            stacks: { "11111111-1111-4111-8111-111111111111": 585 }
+          }
+        }
+      }
+    }
+  });
+  const counterFile = path.join(persisted.dir, "cleanup-count.json");
+  await fs.writeFile(counterFile, JSON.stringify({ count: 0 }), "utf8");
+  const cleanupModule = await writeTestModule(`
+import fs from "node:fs/promises";
+export function createInactiveCleanupExecutor({ env }) {
+  return async () => {
+    const current = JSON.parse(await fs.readFile(env.WS_TEST_JANITOR_COUNTER_FILE, "utf8"));
+    await fs.writeFile(env.WS_TEST_JANITOR_COUNTER_FILE, JSON.stringify({ count: Number(current.count || 0) + 1 }), "utf8");
+    const delayMs = Number(env.WS_TEST_JANITOR_CLEANUP_DELAY_MS || 0);
+    if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return {
+      ok: false,
+      changed: false,
+      closed: false,
+      retryable: false,
+      code: "terminal_accounting_invariant_failed",
+      reason: "terminal_claims_mismatch"
+    };
+  };
+}
+`, "inactive-cleanup-terminal-suppression.mjs");
+  const server = await createServer({
+    env: {
+      WS_PERSISTED_STATE_FILE: persisted.filePath,
+      WS_TEST_JANITOR_COUNTER_FILE: counterFile,
+      WS_TEST_JANITOR_CLEANUP_DELAY_MS: String(cleanupDelayMs),
+      WS_INACTIVE_CLEANUP_ADAPTER_MODULE_PATH: `file://${cleanupModule.filePath}`,
+      WS_STALE_ACTIVE_SEAT_SWEEP_MS: staleSweepMs,
+      WS_OPEN_TABLE_JANITOR_SWEEP_MS: openSweepMs,
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000",
+      WS_TIMEOUT_SWEEP_MS: "60000",
+      WS_DISCONNECT_CLEANUP_SWEEP_MS: "60000"
+    }
+  });
+  return { ...server, ...persisted, counterFile, cleanupModule };
+}
+
+async function destroyTerminalJanitorSuppressionHarness(harness) {
+  harness.child.kill("SIGTERM");
+  await waitForExit(harness.child);
+  await fs.rm(harness.dir, { recursive: true, force: true });
+  await fs.rm(harness.cleanupModule.dir, { recursive: true, force: true });
+}
+
 async function nextMessageOfType(ws, type, timeoutMs = 10000) {
   try {
     return await nextMessageMatching(
@@ -542,6 +638,64 @@ test("zombie cleanup keeps live bots-only table open while the hand is still run
     child.kill("SIGTERM");
     await waitForExit(child);
     await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("automatic janitor suppresses the second unchanged terminal accounting failure before the adapter", async () => {
+  const harness = await createTerminalJanitorSuppressionHarness({
+    tableId: "75200000-0000-4000-8000-000000000001"
+  });
+  try {
+    await waitForListening(harness.child, 5000);
+    await waitForJsonCounter(harness.counterFile, 1);
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const counter = JSON.parse(await fs.readFile(harness.counterFile, "utf8"));
+    assert.equal(counter.count, 1);
+  } finally {
+    await destroyTerminalJanitorSuppressionHarness(harness);
+  }
+});
+
+test("automatic janitor retries once after the persisted state version changes", async () => {
+  const harness = await createTerminalJanitorSuppressionHarness({
+    tableId: "75200000-0000-4000-8000-000000000002"
+  });
+  try {
+    await waitForListening(harness.child, 5000);
+    await waitForJsonCounter(harness.counterFile, 1);
+    const persisted = await readPersistedFile(harness.filePath);
+    const table = persisted.tables["75200000-0000-4000-8000-000000000002"];
+    table.stateRow.version += 1;
+    await fs.writeFile(harness.filePath, `${JSON.stringify(persisted)}\n`, "utf8");
+    await waitForJsonCounter(harness.counterFile, 2);
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    const counter = JSON.parse(await fs.readFile(harness.counterFile, "utf8"));
+    assert.equal(counter.count, 2);
+  } finally {
+    await destroyTerminalJanitorSuppressionHarness(harness);
+  }
+});
+
+test("overlapping stale-seat and open-table janitor triggers share one cleanup execution", async () => {
+  const harness = await createTerminalJanitorSuppressionHarness({
+    tableId: "75200000-0000-4000-8000-000000000003",
+    cleanupDelayMs: 6000,
+    staleSweepMs: "500",
+    openSweepMs: "5000"
+  });
+  const logs = [];
+  harness.child.stdout.on("data", (chunk) => logs.push(String(chunk)));
+  try {
+    await waitForListening(harness.child, 5000);
+    await waitForJsonCounter(harness.counterFile, 1);
+    await new Promise((resolve) => setTimeout(resolve, 7000));
+    const counter = JSON.parse(await fs.readFile(harness.counterFile, "utf8"));
+    const joinedLogs = logs.join("");
+    assert.equal(counter.count, 1);
+    assert.match(joinedLogs, /"trigger":"stale_active_seat_sweep"/);
+    assert.match(joinedLogs, /"trigger":"open_table_reconciler"/);
+  } finally {
+    await destroyTerminalJanitorSuppressionHarness(harness);
   }
 });
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -16,7 +16,12 @@ import { adaptPersistedBootstrap } from "./poker/bootstrap/persisted-bootstrap-a
 import { createSessionStore } from "./poker/runtime/session-store.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
 import { createBotReactionOverrideStore } from "./poker/runtime/bot-reaction-override.mjs";
-import { evaluateTableHealth, runTableJanitor } from "./poker/runtime/table-janitor.mjs";
+import {
+  createNonRetryableTerminalJanitorSuppression,
+  evaluateTableHealth,
+  matchesNonRetryableTerminalJanitorSuppression,
+  runTableJanitor
+} from "./poker/runtime/table-janitor.mjs";
 import { buildStateSnapshotPayload } from "./poker/read-model/state-snapshot.mjs";
 import { buildStatePatch } from "./poker/read-model/state-patch.mjs";
 import { createStreamLog } from "./poker/runtime/stream-log.mjs";
@@ -279,6 +284,15 @@ const persistedSeatTouchByTableUser = new Map();
 const lobbySubscribers = new Set();
 const activeLobbyTablesById = new Map();
 const pendingTableJanitorEvaluationByTableId = new Map();
+const suppressedNonRetryableTerminalJanitorFailuresByTableId = new Map();
+const suppressedTerminalJanitorCountsByReason = new Map();
+const AUTOMATIC_TABLE_JANITOR_TRIGGERS = new Set([
+  "stale_active_seat_sweep",
+  "zombie_table_sweep",
+  "open_table_reconciler"
+]);
+const TERMINAL_JANITOR_SUPPRESSION_TTL_MS = 10 * 60_000;
+const TERMINAL_JANITOR_SUPPRESSION_MAX = 1_000;
 const lobbyEmptyJoinableGraceMs = resolveEmptyJoinableGraceMs(process.env.POKER_TABLE_CLOSE_GRACE_MS);
 const internalRuntimeToken = typeof process.env.POKER_WS_INTERNAL_TOKEN === "string" ? process.env.POKER_WS_INTERNAL_TOKEN.trim() : "";
 const botReactionOverrideStore = createBotReactionOverrideStore({ env: process.env });
@@ -453,6 +467,25 @@ const botAutoplaySummaryTimer = setInterval(() => {
   botAutoplayObservability.flush("interval");
 }, botAutoplayLogSummaryMs);
 botAutoplaySummaryTimer.unref();
+
+function flushSuppressedTerminalJanitorSummary() {
+  if (suppressedTerminalJanitorCountsByReason.size === 0) return;
+  const countsByReason = Object.fromEntries(
+    [...suppressedTerminalJanitorCountsByReason.entries()].sort(([left], [right]) => left.localeCompare(right))
+  );
+  const total = Object.values(countsByReason).reduce((sum, count) => sum + count, 0);
+  suppressedTerminalJanitorCountsByReason.clear();
+  klogSafe("ws_table_janitor_terminal_failure_suppression_summary", {
+    intervalMs: 60_000,
+    total,
+    countsByReason
+  });
+}
+
+const terminalJanitorSuppressionSummaryTimer = setInterval(() => {
+  flushSuppressedTerminalJanitorSummary();
+}, 60_000);
+terminalJanitorSuppressionSummaryTimer.unref();
 
 function loadReleaseMetadata() {
   const fallback = {
@@ -2209,12 +2242,13 @@ async function loadPersistedTableHealthSnapshot(tableId) {
         [tableId]
       );
       const stateRows = await tx.unsafe(
-        "select state from public.poker_state where table_id = $1 limit 1;",
+        "select version, state from public.poker_state where table_id = $1 limit 1;",
         [tableId]
       );
       return {
         table: tableRows?.[0] || null,
         seats: Array.isArray(seatRows) ? seatRows : [],
+        stateVersion: Number.isInteger(Number(stateRows?.[0]?.version)) ? Number(stateRows[0].version) : null,
         state: stateRows?.[0]?.state ?? null
       };
     }, { env: process.env });
@@ -2272,20 +2306,104 @@ async function evaluateTableForJanitor(tableId) {
       }
     };
   }
+  const classification = evaluateTableHealth({
+    tableId,
+    persistedTable: persistedHealth.table,
+    persistedSeats: persistedHealth.seats,
+    persistedState: persistedHealth.state,
+    runtime: buildTableJanitorRuntimeContext(tableId, persistedHealth.seats),
+    nowMs: Date.now(),
+    activeSeatFreshMs,
+    seatedReconnectGraceMs,
+    tableCloseGraceMs: lobbyEmptyJoinableGraceMs,
+    liveHandStaleMs: janitorLiveHandStaleMs
+  });
   return {
-    classification: evaluateTableHealth({
+    classification,
+    suppressionContext: {
       tableId,
-      persistedTable: persistedHealth.table,
-      persistedSeats: persistedHealth.seats,
-      persistedState: persistedHealth.state,
-      runtime: buildTableJanitorRuntimeContext(tableId, persistedHealth.seats),
-      nowMs: Date.now(),
-      activeSeatFreshMs,
-      seatedReconnectGraceMs,
-      tableCloseGraceMs: lobbyEmptyJoinableGraceMs,
-      liveHandStaleMs: janitorLiveHandStaleMs
-    })
+      stateVersion: persistedHealth.stateVersion,
+      tableStatus: typeof persistedHealth.table?.status === "string"
+        ? persistedHealth.table.status.trim().toUpperCase()
+        : "",
+      handId: typeof persistedHealth.state?.handId === "string" ? persistedHealth.state.handId.trim() : "",
+      phase: typeof persistedHealth.state?.phase === "string" ? persistedHealth.state.phase.trim() : ""
+    }
   };
+}
+
+function suppressedTerminalJanitorResult({ trigger, classification, suppressionContext }) {
+  if (!AUTOMATIC_TABLE_JANITOR_TRIGGERS.has(trigger)) return null;
+  const tableId = suppressionContext?.tableId;
+  const existing = suppressedNonRetryableTerminalJanitorFailuresByTableId.get(tableId);
+  if (!existing) return null;
+  if (!matchesNonRetryableTerminalJanitorSuppression(existing, {
+    ...suppressionContext,
+    classification,
+    nowMs: Date.now()
+  })) {
+    suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(tableId);
+    return null;
+  }
+  suppressedTerminalJanitorCountsByReason.set(
+    existing.reason,
+    (suppressedTerminalJanitorCountsByReason.get(existing.reason) || 0) + 1
+  );
+  return {
+    ok: false,
+    changed: false,
+    closed: false,
+    retryable: false,
+    suppressed: true,
+    code: existing.code,
+    reason: existing.reason,
+    status: "same_state_terminal_failure_suppressed"
+  };
+}
+
+function rememberNonRetryableTerminalJanitorFailure({
+  trigger,
+  classification,
+  suppressionContext,
+  result
+}) {
+  if (!AUTOMATIC_TABLE_JANITOR_TRIGGERS.has(trigger)) return;
+  const suppression = createNonRetryableTerminalJanitorSuppression({
+    ...suppressionContext,
+    classification,
+    result,
+    nowMs: Date.now(),
+    ttlMs: TERMINAL_JANITOR_SUPPRESSION_TTL_MS
+  });
+  if (!suppression) return;
+  const existing = suppressedNonRetryableTerminalJanitorFailuresByTableId.get(suppression.tableId);
+  if (existing && matchesNonRetryableTerminalJanitorSuppression(existing, {
+    ...suppressionContext,
+    classification,
+    nowMs: Date.now()
+  })) {
+    return;
+  }
+  if (
+    !suppressedNonRetryableTerminalJanitorFailuresByTableId.has(suppression.tableId)
+    && suppressedNonRetryableTerminalJanitorFailuresByTableId.size >= TERMINAL_JANITOR_SUPPRESSION_MAX
+  ) {
+    const oldestTableId = suppressedNonRetryableTerminalJanitorFailuresByTableId.keys().next().value;
+    if (oldestTableId) {
+      suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(oldestTableId);
+    }
+  }
+  suppressedNonRetryableTerminalJanitorFailuresByTableId.set(suppression.tableId, suppression);
+  klogSafe("ws_table_janitor_terminal_failure_suppression_activated", {
+    tableId: suppression.tableId,
+    stateVersion: suppression.stateVersion,
+    status: suppression.tableStatus,
+    handId: suppressionContext?.handId || null,
+    phase: suppressionContext?.phase || null,
+    code: suppression.code,
+    reason: suppression.reason,
+    ttlMs: TERMINAL_JANITOR_SUPPRESSION_TTL_MS
+  });
 }
 
 async function runEvaluatedTableJanitor({ tableId, trigger, requestId }) {
@@ -2308,15 +2426,29 @@ async function runEvaluatedTableJanitor({ tableId, trigger, requestId }) {
 
   const evaluated = await pendingEvaluation;
   if (evaluated?.result) {
+    suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(tableId);
     return evaluated.result;
   }
-  return runTableJanitor({
+  const suppressedResult = suppressedTerminalJanitorResult({
+    trigger,
+    classification: evaluated?.classification,
+    suppressionContext: evaluated?.suppressionContext
+  });
+  if (suppressedResult) return suppressedResult;
+  const result = await runTableJanitor({
     classification: evaluated?.classification,
     trigger,
     requestId,
     primitives: tableJanitorPrimitives,
     klog: klogSafe
   });
+  rememberNonRetryableTerminalJanitorFailure({
+    trigger,
+    classification: evaluated?.classification,
+    suppressionContext: evaluated?.suppressionContext,
+    result
+  });
+  return result;
 }
 
 async function sweepStaleActiveHumanSeatsAndBroadcast() {


### PR DESCRIPTION
## Summary

- add a bounded process-local suppression map for automatic poker janitor triggers
- suppress only unchanged, non-retryable terminal accounting invariant failures
- invalidate on state version, table status, classification, target, capacity, or 10-minute TTL
- keep manual/admin recovery outside suppression
- add a single activation log and bounded aggregate suppression counts
- include the accepted analysis and implementation plan

## Root cause

`terminal_claims_mismatch` already fails closed with no accounting mutation, but `runEvaluatedTableJanitor()` discarded the non-retryable result after each sweep. Existing evaluation coalescing and command dedupe only covered concurrent in-flight work, so later stale-seat and open-table sweeps repeated the same terminal transaction for unchanged state.

## Safety and impact

- terminal claims, escrow validation, settlement, cash-out, ledger, and close code are unchanged
- only `stale_active_seat_sweep`, `zombie_table_sweep`, and `open_table_reconciler` can be suppressed
- manual/admin recovery remains available
- process restart or TTL expiry permits one fresh fail-closed attempt
- missing version/classification data fails open for scheduling

Breaking diagnostic impact: repeated automatic attempts for the same key no longer emit a full detailed janitor result during the TTL window. They are represented by bounded aggregate counts instead.

## Validation

- `node --test ws-server/poker/runtime/table-janitor.behavior.test.mjs`
- `node --test shared/poker-domain/inactive-cleanup.behavior.test.mjs`
- `node --test ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs`
- `node --test ws-server/server.behavior.test.mjs` — 94 passed
- `npm run syntax` — 215 files passed
- `git diff --check`

The server integration harness additionally proves:

- the first automatic sweep reaches the injectable cleanup adapter and the second identical sweep does not
- incrementing persisted `stateVersion` permits exactly one fresh adapter call
- overlapping `stale_active_seat_sweep` and `open_table_reconciler` triggers share one cleanup execution

Refs #752
