### PR TITLE
fix(poker): evict abandoned guest tables

### DIFF
--- a/ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs
+++ b/ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs
@@ -286,3 +286,19 @@ test('awaited async onChanged', async () => {
     'onChanged:end'
   ]);
 });
+
+test('forgetTable removes only cleanup candidates owned by the evicted table', () => {
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async () => ({ ok: true }),
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_evicted', userId: 'u1' });
+  runtime.enqueue({ tableId: 't_evicted', userId: 'u2' });
+  runtime.enqueue({ tableId: 't_retained', userId: 'u3' });
+
+  assert.equal(runtime.forgetTable('t_evicted'), 2);
+  assert.equal(runtime.forgetTable('t_evicted'), 0);
+  assert.equal(runtime.size(), 1);
+});

--- a/ws-server/poker/runtime/disconnect-cleanup.mjs
+++ b/ws-server/poker/runtime/disconnect-cleanup.mjs
@@ -4,6 +4,7 @@ export function createDisconnectCleanupRuntime({
   socketMatchesTable,
   seatedReconnectGraceMs = 0,
   onChanged = () => {},
+  onCancelled = () => {},
   klog = () => {},
   nowMs = () => Date.now()
 } = {}) {
@@ -46,6 +47,7 @@ export function createDisconnectCleanupRuntime({
       });
       if (hasLiveSocket) {
         candidates.delete(key(candidate.tableId, candidate.userId));
+        await onCancelled(candidate, "active_socket");
         continue;
       }
       if (Number.isFinite(candidate.retryNotBeforeMs) && candidate.retryNotBeforeMs > currentNowMs) {
@@ -114,5 +116,16 @@ export function createDisconnectCleanupRuntime({
     return candidates.size;
   }
 
-  return { enqueue, sweep, size };
+  function forgetTable(tableId) {
+    if (typeof tableId !== 'string' || !tableId) return 0;
+    let deleted = 0;
+    for (const candidate of [...candidates.values()]) {
+      if (candidate.tableId === tableId && candidates.delete(key(candidate.tableId, candidate.userId))) {
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  return { enqueue, sweep, size, forgetTable };
 }

--- a/ws-server/poker/runtime/stream-log.behavior.test.mjs
+++ b/ws-server/poker/runtime/stream-log.behavior.test.mjs
@@ -65,3 +65,14 @@ test("receiver-scoped window is unaffected by unrelated receiver traffic", () =>
   assert.equal(replayB.ok, false);
   assert.equal(replayB.reason, "last_seq_out_of_window");
 });
+
+test("forgetTable removes only the selected replay stream and is idempotent", () => {
+  const streamLog = createStreamLog({ cap: 3 });
+  streamLog.append({ tableId: "forgotten", frame: { type: "stateSnapshot" }, receiverKey: "sess_a" });
+  streamLog.append({ tableId: "retained", frame: { type: "stateSnapshot" }, receiverKey: "sess_b" });
+
+  assert.equal(streamLog.forgetTable("forgotten"), true);
+  assert.equal(streamLog.forgetTable("forgotten"), false);
+  assert.equal(streamLog.latestSeq("forgotten"), 0);
+  assert.equal(streamLog.latestSeq("retained"), 1);
+});

--- a/ws-server/poker/runtime/stream-log.mjs
+++ b/ws-server/poker/runtime/stream-log.mjs
@@ -86,9 +86,17 @@ export function createStreamLog({ cap = DEFAULT_STREAM_CAP } = {}) {
     };
   }
 
+  function forgetTable(tableId) {
+    if (typeof tableId !== "string" || tableId.trim() === "") {
+      return false;
+    }
+    return streamByTableId.delete(tableId.trim());
+  }
+
   return {
     append,
     latestSeq,
-    eventsAfter
+    eventsAfter,
+    forgetTable
   };
 }

--- a/ws-server/server.guest-mode.behavior.test.mjs
+++ b/ws-server/server.guest-mode.behavior.test.mjs
@@ -74,6 +74,17 @@ function waitForExit(proc) {
   return new Promise((resolve) => proc.once("exit", resolve));
 }
 
+async function waitForOutput(getOutput, pattern, timeoutMs = 5000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (pattern.test(getOutput())) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  assert.fail(`Timed out waiting for server output matching ${pattern}. Recent output: ${getOutput().slice(-4000)}`);
+}
+
 function createServer({ env = {} } = {}) {
   return getFreePort().then((port) => {
     const child = spawn(process.execPath, ["ws-server/server.mjs"], {
@@ -294,6 +305,135 @@ test("guest can auth and join only its token-bound guest_table_*", async () => {
     assert.equal(rejected.payload.reason, "guest_multiplayer_requires_account");
 
     ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("explicit guest leave evicts the in-memory table without authoritative persistence", async () => {
+  const secret = "guest-explicit-leave-secret";
+  const guestUserId = "guest_user_explicit_leave";
+  const guestTableId = "guest_table_explicit_leave";
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+    },
+  });
+  let output = "";
+  child.stdout.on("data", (buf) => {
+    output += String(buf);
+  });
+  child.stderr.on("data", (buf) => {
+    output += String(buf);
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const ws = await connectClient(port);
+    await hello(ws);
+    await auth(
+      ws,
+      makeGuestJwt({ secret, sub: guestUserId, tableId: guestTableId, nickname: "Guest3101" }),
+      "auth-guest-explicit-leave"
+    );
+    const joined = await joinTable(ws, guestTableId, "join-guest-explicit-leave");
+    assert.equal(joined.ack.payload.status, "accepted");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_leave",
+      requestId: "leave-guest-explicit",
+      ts: "2026-02-28T00:00:03Z",
+      payload: { tableId: guestTableId },
+    });
+    const leave = await nextCommandResultForRequest(ws, "leave-guest-explicit");
+    assert.equal(leave.payload.status, "accepted");
+
+    await waitForOutput(
+      () => output,
+      /ws_guest_table_evicted \{.*"trigger":"explicit_leave".*"evicted":true/
+    );
+    assert.equal((output.match(/\[klog\] ws_guest_table_evicted /g) || []).length, 1);
+    assert.equal(output.includes("ws_leave_authoritative_failed"), false);
+
+    ws.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("guest reconnect within grace preserves the table, then disconnect evicts it exactly once", async () => {
+  const secret = "guest-disconnect-grace-secret";
+  const guestUserId = "guest_user_disconnect_grace";
+  const guestTableId = "guest_table_disconnect_grace";
+  const guestToken = makeGuestJwt({
+    secret,
+    sub: guestUserId,
+    tableId: guestTableId,
+    nickname: "Guest3102",
+  });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_SEATED_RECONNECT_GRACE_MS: "150",
+      WS_DISCONNECT_CLEANUP_SWEEP_MS: "25",
+      WS_TIMEOUT_SWEEP_MS: "60000",
+    },
+  });
+  let output = "";
+  child.stdout.on("data", (buf) => {
+    output += String(buf);
+  });
+  child.stderr.on("data", (buf) => {
+    output += String(buf);
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const first = await connectClient(port);
+    await hello(first);
+    await auth(first, guestToken, "auth-guest-disconnect-first");
+    const firstJoin = await joinTable(first, guestTableId, "join-guest-disconnect-first");
+    assert.equal(firstJoin.ack.payload.status, "accepted");
+    const firstStack = firstJoin.tableState.payload?.stacks?.[guestUserId];
+    assert.equal(Number.isFinite(Number(firstStack)), true);
+
+    first.terminate();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const second = await connectClient(port);
+    await hello(second);
+    await auth(second, guestToken, "auth-guest-disconnect-second");
+    const secondJoin = await joinTable(second, guestTableId, "join-guest-disconnect-second");
+    assert.equal(secondJoin.ack.payload.status, "accepted");
+    assert.equal(secondJoin.ack.payload.reason, "already_joined");
+    assert.equal(secondJoin.tableState.payload?.stacks?.[guestUserId], firstStack);
+
+    await waitForOutput(
+      () => output,
+      /ws_guest_table_cleanup_cancelled \{.*"tableId":"guest_table_disconnect_grace"/
+    );
+    assert.equal(output.includes('"trigger":"disconnect_cleanup","requestId"'), false);
+
+    second.terminate();
+    await waitForOutput(
+      () => output,
+      /ws_guest_table_evicted \{.*"tableId":"guest_table_disconnect_grace".*"trigger":"disconnect_cleanup".*"evicted":true/,
+      5000
+    );
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const scheduledCount = (output.match(/\[klog\] ws_guest_table_cleanup_scheduled /g) || []).length;
+    const evictedCount = (output.match(/\[klog\] ws_guest_table_evicted /g) || []).length;
+    assert.equal(scheduledCount, 2, "each real disconnect schedules one candidate");
+    assert.equal(evictedCount, 1, "reconnect cancellation and final disconnect must produce one eviction");
+    assert.equal(output.includes("ws_disconnect_cleanup_retry"), false);
+    assert.equal(output.includes("ws_table_janitor_"), false);
+    assert.equal(output.includes("poker_ledger"), false);
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -254,7 +254,10 @@ const tableManager = createTableManager({
   publicProfileLoader: loadPublicProfiles,
   publicProfileStorageBaseUrl,
   publicProfileLog: klogSafe,
-  onTableEvicted: (tableId) => persistedStateWriter?.forgetHoleCardAcknowledgement(tableId),
+  onTableEvicted: (tableId) => {
+    persistedStateWriter?.forgetHoleCardAcknowledgement(tableId);
+    releaseTableRuntimeResources(tableId);
+  },
   observeOnlyJoin: observeOnlyJoinEnabled
 });
 const tableCommandQueue = createTableCommandQueue({
@@ -559,9 +562,9 @@ function staleSeatCandidateKey(tableId, userId) {
 }
 
 function tableSocketMatches(socket, tableId) {
-  const conn = socket && socket.__connState;
-  const joined = conn?.joinedTableId || null;
-  const subscribed = conn?.subscribedTableId || null;
+  const association = tableManager.connectionTableAssociation(socket);
+  const joined = association?.joinedTableId || null;
+  const subscribed = association?.subscribedTableId || null;
   return joined === tableId || subscribed === tableId;
 }
 
@@ -1460,6 +1463,27 @@ function clearSnapshotCacheForTable(tableId) {
   }
 }
 
+function clearPersistedSeatTouchForTable(tableId) {
+  for (const key of [...persistedSeatTouchByTableUser.keys()]) {
+    if (key.startsWith(`${tableId}:`)) {
+      persistedSeatTouchByTableUser.delete(key);
+    }
+  }
+}
+
+function releaseTableRuntimeResources(tableId) {
+  clearSettledRolloverTimer(tableId);
+  clearTurnTimeoutFailureTracker(tableId);
+  clearSnapshotCacheForTable(tableId);
+  clearPersistedSeatTouchForTable(tableId);
+  scheduledObservedBotTurnKeys.delete(tableId);
+  suppressedBotTimeoutSafetyFailures.delete(tableId);
+  pendingTableJanitorEvaluationByTableId.delete(tableId);
+  suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(tableId);
+  guestDisconnectCleanupRuntime?.forgetTable(tableId);
+  streamLog.forgetTable(tableId);
+}
+
 function shouldEvictClosedRuntimeTable(tableId, result) {
   const status = typeof result?.status === "string" ? result.status : null;
   const isClosedResult = result?.closed === true || status === "cleaned_closed" || status === "already_closed";
@@ -1482,9 +1506,6 @@ function shouldSyncCleanupRuntimeState(tableId, result) {
 }
 
 function evictClosedRuntimeTable({ tableId, logPrefix, status = null }) {
-  clearSettledRolloverTimer(tableId);
-  clearTurnTimeoutFailureTracker(tableId);
-  clearSnapshotCacheForTable(tableId);
   const evicted = typeof tableManager?.evictTable === "function"
     ? tableManager.evictTable(tableId)
     : { ok: false, existed: false };
@@ -2014,8 +2035,67 @@ const disconnectCleanupRuntime = createDisconnectCleanupRuntime({
   klog: klogSafe
 });
 
+async function evictDisconnectedGuestTable({ tableId, userId, requestId }) {
+  return enqueueTableCommand({
+    tableId,
+    commandName: "guest_disconnect_cleanup",
+    dedupeKey: "guest_disconnect_cleanup",
+    run: async () => {
+      if (!isGuestTableId(tableId)) {
+        return { ok: false, changed: false, retryable: false, code: "not_guest_table" };
+      }
+      if (!tableManager.listTableIds().includes(tableId)) {
+        return { ok: true, changed: false, closed: true, status: "already_evicted" };
+      }
+      const hasLiveSocket = sessionStore.connectionsForUser(userId)
+        .some((socket) => tableSocketMatches(socket, tableId));
+      if (hasLiveSocket || tableManager.hasConnectedHumanPresence(tableId)) {
+        return { ok: true, changed: false, status: "guest_reconnected" };
+      }
+      const evicted = tableManager.evictTable(tableId);
+      klogSafe("ws_guest_table_evicted", {
+        tableId,
+        trigger: "disconnect_cleanup",
+        requestId,
+        evicted: evicted?.existed === true
+      });
+      return {
+        ok: true,
+        changed: evicted?.existed === true,
+        closed: true,
+        status: evicted?.existed === true ? "guest_evicted" : "already_evicted"
+      };
+    }
+  });
+}
+
+const guestDisconnectCleanupRuntime = createDisconnectCleanupRuntime({
+  executeCleanup: evictDisconnectedGuestTable,
+  listActiveSocketsForUser: (userId) => sessionStore.connectionsForUser(userId),
+  socketMatchesTable: (socket, tableId) => tableSocketMatches(socket, tableId),
+  seatedReconnectGraceMs,
+  onChanged: async () => {},
+  onCancelled: ({ tableId }) => {
+    klogSafe("ws_guest_table_cleanup_cancelled", {
+      tableId,
+      reason: "active_socket"
+    });
+  },
+  klog: klogSafe
+});
+
 function enqueueDisconnectCleanupCandidate({ tableId, userId }) {
   if (typeof userId !== "string" || !userId) return;
+  if (isGuestTableId(tableId)) {
+    const enqueued = guestDisconnectCleanupRuntime.enqueue({ tableId, userId });
+    if (enqueued) {
+      klogSafe("ws_guest_table_cleanup_scheduled", {
+        tableId,
+        graceMs: seatedReconnectGraceMs
+      });
+    }
+    return;
+  }
   // When DB-backed persistence is active, persisted tables always have UUID
   // IDs. Guest and other non-persisted tables use prefixed string IDs that
   // cannot target DB-backed cleanup. Filter them out to prevent 22P02 failures.
@@ -2214,6 +2294,7 @@ async function recordTurnTimeoutOutcome({ tableId, result, nowMs }) {
 
 async function sweepDisconnectCleanupAndBroadcast() {
   await disconnectCleanupRuntime.sweep();
+  await guestDisconnectCleanupRuntime.sweep();
 }
 
 async function listStaleActiveHumanSeatCandidates({ limit = 25 } = {}) {
@@ -3403,6 +3484,63 @@ wss.on("connection", (ws) => {
           code: "INVALID_ROOM_ID",
           message: "roomId is required",
           requestId: frame.requestId ?? null
+        });
+        return;
+      }
+      if (isGuestSession(connState)) {
+        if (!isGuestTableId(tableId) || (connState.guestTableId && connState.guestTableId !== tableId)) {
+          sendCommandResult(ws, connState, {
+            requestId: frame.requestId ?? null,
+            tableId,
+            status: "rejected",
+            reason: "guest_multiplayer_requires_account"
+          });
+          return;
+        }
+        await enqueueTableCommand({
+          tableId,
+          commandName: "guest_leave",
+          dedupeKey: "guest_leave",
+          run: async () => {
+            const detached = tableManager.leave({
+              ws,
+              userId: connState.session.userId,
+              tableId,
+              requestId: frame.requestId
+            });
+            if (!detached?.ok) {
+              sendCommandResult(ws, connState, {
+                requestId: frame.requestId ?? null,
+                tableId,
+                status: "rejected",
+                reason: detached?.code || "state_invalid"
+              });
+              return detached;
+            }
+            const hasLiveSocket = sessionStore.connectionsForUser(connState.session.userId)
+              .some((socket) => tableSocketMatches(socket, tableId));
+            const evicted = hasLiveSocket
+              ? { ok: true, existed: false }
+              : tableManager.evictTable(tableId);
+            sendCommandResult(ws, connState, {
+              requestId: frame.requestId ?? null,
+              tableId,
+              status: "accepted",
+              reason: detached.changed === false ? "already_left" : null
+            });
+            klogSafe("ws_guest_table_evicted", {
+              tableId,
+              trigger: "explicit_leave",
+              requestId: frame.requestId ?? null,
+              evicted: evicted?.existed === true
+            });
+            return {
+              ok: true,
+              changed: detached.changed === true || evicted?.existed === true,
+              closed: evicted?.existed === true,
+              status: evicted?.existed === true ? "guest_evicted" : "guest_leave_detached"
+            };
+          }
         });
         return;
       }


### PR DESCRIPTION
## Summary

- route guest disconnect cleanup through the existing reconnect-grace runtime and per-table command queue
- evict abandoned guest tables from WS memory after grace, while cancelling cleanup when the guest reconnects
- make explicit guest leave detach and evict the guest runtime without calling Supabase, settlement, cashout, or ledger paths
- release table-owned timers, suppression entries, snapshot/touch state, cleanup candidates, and replay streams through the existing table eviction lifecycle hook
- resolve live socket-to-table ownership from `tableManager`, the current authoritative connection-state owner

Closes #761

## Verification

- `node --test ws-server/server.guest-mode.behavior.test.mjs ws-server/poker/runtime/stream-log.behavior.test.mjs`
- `node --test ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs ws-server/poker/table/table-manager.behavior.test.mjs`
- `node --test ws-server/server.behavior.test.mjs` (100/100)
- `node --test ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs ws-server/poker/runtime/stream-log.behavior.test.mjs ws-server/server.guest-mode.behavior.test.mjs` (26/26 final targeted run)
- `npm run syntax`
- `git diff --check`

## Scope and risk

- Guest tables remain process-local and DB-free.
- No persistence, settlement, cashout, ledger, accounting, heartbeat, stale-seat, or reconnect-grace semantics were changed.
- A transport-healthy but application-idle guest timeout is intentionally out of scope; this PR fixes only explicit leave and actual socket disconnect lifecycle ownership.
- Breaking impact: an abandoned guest table is now discarded after the existing reconnect grace, so reconnecting after that grace creates a fresh guest runtime instead of resuming leaked memory state. Reconnect within grace preserves the seat and stack.

## Preview smoke

A manual WS Preview Deploy is required because this PR changes `ws-server/**`. Verify explicit guest leave, reconnect within grace, disconnect beyond grace, a single `ws_guest_table_evicted`, no guest persistence/ledger events, and healthy `/healthz`.