### PR TITLE
perf(poker): make audit inserts conflict safe

### DIFF
--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -462,9 +462,6 @@ test("persisted state writer appends accepted human action audit row", async () 
         if (text === "update public.poker_tables set last_activity_at = now() where id = $1;") {
           return [];
         }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and request_id = $2")) {
-          return [];
-        }
         if (text.startsWith("insert into public.poker_actions")) {
           return [{ id: 100 }];
         }
@@ -513,6 +510,11 @@ test("persisted state writer appends accepted human action audit row", async () 
   assert.deepEqual(result, { ok: true, newVersion: 8 });
   const actionInsert = queries.find((entry) => entry.query.startsWith("insert into public.poker_actions"));
   assert.ok(actionInsert);
+  assert.match(actionInsert.query, /on conflict \(table_id, request_id\)/);
+  assert.match(actionInsert.query, /btrim\(request_id\) <> ''/);
+  assert.match(actionInsert.query, /action_type in \('FOLD', 'CHECK', 'CALL', 'BET', 'RAISE', 'ALL_IN'\)/);
+  assert.match(actionInsert.query, /do nothing\s+returning id/);
+  assert.equal(queries.some((entry) => entry.query.startsWith("select id from public.poker_actions")), false);
   assert.equal(actionInsert.params[0], "t_action");
   assert.equal(actionInsert.params[1], 8);
   assert.equal(actionInsert.params[2], "u2");
@@ -548,11 +550,12 @@ test("persisted state writer appends accepted human action audit row", async () 
   assert.equal(JSON.stringify(meta).includes("AD"), false);
 });
 
-test("persisted state writer dedupes replayed accepted action audit by request_id", async () => {
+test("persisted state writer atomically dedupes concurrent accepted action audit replay", async () => {
   let stateVersion = 7;
   let currentState = null;
   let actionExists = false;
   const queries = [];
+  const logs = [];
   const writer = createPersistedStateWriter({
     env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
     beginSql: async (fn) => fn({
@@ -573,17 +576,15 @@ test("persisted state writer dedupes replayed accepted action audit by request_i
         if (text.startsWith("select version, state from public.poker_state where table_id = $1 limit 1;")) {
           return [{ version: stateVersion, state: currentState }];
         }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and request_id = $2")) {
-          return actionExists ? [{ id: 1 }] : [];
-        }
         if (text.startsWith("insert into public.poker_actions")) {
+          if (actionExists) return [];
           actionExists = true;
           return [{ id: 1 }];
         }
         return [];
       }
     }),
-    klog: () => {}
+    klog: (kind, payload) => logs.push({ kind, payload })
   });
 
   const nextState = { tableId: "t_action", handId: "hand_action", phase: "FLOP", potTotal: 12, stacks: { u2: 94 } };
@@ -597,12 +598,17 @@ test("persisted state writer dedupes replayed accepted action audit by request_i
     phaseTo: "FLOP"
   };
 
-  const first = await writer.writeMutation({ tableId: "t_action", expectedVersion: 7, nextState, acceptedActionAudit });
-  const second = await writer.writeMutation({ tableId: "t_action", expectedVersion: 7, nextState, acceptedActionAudit });
+  const [first, second] = await Promise.all([
+    writer.writeMutation({ tableId: "t_action", expectedVersion: 7, nextState, acceptedActionAudit }),
+    writer.writeMutation({ tableId: "t_action", expectedVersion: 7, nextState, acceptedActionAudit })
+  ]);
 
   assert.deepEqual(first, { ok: true, newVersion: 8 });
   assert.deepEqual(second, { ok: true, newVersion: 8, alreadyApplied: true });
-  assert.equal(queries.filter((entry) => entry.query.startsWith("insert into public.poker_actions")).length, 1);
+  assert.equal(queries.filter((entry) => entry.query.startsWith("select id from public.poker_actions")).length, 0);
+  assert.equal(queries.filter((entry) => entry.query.startsWith("insert into public.poker_actions")).length, 2);
+  assert.equal(logs.filter((entry) => entry.kind === "ws_accepted_action_audit_written").length, 1);
+  assert.equal(logs.filter((entry) => entry.kind === "ws_accepted_action_audit_failed").length, 0);
 });
 
 test("persisted state writer logs accepted action audit failures without private hole cards", async () => {
@@ -616,9 +622,6 @@ test("persisted state writer logs accepted action audit failures without private
           return [{ version: 8 }];
         }
         if (text === "update public.poker_tables set last_activity_at = now() where id = $1;") {
-          return [];
-        }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and request_id = $2")) {
           return [];
         }
         if (text.startsWith("insert into public.poker_actions")) {
@@ -676,9 +679,6 @@ test("persisted state writer appends exactly one HAND_SETTLED audit event with s
         if (text === "update public.poker_tables set last_activity_at = now() where id = $1;") {
           return [];
         }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = $3")) {
-          return [];
-        }
         if (text.startsWith("insert into public.poker_actions")) {
           return [{ id: 99 }];
         }
@@ -722,6 +722,11 @@ test("persisted state writer appends exactly one HAND_SETTLED audit event with s
   assert.deepEqual(result, { ok: true, newVersion: 5 });
   const auditInsert = queries.find((entry) => entry.query.startsWith("insert into public.poker_actions"));
   assert.ok(auditInsert);
+  assert.match(auditInsert.query, /on conflict \(table_id, hand_id\)/);
+  assert.match(auditInsert.query, /btrim\(hand_id\) <> ''/);
+  assert.match(auditInsert.query, /action_type = 'HAND_SETTLED'/);
+  assert.match(auditInsert.query, /do nothing\s+returning id/);
+  assert.equal(queries.some((entry) => entry.query.startsWith("select id from public.poker_actions")), false);
   assert.equal(auditInsert.params[3], "HAND_SETTLED");
   const auditMeta = JSON.parse(auditInsert.params[9]);
   assert.deepEqual(auditMeta, {
@@ -741,11 +746,12 @@ test("persisted state writer appends exactly one HAND_SETTLED audit event with s
   });
 });
 
-test("persisted state writer does not duplicate HAND_SETTLED audit on replayed settlement write", async () => {
+test("persisted state writer atomically dedupes concurrent HAND_SETTLED audit replay", async () => {
   let stateVersion = 4;
   let currentState = null;
   let auditExists = false;
   const queries = [];
+  const logs = [];
   const writer = createPersistedStateWriter({
     env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
     beginSql: async (fn) => fn({
@@ -766,17 +772,15 @@ test("persisted state writer does not duplicate HAND_SETTLED audit on replayed s
         if (text.startsWith("select version, state from public.poker_state where table_id = $1 limit 1;")) {
           return [{ version: stateVersion, state: currentState }];
         }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = $3")) {
-          return auditExists ? [{ id: 1 }] : [];
-        }
         if (text.startsWith("insert into public.poker_actions")) {
+          if (auditExists) return [];
           auditExists = true;
           return [{ id: 1 }];
         }
         return [];
       }
     }),
-    klog: () => {}
+    klog: (kind, payload) => logs.push({ kind, payload })
   });
 
   const nextState = {
@@ -790,12 +794,17 @@ test("persisted state writer does not duplicate HAND_SETTLED audit on replayed s
     showdown: { reason: "all_folded", winners: ["u1"], potsAwarded: [{ amount: 10, winners: ["u1"], eligibleUserIds: ["u1"] }] }
   };
 
-  const first = await writer.writeMutation({ tableId: "t_settled", expectedVersion: 4, nextState });
-  const second = await writer.writeMutation({ tableId: "t_settled", expectedVersion: 4, nextState });
+  const [first, second] = await Promise.all([
+    writer.writeMutation({ tableId: "t_settled", expectedVersion: 4, nextState }),
+    writer.writeMutation({ tableId: "t_settled", expectedVersion: 4, nextState })
+  ]);
 
   assert.deepEqual(first, { ok: true, newVersion: 5 });
   assert.deepEqual(second, { ok: true, newVersion: 5, alreadyApplied: true });
-  assert.equal(queries.filter((entry) => entry.query.startsWith("insert into public.poker_actions")).length, 1);
+  assert.equal(queries.filter((entry) => entry.query.startsWith("select id from public.poker_actions")).length, 0);
+  assert.equal(queries.filter((entry) => entry.query.startsWith("insert into public.poker_actions")).length, 2);
+  assert.equal(logs.filter((entry) => entry.kind === "ws_hand_settlement_audit_written").length, 1);
+  assert.equal(logs.filter((entry) => entry.kind === "ws_hand_settlement_audit_failed").length, 0);
 });
 
 test("persisted state writer logs settlement audit failures without private hole cards", async () => {
@@ -809,9 +818,6 @@ test("persisted state writer logs settlement audit failures without private hole
           return [{ version: 5 }];
         }
         if (text === "update public.poker_tables set last_activity_at = now() where id = $1;") {
-          return [];
-        }
-        if (text.startsWith("select id from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = $3")) {
           return [];
         }
         if (text.startsWith("insert into public.poker_actions")) {

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -350,15 +350,15 @@ async function maybeWriteSettlementAudit({ tx, tableId, stateVersion, state, klo
   if (!auditMeta) {
     return { ok: true, skipped: true };
   }
-  const existingRows = await tx.unsafe(
-    "select id from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = $3 limit 1;",
-    [tableId, auditMeta.handId, HAND_SETTLED_ACTION_TYPE]
-  );
-  if (existingRows?.[0]?.id) {
-    return { ok: true, skipped: true, alreadyApplied: true };
-  }
-  await tx.unsafe(
-    "insert into public.poker_actions (table_id, version, user_id, action_type, amount, hand_id, request_id, phase_from, phase_to, meta) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb);",
+  const insertedRows = await tx.unsafe(
+    `insert into public.poker_actions (table_id, version, user_id, action_type, amount, hand_id, request_id, phase_from, phase_to, meta)
+     values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+     on conflict (table_id, hand_id)
+       where hand_id is not null
+         and btrim(hand_id) <> ''
+         and action_type = 'HAND_SETTLED'
+     do nothing
+     returning id;`,
     [
       tableId,
       stateVersion,
@@ -372,6 +372,9 @@ async function maybeWriteSettlementAudit({ tx, tableId, stateVersion, state, klo
       JSON.stringify(auditMeta)
     ]
   );
+  if (!insertedRows?.[0]?.id) {
+    return { ok: true, skipped: true, alreadyApplied: true };
+  }
   klog("ws_hand_settlement_audit_written", {
     tableId,
     handId: auditMeta.handId,
@@ -387,16 +390,15 @@ async function maybeWriteAcceptedActionAudit({ tx, tableId, stateVersion, state,
     return { ok: true, skipped: true };
   }
 
-  const existingRows = await tx.unsafe(
-    "select id from public.poker_actions where table_id = $1 and request_id = $2 limit 1;",
-    [tableId, audit.requestId]
-  );
-  if (existingRows?.[0]?.id) {
-    return { ok: true, skipped: true, alreadyApplied: true };
-  }
-
-  await tx.unsafe(
-    "insert into public.poker_actions (table_id, version, user_id, action_type, amount, hand_id, request_id, phase_from, phase_to, meta) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb);",
+  const insertedRows = await tx.unsafe(
+    `insert into public.poker_actions (table_id, version, user_id, action_type, amount, hand_id, request_id, phase_from, phase_to, meta)
+     values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+     on conflict (table_id, request_id)
+       where request_id is not null
+         and btrim(request_id) <> ''
+         and action_type in ('FOLD', 'CHECK', 'CALL', 'BET', 'RAISE', 'ALL_IN')
+     do nothing
+     returning id;`,
     [
       audit.tableId,
       audit.version,
@@ -410,6 +412,9 @@ async function maybeWriteAcceptedActionAudit({ tx, tableId, stateVersion, state,
       JSON.stringify(audit.meta)
     ]
   );
+  if (!insertedRows?.[0]?.id) {
+    return { ok: true, skipped: true, alreadyApplied: true };
+  }
   klog("ws_accepted_action_audit_written", {
     tableId,
     handId: audit.handId,


### PR DESCRIPTION
## Summary

- replace accepted-action audit `SELECT -> INSERT` with one atomic `INSERT ... ON CONFLICT DO NOTHING RETURNING id`
- replace settlement audit `SELECT -> INSERT` with the matching atomic insert
- emit `ws_accepted_action_audit_written` and `ws_hand_settlement_audit_written` only when PostgreSQL actually inserts a row
- treat concurrent/replayed audit conflicts as successful no-ops without failure logs

## F1 dependency

PR #755 is merged and both partial unique indexes have been verified on stage and production. PostgreSQL `EXPLAIN` against both environments confirms that the exact conflict targets in this PR infer the deployed indexes.

The runtime predicates exactly match F1:

- accepted actions: non-null, non-blank `request_id` and `FOLD/CHECK/CALL/BET/RAISE/ALL_IN`
- settlement: non-null, non-blank `hand_id` and `HAND_SETTLED`

## Query impact

- first accepted-action audit: 2 statements -> 1
- accepted-action replay: 1 SELECT -> 1 conflict-safe INSERT no-op
- first settlement audit: 2 statements -> 1
- settlement replay: 1 SELECT -> 1 conflict-safe INSERT no-op

The main reduction is one SQL statement for every newly written accepted-action and settlement audit. Concurrent replay no longer produces a unique-violation failure log.

## Safety and breaking impact

No intended protocol, gameplay, persistence ordering, settlement, ledger, stack, or audit-metadata behavior changes. Audit writes remain best-effort relative to gameplay persistence.

Potential breaking impact: deploying this runtime to a database without the exact F1 indexes causes PostgreSQL conflict-target inference to fail. Both stage and production were verified before this PR; rollback is to restore the previous pre-read writer while leaving the F1 indexes in place.

No private cards, full state, or secrets are logged.

## Verification

- `node --test ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs` — 21/21
- concurrent accepted-action replay: two attempts, one insert result, one written log, zero failure logs
- concurrent settlement replay: two attempts, one insert result, one written log, zero failure logs
- `node --test ws-server/server.behavior.test.mjs ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs` — 131/131
- PostgreSQL read-only `EXPLAIN` for both conflict targets on stage and production — PASS
- `npm test` — PASS
- `npm run syntax` — PASS
- `git diff --check` — PASS

Manual **WS Preview Deploy** for the exact PR SHA is required before E2E preview verification because this PR changes `ws-server/**`.

Refs #742