### PR TITLE
fix(ci): prevent WS Preview deploy artifact races

### DIFF
--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -272,13 +272,16 @@ jobs:
                 try {
                   metadata = JSON.parse(fs.readFileSync(metadataFile, "utf8"));
                 } catch {
+                  process.stderr.write(`release metadata missing or invalid: ${metadataFile}\n`);
                   process.exit(1);
                 }
-                if (
-                  metadata?.releaseSha !== expectedSha
-                  || metadata?.deployRef !== expectedRef
-                  || metadata?.environment !== expectedEnvironment
-                ) {
+                const mismatchedFields = [
+                  metadata?.releaseSha !== expectedSha ? "releaseSha" : null,
+                  metadata?.deployRef !== expectedRef ? "deployRef" : null,
+                  metadata?.environment !== expectedEnvironment ? "environment" : null
+                ].filter(Boolean);
+                if (mismatchedFields.length > 0) {
+                  process.stderr.write(`release metadata mismatch: ${mismatchedFields.join(",")}\n`);
                   process.exit(1);
                 }
               ' "$metadata_file" "$RELEASE_SHA" "$DEPLOY_REF" preview
@@ -359,8 +362,9 @@ jobs:
                       } catch {
                         return false;
                       }
-                    });
+                  });
                   if (!matched) {
+                    process.stderr.write("expected ws_artifact_start identity not found\n");
                     process.exit(1);
                   }
                 ' "$RELEASE_SHA" "$DEPLOY_REF" preview

--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: ws-preview-deploy-${{ inputs.ref }}
+  group: ws-preview-deploy
   cancel-in-progress: false
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
       PREVIEW_ARTIFACT_FILE: ${{ github.workspace }}/.artifacts/ws-preview/ws-preview-dist.tgz
       PREVIEW_STAGE_DIR: ${{ github.workspace }}/.artifacts/ws-preview/stage
       PREVIEW_STAGE_WS_DIR: ${{ github.workspace }}/.artifacts/ws-preview/stage/ws-server
-      PREVIEW_REMOTE_TMP_DIR: /tmp/arcadeplatform-ws-preview
+      PREVIEW_REMOTE_TMP_DIR: /tmp/arcadeplatform-ws-preview-${{ github.run_id }}-${{ github.run_attempt }}
       PREVIEW_BASE_DIR: /opt/arcade-ws-preview
       PREVIEW_APP_DIR: /opt/arcade-ws-preview/ws-server
       PREVIEW_ENV_FILE: /opt/arcade-ws-preview/.env.preview
@@ -167,7 +167,7 @@ jobs:
           username: ${{ secrets.WS_PREVIEW_USER }}
           key: ${{ secrets.WS_PREVIEW_SSH_KEY }}
           source: .artifacts/ws-preview/ws-preview-dist.tgz
-          target: /tmp/arcadeplatform-ws-preview
+          target: ${{ env.PREVIEW_REMOTE_TMP_DIR }}
 
       - name: Atomic preview release switch + restart + health gates on preview VPS
         uses: appleboy/ssh-action@v1.0.3
@@ -201,9 +201,22 @@ jobs:
             set -Eeuo pipefail
 
             TMP_ARCHIVE="$PREVIEW_REMOTE_TMP_DIR/.artifacts/ws-preview/ws-preview-dist.tgz"
-            TMP_EXTRACT_DIR="$PREVIEW_REMOTE_TMP_DIR/extract-$RELEASE_SHA"
+            TMP_EXTRACT_DIR="$PREVIEW_REMOTE_TMP_DIR/extract"
             HEALTH_RETRIES=30
             HEALTH_SLEEP_SEC=1
+
+            case "$PREVIEW_REMOTE_TMP_DIR" in
+              /tmp/arcadeplatform-ws-preview-[0-9]*-[0-9]*) ;;
+              *) echo "invalid run-scoped preview temp dir: $PREVIEW_REMOTE_TMP_DIR"; exit 1 ;;
+            esac
+
+            cleanup() {
+              sudo -n rm -rf -- "$PREVIEW_REMOTE_TMP_DIR" >/dev/null 2>&1 \
+                || rm -rf -- "$PREVIEW_REMOTE_TMP_DIR" >/dev/null 2>&1 \
+                || true
+            }
+
+            trap cleanup EXIT
 
             command -v node >/dev/null 2>&1 || { echo "preview VPS missing nodejs"; exit 1; }
             command -v systemctl >/dev/null 2>&1 || { echo "preview VPS missing systemctl"; exit 1; }
@@ -250,11 +263,26 @@ jobs:
 
             test -f "$TMP_ARCHIVE"
 
-            cleanup() {
-              sudo -n rm -rf "$TMP_EXTRACT_DIR"
+            verify_release_metadata() {
+              metadata_file="$1"
+              sudo -n node -e '
+                const fs = require("fs");
+                const [metadataFile, expectedSha, expectedRef, expectedEnvironment] = process.argv.slice(1);
+                let metadata;
+                try {
+                  metadata = JSON.parse(fs.readFileSync(metadataFile, "utf8"));
+                } catch {
+                  process.exit(1);
+                }
+                if (
+                  metadata?.releaseSha !== expectedSha
+                  || metadata?.deployRef !== expectedRef
+                  || metadata?.environment !== expectedEnvironment
+                ) {
+                  process.exit(1);
+                }
+              ' "$metadata_file" "$RELEASE_SHA" "$DEPLOY_REF" preview
             }
-
-            trap cleanup EXIT
 
             sudo -n rm -rf "$TMP_EXTRACT_DIR"
             sudo -n mkdir -p "$TMP_EXTRACT_DIR"
@@ -266,6 +294,8 @@ jobs:
             sudo -n test -f "$TMP_EXTRACT_DIR/netlify/functions/_generated/deploy-context.mjs"
             sudo -n test -d "$TMP_EXTRACT_DIR/node_modules/postgres"
 
+            verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json"
+
             sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/shared"
             sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/shared/" "$PREVIEW_BASE_DIR/shared"/
@@ -276,12 +306,14 @@ jobs:
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/node_modules"
             sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/node_modules/" "$PREVIEW_BASE_DIR/node_modules"/
 
+            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"
             sudo -n test -f "$PREVIEW_BASE_DIR/netlify/functions/_generated/deploy-context.mjs"
             (
               cd "$PREVIEW_BASE_DIR"
               sudo -n node --input-type=module -e "await import('./ws-server/shared/poker-domain/inactive-cleanup-deps.mjs')"
             )
 
+            RESTART_SINCE="$(date --utc +'%Y-%m-%d %H:%M:%S UTC')"
             sudo -n systemctl restart "$PREVIEW_SERVICE_NAME"
 
             LOCAL_HEALTHZ_BODY=""
@@ -308,8 +340,32 @@ jobs:
               sleep "$HEALTH_SLEEP_SEC"
             done
 
-            trap - EXIT
-            cleanup
+            sudo -n journalctl -u "$PREVIEW_SERVICE_NAME" --since "$RESTART_SINCE" --no-pager -o cat \
+              | node -e '
+                  const fs = require("fs");
+                  const [expectedSha, expectedRef, expectedEnvironment] = process.argv.slice(1);
+                  const prefix = "[klog] ws_artifact_start ";
+                  const matched = fs.readFileSync(0, "utf8")
+                    .split(/\r?\n/)
+                    .filter((line) => line.startsWith(prefix))
+                    .some((line) => {
+                      try {
+                        const metadata = JSON.parse(line.slice(prefix.length));
+                        return (
+                          metadata?.releaseSha === expectedSha
+                          && metadata?.deployRef === expectedRef
+                          && metadata?.environment === expectedEnvironment
+                        );
+                      } catch {
+                        return false;
+                      }
+                    });
+                  if (!matched) {
+                    process.exit(1);
+                  }
+                ' "$RELEASE_SHA" "$DEPLOY_REF" preview
+
+            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"
             BASH
             rc=$?
             if [ "$rc" != "0" ]; then

--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -310,15 +310,15 @@ jobs:
 
             verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json" extracted
 
-            sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/
+            sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/shared"
-            sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/shared/" "$PREVIEW_BASE_DIR/shared"/
+            sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/shared/" "$PREVIEW_BASE_DIR/shared"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/netlify/functions/_shared"
-            sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/netlify/functions/_shared/" "$PREVIEW_BASE_DIR/netlify/functions/_shared"/
+            sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/netlify/functions/_shared/" "$PREVIEW_BASE_DIR/netlify/functions/_shared"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/netlify/functions/_generated"
-            sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/netlify/functions/_generated/" "$PREVIEW_BASE_DIR/netlify/functions/_generated"/
+            sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/netlify/functions/_generated/" "$PREVIEW_BASE_DIR/netlify/functions/_generated"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/node_modules"
-            sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/node_modules/" "$PREVIEW_BASE_DIR/node_modules"/
+            sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/node_modules/" "$PREVIEW_BASE_DIR/node_modules"/
 
             verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json" installed-before-restart
             sudo -n test -f "$PREVIEW_BASE_DIR/netlify/functions/_generated/deploy-context.mjs"

--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -265,14 +265,21 @@ jobs:
 
             verify_release_metadata() {
               metadata_file="$1"
+              verification_stage="$2"
               sudo -n node -e '
                 const fs = require("fs");
-                const [metadataFile, expectedSha, expectedRef, expectedEnvironment] = process.argv.slice(1);
+                const [
+                  metadataFile,
+                  expectedSha,
+                  expectedRef,
+                  expectedEnvironment,
+                  verificationStage
+                ] = process.argv.slice(1);
                 let metadata;
                 try {
                   metadata = JSON.parse(fs.readFileSync(metadataFile, "utf8"));
                 } catch {
-                  process.stderr.write(`release metadata missing or invalid: ${metadataFile}\n`);
+                  process.stderr.write(`release metadata missing or invalid at ${verificationStage}\n`);
                   process.exit(1);
                 }
                 const mismatchedFields = [
@@ -281,10 +288,14 @@ jobs:
                   metadata?.environment !== expectedEnvironment ? "environment" : null
                 ].filter(Boolean);
                 if (mismatchedFields.length > 0) {
-                  process.stderr.write(`release metadata mismatch: ${mismatchedFields.join(",")}\n`);
+                  process.stderr.write(
+                    `release metadata mismatch at ${verificationStage}: ${mismatchedFields.join(",")}`
+                    + ` expectedSha=${expectedSha} actualSha=${metadata?.releaseSha ?? "missing"}`
+                    + ` expectedRef=${expectedRef} actualRef=${metadata?.deployRef ?? "missing"}\n`
+                  );
                   process.exit(1);
                 }
-              ' "$metadata_file" "$RELEASE_SHA" "$DEPLOY_REF" preview
+              ' "$metadata_file" "$RELEASE_SHA" "$DEPLOY_REF" preview "$verification_stage"
             }
 
             sudo -n rm -rf "$TMP_EXTRACT_DIR"
@@ -297,7 +308,7 @@ jobs:
             sudo -n test -f "$TMP_EXTRACT_DIR/netlify/functions/_generated/deploy-context.mjs"
             sudo -n test -d "$TMP_EXTRACT_DIR/node_modules/postgres"
 
-            verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json"
+            verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json" extracted
 
             sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/shared"
@@ -309,7 +320,7 @@ jobs:
             sudo -n mkdir -p "$PREVIEW_BASE_DIR/node_modules"
             sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/node_modules/" "$PREVIEW_BASE_DIR/node_modules"/
 
-            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"
+            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json" installed-before-restart
             sudo -n test -f "$PREVIEW_BASE_DIR/netlify/functions/_generated/deploy-context.mjs"
             (
               cd "$PREVIEW_BASE_DIR"
@@ -369,7 +380,7 @@ jobs:
                   }
                 ' "$RELEASE_SHA" "$DEPLOY_REF" preview
 
-            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"
+            verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json" installed-after-restart
             BASH
             rc=$?
             if [ "$rc" != "0" ]; then

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -1,11 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 const WORKFLOW_PATH = ".github/workflows/ws-preview-deploy.yml";
 
 function workflowText() {
   return fs.readFileSync(WORKFLOW_PATH, "utf8");
+}
+
+function metadataVerifierSource(text) {
+  const match = text.match(
+    /verify_release_metadata\(\) \{[\s\S]*?sudo -n node -e '\n([\s\S]*?)\n\s+' "\$metadata_file"/
+  );
+  assert.ok(match, "missing executable release metadata verifier");
+  return match[1];
 }
 
 test("ws preview deploy remote script matches fixed preview app-dir contract", () => {
@@ -64,4 +75,69 @@ test("ws preview deploy remote script rejects non-stage Supabase env", () => {
   assert.match(text, /preview env SUPABASE_DB_URL must target SUPABASE_STAGE_PROJECT_REF/);
   assert.match(text, /preview env file must define POKER_WS_INTERNAL_TOKEN/);
   assert.match(text, /WS_BOT_REACTION_\(MIN\|MAX\)_MS/);
+});
+
+test("ws preview deploy verifies release identity before and after rsync and after restart", () => {
+  const text = workflowText();
+  const beforeRsync = text.indexOf('verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json"');
+  const firstRsync = text.indexOf('sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/');
+  const afterRsync = text.indexOf('verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"');
+  const restart = text.indexOf('sudo -n systemctl restart "$PREVIEW_SERVICE_NAME"');
+  const journalCheck = text.indexOf('sudo -n journalctl -u "$PREVIEW_SERVICE_NAME" --since "$RESTART_SINCE"');
+  const finalMetadataCheck = text.lastIndexOf('verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"');
+
+  assert.ok(beforeRsync > 0 && beforeRsync < firstRsync, "archive metadata must be verified before rsync");
+  assert.ok(afterRsync > firstRsync && afterRsync < restart, "installed metadata must be verified before restart");
+  assert.ok(journalCheck > restart, "runtime startup identity must be verified after restart");
+  assert.ok(finalMetadataCheck > journalCheck, "installed metadata must be verified again after runtime startup");
+  assert.match(text, /metadata\?\.releaseSha !== expectedSha/);
+  assert.match(text, /metadata\?\.deployRef !== expectedRef/);
+  assert.match(text, /metadata\?\.environment !== expectedEnvironment/);
+  assert.match(text, /metadata\?\.releaseSha === expectedSha/);
+  assert.match(text, /metadata\?\.deployRef === expectedRef/);
+  assert.match(text, /metadata\?\.environment === expectedEnvironment/);
+  assert.match(text, /ws_artifact_start/);
+});
+
+test("ws preview deploy metadata verifier fails closed on a mismatched SHA", () => {
+  const source = metadataVerifierSource(workflowText());
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ws-preview-metadata-"));
+  const metadataPath = path.join(tempDir, "release-metadata.json");
+  try {
+    fs.writeFileSync(
+      metadataPath,
+      JSON.stringify({ releaseSha: "sha-a", deployRef: "branch-a", environment: "preview" })
+    );
+    const matching = spawnSync(process.execPath, [
+      "-e",
+      source,
+      metadataPath,
+      "sha-a",
+      "branch-a",
+      "preview"
+    ]);
+    assert.equal(matching.status, 0);
+
+    const mismatched = spawnSync(process.execPath, [
+      "-e",
+      source,
+      metadataPath,
+      "sha-b",
+      "branch-a",
+      "preview"
+    ]);
+    assert.notEqual(mismatched.status, 0);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("ws preview deploy cleanup is scoped to the current run temp directory and keeps health gates", () => {
+  const text = workflowText();
+
+  assert.match(text, /trap cleanup EXIT/);
+  assert.match(text, /sudo -n rm -rf -- "\$PREVIEW_REMOTE_TMP_DIR"/);
+  assert.doesNotMatch(text, /rm -rf --? "\/tmp\/arcadeplatform-ws-preview"/);
+  assert.match(text, /curl -fsS "\$PREVIEW_LOCAL_HEALTHZ_URL"/);
+  assert.match(text, /curl -fsS "\$PREVIEW_PUBLIC_HEALTHZ_URL"/);
 });

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -34,17 +34,17 @@ test("ws preview deploy remote script matches fixed preview app-dir contract", (
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/chips-ledger\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/deploy-context\.mjs"/);
   assert.match(text, /sudo -n test -d "\$TMP_EXTRACT_DIR\/node_modules\/postgres"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/ws-server\/" "\$PREVIEW_APP_DIR"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/ws-server\/" "\$PREVIEW_APP_DIR"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/shared"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/shared\/" "\$PREVIEW_BASE_DIR\/shared"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/shared\/" "\$PREVIEW_BASE_DIR\/shared"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"\//);
   assert.match(text, /sudo -n test -f "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated\/deploy-context\.mjs"/);
   assert.match(text, /sudo -n node --input-type=module -e "await import\('\.\/ws-server\/shared\/poker-domain\/inactive-cleanup-deps\.mjs'\)"/);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/node_modules"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/node_modules\/" "\$PREVIEW_BASE_DIR\/node_modules"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/node_modules\/" "\$PREVIEW_BASE_DIR\/node_modules"\//);
   assert.doesNotMatch(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR"\/ "\$PREVIEW_BASE_DIR"\//);
   assert.doesNotMatch(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/node_modules"\/ "\$PREVIEW_BASE_DIR\/node_modules"\//);
   assert.doesNotMatch(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/ws-server"\/ "\$PREVIEW_APP_DIR"\//);
@@ -80,7 +80,7 @@ test("ws preview deploy remote script rejects non-stage Supabase env", () => {
 test("ws preview deploy verifies release identity before and after rsync and after restart", () => {
   const text = workflowText();
   const beforeRsync = text.indexOf('verify_release_metadata "$TMP_EXTRACT_DIR/ws-server/release-metadata.json"');
-  const firstRsync = text.indexOf('sudo -n rsync -a --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/');
+  const firstRsync = text.indexOf('sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/');
   const afterRsync = text.indexOf('verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"');
   const restart = text.indexOf('sudo -n systemctl restart "$PREVIEW_SERVICE_NAME"');
   const journalCheck = text.indexOf('sudo -n journalctl -u "$PREVIEW_SERVICE_NAME" --since "$RESTART_SINCE"');

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -71,6 +71,21 @@ test("ws preview deploy validates workflow files from workflow ref and builds ap
   assert.doesNotMatch(validateSection, /Validate preview-only workflow contract literals/);
 });
 
+test("ws preview deploy serializes all refs and uses one run-scoped remote temp directory", () => {
+  const text = workflowText();
+  const concurrencyBlock = text.match(/^concurrency:\n([\s\S]*?)(?=\n\S)/m)?.[0] ?? "";
+
+  assert.match(concurrencyBlock, /group: ws-preview-deploy\n/);
+  assert.doesNotMatch(concurrencyBlock, /inputs\.ref/);
+  assert.match(
+    text,
+    /PREVIEW_REMOTE_TMP_DIR: \/tmp\/arcadeplatform-ws-preview-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/
+  );
+  assert.match(text, /target: \$\{\{ env\.PREVIEW_REMOTE_TMP_DIR \}\}/);
+  assert.match(text, /PREVIEW_REMOTE_TMP_DIR: \$\{\{ env\.PREVIEW_REMOTE_TMP_DIR \}\}/);
+  assert.match(text, /TMP_ARCHIVE="\$PREVIEW_REMOTE_TMP_DIR\/\.artifacts\/ws-preview\/ws-preview-dist\.tgz"/);
+});
+
 
 test("ws preview deploy workflow keeps preview runtime contract and does not manage Caddy", () => {
   const text = workflowText();

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -132,16 +132,16 @@ test("ws preview deploy workflow packages and validates shared runtime files", (
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/chips-ledger\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/deploy-context\.mjs"/);
   assert.match(text, /sudo -n test -d "\$TMP_EXTRACT_DIR\/node_modules\/postgres"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/ws-server\/" "\$PREVIEW_APP_DIR"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/ws-server\/" "\$PREVIEW_APP_DIR"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/shared"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/shared\/" "\$PREVIEW_BASE_DIR\/shared"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/shared\/" "\$PREVIEW_BASE_DIR\/shared"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_shared"\//);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/netlify\/functions\/_generated\/" "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated"\//);
   assert.match(text, /sudo -n test -f "\$PREVIEW_BASE_DIR\/netlify\/functions\/_generated\/deploy-context\.mjs"/);
   assert.match(text, /sudo -n mkdir -p "\$PREVIEW_BASE_DIR\/node_modules"/);
-  assert.match(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR\/node_modules\/" "\$PREVIEW_BASE_DIR\/node_modules"\//);
+  assert.match(text, /sudo -n rsync -a --checksum --delete "\$TMP_EXTRACT_DIR\/node_modules\/" "\$PREVIEW_BASE_DIR\/node_modules"\//);
   assert.doesNotMatch(text, /sudo -n rsync -a --delete "\$TMP_EXTRACT_DIR"\/ "\$PREVIEW_BASE_DIR"\//);
 });
 


### PR DESCRIPTION
## Summary
- serialize every WS Preview deployment through one repository-wide `ws-preview-deploy` concurrency group
- isolate remote upload and extraction under `/tmp/arcadeplatform-ws-preview-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`
- validate exact `releaseSha`, `deployRef`, and `environment=preview` before rsync, after rsync, and again after restart
- require a matching `ws_artifact_start` entry from journald after restart
- clean only the current run temporary directory on success or failure
- retain local and public `/healthz` gates
- use rsync checksum comparison because deterministic tar mtime 1970 plus equal-sized metadata otherwise allows stale content to survive rsync

## Root cause
Deploys for different refs used distinct concurrency groups while sharing one VPS temp path and one application directory. A second upload could overwrite the first run artifact. Runtime verification also exposed a second contributing issue: deterministic archive timestamps make old and new equal-sized files share both size and mtime, so plain `rsync -a` could retain stale content.

## Verification
- workflow guard tests: 11 passed
- `npm run syntax`: passed
- `git diff --check`: passed
- concurrent run 1: https://github.com/krzysztofcal/arcadePlatform/actions/runs/30177796208 — deployed `cf8774b63db3ac2d37135647391c5d8c70da226c`, success
- concurrent run 2: https://github.com/krzysztofcal/arcadePlatform/actions/runs/30177796899 — remained pending until run 1 completed, then deployed `19bda43bc5f22636a82962f94ab0d128e85c4b51`, success
- both runs passed extracted/installed metadata identity, startup-log identity, and local/public health gates
- final public `https://ws-preview.kcswh.pl/healthz`: `ok`

## Breaking impact
WS Preview deploys no longer run concurrently. A later deploy waits instead of racing, checksum comparison adds a small amount of deployment work, and any artifact/runtime identity mismatch now fails closed. There are no application or `ws-server/**` changes.