### PR TITLE
perf(poker): acknowledge persisted hole cards

### DIFF
--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -169,7 +169,7 @@ test("persisted state writer persists WS hand hole cards after successful db mut
   ]);
 });
 
-test("persisted state writer hole card persistence is idempotent on replayed state write", async () => {
+test("persisted state writer skips acknowledged hole cards on replayed state write", async () => {
   let stateVersion = 4;
   let currentState = null;
   const queries = [];
@@ -212,8 +212,62 @@ test("persisted state writer hole card persistence is idempotent on replayed sta
   assert.deepEqual(first, { ok: true, newVersion: 5 });
   assert.deepEqual(second, { ok: true, newVersion: 5, alreadyApplied: true });
   const holeCardInserts = queries.filter((entry) => entry.query.startsWith("insert into public.poker_hole_cards"));
-  assert.equal(holeCardInserts.length, 2);
+  assert.equal(holeCardInserts.length, 1);
   assert.equal(holeCardInserts.every((entry) => entry.query.includes("on conflict (table_id, hand_id, user_id) do update")), true);
+});
+
+test("persisted state writer rewrites changed or forgotten hole-card acknowledgements", async () => {
+  let stateVersion = 4;
+  const holeCardInserts = [];
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (fn) => fn({
+      unsafe: async (query) => {
+        const text = String(query);
+        if (text.startsWith("update public.poker_state set version = version + 1")) {
+          stateVersion += 1;
+          return [{ version: stateVersion }];
+        }
+        if (text.startsWith("insert into public.poker_hole_cards")) {
+          holeCardInserts.push(text);
+        }
+        return [];
+      }
+    }),
+    klog: () => {}
+  });
+  const tableId = "00000000-0000-4000-8000-000000000012";
+  const privateState = {
+    tableId,
+    handId: "hand_ack_1",
+    phase: "PREFLOP",
+    holeCardsByUserId: {
+      "00000000-0000-4000-8000-0000000000a1": ["AS", "KD"],
+      "00000000-0000-4000-8000-0000000000b2": ["2C", "2D"]
+    }
+  };
+
+  assert.equal((await writer.writeMutation({ tableId, expectedVersion: 4, nextState: privateState })).ok, true);
+  assert.equal((await writer.writeMutation({ tableId, expectedVersion: 5, nextState: privateState })).ok, true);
+  assert.equal(holeCardInserts.length, 1);
+
+  const changedCards = {
+    ...privateState,
+    holeCardsByUserId: {
+      ...privateState.holeCardsByUserId,
+      "00000000-0000-4000-8000-0000000000b2": ["3C", "3D"]
+    }
+  };
+  assert.equal((await writer.writeMutation({ tableId, expectedVersion: 6, nextState: changedCards })).ok, true);
+  assert.equal(holeCardInserts.length, 2);
+
+  assert.equal(writer.forgetHoleCardAcknowledgement(tableId), true);
+  assert.equal((await writer.writeMutation({ tableId, expectedVersion: 7, nextState: changedCards })).ok, true);
+  assert.equal(holeCardInserts.length, 3);
+
+  const nextHand = { ...changedCards, handId: "hand_ack_2" };
+  assert.equal((await writer.writeMutation({ tableId, expectedVersion: 8, nextState: nextHand })).ok, true);
+  assert.equal(holeCardInserts.length, 4);
 });
 
 test("persisted state writer persists hole cards from real WS bootstrap private audit state when public state is sanitized", async () => {
@@ -331,18 +385,24 @@ test("persisted state writer persists hole cards from real WS rollover private a
 
 test("persisted state writer logs hole card persistence failures without failing gameplay or leaking cards", async () => {
   const logs = [];
+  let stateVersion = 4;
+  let holeCardAttempts = 0;
   const writer = createPersistedStateWriter({
     env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
     beginSql: async (fn) => fn({
       unsafe: async (query) => {
         const text = String(query);
         if (text.startsWith("update public.poker_state set version = version + 1")) {
-          return [{ version: 5 }];
+          stateVersion += 1;
+          return [{ version: stateVersion }];
         }
         if (text.startsWith("insert into public.poker_hole_cards")) {
-          const error = new Error("driver leaked AS KD");
-          error.code = "23505";
-          throw error;
+          holeCardAttempts += 1;
+          if (holeCardAttempts === 1) {
+            const error = new Error("driver leaked AS KD");
+            error.code = "23505";
+            throw error;
+          }
         }
         return [];
       }
@@ -350,7 +410,7 @@ test("persisted state writer logs hole card persistence failures without failing
     klog: (kind, payload) => logs.push({ kind, payload })
   });
 
-  const result = await writer.writeMutation({
+  const mutation = {
     tableId: "00000000-0000-4000-8000-000000000003",
     expectedVersion: 4,
     nextState: {
@@ -363,10 +423,14 @@ test("persisted state writer logs hole card persistence failures without failing
       },
       deck: ["3H"]
     }
-  });
+  };
+  const result = await writer.writeMutation(mutation);
+  const retry = await writer.writeMutation({ ...mutation, expectedVersion: 5 });
 
   assert.deepEqual(result, { ok: true, newVersion: 5 });
-  assert.deepEqual(logs, [{
+  assert.deepEqual(retry, { ok: true, newVersion: 6 });
+  assert.equal(holeCardAttempts, 2);
+  assert.deepEqual(logs.filter((entry) => entry.kind === "ws_hole_cards_persist_failed"), [{
     kind: "ws_hole_cards_persist_failed",
     payload: {
       tableId: "00000000-0000-4000-8000-000000000003",
@@ -375,6 +439,7 @@ test("persisted state writer logs hole card persistence failures without failing
       reason: "23505"
     }
   }]);
+  assert.equal(logs.filter((entry) => entry.kind === "ws_hole_cards_persist_written").length, 1);
   const serializedLogs = JSON.stringify(logs);
   assert.equal(serializedLogs.includes("AS"), false);
   assert.equal(serializedLogs.includes("KD"), false);

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 import { writePersistedTableToFile } from "./persisted-state-file-store.mjs";
@@ -167,8 +168,13 @@ function buildHoleCardRows(state) {
       userId: normalizeAuditString(userId),
       cards: normalizeCardList(cards)
     }))
-    .filter((entry) => entry.userId && entry.cards.length === 2);
+    .filter((entry) => entry.userId && entry.cards.length === 2)
+    .sort((left, right) => left.userId.localeCompare(right.userId));
   return { handId, rows };
+}
+
+function buildHoleCardFingerprint(rows) {
+  return createHash("sha256").update(JSON.stringify(rows)).digest("hex");
 }
 
 function safeHoleCardPersistReason(error) {
@@ -414,7 +420,7 @@ async function maybeWriteAcceptedActionAudit({ tx, tableId, stateVersion, state,
   return { ok: true };
 }
 
-async function maybeWriteHoleCards({ tx, tableId, state, klog = () => {} }) {
+async function maybeWriteHoleCards({ tx, tableId, state, acknowledgement = null, klog = () => {} }) {
   const { handId, rows } = buildHoleCardRows(state);
   if (!tableId || !handId || rows.length === 0) {
     if (tableId || handId) {
@@ -429,6 +435,10 @@ async function maybeWriteHoleCards({ tx, tableId, state, klog = () => {} }) {
     }
     return { ok: true, skipped: true };
   }
+  const fingerprint = buildHoleCardFingerprint(rows);
+  if (acknowledgement?.handId === handId && acknowledgement?.fingerprint === fingerprint) {
+    return { ok: true, skipped: true, acknowledged: true };
+  }
   const placeholders = rows.map((_, index) => `($${index * 4 + 1}, $${index * 4 + 2}, $${index * 4 + 3}, $${index * 4 + 4}::jsonb)`).join(", ");
   const params = rows.flatMap((entry) => [tableId, handId, entry.userId, JSON.stringify(entry.cards)]);
   await tx.unsafe(
@@ -440,7 +450,11 @@ async function maybeWriteHoleCards({ tx, tableId, state, klog = () => {} }) {
     handId,
     playerCount: rows.length
   });
-  return { ok: true, playerCount: rows.length };
+  return {
+    ok: true,
+    playerCount: rows.length,
+    acknowledgement: { handId, fingerprint }
+  };
 }
 
 function normalizeReplacementFundings({ replacementFundings, tableId, expectedVersion }) {
@@ -602,6 +616,8 @@ async function writeReplacementFundings({ tx, tableId, fundings, botFundingSyste
 }
 
 export function createPersistedStateWriter({ env = process.env, beginSql = beginSqlWs, klog = () => {} } = {}) {
+  const holeCardAcknowledgementByTableId = new Map();
+
   async function writeViaDb({
     tableId,
     expectedVersion,
@@ -613,7 +629,8 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     botFundingSystemKey = null,
     durableActionPlan
   }) {
-    return beginSql(async (tx) => {
+    let successfulHoleCardWrite = null;
+    const result = await beginSql(async (tx) => {
       const persistedState = sanitizePersistedState(nextState);
       const holeCardState = normalizeJsonState(privateStateForHoleCards) || {};
       const payload = JSON.stringify(persistedState);
@@ -641,7 +658,14 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         });
         await tx.unsafe("update public.poker_tables set last_activity_at = now() where id = $1;", [tableId]);
         try {
-          await maybeWriteHoleCards({ tx, tableId, state: holeCardState, klog });
+          const holeCardResult = await maybeWriteHoleCards({
+            tx,
+            tableId,
+            state: holeCardState,
+            acknowledgement: holeCardAcknowledgementByTableId.get(tableId),
+            klog
+          });
+          successfulHoleCardWrite = holeCardResult.acknowledgement || null;
         } catch (error) {
           const { handId, rows } = buildHoleCardRows(holeCardState);
           klog("ws_hole_cards_persist_failed", {
@@ -711,7 +735,14 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
       const equalState = stableStringify(currentState) === stableStringify(sanitizePersistedState(nextState));
       if (equalState) {
         try {
-          await maybeWriteHoleCards({ tx, tableId, state: holeCardState, klog });
+          const holeCardResult = await maybeWriteHoleCards({
+            tx,
+            tableId,
+            state: holeCardState,
+            acknowledgement: holeCardAcknowledgementByTableId.get(tableId),
+            klog
+          });
+          successfulHoleCardWrite = holeCardResult.acknowledgement || null;
         } catch (error) {
           const { handId, rows } = buildHoleCardRows(holeCardState);
           klog("ws_hole_cards_persist_failed", {
@@ -746,6 +777,14 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
       }
       return { ok: false, reason: "conflict", currentVersion: Number.isInteger(currentVersion) ? currentVersion : null };
     }, { env });
+    if (successfulHoleCardWrite) {
+      holeCardAcknowledgementByTableId.set(tableId, successfulHoleCardWrite);
+    }
+    return result;
+  }
+
+  function forgetHoleCardAcknowledgement(tableId) {
+    return holeCardAcknowledgementByTableId.delete(tableId);
   }
 
   async function writeMutation({
@@ -863,5 +902,5 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     }
   }
 
-  return { writeMutation, readDurableActionRequest };
+  return { writeMutation, readDurableActionRequest, forgetHoleCardAcknowledgement };
 }

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -670,7 +670,11 @@ test("persistedPokerState keeps runtime private cards available for autoplay", (
 });
 
 test("evictTable removes restored runtime table state", () => {
-  const tableManager = createTableManager({ maxSeats: 6 });
+  const evictedTableIds = [];
+  const tableManager = createTableManager({
+    maxSeats: 6,
+    onTableEvicted: (tableId) => evictedTableIds.push(tableId)
+  });
   const tableId = "table_evict_runtime";
 
   const restored = tableManager.restoreTableFromPersisted(tableId, {
@@ -701,6 +705,23 @@ test("evictTable removes restored runtime table state", () => {
   assert.equal(tableManager.evictTable(tableId).existed, true);
   assert.equal(tableManager.listTableIds().includes(tableId), false);
   assert.deepEqual(tableManager.tableState(tableId), { tableId, members: [] });
+  assert.deepEqual(evictedTableIds, [tableId]);
+});
+
+test("normal empty-table removal uses the eviction lifecycle callback", () => {
+  const evictedTableIds = [];
+  const tableManager = createTableManager({
+    maxSeats: 2,
+    presenceTtlMs: 0,
+    onTableEvicted: (tableId) => evictedTableIds.push(tableId)
+  });
+  const tableId = "table_normal_eviction";
+  const ws = fakeWs("ws-normal-eviction");
+
+  assert.equal(tableManager.join({ ws, userId: "user_1", tableId, requestId: "join-1", nowTs: 100 }).ok, true);
+  assert.equal(tableManager.leave({ ws, userId: "user_1", tableId, requestId: "leave-1" }).ok, true);
+  assert.equal(tableManager.listTableIds().includes(tableId), false);
+  assert.deepEqual(evictedTableIds, [tableId]);
 });
 
 test("table manager exposes connected members as sorted {userId, seat} and reuses freed seats", () => {

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -283,6 +283,7 @@ export function createTableManager({
   publicProfileFreshMs = DEFAULT_PUBLIC_PROFILE_FRESH_MS,
   publicProfileTimeoutMs = DEFAULT_PUBLIC_PROFILE_TIMEOUT_MS,
   publicProfileLog = null,
+  onTableEvicted = null,
   observeOnlyJoin = false,
   enableDebugCore = false,
   nodeEnv = process.env.NODE_ENV
@@ -1513,7 +1514,7 @@ export function createTableManager({
     }
 
     if (table.coreState.members.length === 0 && table.subscribers.size === 0) {
-      tables.delete(resolvedTableId);
+      evictTable(resolvedTableId);
     }
 
     return {
@@ -1788,7 +1789,7 @@ export function createTableManager({
     }
 
     if (table.coreState.members.length === 0 && table.subscribers.size === 0) {
-      tables.delete(resolvedTableId);
+      evictTable(resolvedTableId);
     }
 
     const nextMembersJson = JSON.stringify(nextMembers);
@@ -1896,7 +1897,7 @@ export function createTableManager({
         }
 
         if (table.coreState.members.length === 0 && table.subscribers.size === 0) {
-          tables.delete(joinedTableId);
+          evictTable(joinedTableId);
         }
       }
 
@@ -1914,7 +1915,7 @@ export function createTableManager({
         table.subscribers.delete(ws);
         shouldEmitUpdate = persistedPokerState(subscribedTableId)?.phase === "SETTLED";
         if (table.coreState.members.length === 0 && table.subscribers.size === 0) {
-          tables.delete(subscribedTableId);
+          evictTable(subscribedTableId);
         }
       }
       conn.subscribedTableId = null;
@@ -1940,7 +1941,7 @@ export function createTableManager({
         table.presenceByUserId.delete(userId);
       }
       if (table.coreState.members.length === 0 && table.subscribers.size === 0) {
-        tables.delete(tableId);
+        evictTable(tableId);
       }
     }
     return updates;
@@ -2030,6 +2031,9 @@ export function createTableManager({
 
   function evictTable(tableId) {
     const existed = tables.delete(tableId);
+    if (typeof onTableEvicted === "function") {
+      onTableEvicted(tableId);
+    }
     return { ok: true, existed };
   }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -238,6 +238,7 @@ function createPublicProfileLoader({ env = process.env } = {}) {
 
 const loadPersistedTableBootstrap = persistedBootstrapEnabled ? createPersistedBootstrapLoader() : null;
 const loadPublicProfiles = hasSupabaseDbUrl ? createPublicProfileLoader() : null;
+let persistedStateWriter = null;
 
 const tableManager = createTableManager({
   presenceTtlMs: resolvePresenceTtlMs(process.env.WS_PRESENCE_TTL_MS),
@@ -247,6 +248,7 @@ const tableManager = createTableManager({
   publicProfileLoader: loadPublicProfiles,
   publicProfileStorageBaseUrl,
   publicProfileLog: klogSafe,
+  onTableEvicted: (tableId) => persistedStateWriter?.forgetHoleCardAcknowledgement(tableId),
   observeOnlyJoin: observeOnlyJoinEnabled
 });
 const tableCommandQueue = createTableCommandQueue({
@@ -274,7 +276,7 @@ const persistedSeatTouchThrottleMs = resolvePositiveInt(
 );
 const streamLog = createStreamLog({ cap: Number(process.env.WS_STREAM_REPLAY_CAP || 128) });
 const tableSnapshotLoader = createTableSnapshotLoader({ env: process.env });
-const persistedStateWriter = persistedStateWriteEnabled ? createPersistedStateWriter({ env: process.env, klog: klogSafe }) : null;
+persistedStateWriter = persistedStateWriteEnabled ? createPersistedStateWriter({ env: process.env, klog: klogSafe }) : null;
 const durableActionStore = hasSupabaseDbUrl && persistedStateWriter?.readDurableActionRequest
   ? persistedStateWriter
   : null;
@@ -1397,6 +1399,7 @@ async function restoreTableFromPersisted(tableId) {
     if (!restored?.ok || !restored?.table) {
       return { ok: false, reason: restored?.code || "restore_failed" };
     }
+    persistedStateWriter?.forgetHoleCardAcknowledgement(tableId);
     const applied = tableManager.restoreTableFromPersisted(tableId, restored.table);
     klogSafe("ws_restore_apply_result", { ok: applied?.ok === true });
     if (!applied?.ok) {


### PR DESCRIPTION
## Summary

- record a process-local SHA-256 acknowledgement only after the hole-card transaction commits
- skip identical normalized hole-card UPSERTs for the same table and hand
- clear acknowledgements on restore, terminal eviction, and normal runtime table removal
- preserve fresh writes after failure, restart, new hand, or changed private-card fingerprint

## Query impact

The existing deterministic harness now proves that an initial successful mutation followed by an equal-state replay performs one `poker_hole_cards` UPSERT instead of two. Normal play should perform approximately one hole-card UPSERT per hand per WS process rather than one per persisted mutation.

## Safety and breaking impact

Risk is high because private cards support restart recovery. The acknowledgement is therefore stored only after the enclosing DB transaction resolves successfully. Failed writes are retried, process restart begins without acknowledgements, restore clears the table entry before applying restored runtime, and every runtime deletion path uses the existing `evictTable()` lifecycle.

No intended protocol or gameplay breaking impact. An incorrect acknowledgement could make private-card recovery incomplete; the implementation limits this risk to an exact normalized table/hand/user/card fingerprint and keeps the existing idempotent UPSERT as the fallback.

No private cards or complete private state are logged. No schema, RLS, settlement, ledger, state-version, browser JavaScript, CSS, or CSP behavior changes.

## Verification

- `npm run syntax`
- `node --test ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs ws-server/poker/table/table-manager.behavior.test.mjs` (105/105)
- `node --test ws-server/server.behavior.test.mjs ws-server/poker/table/table-manager.leave-restore.behavior.test.mjs ws-server/poker/runtime/persist-conflict-recovery.behavior.test.mjs` (100/100)
- `npm test`
- `git diff --check`

Manual **WS Preview Deploy** for the exact PR SHA is required before E2E preview verification because this PR changes `ws-server/**`.

Refs #742