### PR TITLE
db(poker): enforce audit uniqueness

### DIFF
--- a/supabase/migrations/20260724212000_poker_actions_audit_uniqueness.sql
+++ b/supabase/migrations/20260724212000_poker_actions_audit_uniqueness.sql
@@ -1,0 +1,11 @@
+create unique index poker_actions_accepted_request_id_key
+  on public.poker_actions (table_id, request_id)
+  where request_id is not null
+    and btrim(request_id) <> ''
+    and action_type in ('FOLD', 'CHECK', 'CALL', 'BET', 'RAISE', 'ALL_IN');
+
+create unique index poker_actions_hand_settled_hand_id_key
+  on public.poker_actions (table_id, hand_id)
+  where hand_id is not null
+    and btrim(hand_id) <> ''
+    and action_type = 'HAND_SETTLED';


### PR DESCRIPTION
## Summary

- add a partial unique index for accepted poker actions on `(table_id, request_id)`
- add a partial unique index for settlement audits on `(table_id, hand_id)`
- keep technical/admin actions outside the accepted-action predicate
- fail closed if duplicates appear; this migration performs no data repair or deletion

## Exact predicates

Accepted-action uniqueness applies only when `request_id IS NOT NULL`, `btrim(request_id) <> '\`, and `action_type IN ('FOLD', 'CHECK', 'CALL', 'BET', 'RAISE', 'ALL_IN')`.

Settlement uniqueness applies only when `hand_id IS NOT NULL`, `btrim(hand_id) <> '\`, and `action_type = 'HAND_SETTLED'`.

These predicates are the required conflict targets for the follow-up runtime PR F2. This PR intentionally does not change the current `SELECT -> INSERT` writer.

## Read-only preflight

Preflight was run against distinct Supabase stage and production projects on current main before implementation:

- stage: 1,864 accepted rows, 78 settlement rows
- production: 184 accepted rows, 20 settlement rows
- zero duplicate accepted identities
- zero duplicate settlement identities
- zero accepted rows with null request IDs
- zero settlement rows with null hand IDs
- zero mixed accepted/non-accepted request-ID collision groups
- neither environment currently has these unique indexes

## Risk and breaking impact

Risk is high because an incorrect predicate could reject legitimate audit history. The indexes are deliberately partial and match the current accepted-action set exactly.

Potential breaking impact: migration application will fail if duplicates are introduced after preflight. That is intentional. The migration does not delete, deduplicate, or choose historical rows automatically.

Until F2 is deployed, a concurrent replay can still cause the losing `SELECT -> INSERT` writer to observe a unique violation and emit a best-effort audit failure. F2 must follow after these indexes are deployed and verified in every target environment.

## Rollout

- the repository PR workflow applies migration changes to shared stage and must verify both indexes are valid/ready
- production rollout occurs separately after merge and must verify the exact index definitions
- no WS Preview Deploy is required because this PR changes only a database migration
- do not deploy F2 runtime code before both target environments have these indexes

## Verification

- `node scripts/check-db-migrations.mjs` — 37 migration files validated
- `node --test tests/db-stage-workflows.guard.test.mjs` — 4/4 passing
- `git diff --check`

Refs #742