### PR TITLE
fix(poker): narrow mobile payout panel

### DIFF
--- a/docs/poker-mobile-payout-panel-fix-plan.md
+++ b/docs/poker-mobile-payout-panel-fix-plan.md
@@ -20,18 +20,19 @@ The relevant layout is:
 
 Consequently, the summary remains approximately 86% of a 360 px viewport and approximately 85% of a 390 px viewport. Its centered overlay can obscure seats and table information even though the individual rows already wrap vertically.
 
-The issue is therefore valid and remains present at the analyzed revision. The payout data, labels, settlement projection, and DOM structure do not need to change.
+The issue is therefore valid and remains present at the analyzed revision. The payout data, labels, settlement projection, and DOM structure do not need to change. Deploy Preview verification additionally showed that limiting the compact rule to 420 px misses mobile viewports between 421 and 479 px, which continue to receive the 330 px desktop summary.
 
 ## Implementation approach
 
-Implement one small CSS-only change in the existing `@media (max-width:420px)` block in `poker/poker-v2.css`:
+Implement one small CSS-only change in the existing mobile block in `poker/poker-v2.css`:
 
-1. Set `.poker-settlement-summary` to `width:min(36vw, 135px)` while retaining its existing mobile `max-height` and font size.
-2. Keep the existing one-column row layout and left-aligned, wrapping recipient text. These rules preserve readability after narrowing the container.
-3. Keep the existing desktop declaration unchanged. The new width applies only at or below 420 px.
-4. Preserve the repository's one-line-per-selector CSS format.
+1. Align the mobile upper boundary with the existing desktop `min-width:480px` breakpoint by changing it to `@media (max-width:479px)`.
+2. Set `.poker-settlement-summary` to `width:min(36vw, 135px)` while retaining its existing mobile `max-height` and font size.
+3. Keep the existing one-column row layout and left-aligned, wrapping recipient text. These rules preserve readability after narrowing the container.
+4. Keep the existing desktop declaration unchanged. The compact layout applies only below the existing 480 px desktop breakpoint.
+5. Preserve the repository's one-line-per-selector CSS format.
 
-This produces a panel of approximately 115 px at a 320 px viewport, 130 px at 360 px, and 135 px at 390–420 px. It is approximately half the width of the initial implementation proposal and is intentionally compact without requiring abbreviated labels or a new presentation component.
+This produces a panel of approximately 115 px at a 320 px viewport, 130 px at 360 px, and 135 px at 390–479 px. It is approximately half the width of the initial implementation proposal and is intentionally compact without requiring abbreviated labels or a new presentation component.
 
 Do not change:
 
@@ -39,7 +40,7 @@ Do not change:
 - payout ordering, amounts, labels, translations, or recipient names;
 - settlement timing, animation, seat badges, poker state, or accounting;
 - `poker/table-v2.html`, JSP-compatible JavaScript, CSP, or deployment configuration;
-- desktop and tablet styling above the existing 420 px breakpoint.
+- desktop and tablet styling at and above the existing 480 px breakpoint.
 
 No CSP SHA update is required because the implementation adds no script or inline style.
 
@@ -48,14 +49,14 @@ No CSP SHA update is required because the implementation adds no script or inlin
 ### Task 1: Narrow the mobile summary
 
 - File: `poker/poker-v2.css`
-- Selector: `.poker-settlement-summary` inside `@media (max-width:420px)`
-- Change: add the bounded mobile width while preserving `max-height:132px` and `font-size:0.6rem`.
+- Selector: `.poker-settlement-summary` inside the mobile media query
+- Change: align the query with `max-width:479px` and add the bounded mobile width while preserving `max-height:132px` and `font-size:0.6rem`.
 - Reuse: the existing breakpoint, overflow behavior, one-column row layout, and `overflow-wrap:anywhere`.
 - Boundary conditions:
   - the panel must fit at a 320 px viewport without horizontal overflow;
   - multiple recipients and translated labels must wrap rather than be truncated;
   - a long list may scroll within the existing maximum height;
-  - widths above 420 px must continue to use the current desktop/tablet rule.
+  - widths at and above 480 px must continue to use the current desktop/tablet rule.
 
 ### Task 2: Keep the existing presentation contract intact
 
@@ -84,11 +85,11 @@ These checks cover the existing settlement DOM/content contract, the static live
 
 Verify the implementation on a Netlify Deploy Preview using a completed hand that displays at least Main pot, Side pot 1, and Returned:
 
-1. At viewport widths 320, 360, 390, and 420 px, confirm the panel is centered, noticeably narrower, and does not overflow horizontally.
+1. At viewport widths 320, 360, 390, 430, and 479 px, confirm the panel is centered, noticeably narrower, and does not overflow horizontally.
 2. Confirm all payout amounts and recipients remain readable, including a long display name or multiple recipients.
 3. Confirm a list exceeding the existing maximum height scrolls inside the panel.
 4. Confirm surrounding seats and table information have materially more horizontal visibility than before.
-5. At 421 px and representative desktop widths such as 768 and 1280 px, confirm the existing layout and maximum width are unchanged.
+5. At 480 px and representative desktop widths such as 768 and 1280 px, confirm the existing layout and maximum width are unchanged.
 6. Check both Polish and English presentation where practical; do not shorten translations as part of this fix.
 
 No WS Preview Deploy is required because the proposed implementation does not touch `ws-server/**`.
@@ -98,7 +99,7 @@ No WS Preview Deploy is required because the proposed implementation does not to
 - Breaking impact: none expected for poker state, protocol, settlement, or accounting; this is a presentation-only change.
 - Narrower content can wrap onto more lines and consume more vertical space. The existing maximum height and overflow scrolling bound that effect.
 - Very long names can produce taller rows. Existing `overflow-wrap:anywhere` must remain in place.
-- A rule applied outside the intended media query could alter desktop presentation. Keep the override inside `@media (max-width:420px)` and verify the 421 px boundary.
+- A rule applied outside the intended media query could alter desktop presentation. Keep the override inside `@media (max-width:479px)` and verify the 479/480 px boundary.
 
 ## Rollback
 
@@ -118,4 +119,4 @@ Revert the single mobile width declaration. No data migration, server rollback, 
 - Noticeably narrower on mobile: the explicit `36vw`/`135px` bound replaces the effective 79–86% viewport width at the affected sizes.
 - Important table information remains visible: the overlay releases horizontal space on both sides; visual verification covers representative mobile widths.
 - Multiple entries remain readable: the existing one-column rows, wrapping recipients, bounded height, and scrolling remain unchanged.
-- Desktop is unaffected: the override is scoped to the existing `max-width:420px` media query and is checked immediately above the breakpoint and at desktop widths.
+- Desktop is unaffected: the override ends immediately below the existing `min-width:480px` desktop breakpoint and is checked at the boundary and at representative desktop widths.

--- a/docs/poker-mobile-payout-panel-fix-plan.md
+++ b/docs/poker-mobile-payout-panel-fix-plan.md
@@ -1,0 +1,121 @@
+# Poker mobile payout panel fix plan
+
+## Metadata
+
+- Issue: `#723` — Poker: reduce winner payout panel width on mobile
+- Analyzed revision: `origin/main` at `ea48a0eeab9901c7d405e440eef426ad73928604`
+- Analysis date: 2026-07-26
+- Scope: responsive presentation of the completed-hand payout summary
+- Delivery scope: this document only; no runtime or UI behavior is changed by the planning PR
+
+## Current behavior and confirmed cause
+
+The live table page `poker/table-v2.html` loads `poker/poker-v2.css` and renders the payout summary inside `.poker-center-layer`. `renderSettlementSummary()` in `poker/poker-v2.js` creates one `.poker-settlement-summary__row` for each main-pot, side-pot, or returned-chip entry.
+
+The relevant layout is:
+
+- `.poker-center-layer` has `width:min(86%, 350px)`;
+- `.poker-settlement-summary` has `width:min(100%, 330px)`;
+- the existing `@media (max-width:420px)` rule reduces the summary height and font size and changes each row to a one-column layout, but does not reduce the summary width.
+
+Consequently, the summary remains approximately 86% of a 360 px viewport and approximately 85% of a 390 px viewport. Its centered overlay can obscure seats and table information even though the individual rows already wrap vertically.
+
+The issue is therefore valid and remains present at the analyzed revision. The payout data, labels, settlement projection, and DOM structure do not need to change.
+
+## Implementation approach
+
+Implement one small CSS-only change in the existing `@media (max-width:420px)` block in `poker/poker-v2.css`:
+
+1. Set `.poker-settlement-summary` to `width:min(72vw, 270px)` while retaining its existing mobile `max-height` and font size.
+2. Keep the existing one-column row layout and left-aligned, wrapping recipient text. These rules preserve readability after narrowing the container.
+3. Keep the existing desktop declaration unchanged. The new width applies only at or below 420 px.
+4. Preserve the repository's one-line-per-selector CSS format.
+
+This produces a panel of approximately 230 px at a 320 px viewport, 259 px at 360 px, 270 px at 390 px, and 270 px at 420 px. It is materially narrower than the current panel without requiring abbreviated labels or a new presentation component.
+
+Do not change:
+
+- `renderSettlementSummary()` or other code in `poker/poker-v2.js`;
+- payout ordering, amounts, labels, translations, or recipient names;
+- settlement timing, animation, seat badges, poker state, or accounting;
+- `poker/table-v2.html`, JSP-compatible JavaScript, CSP, or deployment configuration;
+- desktop and tablet styling above the existing 420 px breakpoint.
+
+No CSP SHA update is required because the implementation adds no script or inline style.
+
+## Implementation tasks
+
+### Task 1: Narrow the mobile summary
+
+- File: `poker/poker-v2.css`
+- Selector: `.poker-settlement-summary` inside `@media (max-width:420px)`
+- Change: add the bounded mobile width while preserving `max-height:132px` and `font-size:0.6rem`.
+- Reuse: the existing breakpoint, overflow behavior, one-column row layout, and `overflow-wrap:anywhere`.
+- Boundary conditions:
+  - the panel must fit at a 320 px viewport without horizontal overflow;
+  - multiple recipients and translated labels must wrap rather than be truncated;
+  - a long list may scroll within the existing maximum height;
+  - widths above 420 px must continue to use the current desktop/tablet rule.
+
+### Task 2: Keep the existing presentation contract intact
+
+- File: `tests/poker-v2-live.behavior.test.mjs`
+- Existing scenario: `poker v2 renders per-pot settlement summary and seat-level award badges`
+- Action: run this test unchanged to confirm that main-pot, side-pot, and returned-chip rows and their recipient content remain intact.
+- Do not add JavaScript behavior solely to make the visual rule testable.
+
+If a focused automated guard is considered necessary during implementation, extend the existing CSS-reading setup in `tests/poker-v2-live.behavior.test.mjs` with one assertion for the bounded width inside the existing mobile media query. Do not introduce a new test framework, snapshot the stylesheet, or duplicate the settlement behavior assertions.
+
+## Verification strategy
+
+### Automated checks
+
+Run:
+
+```text
+node tests/poker-v2-live.behavior.test.mjs
+node tests/static-html.behavior.test.mjs
+git diff --check
+```
+
+These checks cover the existing settlement DOM/content contract, the static live-table assets, and formatting. They do not replace visual verification because the behavior harness does not perform browser layout.
+
+### Deploy Preview visual smoke test
+
+Verify the implementation on a Netlify Deploy Preview using a completed hand that displays at least Main pot, Side pot 1, and Returned:
+
+1. At viewport widths 320, 360, 390, and 420 px, confirm the panel is centered, noticeably narrower, and does not overflow horizontally.
+2. Confirm all payout amounts and recipients remain readable, including a long display name or multiple recipients.
+3. Confirm a list exceeding the existing maximum height scrolls inside the panel.
+4. Confirm surrounding seats and table information have materially more horizontal visibility than before.
+5. At 421 px and representative desktop widths such as 768 and 1280 px, confirm the existing layout and maximum width are unchanged.
+6. Check both Polish and English presentation where practical; do not shorten translations as part of this fix.
+
+No WS Preview Deploy is required because the proposed implementation does not touch `ws-server/**`.
+
+## Risks and breaking impact
+
+- Breaking impact: none expected for poker state, protocol, settlement, or accounting; this is a presentation-only change.
+- Narrower content can wrap onto more lines and consume more vertical space. The existing maximum height and overflow scrolling bound that effect.
+- Very long names can produce taller rows. Existing `overflow-wrap:anywhere` must remain in place.
+- A rule applied outside the intended media query could alter desktop presentation. Keep the override inside `@media (max-width:420px)` and verify the 421 px boundary.
+
+## Rollback
+
+Revert the single mobile width declaration. No data migration, server rollback, cache framework, or recovery action is involved.
+
+## Out of scope
+
+- payout or side-pot calculation;
+- settlement and animation logic;
+- label shortening or translation changes;
+- seat placement or a broader mobile poker-table redesign;
+- changes to JavaScript, JSP pages, CSP, WebSocket runtime, persistence, ledger, or accounting;
+- a new responsive-layout abstraction or test framework.
+
+## Acceptance mapping
+
+- Noticeably narrower on mobile: the explicit `72vw`/`270px` bound replaces the effective 79–86% viewport width at the affected sizes.
+- Important table information remains visible: the overlay releases horizontal space on both sides; visual verification covers representative mobile widths.
+- Multiple entries remain readable: the existing one-column rows, wrapping recipients, bounded height, and scrolling remain unchanged.
+- Desktop is unaffected: the override is scoped to the existing `max-width:420px` media query and is checked immediately above the breakpoint and at desktop widths.

--- a/docs/poker-mobile-payout-panel-fix-plan.md
+++ b/docs/poker-mobile-payout-panel-fix-plan.md
@@ -26,12 +26,12 @@ The issue is therefore valid and remains present at the analyzed revision. The p
 
 Implement one small CSS-only change in the existing `@media (max-width:420px)` block in `poker/poker-v2.css`:
 
-1. Set `.poker-settlement-summary` to `width:min(72vw, 270px)` while retaining its existing mobile `max-height` and font size.
+1. Set `.poker-settlement-summary` to `width:min(36vw, 135px)` while retaining its existing mobile `max-height` and font size.
 2. Keep the existing one-column row layout and left-aligned, wrapping recipient text. These rules preserve readability after narrowing the container.
 3. Keep the existing desktop declaration unchanged. The new width applies only at or below 420 px.
 4. Preserve the repository's one-line-per-selector CSS format.
 
-This produces a panel of approximately 230 px at a 320 px viewport, 259 px at 360 px, 270 px at 390 px, and 270 px at 420 px. It is materially narrower than the current panel without requiring abbreviated labels or a new presentation component.
+This produces a panel of approximately 115 px at a 320 px viewport, 130 px at 360 px, and 135 px at 390–420 px. It is approximately half the width of the initial implementation proposal and is intentionally compact without requiring abbreviated labels or a new presentation component.
 
 Do not change:
 
@@ -115,7 +115,7 @@ Revert the single mobile width declaration. No data migration, server rollback, 
 
 ## Acceptance mapping
 
-- Noticeably narrower on mobile: the explicit `72vw`/`270px` bound replaces the effective 79–86% viewport width at the affected sizes.
+- Noticeably narrower on mobile: the explicit `36vw`/`135px` bound replaces the effective 79–86% viewport width at the affected sizes.
 - Important table information remains visible: the overlay releases horizontal space on both sides; visual verification covers representative mobile widths.
 - Multiple entries remain readable: the existing one-column rows, wrapping recipients, bounded height, and scrolling remain unchanged.
 - Desktop is unaffected: the override is scoped to the existing `max-width:420px` media query and is checked immediately above the breakpoint and at desktop widths.

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -316,7 +316,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
 
-@media (max-width:420px){.poker-settlement-summary{max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
+@media (max-width:420px){.poker-settlement-summary{width:min(72vw, 270px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 
 @media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before{animation:none!important;}}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -316,7 +316,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
 
-@media (max-width:420px){.poker-settlement-summary{width:min(72vw, 270px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
+@media (max-width:420px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 
 @media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before{animation:none!important;}}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -316,7 +316,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;}}
 
-@media (max-width:420px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
+@media (max-width:479px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 
 @media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before{animation:none!important;}}
 


### PR DESCRIPTION
## Summary

- documents the revalidated cause and implementation plan for #723 against `origin/main` at `ea48a0eeab9901c7d405e440eef426ad73928604`
- narrows the payout summary to `min(36vw, 135px)` below the existing 480 px desktop breakpoint
- covers 421–479 px mobile viewports that previously continued to receive the 330 px desktop summary
- preserves the existing one-column wrapping layout, bounded height, payout content, and settlement behavior

## Scope

The runtime change is CSS-only. No JavaScript, WebSocket, persistence, settlement, ledger, accounting, CSP, or deployment configuration was changed. No new tests were added.

## Verification

- verified the prior Deploy Preview served the correct PR SHA and CSS; the remaining issue was the 420 px breakpoint, not stale cache
- `node tests/poker-v2-live.behavior.test.mjs` — PASS, 56/56
- `node tests/static-html.behavior.test.mjs` — PASS
- `git diff --check` — PASS

## Risk and breaking impact

Low presentation-only risk. The compact layout now applies through 479 px and desktop begins at the repository’s existing 480 px boundary. Mobile payout rows can wrap onto additional lines, while the existing maximum height and scrolling keep the overlay bounded. No protocol or data breaking impact.

Closes #723