### PR TITLE
fix(poker): redirect guests from evicted tables

### DIFF
--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -381,6 +381,20 @@
     }
   }
 
+  function consumeGuestJoinIntent(){
+    if (!isGuestMode || !currentGuestSession) return null;
+    var intent = currentGuestSession.createPending === true ? 'create' : 'resume';
+    if (intent === 'create'){
+      currentGuestSession.createPending = false;
+      try {
+        if (window.sessionStorage) {
+          window.sessionStorage.setItem('poker:guestSession', JSON.stringify(currentGuestSession));
+        }
+      } catch (_err){}
+    }
+    return intent;
+  }
+
   function klog(kind, data){
     try {
       if (window.KLog && typeof window.KLog.log === 'function') window.KLog.log(kind, data || {});
@@ -2996,6 +3010,8 @@
     } else {
       payload.seatNo = preferredSeatNo;
     }
+    var guestJoinIntent = consumeGuestJoinIntent();
+    if (guestJoinIntent) payload.guestJoinIntent = guestJoinIntent;
     return payload;
   }
 
@@ -3158,11 +3174,13 @@
     var preferredSeatNo = reconnectSeatNo;
     autoJoinAttempted = true;
     setError('');
-    sendCommand('sendJoin', {
+    var reconnectPayload = {
       tableId: state.tableId,
       autoSeat: true,
       preferredSeatNo: preferredSeatNo
-    }).then(function(result){
+    };
+    if (isGuestMode) reconnectPayload.guestJoinIntent = 'resume';
+    sendCommand('sendJoin', reconnectPayload).then(function(result){
       var resolvedSeatNo = result && Number.isInteger(Number(result.seatNo))
         ? Number(result.seatNo)
         : preferredSeatNo;

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1830,7 +1830,8 @@
           tableId: data.tableId,
           guestId: data.guestId || data.userId || null,
           nickname: data.nickname || null,
-          expiresAt: Date.now() + Math.max(1, Number(data.expiresInSec || 1800)) * 1000
+          expiresAt: Date.now() + Math.max(1, Number(data.expiresInSec || 1800)) * 1000,
+          createPending: true
         }));
         return true;
       } catch (_err){

--- a/tests/poker-ui.behavior.test.mjs
+++ b/tests/poker-ui.behavior.test.mjs
@@ -243,6 +243,7 @@ function loadLobbyHarness(options = {}){
     pokerBb: makeElement('pokerBb'),
     pokerMaxPlayers: makeElement('pokerMaxPlayers'),
     pokerSignIn: makeElement('pokerSignIn'),
+    pokerGuestPlay: makeElement('pokerGuestPlay'),
   };
   elements.pokerSb.value = '1';
   elements.pokerBb.value = '2';
@@ -256,6 +257,7 @@ function loadLobbyHarness(options = {}){
   const windowEvents = {};
   const documentEvents = {};
   const timeoutTimers = [];
+  const sessionStorageEntries = new Map();
   let nextTimeoutId = 1;
   let nextIntervalId = 1;
   let nowMs = 0;
@@ -288,6 +290,11 @@ function loadLobbyHarness(options = {}){
       removeEventListener: () => {},
       __RUNNING_POKER_UI_TESTS__: false,
       KLog: { log: () => {} },
+      sessionStorage: {
+        getItem(key){ return sessionStorageEntries.has(String(key)) ? sessionStorageEntries.get(String(key)) : null; },
+        setItem(key, value){ sessionStorageEntries.set(String(key), String(value)); },
+        removeItem(key){ sessionStorageEntries.delete(String(key)); }
+      },
       ChipsClient: options.balanceError
         ? { fetchBalance: async () => { throw new Error('balance_failed'); } }
         : (options.balanceResult ? { fetchBalance: async () => options.balanceResult } : null),
@@ -364,6 +371,8 @@ function loadLobbyHarness(options = {}){
     getLobbyOptions: () => lobbyClients.length ? lobbyClients[lobbyClients.length - 1].options : null,
     getLobbyClient: (index) => lobbyClients[index == null ? lobbyClients.length - 1 : index] || null,
     getRequestLobbySnapshotCalls: () => requestLobbySnapshotCalls,
+    getSessionStorage: (key) => sandbox.window.sessionStorage.getItem(key),
+    getLocationHref: () => sandbox.window.location.href,
     advanceTime(ms){
       nowMs += Math.max(0, Number(ms) || 0);
       flushTimers();
@@ -378,6 +387,30 @@ function loadLobbyHarness(options = {}){
 const lobbyHarness = loadLobbyHarness();
 await new Promise((resolve) => setTimeout(resolve, 0));
 assert.equal(lobbyHarness.wsCreates.length > 0, true, 'lobby should bootstrap websocket client when authenticated');
+
+const guestLobbyHarness = loadLobbyHarness({
+  fetchResponse: async (url) => {
+    if (url.includes('/.netlify/functions/poker-guest-session')) {
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          token: 'guest-token',
+          tableId: 'guest_table_new',
+          guestId: 'guest_new',
+          nickname: 'Guest1234',
+          expiresInSec: 1800
+        })
+      };
+    }
+    return { ok: true, json: async () => ({ ok: true }) };
+  }
+});
+guestLobbyHarness.elements.pokerGuestPlay.click();
+await new Promise((resolve) => setTimeout(resolve, 0));
+const createdGuestSession = JSON.parse(guestLobbyHarness.getSessionStorage('poker:guestSession'));
+assert.equal(createdGuestSession.createPending, true, 'lobby must mark a newly minted guest table as pending initial creation');
+assert.match(guestLobbyHarness.getLocationHref(), /tableId=guest_table_new/);
 
 const lobbyOptions = lobbyHarness.getLobbyOptions();
 assert.ok(lobbyOptions, 'lobby should provide websocket callbacks');

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -320,7 +320,8 @@ async function flush(){
     flush,
     advanceTime,
     getCreateOptions(){ return createOptions; },
-    getIntervalCount(){ return intervalTimers.length; }
+    getIntervalCount(){ return intervalTimers.length; },
+    getSessionStorage(key){ return sandbox.sessionStorage.getItem(key); }
   };
 }
 
@@ -449,7 +450,8 @@ test('poker v2 guest mode shows restrictions panel, hides XP badge, and still au
       tableId: 'guest_table_1',
       guestId: 'guest_user_1',
       nickname: 'Guest1234',
-      expiresAt: Date.now() + 3_600_000
+      expiresAt: Date.now() + 3_600_000,
+      createPending: true
     }
   });
   harness.fireDomContentLoaded();
@@ -463,7 +465,49 @@ test('poker v2 guest mode shows restrictions panel, hides XP badge, and still au
   assert.equal(harness.elements.pokerV2GuestPanel.hidden, false, 'guest mode should show the restrictions panel');
 
   await waitFor(() => harness.joinPayloads.length === 1);
-  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'guest_table_1', buyIn: 100, autoSeat: true, preferredSeatNo: 1 }));
+  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({
+    tableId: 'guest_table_1',
+    buyIn: 100,
+    autoSeat: true,
+    preferredSeatNo: 1,
+    guestJoinIntent: 'create'
+  }));
+  const storedGuestSession = JSON.parse(harness.getSessionStorage('poker:guestSession'));
+  assert.equal(storedGuestSession.createPending, false, 'create intent must be consumed before the join resolves');
+});
+
+test('poker v2 treats a historical guest session as resume-only and redirects on table_closed', async () => {
+  const guestPayload = Buffer.from(JSON.stringify({ sub: 'guest_user_resume' })).toString('base64url');
+  const guestToken = `aaa.${guestPayload}.zzz`;
+  const harness = createHarness({
+    search: '?tableId=guest_table_resume&guest=1&autoJoin=1',
+    token: null,
+    guestSession: {
+      token: guestToken,
+      tableId: 'guest_table_resume',
+      guestId: 'guest_user_resume',
+      nickname: 'Guest4321',
+      expiresAt: Date.now() + 3_600_000
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  await waitFor(() => harness.joinPayloads.length === 1);
+  assert.equal(harness.joinPayloads[0].guestJoinIntent, 'resume');
+
+  const ws = harness.getCreateOptions();
+  ws.onStatus('command_result', { reason: 'table_closed' });
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2ClosedTableModal.hidden, false);
+  assert.equal(harness.elements.pokerV2ClosedTableCountdown.textContent, 'Returning to lobby in 5 seconds…');
+
+  for (let i = 0; i < 5; i += 1){
+    harness.advanceTime(1000);
+    await harness.flush();
+  }
+  assert.equal(harness.windowLocation.href, '/poker/');
+  assert.equal(harness.joinPayloads.length, 1, 'closed guest table must not trigger another auto-join');
 });
 
 test('poker v2 authenticated user takes precedence over a matching guest session', async () => {

--- a/ws-server/server.guest-mode.behavior.test.mjs
+++ b/ws-server/server.guest-mode.behavior.test.mjs
@@ -253,18 +253,21 @@ async function auth(ws, token, requestId = "req-auth") {
   return nextMessage(ws);
 }
 
-function tableJoinFrame(tableId, requestId) {
+function tableJoinFrame(tableId, requestId, guestJoinIntent = null) {
+  const payload = { tableId };
+  if (guestJoinIntent) payload.guestJoinIntent = guestJoinIntent;
+  else if (tableId.startsWith("guest_table_")) payload.guestJoinIntent = "create";
   return {
     version: "1.0",
     type: "table_join",
     requestId,
     ts: "2026-02-28T00:00:02Z",
-    payload: { tableId },
+    payload,
   };
 }
 
-async function joinTable(ws, tableId, requestId) {
-  sendFrame(ws, tableJoinFrame(tableId, requestId));
+async function joinTable(ws, tableId, requestId, guestJoinIntent = null) {
+  sendFrame(ws, tableJoinFrame(tableId, requestId, guestJoinIntent));
   const ack = await nextCommandResultForRequest(ws, requestId);
   const tableState = await nextMessageOfType(ws, "table_state");
   return { ack, tableState };
@@ -294,6 +297,17 @@ test("guest can auth and join only its token-bound guest_table_*", async () => {
     assert.equal(authOk.type, "authOk");
     assert.equal(authOk.payload.mode, "guest");
     assert.equal(authOk.payload.nickname, "Guest2468");
+
+    sendFrame(ws, {
+      version: "1.0",
+      type: "table_join",
+      requestId: "join-guest-missing-intent",
+      ts: "2026-02-28T00:00:02Z",
+      payload: { tableId: boundTableId },
+    });
+    const missingIntent = await nextCommandResultForRequest(ws, "join-guest-missing-intent");
+    assert.equal(missingIntent.payload.status, "rejected");
+    assert.equal(missingIntent.payload.reason, "table_closed");
 
     const accepted = await joinTable(ws, boundTableId, "join-guest-bound");
     assert.equal(accepted.ack.payload.status, "accepted");
@@ -400,7 +414,9 @@ test("guest reconnect within grace preserves the table, then disconnect evicts i
     const firstJoin = await joinTable(first, guestTableId, "join-guest-disconnect-first");
     assert.equal(firstJoin.ack.payload.status, "accepted");
     const firstStack = firstJoin.tableState.payload?.stacks?.[guestUserId];
+    const firstHandId = firstJoin.tableState.payload?.hand?.handId;
     assert.equal(Number.isFinite(Number(firstStack)), true);
+    assert.equal(typeof firstHandId, "string");
 
     first.terminate();
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -408,10 +424,11 @@ test("guest reconnect within grace preserves the table, then disconnect evicts i
     const second = await connectClient(port);
     await hello(second);
     await auth(second, guestToken, "auth-guest-disconnect-second");
-    const secondJoin = await joinTable(second, guestTableId, "join-guest-disconnect-second");
+    const secondJoin = await joinTable(second, guestTableId, "join-guest-disconnect-second", "resume");
     assert.equal(secondJoin.ack.payload.status, "accepted");
     assert.equal(secondJoin.ack.payload.reason, "already_joined");
     assert.equal(secondJoin.tableState.payload?.stacks?.[guestUserId], firstStack);
+    assert.equal(secondJoin.tableState.payload?.hand?.handId, firstHandId);
 
     await waitForOutput(
       () => output,
@@ -434,6 +451,22 @@ test("guest reconnect within grace preserves the table, then disconnect evicts i
     assert.equal(output.includes("ws_disconnect_cleanup_retry"), false);
     assert.equal(output.includes("ws_table_janitor_"), false);
     assert.equal(output.includes("poker_ledger"), false);
+
+    const afterEvictionOutputOffset = output.lastIndexOf("[klog] ws_guest_table_evicted ");
+    const third = await connectClient(port);
+    await hello(third);
+    await auth(third, guestToken, "auth-guest-disconnect-third");
+    sendFrame(third, tableJoinFrame(guestTableId, "join-guest-after-eviction", "resume"));
+    const rejected = await nextCommandResultForRequest(third, "join-guest-after-eviction");
+    assert.equal(rejected.payload.status, "rejected");
+    assert.equal(rejected.payload.reason, "table_closed");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(
+      output.slice(afterEvictionOutputOffset).includes('"trigger":"guest_join_bootstrap"'),
+      false,
+      "resume after eviction must not recreate the guest runtime or schedule bots"
+    );
+    third.close();
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -3156,59 +3156,84 @@ wss.on("connection", (ws) => {
           });
           return;
         }
-        const materializedGuest = tableManager.materializeGuestTable({
-          tableId: frame.__resolvedTableId,
-          guestUserId: connState.session.userId,
-          nickname: connState.session.nickname || connState.nickname || null,
-          nowMs: Date.now()
+        const tableId = frame.__resolvedTableId;
+        const guestJoinIntent = frame.payload?.guestJoinIntent === "create" ? "create" : "resume";
+        await enqueueTableCommand({
+          tableId,
+          commandName: "guest_join",
+          run: async () => {
+            const runtimeExists = tableManager.listTableIds().includes(tableId);
+            if (!runtimeExists && guestJoinIntent !== "create") {
+              sendCommandResult(ws, connState, {
+                requestId: frame.requestId ?? null,
+                tableId,
+                status: "rejected",
+                reason: "table_closed"
+              });
+              return { ok: false, changed: false, code: "table_closed", retryable: false };
+            }
+            if (!runtimeExists) {
+              const materializedGuest = tableManager.materializeGuestTable({
+                tableId,
+                guestUserId: connState.session.userId,
+                nickname: connState.session.nickname || connState.nickname || null,
+                nowMs: Date.now()
+              });
+              if (!materializedGuest?.ok) {
+                sendCommandResult(ws, connState, {
+                  requestId: frame.requestId ?? null,
+                  tableId,
+                  status: "rejected",
+                  reason: materializedGuest?.code || "guest_table_failed"
+                });
+                return materializedGuest;
+              }
+            }
+            sessionStore.trackConnection({ ws, userId: connState.session.userId, sessionId: connState.session.sessionId });
+            const joined = tableManager.join({
+              ws,
+              userId: connState.session.userId,
+              tableId,
+              requestId: frame.requestId,
+              nowTs: Date.now(),
+              authoritativeSeatNo: 1,
+              buyIn: 100
+            });
+            if (!joined.ok) {
+              sendCommandResult(ws, connState, {
+                requestId: frame.requestId ?? null,
+                tableId,
+                status: "rejected",
+                reason: joined.code || "join_failed"
+              });
+              return joined;
+            }
+            const bootstrapped = tableManager.bootstrapHand(tableId, { nowMs: Date.now() });
+            sendCommandResult(ws, connState, {
+              requestId: frame.requestId ?? null,
+              tableId,
+              status: "accepted",
+              reason: joined.changed ? null : "already_joined"
+            });
+            const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);
+            sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: joined.tableState, tableSnapshot });
+            if (joined.changed || bootstrapped?.changed) {
+              broadcastStateSnapshots(tableId);
+              broadcastTableState(tableId, { excludeWs: ws });
+              scheduleBotStep({
+                tableId,
+                trigger: "guest_join_bootstrap",
+                requestId: frame.requestId ?? null,
+                frameTs: frame.ts
+              });
+            }
+            return {
+              ok: true,
+              changed: joined.changed === true || bootstrapped?.changed === true,
+              status: joined.changed ? "guest_joined" : "already_joined"
+            };
+          }
         });
-        if (!materializedGuest?.ok) {
-          sendCommandResult(ws, connState, {
-            requestId: frame.requestId ?? null,
-            tableId: frame.__resolvedTableId,
-            status: "rejected",
-            reason: materializedGuest?.code || "guest_table_failed"
-          });
-          return;
-        }
-        sessionStore.trackConnection({ ws, userId: connState.session.userId, sessionId: connState.session.sessionId });
-        const joined = tableManager.join({
-          ws,
-          userId: connState.session.userId,
-          tableId: frame.__resolvedTableId,
-          requestId: frame.requestId,
-          nowTs: Date.now(),
-          authoritativeSeatNo: 1,
-          buyIn: 100
-        });
-        if (!joined.ok) {
-          sendCommandResult(ws, connState, {
-            requestId: frame.requestId ?? null,
-            tableId: frame.__resolvedTableId,
-            status: "rejected",
-            reason: joined.code || "join_failed"
-          });
-          return;
-        }
-        const bootstrapped = tableManager.bootstrapHand(frame.__resolvedTableId, { nowMs: Date.now() });
-        sendCommandResult(ws, connState, {
-          requestId: frame.requestId ?? null,
-          tableId: frame.__resolvedTableId,
-          status: "accepted",
-          reason: joined.changed ? null : "already_joined"
-        });
-        const tableSnapshot = tableManager.tableSnapshot(frame.__resolvedTableId, connState.session.userId);
-        sendTableState(ws, connState, { requestId: frame.requestId ?? null, tableState: joined.tableState, tableSnapshot });
-        if (joined.changed || bootstrapped?.changed) {
-          broadcastStateSnapshots(frame.__resolvedTableId);
-          broadcastTableState(frame.__resolvedTableId, { excludeWs: ws });
-          scheduleBotStep({
-            tableId: frame.__resolvedTableId,
-            trigger: "guest_join_bootstrap",
-            requestId: frame.requestId ?? null,
-            frameTs: frame.ts
-          });
-        }
         return;
       }
 


### PR DESCRIPTION
## Summary

- marks a newly issued browser guest session as having one pending `create` join
- consumes that intent before the first network attempt and uses `resume` for reconnects and historical sessions
- serializes guest join with the existing per-table command queue used by eviction
- rejects `resume` when the guest runtime no longer exists with the existing `table_closed` result
- reuses the existing five-second closed-table redirect to the poker lobby

Closes #763

## Root cause

The guest join path always called `materializeGuestTable()`. After disconnect grace evicted an in-memory guest table, reopening the old page therefore silently created a replacement runtime under the same table ID instead of reporting that the previous game had ended.

## Scope and impact

This is the intentionally small UX fix agreed for #763. It adds no capability system, runtime epoch, JWT claims, database state, Supabase traffic, ledger behavior, or settlement changes.

Historical guest sessions without the new browser marker are resume-only. If their runtime is gone, they now receive `table_closed` and return to the lobby. Reconnect while the runtime still exists preserves the current seat, stack, and hand.

Accepted compromise: a modified client can manually send `guestJoinIntent: "create"`. Guest state is process-local and has no financial or ledger impact; preventing adversarial frame modification is outside this issue.

## Validation

- `node --test ws-server/server.guest-mode.behavior.test.mjs tests/poker-v2-live.behavior.test.mjs tests/poker-ui.behavior.test.mjs` — 67 passed
- `node --test ws-server/server.behavior.test.mjs` — 100 passed
- `npm run syntax`
- `npm run check:csp-inline`
- `git diff --check`

## Preview verification

Because this changes both browser code and `ws-server/**`, verify the Netlify Deploy Preview and run a manual WS Preview Deploy for the exact PR SHA before smoke testing create, reconnect within grace, eviction, and reopening the old guest page.
