### PR TITLE
fix(ws): terminate unresponsive poker sockets

### DIFF
--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -167,6 +167,7 @@ The preview VPS contract is:
 - Supabase target: `SUPABASE_STAGE_PROJECT_REF` must be set, and `SUPABASE_URL` plus `SUPABASE_DB_URL` must target that same stage project ref
 - Internal admin token: `POKER_WS_INTERNAL_TOKEN` must be a long preview-only secret shared only with the deploy-preview-scoped Netlify Function configuration
 - Optional close grace: `POKER_TABLE_CLOSE_GRACE_MS=60000` keeps newly created empty tables open for 60s before cleanup may close them
+- Optional transport watchdog timeout: `WS_TRANSPORT_PONG_TIMEOUT_MS=60000` waits for one outstanding WebSocket control-ping acknowledgement before terminating an unresponsive socket through the existing close/reconnect lifecycle. The accepted range is 30–300 seconds.
 
 Preview deploys unpack into a temporary directory under `/tmp/arcadeplatform-ws-preview` and then sync the extracted files into `/opt/arcade-ws-preview/ws-server`.
 The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n bash -c 'true'` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`. Do not use `sudo -n -v` as the local smoke check here: it can still require a password when the same user has both normal passworded sudo rules and command-specific `NOPASSWD` rules.

--- a/ws-server/poker/runtime/conn-state.mjs
+++ b/ws-server/poker/runtime/conn-state.mjs
@@ -11,6 +11,8 @@ export function createConnState(nowTs = () => new Date().toISOString()) {
     negotiatedVersion: PROTOCOL_VERSION,
     protocolViolations: [],
     userId: null,
+    pendingTransportPingSentAtMs: null,
+    transportTerminationStarted: false,
     session: createSession({ sessionId, nowTs })
   };
 }

--- a/ws-server/poker/runtime/transport-watchdog.mjs
+++ b/ws-server/poker/runtime/transport-watchdog.mjs
@@ -1,0 +1,64 @@
+function normalizeNowMs(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function normalizeTimeoutMs(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
+}
+
+export function acknowledgeTransportEvidence(connState) {
+  if (!connState || connState.transportTerminationStarted === true) {
+    return false;
+  }
+  connState.pendingTransportPingSentAtMs = null;
+  return true;
+}
+
+export function beginTransportTermination(connState) {
+  if (!connState || connState.transportTerminationStarted === true) {
+    return false;
+  }
+  connState.transportTerminationStarted = true;
+  return true;
+}
+
+export function decideTransportWatchdogAction(connState, {
+  nowMs = Date.now(),
+  timeoutMs = 60_000
+} = {}) {
+  if (!connState || connState.transportTerminationStarted === true) {
+    return { action: "noop", reason: "termination_started" };
+  }
+
+  const normalizedNowMs = normalizeNowMs(nowMs);
+  const rawPendingAtMs = connState.pendingTransportPingSentAtMs;
+  const pendingAtMs = Number(rawPendingAtMs);
+  if (rawPendingAtMs == null || !Number.isFinite(pendingAtMs)) {
+    return { action: "ping", nowMs: normalizedNowMs };
+  }
+
+  const ageMs = Math.max(0, normalizedNowMs - pendingAtMs);
+  if (ageMs < normalizeTimeoutMs(timeoutMs)) {
+    return { action: "noop", reason: "probe_pending", ageMs };
+  }
+
+  beginTransportTermination(connState);
+  return { action: "terminate", reason: "pong_timeout", ageMs };
+}
+
+export function markTransportPingSent(connState, sentAtMs = Date.now()) {
+  if (
+    !connState
+    || connState.transportTerminationStarted === true
+    || (
+      connState.pendingTransportPingSentAtMs != null
+      && Number.isFinite(Number(connState.pendingTransportPingSentAtMs))
+    )
+  ) {
+    return false;
+  }
+  connState.pendingTransportPingSentAtMs = normalizeNowMs(sentAtMs);
+  return true;
+}

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -11,6 +11,13 @@ import WebSocket from "ws";
 import { makeBotUserId } from "../shared/poker-domain/bots.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "./poker/shared/poker-primitives.mjs";
 import { createDisconnectCleanupRuntime } from "./poker/runtime/disconnect-cleanup.mjs";
+import { createConnState } from "./poker/runtime/conn-state.mjs";
+import {
+  acknowledgeTransportEvidence,
+  beginTransportTermination,
+  decideTransportWatchdogAction,
+  markTransportPingSent
+} from "./poker/runtime/transport-watchdog.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 
@@ -18,6 +25,260 @@ const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
   import.meta.url
 ).href;
+
+test("transport watchdog keeps one pending probe and terminates at the timeout boundary", () => {
+  const connState = createConnState();
+
+  const first = decideTransportWatchdogAction(connState, { nowMs: 1_000, timeoutMs: 60_000 });
+  assert.equal(first.action, "ping");
+  assert.equal(markTransportPingSent(connState, first.nowMs), true);
+
+  const beforeBoundary = decideTransportWatchdogAction(connState, { nowMs: 60_999, timeoutMs: 60_000 });
+  assert.deepEqual(beforeBoundary, { action: "noop", reason: "probe_pending", ageMs: 59_999 });
+  assert.equal(markTransportPingSent(connState, 60_999), false, "a pending probe must not be replaced");
+
+  assert.equal(acknowledgeTransportEvidence(connState), true);
+  assert.equal(connState.pendingTransportPingSentAtMs, null);
+
+  const second = decideTransportWatchdogAction(connState, { nowMs: 61_000, timeoutMs: 60_000 });
+  assert.equal(second.action, "ping");
+  assert.equal(markTransportPingSent(connState, second.nowMs), true);
+
+  const atBoundary = decideTransportWatchdogAction(connState, { nowMs: 121_000, timeoutMs: 60_000 });
+  assert.deepEqual(atBoundary, { action: "terminate", reason: "pong_timeout", ageMs: 60_000 });
+  assert.equal(connState.transportTerminationStarted, true);
+
+  const afterBoundaryState = createConnState();
+  assert.equal(markTransportPingSent(afterBoundaryState, 1_000), true);
+  assert.deepEqual(
+    decideTransportWatchdogAction(afterBoundaryState, { nowMs: 61_001, timeoutMs: 60_000 }),
+    { action: "terminate", reason: "pong_timeout", ageMs: 60_001 }
+  );
+});
+
+test("transport watchdog ignores late pong and message evidence after termination starts", () => {
+  const connState = createConnState();
+  assert.equal(markTransportPingSent(connState, 1_000), true);
+  assert.equal(
+    decideTransportWatchdogAction(connState, { nowMs: 61_001, timeoutMs: 60_000 }).action,
+    "terminate"
+  );
+
+  assert.equal(acknowledgeTransportEvidence(connState), false);
+  assert.equal(connState.pendingTransportPingSentAtMs, 1_000);
+  assert.deepEqual(
+    decideTransportWatchdogAction(connState, { nowMs: 70_000, timeoutMs: 60_000 }),
+    { action: "noop", reason: "termination_started" }
+  );
+  assert.equal(beginTransportTermination(connState), false, "termination must remain idempotent");
+});
+
+test("transport watchdog keeps an auto-pong client connected", async () => {
+  const { port, child } = await createServer({
+    env: {
+      NODE_ENV: "test",
+      WS_TRANSPORT_PONG_TIMEOUT_MS: "75"
+    }
+  });
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    assert.equal(ws.readyState, WebSocket.OPEN);
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "hello",
+      requestId: "req-watchdog-healthy",
+      ts: "2026-02-28T00:00:00Z",
+      payload: { supportedVersions: ["1.0"] }
+    });
+    const helloAck = await nextMessage(ws);
+    assert.equal(helloAck.type, "helloAck");
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("transport watchdog terminates a silent autoPong false client exactly once", async () => {
+  const { port, child } = await createServer({
+    env: {
+      NODE_ENV: "test",
+      WS_TRANSPORT_PONG_TIMEOUT_MS: "75"
+    }
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => {
+    output += String(chunk);
+  });
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port, { autoPong: false });
+    let closeCount = 0;
+    ws.on("close", () => {
+      closeCount += 1;
+    });
+
+    await waitForSocketClose(ws);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    assert.equal(closeCount, 1);
+    assert.equal(
+      output.split("ws_transport_watchdog_terminated").length - 1,
+      1,
+      "one unresponsive socket should emit one terminal watchdog event"
+    );
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("transport watchdog leaves a seat connected when another table socket stays healthy", async () => {
+  const secret = "watchdog-multi-secret";
+  const userId = "watchdog_multi_user";
+  const tableId = "table_watchdog_multi";
+  const fixtures = {
+    [tableId]: {
+      tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+      seatRows: [{ user_id: userId, seat_no: 2, status: "ACTIVE", is_bot: false, stack: 123 }],
+      stateRow: {
+        version: 4,
+        state: {
+          tableId,
+          handId: "hand_watchdog_multi",
+          phase: "PREFLOP",
+          turnUserId: userId,
+          stacks: { [userId]: 123 }
+        }
+      }
+    }
+  };
+  const { port, child } = await createServer({
+    env: {
+      NODE_ENV: "test",
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_TRANSPORT_PONG_TIMEOUT_MS: "500",
+      WS_PRESENCE_TTL_MS: "5000",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
+  try {
+    await waitForListening(child, 5000);
+    const token = makeHs256Jwt({ secret, sub: userId });
+    const staleSocket = await connectClient(port, { autoPong: false });
+    await hello(staleSocket);
+    await auth(staleSocket, token, "auth-watchdog-multi-a");
+    sendFrame(staleSocket, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "join-watchdog-multi-a",
+      ts: "2026-02-28T00:00:02Z",
+      payload: { tableId }
+    });
+    await nextMessageOfType(staleSocket, "commandResult");
+
+    const healthySocket = await connectClient(port);
+    await hello(healthySocket);
+    await auth(healthySocket, token, "auth-watchdog-multi-b");
+    sendFrame(healthySocket, {
+      version: "1.0",
+      type: "resync",
+      requestId: "resync-watchdog-multi-b",
+      ts: "2026-02-28T00:00:03Z",
+      payload: { tableId }
+    });
+    const beforeTermination = await nextMessageOfType(healthySocket, "table_state");
+    assert.deepEqual(beforeTermination.payload.members, [{ userId, seat: 2 }]);
+
+    await waitForSocketClose(staleSocket, 3000);
+
+    sendFrame(healthySocket, {
+      version: "1.0",
+      type: "resync",
+      requestId: "resync-watchdog-multi-after",
+      ts: "2026-02-28T00:00:04Z",
+      payload: { tableId }
+    });
+    const afterTermination = await nextMessageOfType(healthySocket, "table_state");
+    assert.deepEqual(afterTermination.payload.members, [{ userId, seat: 2 }]);
+    assert.equal(afterTermination.payload.stacks[userId], 123);
+    healthySocket.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("transport watchdog allows reconnect within grace with the same seat and stack", async () => {
+  const secret = "watchdog-reconnect-secret";
+  const userId = "watchdog_reconnect_user";
+  const tableId = "table_watchdog_reconnect";
+  const fixtures = {
+    [tableId]: {
+      tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+      seatRows: [{ user_id: userId, seat_no: 3, status: "ACTIVE", is_bot: false, stack: 147 }],
+      stateRow: {
+        version: 6,
+        state: {
+          tableId,
+          handId: "hand_watchdog_reconnect",
+          phase: "PREFLOP",
+          turnUserId: userId,
+          stacks: { [userId]: 147 }
+        }
+      }
+    }
+  };
+  const { port, child } = await createServer({
+    env: {
+      NODE_ENV: "test",
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_TRANSPORT_PONG_TIMEOUT_MS: "500",
+      WS_PRESENCE_TTL_MS: "5000",
+      WS_SEATED_RECONNECT_GRACE_MS: "5000",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
+  try {
+    await waitForListening(child, 5000);
+    const token = makeHs256Jwt({ secret, sub: userId });
+    const staleSocket = await connectClient(port, { autoPong: false });
+    await hello(staleSocket);
+    await auth(staleSocket, token, "auth-watchdog-reconnect-a");
+    sendFrame(staleSocket, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "join-watchdog-reconnect-a",
+      ts: "2026-02-28T00:00:02Z",
+      payload: { tableId }
+    });
+    await nextMessageOfType(staleSocket, "commandResult");
+    await waitForSocketClose(staleSocket, 3000);
+
+    const reconnectedSocket = await connectClient(port);
+    await hello(reconnectedSocket);
+    await auth(reconnectedSocket, token, "auth-watchdog-reconnect-b");
+    sendFrame(reconnectedSocket, {
+      version: "1.0",
+      type: "resync",
+      requestId: "resync-watchdog-reconnect-b",
+      ts: "2026-02-28T00:00:03Z",
+      payload: { tableId }
+    });
+    const reconnectedState = await nextMessageOfType(reconnectedSocket, "table_state");
+    assert.deepEqual(reconnectedState.payload.members, [{ userId, seat: 3 }]);
+    assert.equal(reconnectedState.payload.stacks[userId], 147);
+    reconnectedSocket.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
 
 test("internal bot reaction admin endpoint requires its token and fails closed outside WS Preview", async () => {
   const { port, child } = await createServer({
@@ -138,11 +399,29 @@ function createServer({ env = {} } = {}) {
   });
 }
 
-function connectClient(port) {
+function connectClient(port, options = {}) {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, options);
     ws.once("open", () => resolve(ws));
     ws.once("error", reject);
+  });
+}
+
+function waitForSocketClose(ws, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.CLOSED) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      ws.off("close", onClose);
+      reject(new Error("Timed out waiting for watchdog socket close"));
+    }, timeoutMs);
+    const onClose = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    ws.once("close", onClose);
   });
 }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -9,6 +9,12 @@ import { handleAuth } from "./poker/handlers/auth.mjs";
 import { handleProtectedEcho } from "./poker/handlers/protected-echo.mjs";
 import { verifyToken } from "./poker/auth/verify-token.mjs";
 import { createConnState, HEARTBEAT_MS } from "./poker/runtime/conn-state.mjs";
+import {
+  acknowledgeTransportEvidence,
+  beginTransportTermination,
+  decideTransportWatchdogAction,
+  markTransportPingSent
+} from "./poker/runtime/transport-watchdog.mjs";
 import { ackSessionSeq, touchSession } from "./poker/runtime/session.mjs";
 import { recordProtocolViolation, shouldClose } from "./poker/runtime/conn-guards.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
@@ -436,6 +442,18 @@ function resolvePositiveInt(rawValue, fallback, { min = 1, max = Number.MAX_SAFE
   if (rounded > max) return max;
   return rounded;
 }
+
+const transportPongTimeoutMs = resolvePositiveInt(
+  process.env.WS_TRANSPORT_PONG_TIMEOUT_MS,
+  60_000,
+  {
+    min: process.env.NODE_ENV === "test" ? 25 : HEARTBEAT_MS * 2,
+    max: 5 * 60_000
+  }
+);
+const transportWatchdogSweepMs = process.env.NODE_ENV === "test"
+  ? Math.min(HEARTBEAT_MS, transportPongTimeoutMs)
+  : HEARTBEAT_MS;
 
 const turnTimeoutFailureThreshold = resolvePositiveInt(process.env.WS_TIMEOUT_FAILURE_THRESHOLD, 5, { min: 1, max: 100 });
 const turnTimeoutQuarantineMs = resolvePositiveInt(process.env.WS_TIMEOUT_QUARANTINE_MS, 300_000, {
@@ -2843,6 +2861,7 @@ wss.on("connection", (ws) => {
   ws.__connState = connState;
 
   let messageQueue = Promise.resolve();
+  let connectionCleanupStarted = false;
 
   async function processMessage(msg, isBinary) {
     sweepExpiredSessionsOnly();
@@ -3606,6 +3625,10 @@ wss.on("connection", (ws) => {
   }
 
   ws.on("message", (msg, isBinary) => {
+    if (connState.transportTerminationStarted === true) {
+      return;
+    }
+    acknowledgeTransportEvidence(connState);
     messageQueue = messageQueue
       .then(() => processMessage(msg, isBinary))
       .catch((error) => {
@@ -3627,7 +3650,18 @@ wss.on("connection", (ws) => {
       });
   });
 
-  ws.on("error", (err) => {
+  ws.on("pong", () => {
+    if (connState.transportTerminationStarted === true) {
+      return;
+    }
+    acknowledgeTransportEvidence(connState);
+  });
+
+  const cleanupConnectionOnce = () => {
+    if (connectionCleanupStarted) {
+      return;
+    }
+    connectionCleanupStarted = true;
     lobbySubscribers.delete(ws);
     sessionStore.untrackConnection({ ws, userId: connState.session.userId });
     const cleanupUpdates = tableManager.cleanupConnection({
@@ -3644,28 +3678,75 @@ wss.on("connection", (ws) => {
     }
     sweepExpiredSessionsOnly();
     void sweepDisconnectCleanupAndBroadcast();
+  };
+
+  ws.on("error", (err) => {
+    cleanupConnectionOnce();
     klogSafe("ws_error", { message: err.message });
   });
 
   ws.on("close", () => {
-    lobbySubscribers.delete(ws);
-    sessionStore.untrackConnection({ ws, userId: connState.session.userId });
-    const cleanupUpdates = tableManager.cleanupConnection({
-      ws,
-      userId: connState.session.userId,
-      nowTs: Date.now(),
-      activeSockets: sessionStore.connectionsForUser(connState.session.userId)
-    });
-    for (const update of cleanupUpdates) {
-      broadcastTableState(update.tableId);
-      if (update && update.disconnectedUserId) {
-        enqueueDisconnectCleanupCandidate({ tableId: update.tableId, userId: update.disconnectedUserId });
-      }
-    }
-    sweepExpiredSessionsOnly();
-    void sweepDisconnectCleanupAndBroadcast();
+    cleanupConnectionOnce();
   });
 });
+
+function terminateUnresponsiveTransport(ws, connState, { ageMs, reason }) {
+  klogSafe("ws_transport_watchdog_terminated", {
+    sessionId: connState?.session?.sessionId || connState?.sessionId || null,
+    userId: connState?.session?.userId || null,
+    reason,
+    ageMs,
+    timeoutMs: transportPongTimeoutMs
+  });
+  try {
+    ws.terminate();
+  } catch (error) {
+    klogSafe("ws_transport_watchdog_terminate_failed", {
+      sessionId: connState?.session?.sessionId || connState?.sessionId || null,
+      reason,
+      message: error?.message || "unknown"
+    });
+  }
+}
+
+function sweepTransportWatchdog() {
+  const nowMs = Date.now();
+  for (const ws of wss.clients) {
+    if (ws.readyState !== WebSocket.OPEN) {
+      continue;
+    }
+    const connState = ws.__connState;
+    const decision = decideTransportWatchdogAction(connState, {
+      nowMs,
+      timeoutMs: transportPongTimeoutMs
+    });
+    if (decision.action === "ping") {
+      try {
+        ws.ping();
+        markTransportPingSent(connState, decision.nowMs);
+      } catch (error) {
+        if (beginTransportTermination(connState)) {
+          terminateUnresponsiveTransport(ws, connState, {
+            ageMs: 0,
+            reason: "ping_failed"
+          });
+        }
+      }
+      continue;
+    }
+    if (decision.action === "terminate") {
+      terminateUnresponsiveTransport(ws, connState, {
+        ageMs: decision.ageMs,
+        reason: decision.reason
+      });
+    }
+  }
+}
+
+const transportWatchdogTimer = setInterval(() => {
+  sweepTransportWatchdog();
+}, transportWatchdogSweepMs);
+transportWatchdogTimer.unref();
 
 
 const timeoutSweepIntervalMs = Number(process.env.WS_TIMEOUT_SWEEP_MS || 250);


### PR DESCRIPTION
## Summary
- add a WebSocket control ping/pong watchdog with one outstanding probe and a 60-second default timeout
- terminate unresponsive sockets through the existing disconnect/reconnect lifecycle
- make connection cleanup idempotent across terminate, close, and error events
- document `WS_TRANSPORT_PONG_TIMEOUT_MS`
- add focused behavior coverage for healthy and silent clients, timeout boundaries, late transport evidence, multi-socket presence, and reconnect grace

## Safety and breaking impact
- healthy browser clients continue to use standard automatic control-pong behavior
- unresponsive transports are now terminated after the configured deadline; this is the intended behavior change
- no poker action, settlement, ledger, cashout, terminal-close, heartbeat-message, reconnect-grace, or janitor semantics are changed
- session rebind continues to close the prior socket through the existing stale-session path

## Verification
- `node --test --test-name-pattern="transport watchdog" ws-server/server.behavior.test.mjs` — 6 passed
- focused server/reconnect/runtime/table suites — 219 passed
- `npm run syntax` — passed
- `npm test` — passed
- `git diff --check` — passed

Manual `WS Preview Deploy` for the exact PR SHA is required before runtime smoke verification.

Closes #378