### PR TITLE
chore(poker): reduce remaining log noise

### DIFF
--- a/netlify/functions/poker-guest-session.mjs
+++ b/netlify/functions/poker-guest-session.mjs
@@ -108,7 +108,6 @@ export async function handler(event) {
   const expiresInSec = resolveTtlSec(process.env);
   const token = signGuestToken({ sub: guestId, nickname, tableId, secret: mintSecret, ttlSec: expiresInSec });
 
-  klog("poker_guest_session_created", { tableId, guestIdPrefix: guestId.slice(0, 12), expiresInSec });
   return {
     statusCode: 200,
     headers: originCors,

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -209,7 +209,6 @@ export async function handler(event) {
       const matchKey = `quickseat:${maxPlayers}:${stakesParsed.value.sb}:${stakesParsed.value.bb}`;
       const humanSeatFreshCutoffIso = new Date(Date.now() - resolveHumanSeatFreshMs(process.env.POKER_ACTIVE_HUMAN_SEAT_FRESH_MS)).toISOString();
 
-      klog("poker_quick_seat_lock", { matchKey, maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb, stakesJson });
       await tx.unsafe("select pg_advisory_xact_lock(hashtext($1));", [matchKey]);
 
       const preferredRows = await selectCandidate(tx, { stakesJson, maxPlayers, requireHuman: true, humanSeatFreshCutoffIso });
@@ -223,7 +222,6 @@ export async function handler(event) {
         });
         if (recommendation.kind === "insufficient_chips") return recommendation;
         if (recommendation.kind === "recommended") {
-          klog("poker_quick_seat_selected", { tableId: recommendation.tableId, strategy: "prefer_humans", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
           return { ...recommendation, strategy: "prefer_humans" };
         }
       }
@@ -239,15 +237,11 @@ export async function handler(event) {
         });
         if (recommendation.kind === "insufficient_chips") return recommendation;
         if (recommendation.kind === "recommended") {
-          klog("poker_quick_seat_selected", { tableId: recommendation.tableId, strategy: "any_open", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
           return { ...recommendation, strategy: "any_open" };
         }
       }
 
       const createdRecommendation = await createAndRecommend(tx, createPayload);
-      if (createdRecommendation.kind === "recommended") {
-        klog("poker_quick_seat_selected", { tableId: createdRecommendation.tableId, strategy: "create", maxPlayers, sb: stakesParsed.value.sb, bb: stakesParsed.value.bb });
-      }
       return createdRecommendation;
     });
 
@@ -267,7 +261,6 @@ export async function handler(event) {
       triggerWsLobbyMaterialize({ tableId: result.tableId, maxPlayers, stakes: stakesParsed.value, klog });
     }
 
-    klog("poker_quick_seat_ok", { tableId: result.tableId, seatNo: result.seatNo, userId: auth.userId, strategy: result.strategy });
     return {
       statusCode: 200,
       headers: mergeHeaders(cors),

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1716,6 +1716,7 @@
           if (status === 'auth_ok'){
             lobbyReconnectAttempt = 0;
             setLobbyConnectingState(null);
+            klog('poker_lobby_ws_connected', { reason: reason });
             return;
           }
           if (status === 'closed'){

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -875,22 +875,9 @@
     flyoutEl.classList.remove('poker-showdown-flyout--exiting');
     void flyoutEl.offsetWidth;
     flyoutEl.classList.add('poker-showdown-flyout--visible');
-    klog('poker_showdown_flyout_show', {
-      tableId: tableIdValue || null,
-      handId: handId || null,
-      reason: reason || null,
-      winnersCount: winners.length,
-      payoutCount: payoutUserIds.length,
-      viewerWon: viewerWon,
-      cardsVisible: canShowCards && viewerWon && viewerHoleCards.length === 2
-    });
     showdownFlyoutHideTimer = setTimeout(function(){
       flyoutEl.classList.remove('poker-showdown-flyout--visible');
       flyoutEl.classList.add('poker-showdown-flyout--exiting');
-      klog('poker_showdown_flyout_hide', {
-        tableId: tableIdValue || null,
-        handId: handId || null
-      });
       if (showdownFlyoutExitTimer){
         clearTimeout(showdownFlyoutExitTimer);
       }
@@ -1591,7 +1578,6 @@
       ensureLobbyLoadingVisible();
       if (lobbyWsClient && lobbyWsClient.isReady()) {
         if (lobbyWsClient.requestLobbySnapshot()) {
-          klog('poker_lobby_ws_snapshot_request', { reason: reason || 'refresh' });
           return true;
         }
       }
@@ -1730,7 +1716,6 @@
           if (status === 'auth_ok'){
             lobbyReconnectAttempt = 0;
             setLobbyConnectingState(null);
-            klog('poker_lobby_ws_connected', { reason: reason });
             return;
           }
           if (status === 'closed'){
@@ -1762,7 +1747,6 @@
           if (tableList) tableList.innerHTML = '';
         }
       });
-      klog('poker_lobby_ws_connect_start', { reason: reason });
       lobbyWsClient.start();
     }
 
@@ -1981,7 +1965,6 @@
 
   // ========== INIT ==========
   function init(){
-    klog('poker_ui_loaded', { version: UI_VERSION, page: 'lobby' });
     initLobby();
   }
 

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -553,7 +553,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
     throw makeError("temporarily_unavailable");
   }
   const runPostTransaction = await resolvePostTransactionFn(postTransactionFn);
-  klog("shared_join_start", { tableId, userId, seatNo, autoSeat: autoSeat === true, preferredSeatNo, buyIn });
   return beginSql(async (tx) => {
     try {
       const resolvedBuyIn = normalizePositiveInt(buyIn);
@@ -589,7 +588,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
             throw makeError("authoritative_state_invalid");
           }
           await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-          klog("shared_join_success", { seatNo: persisted.seatNo, stack: persisted.stack, snapshotVersion: stateRow.version });
           return {
             ok: true,
             tableId,
@@ -618,9 +616,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         }
         const updatedState = writeLockedStateResult(await updateStateLocked(tx, { tableId, nextState: nextStateForStorage }));
         const snapshotVersion = requirePostMutationVersion({ previousVersion: stateRow.version, nextVersion: updatedState.version });
-        klog("shared_join_state_written", { previousVersion: stateRow.version, newVersion: snapshotVersion });
         await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-        klog("shared_join_success", { seatNo: persisted.seatNo, stack: persisted.stack, snapshotVersion });
         return {
           ok: true,
           tableId,
@@ -673,7 +669,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       }
 
       if (!Number.isInteger(resolvedSeatNo)) throw makeError("table_full");
-      klog("shared_join_seat_selected", { seatNo: resolvedSeatNo, occupiedCount: occupied.size });
 
       while (true) {
         const insertedRows = await insertSeatRow({
@@ -717,7 +712,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         : `join-buyin:${tableId}:${userId}:${resolvedSeatNo}:${resolvedBuyIn}`;
 
       let buyInDuplicated = false;
-      klog("shared_join_ledger_start", { buyIn: resolvedBuyIn });
       try {
         await postUserTableBuyIn({
           postTransaction: runPostTransaction,
@@ -732,7 +726,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         buyInDuplicated = true;
         klog("ws_join_authoritative_buyin_duplicate_idempotency", { tableId, userId, idempotencyKey });
       }
-      klog("shared_join_ledger_result", { ok: true });
 
       let fundedStack = resolvedBuyIn;
       if (buyInDuplicated) {
@@ -747,7 +740,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
           [tableId, userId, resolvedSeatNo, resolvedBuyIn]
         );
       }
-      klog("shared_join_stack_updated", { userId, stack: fundedStack });
 
       const botCfg = getBotConfig(process.env);
       const seededBots = await seedBotsForJoin({
@@ -759,10 +751,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       humanUserId: userId,
       postTransaction: runPostTransaction,
       klog
-      });
-      klog("shared_join_bots_seeded", {
-        botCount: Array.isArray(seededBots) ? seededBots.length : 0,
-        botSeats: Array.isArray(seededBots) ? seededBots.map((bot) => Number(bot?.seatNo)).filter((botSeatNo) => Number.isInteger(botSeatNo) && botSeatNo >= 1) : []
       });
       const updatedStateRow = await syncStateSeatAndStack({
       tx,
@@ -776,10 +764,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       maxPlayers,
       botCfg
       });
-      klog("shared_join_state_written", { previousVersion: null, newVersion: updatedStateRow.version });
       await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
-      klog("ws_join_authoritative_persisted", { tableId, userId, seatNo: resolvedSeatNo, autoSeat: autoSeat === true, preferredSeatNo: preferredSeatNoRequested, buyIn: resolvedBuyIn, fundedStack });
-      klog("shared_join_success", { seatNo: resolvedSeatNo, stack: fundedStack, snapshotVersion: updatedStateRow.version });
       return {
         ok: true,
         tableId,
@@ -798,10 +783,6 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         })
       };
     } catch (error) {
-      klog("shared_join_error", {
-        code: typeof error?.code === "string" ? error.code : "authoritative_join_failed",
-        message: error?.message || "unknown"
-      });
       throw error;
     }
   });

--- a/shared/poker-domain/leave.behavior.test.mjs
+++ b/shared/poker-domain/leave.behavior.test.mjs
@@ -709,14 +709,13 @@ for (const settledPhase of ["SETTLED", "HAND_DONE"]) {
   assert.equal(ctx.calls.closeTable, 1);
   assert.equal(ctx.calls.holeCardDelete, 0, "close path should preserve audit hole cards");
   assert.equal(ctx.calls.storeResult, 1);
-  assert.equal(logNames.includes("poker_leave_bot_autoplay_start"), true);
-  assert.equal(logNames.includes("poker_leave_bot_autoplay_finish"), true);
-  assert.equal(logNames.includes("poker_leave_detach_start"), true);
-  assert.equal(logNames.includes("poker_leave_post_hand_cashout"), true);
-  assert.equal(logNames.includes("poker_leave_detach_finish"), true);
-  assert.equal(logNames.includes("poker_leave_table_closed_terminal_bots_only"), true);
-  assert.equal(logNames.indexOf("poker_leave_bot_autoplay_start") < logNames.indexOf("poker_leave_bot_autoplay_finish"), true);
-  assert.equal(logNames.indexOf("poker_leave_detach_start") < logNames.indexOf("poker_leave_detach_finish"), true);
+  assert.equal(logNames.includes("poker_leave_bot_autoplay_start"), false);
+  assert.equal(logNames.includes("poker_leave_bot_autoplay_finish"), false);
+  assert.equal(logNames.includes("poker_leave_detach_start"), false);
+  assert.equal(logNames.includes("poker_leave_post_hand_cashout"), false);
+  assert.equal(logNames.includes("poker_leave_detach_finish"), false);
+  assert.equal(logNames.includes("poker_leave_table_closed_terminal_bots_only"), false);
+  assert.equal(logNames.includes("poker_leave_cashout"), true);
 }
 
 {

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -378,6 +378,7 @@ const executePostLeaveBotAutoplayLoop = async ({
   botsOnlyInHand,
   klog,
   klogVerbose,
+  verboseLogsEnabled,
 }) => {
   if (!isActionPhase(state?.phase)) {
     return { state, version, attempted: false, reason: "not_applicable" };
@@ -416,7 +417,7 @@ const executePostLeaveBotAutoplayLoop = async ({
     return { state, version, attempted: true, reason: privateStateResult.reason };
   }
 
-  const autoplayStartedAtMs = Date.now();
+  const autoplayStartedAtMs = verboseLogsEnabled ? Date.now() : null;
   klogVerbose("poker_leave_bot_autoplay_loop", () => ({
     tableId,
     requestId: requestId || null,
@@ -524,6 +525,7 @@ export async function executePokerLeave({
   nowMs = Date.now(),
   klog,
   klogVerbose = () => {},
+  verboseLogsEnabled = false,
   includeState = false,
   runPostLeaveBotAutoplay = true,
   hasConnectedHumanPresence = () => false
@@ -847,6 +849,7 @@ export async function executePokerLeave({
               botsOnlyInHand,
               klog,
               klogVerbose,
+              verboseLogsEnabled,
             });
             latestState = autoplayResult.state;
             latestVersion = autoplayResult.version;

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -467,14 +467,6 @@ const executePostLeaveBotAutoplayLoop = async ({
     },
   });
 
-  klog("poker_leave_bot_autoplay_finish", {
-    tableId,
-    userId,
-    requestId: requestId || null,
-    botActionCount: botLoop.botActionCount,
-    botStopReason: botLoop.botStopReason,
-  });
-
   return {
     state: sanitizePersistedState(botLoop.responseFinalState),
     version: botLoop.loopVersion,
@@ -518,7 +510,6 @@ export async function executePokerLeave({
   hasConnectedHumanPresence = () => false
 }) {
   void nowMs;
-  let txId = null;
   const result = await beginSql(async (tx) => {
       let mutated = false;
       let requestInfo = { status: "none" };
@@ -609,7 +600,6 @@ export async function executePokerLeave({
           throw makeError(409, "stack_ambiguous");
         }
         const stateStack = authoritativeStack.amount;
-        const cashOutAmount = authoritativeStack.amount;
         const isStackMissing = rawSeatStack == null;
         if (isStackMissing) {
           klog("poker_leave_stack_missing", { tableId, userId: userId, seatNo });
@@ -822,15 +812,6 @@ export async function executePokerLeave({
           );
           const botsOnlyInHand = !hasParticipatingHumanInHand(latestState, seatBotMap);
           if (runPostLeaveBotAutoplay && (isBotTurn(latestState.turnUserId, seatBotMap) || botsOnlyInHand)) {
-            klog("poker_leave_bot_autoplay_start", {
-              tableId,
-              userId,
-              requestId: requestId || null,
-              handId: typeof latestState.handId === "string" ? latestState.handId : null,
-              phase: typeof latestState.phase === "string" ? latestState.phase : null,
-              turnUserId: typeof latestState.turnUserId === "string" ? latestState.turnUserId : null,
-              botsOnlyInHand
-            });
             const autoplayResult = await executePostLeaveBotAutoplayLoop({
               tx,
               tableId,
@@ -856,16 +837,6 @@ export async function executePokerLeave({
         let detachedCashOutAmount = 0;
         if (shouldDetachSeatAndStack) {
           const latestStacks = parseStacks(latestState.stacks);
-          const latestSeats = parseSeats(latestState.seats);
-          klog("poker_leave_detach_start", {
-            tableId,
-            userId,
-            requestId: requestId || null,
-            handId: typeof latestState.handId === "string" ? latestState.handId : null,
-            phase: typeof latestState.phase === "string" ? latestState.phase : null,
-            hasSeatInState: latestSeats.some((seatItem) => seatItem?.userId === userId),
-            hasStackInState: Object.prototype.hasOwnProperty.call(latestStacks, userId)
-          });
           try {
             const latestHasAuthoritativeStack = Object.prototype.hasOwnProperty.call(latestStacks, userId);
             detachedCashOutAmount = requireAuthoritativeHumanStack({ state: latestHasAuthoritativeStack ? latestState : currentState, userId }).amount;
@@ -873,20 +844,12 @@ export async function executePokerLeave({
             klog("poker_leave_post_hand_stack_ambiguous", { tableId, userId, reason: error?.code || "stack_ambiguous", source: "ambiguous" });
             throw makeError(409, "stack_ambiguous");
           }
-          klog("poker_leave_post_hand_cashout", {
-            tableId,
-            userId,
-            requestId: requestId || null,
-            handId: typeof latestState.handId === "string" ? latestState.handId : null,
-            phase: typeof latestState.phase === "string" ? latestState.phase : null,
-            amount: detachedCashOutAmount
-          });
           if (detachedCashOutAmount > 0) {
             const idempotencyKey = requestId
               ? `poker:leave:${tableId}:${userId}:${requestId}`
               : `poker:leave:${tableId}:${userId}:${detachedCashOutAmount}`;
 
-            txId = await postHumanLeaveCashoutInTx({
+            await postHumanLeaveCashoutInTx({
               tx,
               tableId,
               userId,
@@ -927,14 +890,6 @@ export async function executePokerLeave({
             tableId,
             userId,
           ]);
-          klog("poker_leave_detach_finish", {
-            tableId,
-            userId,
-            requestId: requestId || null,
-            handId: typeof latestState.handId === "string" ? latestState.handId : null,
-            phase: typeof latestState.phase === "string" ? latestState.phase : null,
-            amount: detachedCashOutAmount
-          });
         }
 
         klog("poker_leave_cashout", {
@@ -981,14 +936,6 @@ export async function executePokerLeave({
           latestState = sanitizePersistedState(toClosedInertState(latestState, {}));
           finalTableStatus = "CLOSED";
           mutated = terminalCloseResult.changed === true || mutated;
-          klog("poker_leave_table_closed_terminal_bots_only", {
-            tableId,
-            userId,
-            requestId: requestId || null,
-            handId: typeof latestState.handId === "string" ? latestState.handId : null,
-            phase: typeof latestState.phase === "string" ? latestState.phase : null,
-            remainingSeats: allSeatRows.length
-          });
         }
 
         if (mutated) {
@@ -1024,13 +971,6 @@ export async function executePokerLeave({
             result: resultPayload,
           });
         }
-        klog("poker_leave_ok", {
-          tableId,
-          userId: userId,
-          requestId: requestId || null,
-          cashedOut: shouldDetachSeatAndStack && cashOutAmount > 0,
-          txId,
-        });
         return resultPayload;
       } catch (error) {
         if (requestId && !mutated) {

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -377,6 +377,7 @@ const executePostLeaveBotAutoplayLoop = async ({
   validatePersistedState,
   botsOnlyInHand,
   klog,
+  klogVerbose,
 }) => {
   if (!isActionPhase(state?.phase)) {
     return { state, version, attempted: false, reason: "not_applicable" };
@@ -415,6 +416,14 @@ const executePostLeaveBotAutoplayLoop = async ({
     return { state, version, attempted: true, reason: privateStateResult.reason };
   }
 
+  const autoplayStartedAtMs = Date.now();
+  klogVerbose("poker_leave_bot_autoplay_loop", () => ({
+    tableId,
+    requestId: requestId || null,
+    stage: "start",
+    phase: typeof autoplayStartState?.phase === "string" ? autoplayStartState.phase : null,
+    botsOnlyInHand
+  }));
   const botLoop = await runBotAutoplayLoop({
     tableId,
     requestId: `bot-auto:post-leave:${requestId || "no-request-id"}`,
@@ -466,6 +475,15 @@ const executePostLeaveBotAutoplayLoop = async ({
       };
     },
   });
+  klogVerbose("poker_leave_bot_autoplay_loop", () => ({
+    tableId,
+    requestId: requestId || null,
+    stage: "outcome",
+    ok: botLoop.botFailureReason == null,
+    actionCount: Number(botLoop.botActionCount || 0),
+    reason: botLoop.botFailureReason || botLoop.botStopReason || "completed",
+    durationMs: Math.max(0, Date.now() - autoplayStartedAtMs)
+  }));
 
   return {
     state: sanitizePersistedState(botLoop.responseFinalState),
@@ -505,6 +523,7 @@ export async function executePokerLeave({
   requestId = null,
   nowMs = Date.now(),
   klog,
+  klogVerbose = () => {},
   includeState = false,
   runPostLeaveBotAutoplay = true,
   hasConnectedHumanPresence = () => false
@@ -827,6 +846,7 @@ export async function executePokerLeave({
               validatePersistedState: (stateToValidate) => validatePersistedStateOrThrow(stateToValidate, makeError),
               botsOnlyInHand,
               klog,
+              klogVerbose,
             });
             latestState = autoplayResult.state;
             latestVersion = autoplayResult.version;

--- a/ws-server/poker/handlers/join.behavior.test.mjs
+++ b/ws-server/poker/handlers/join.behavior.test.mjs
@@ -500,7 +500,7 @@ test('handleJoinCommand preserves temporarily_unavailable for runtime authoritat
   assert.equal(calls.snapshots, 0);
 });
 
-test('logs authoritative join lifecycle for debugging', async () => {
+test('does not emit routine authoritative join lifecycle logs', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 100 });
   ctx.authoritativeJoinEnabled = true;
   ctx.persistedBootstrapEnabled = true;
@@ -528,9 +528,9 @@ test('logs authoritative join lifecycle for debugging', async () => {
   await handleJoinCommand(ctx);
 
   const eventNames = calls.logs.map((entry) => entry.event);
-  assert.equal(eventNames.includes('ws_join_authoritative_start'), true);
-  assert.equal(eventNames.includes('ws_join_authoritative_result'), true);
-  assert.equal(eventNames.includes('ws_join_restore_result'), true);
-  assert.equal(eventNames.includes('ws_join_restore_validate'), true);
+  assert.equal(eventNames.includes('ws_join_authoritative_start'), false);
+  assert.equal(eventNames.includes('ws_join_authoritative_result'), false);
+  assert.equal(eventNames.includes('ws_join_restore_result'), false);
+  assert.equal(eventNames.includes('ws_join_restore_validate'), false);
   assert.equal(calls.command[0].status, 'accepted');
 });

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -47,26 +47,39 @@ function classifyRestoreFailureAsMissingState(reason) {
   return ["state_missing", "poker_state_missing", "invalid_persisted_state"].includes(String(reason || ""));
 }
 
-function restoredAuthoritativeStateLooksComplete({ restoredTable, userId, seatNo, seededBots = [], expectedStateVersion = null }) {
+function evaluateRestoredAuthoritativeState({ restoredTable, userId, seatNo, seededBots = [], expectedStateVersion = null }) {
   const coreState = restoredTable?.coreState && typeof restoredTable.coreState === "object" ? restoredTable.coreState : null;
   const seats = coreState?.seats && typeof coreState.seats === "object" && !Array.isArray(coreState.seats) ? coreState.seats : {};
   const stacks = coreState?.publicStacks && typeof coreState.publicStacks === "object" && !Array.isArray(coreState.publicStacks) ? coreState.publicStacks : {};
   const restoredVersion = Number(coreState?.version);
-  if (!Number.isInteger(restoredVersion) || restoredVersion <= 0) return false;
-  if (expectedStateVersion !== null && restoredVersion !== Number(expectedStateVersion)) return false;
-  if (Number(seats[userId]) !== Number(seatNo) || Number(stacks[userId]) <= 0) return false;
-  for (const bot of seededBots) {
+  const expectedVersionValid = Number.isInteger(restoredVersion)
+    && restoredVersion > 0
+    && (expectedStateVersion === null || restoredVersion === Number(expectedStateVersion));
+  const humanSeatValid = Number(seats[userId]) === Number(seatNo);
+  const humanStackValid = Number(stacks[userId]) > 0;
+  const seededBotProjectionValid = seededBots.every((bot) => {
     const botUserId = typeof bot?.userId === "string" ? bot.userId : "";
     const botSeatNo = Number(bot?.seatNo);
-    if (!botUserId || !Number.isInteger(botSeatNo) || botSeatNo < 1) return false;
-    if (Number(seats[botUserId]) !== botSeatNo || Number(stacks[botUserId]) <= 0) return false;
-  }
-  return true;
+    return Boolean(
+      botUserId
+      && Number.isInteger(botSeatNo)
+      && botSeatNo >= 1
+      && Number(seats[botUserId]) === botSeatNo
+      && Number(stacks[botUserId]) > 0
+    );
+  });
+  return {
+    ok: expectedVersionValid && humanSeatValid && humanStackValid && seededBotProjectionValid,
+    expectedVersionValid,
+    humanSeatValid,
+    humanStackValid,
+    seededBotProjectionValid
+  };
 }
 
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
 
-export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {} }) {
+export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {}, klogVerbose = () => {} }) {
   const tableId = frame.__resolvedTableId;
   const authoritativeJoinRequired = authoritativeJoinEnabled && !observeOnlyJoinEnabled;
   const parsedJoinIntent = parseJoinIntent(frame.payload);
@@ -93,6 +106,11 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
 
   if (authoritativeJoinRequired && persistedBootstrapEnabled) {
     const authoritativeJoinExecutor = await loadAuthoritativeJoinExecutor();
+    const authoritativeJoinStartedAtMs = Date.now();
+    klogVerbose("ws_join_authoritative_start", () => ({
+      tableId,
+      requestId: frame.requestId ?? null
+    }));
     const authoritativeJoin = await authoritativeJoinExecutor({
       tableId,
       userId: connState.session.userId,
@@ -110,6 +128,13 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
           reason = "state_missing";
         }
       }
+      klogVerbose("ws_join_authoritative_result", () => ({
+        tableId,
+        requestId: frame.requestId ?? null,
+        ok: false,
+        reason,
+        durationMs: Math.max(0, Date.now() - authoritativeJoinStartedAtMs)
+      }));
       sendCommandResult(ws, connState, {
         requestId: frame.requestId ?? null,
         tableId,
@@ -118,6 +143,14 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       });
       return;
     }
+    klogVerbose("ws_join_authoritative_result", () => ({
+      tableId,
+      requestId: frame.requestId ?? null,
+      ok: true,
+      rejoin: authoritativeJoin?.rejoin === true,
+      stateVersion: Number(authoritativeJoin?.snapshot?.stateVersion) || null,
+      durationMs: Math.max(0, Date.now() - authoritativeJoinStartedAtMs)
+    }));
     authoritativeJoinResult = authoritativeJoin;
   }
 
@@ -146,17 +179,24 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     const expectedVersionRaw = authoritativeJoinResult?.snapshot?.stateVersion ?? null;
     const expectedVersion = expectedVersionRaw === null || expectedVersionRaw === undefined ? null : Number(expectedVersionRaw);
     const seededBots = Array.isArray(authoritativeJoinResult?.seededBots) ? authoritativeJoinResult.seededBots : [];
-    if (!restoredAuthoritativeStateLooksComplete({
+    const restoreValidation = evaluateRestoredAuthoritativeState({
       restoredTable: restored?.restoredTable,
       userId: connState.session.userId,
       seatNo: authoritativeJoinResult?.seatNo,
       seededBots,
       expectedStateVersion: expectedVersionRaw
-    })) {
+    });
+    if (!restoreValidation.ok) {
       klog("ws_join_restore_invalid", {
+        tableId,
+        requestId: frame.requestId ?? null,
         reason: "validation_failed",
         restoredVersion: Number.isInteger(restoredVersion) ? restoredVersion : null,
-        expectedVersion: Number.isInteger(expectedVersion) ? expectedVersion : null
+        expectedVersion: Number.isInteger(expectedVersion) ? expectedVersion : null,
+        expectedVersionValid: restoreValidation.expectedVersionValid,
+        humanSeatValid: restoreValidation.humanSeatValid,
+        humanStackValid: restoreValidation.humanStackValid,
+        seededBotProjectionValid: restoreValidation.seededBotProjectionValid
       });
       sendCommandResult(ws, connState, {
         requestId: frame.requestId ?? null,
@@ -184,6 +224,11 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     authoritativeSeatNo: authoritativeJoinResult?.seatNo ?? null
   });
   if (!joined.ok) {
+    klog("ws_join_attach_failed", {
+      tableId,
+      requestId: frame.requestId ?? null,
+      code: joined?.code || "join_failed"
+    });
     sendCommandResult(ws, connState, {
       requestId: frame.requestId ?? null,
       tableId,

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -47,11 +47,6 @@ function classifyRestoreFailureAsMissingState(reason) {
   return ["state_missing", "poker_state_missing", "invalid_persisted_state"].includes(String(reason || ""));
 }
 
-function countObjectKeys(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return 0;
-  return Object.keys(value).length;
-}
-
 function restoredAuthoritativeStateLooksComplete({ restoredTable, userId, seatNo, seededBots = [], expectedStateVersion = null }) {
   const coreState = restoredTable?.coreState && typeof restoredTable.coreState === "object" ? restoredTable.coreState : null;
   const seats = coreState?.seats && typeof coreState.seats === "object" && !Array.isArray(coreState.seats) ? coreState.seats : {};
@@ -98,14 +93,6 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
 
   if (authoritativeJoinRequired && persistedBootstrapEnabled) {
     const authoritativeJoinExecutor = await loadAuthoritativeJoinExecutor();
-    klog("ws_join_authoritative_start", {
-      tableId,
-      userId: connState.session.userId,
-      seatNo: joinIntent.seatNo,
-      autoSeat: joinIntent.autoSeat,
-      preferredSeatNo: joinIntent.preferredSeatNo,
-      buyIn: joinIntent.buyIn
-    });
     const authoritativeJoin = await authoritativeJoinExecutor({
       tableId,
       userId: connState.session.userId,
@@ -115,27 +102,10 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       preferredSeatNo: joinIntent.preferredSeatNo,
       buyIn: joinIntent.buyIn
     });
-    const resultSnapshotVersion = Number(authoritativeJoin?.snapshot?.stateVersion);
-    klog("ws_join_authoritative_result", {
-      ok: authoritativeJoin?.ok === true,
-      seatNo: authoritativeJoin?.seatNo ?? null,
-      stack: authoritativeJoin?.stack ?? null,
-      rejoin: authoritativeJoin?.rejoin === true,
-      hasSnapshot: Boolean(authoritativeJoin?.snapshot && typeof authoritativeJoin.snapshot === "object"),
-      snapshotVersion: Number.isInteger(resultSnapshotVersion) ? resultSnapshotVersion : null,
-      seededBotsCount: Array.isArray(authoritativeJoin?.seededBots) ? authoritativeJoin.seededBots.length : 0
-    });
     if (!authoritativeJoin?.ok) {
       let reason = normalizeAuthoritativeJoinReason(authoritativeJoin?.code);
       if (reason === "authoritative_join_failed") {
-        klog("ws_join_restore_start", { tableId });
         const restored = await restoreTableFromPersisted(tableId);
-        klog("ws_join_restore_result", {
-          ok: restored?.ok === true,
-          version: restored?.restoredTable?.coreState?.version ?? null,
-          seatsCount: countObjectKeys(restored?.restoredTable?.coreState?.seats),
-          stacksCount: countObjectKeys(restored?.restoredTable?.coreState?.publicStacks)
-        });
         if (!restored?.ok && classifyRestoreFailureAsMissingState(restored?.reason || restored?.code)) {
           reason = "state_missing";
         }
@@ -163,14 +133,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
   }
 
   if (authoritativeJoinRequired && persistedBootstrapEnabled) {
-    klog("ws_join_restore_start", { tableId });
     const restored = await restoreTableFromPersisted(tableId);
-    klog("ws_join_restore_result", {
-      ok: restored?.ok === true,
-      version: restored?.restoredTable?.coreState?.version ?? null,
-      seatsCount: countObjectKeys(restored?.restoredTable?.coreState?.seats),
-      stacksCount: countObjectKeys(restored?.restoredTable?.coreState?.publicStacks)
-    });
     if (!restored.ok) {
       sendError(ws, connState, {
         code: "TABLE_BOOTSTRAP_FAILED",
@@ -182,23 +145,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     const restoredVersion = Number(restored?.restoredTable?.coreState?.version);
     const expectedVersionRaw = authoritativeJoinResult?.snapshot?.stateVersion ?? null;
     const expectedVersion = expectedVersionRaw === null || expectedVersionRaw === undefined ? null : Number(expectedVersionRaw);
-    const restoredSeats = restored?.restoredTable?.coreState?.seats && typeof restored.restoredTable.coreState.seats === "object" && !Array.isArray(restored.restoredTable.coreState.seats)
-      ? restored.restoredTable.coreState.seats
-      : {};
-    const restoredStacks = restored?.restoredTable?.coreState?.publicStacks && typeof restored.restoredTable.coreState.publicStacks === "object" && !Array.isArray(restored.restoredTable.coreState.publicStacks)
-      ? restored.restoredTable.coreState.publicStacks
-      : {};
     const seededBots = Array.isArray(authoritativeJoinResult?.seededBots) ? authoritativeJoinResult.seededBots : [];
-    const userSeatMatch = Number(restoredSeats[connState.session.userId]) === Number(authoritativeJoinResult?.seatNo);
-    const userStackValid = Number(restoredStacks[connState.session.userId]) > 0;
-    const botsValidated = seededBots.every((bot) => Number(restoredSeats[bot?.userId]) === Number(bot?.seatNo) && Number(restoredStacks[bot?.userId]) > 0);
-    klog("ws_join_restore_validate", {
-      restoredVersion: Number.isInteger(restoredVersion) ? restoredVersion : null,
-      expectedVersion: Number.isInteger(expectedVersion) ? expectedVersion : null,
-      userSeatMatch,
-      userStackValid,
-      botsValidated
-    });
     if (!restoredAuthoritativeStateLooksComplete({
       restoredTable: restored?.restoredTable,
       userId: connState.session.userId,
@@ -222,11 +169,6 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
   }
 
   sessionStore.trackConnection({ ws, userId: connState.session.userId, sessionId: connState.session.sessionId });
-  klog("ws_join_attach_start", {
-    userId: connState.session.userId,
-    tableId,
-    authoritativeSeatNo: authoritativeJoinResult?.seatNo ?? null
-  });
   const joined = tableManager.join({
     ws,
     userId: connState.session.userId,
@@ -240,11 +182,6 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       ? null
       : (authoritativeJoinResult?.stack ?? joinIntent.buyIn),
     authoritativeSeatNo: authoritativeJoinResult?.seatNo ?? null
-  });
-  klog("ws_join_attach_result", {
-    ok: joined?.ok === true,
-    changed: joined?.changed === true,
-    hasTableState: Boolean(joined?.tableState)
   });
   if (!joined.ok) {
     sendCommandResult(ws, connState, {

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -79,7 +79,7 @@ function evaluateRestoredAuthoritativeState({ restoredTable, userId, seatNo, see
 
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
 
-export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {}, klogVerbose = () => {} }) {
+export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {}, klogVerbose = () => {}, verboseLogsEnabled = false }) {
   const tableId = frame.__resolvedTableId;
   const authoritativeJoinRequired = authoritativeJoinEnabled && !observeOnlyJoinEnabled;
   const parsedJoinIntent = parseJoinIntent(frame.payload);
@@ -106,7 +106,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
 
   if (authoritativeJoinRequired && persistedBootstrapEnabled) {
     const authoritativeJoinExecutor = await loadAuthoritativeJoinExecutor();
-    const authoritativeJoinStartedAtMs = Date.now();
+    const authoritativeJoinStartedAtMs = verboseLogsEnabled ? Date.now() : null;
     klogVerbose("ws_join_authoritative_start", () => ({
       tableId,
       requestId: frame.requestId ?? null

--- a/ws-server/poker/persistence/authoritative-join-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.behavior.test.mjs
@@ -37,9 +37,10 @@ test("authoritative join adapter returns unavailable when join core is missing",
 });
 
 test("authoritative join adapter maps unknown thrown errors", async () => {
+  const logs = [];
   const execute = createAuthoritativeJoinExecutor({
     env: {},
-    klog: () => {},
+    klog: (event, payload) => logs.push({ event, payload }),
     loadLockedStateHelpersFn: lockedStateHelpers,
     loadPostTransactionFn: async () => async () => ({ ok: true }),
     loadJoinModule: async () => ({
@@ -50,6 +51,7 @@ test("authoritative join adapter maps unknown thrown errors", async () => {
   });
   const result = await execute({ tableId: "t1", userId: "u1", requestId: "r1" });
   assert.deepEqual(result, { ok: false, code: "authoritative_join_failed" });
+  assert.equal(logs.filter((entry) => entry.event === "ws_join_authoritative_failed").length, 1);
 });
 
 test("authoritative join adapter returns unavailable when locked-state validator helper is missing", async () => {
@@ -325,9 +327,10 @@ test("authoritative join adapter preserves poker_state_missing as protocol-safe 
 
 
 test("authoritative join adapter preserves seat_taken as protocol-safe known code", async () => {
+  const logs = [];
   const execute = createAuthoritativeJoinExecutor({
     env: {},
-    klog: () => {},
+    klog: (event, payload) => logs.push({ event, payload }),
     beginSql: async (fn) => fn({ ok: true }),
     loadLockedStateHelpersFn: lockedStateHelpers,
     loadPostTransactionFn: async () => async () => ({ ok: true }),
@@ -342,6 +345,7 @@ test("authoritative join adapter preserves seat_taken as protocol-safe known cod
 
   const result = await execute({ tableId: "t1", userId: "u1", requestId: "r7", buyIn: 100 });
   assert.deepEqual(result, { ok: false, code: "seat_taken" });
+  assert.equal(logs.some((entry) => entry.event === "ws_join_authoritative_failed"), false);
 });
 
 

--- a/ws-server/poker/persistence/authoritative-join-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.mjs
@@ -56,6 +56,25 @@ function normalizeJoinError(error) {
   return { ok: false, code: "authoritative_join_failed" };
 }
 
+const EXPECTED_JOIN_REJECTION_CODES = new Set([
+  "table_not_found",
+  "table_closed",
+  "table_not_open",
+  "seat_taken",
+  "table_full",
+  "table_full_bot_leaving",
+  "duplicate_seat",
+  "invalid_seat_no",
+  "invalid_buy_in",
+  "request_pending",
+  "insufficient_funds"
+]);
+
+function shouldLogAuthoritativeJoinFailure(error) {
+  const code = typeof error?.code === "string" ? error.code : "";
+  return !EXPECTED_JOIN_REJECTION_CODES.has(code);
+}
+
 function shouldUseLedgerFallback(env = process.env) {
   const hasFileStore = Boolean(typeof env?.WS_PERSISTED_STATE_FILE === "string" && env.WS_PERSISTED_STATE_FILE.trim());
   const hasSupabaseDb = Boolean(typeof env?.SUPABASE_DB_URL === "string" && env.SUPABASE_DB_URL.trim());
@@ -233,13 +252,15 @@ export function createAuthoritativeJoinExecutor({
       }
       return normalized;
     } catch (error) {
-      klog("ws_join_authoritative_failed", {
-        tableId,
-        userId,
-        requestId: requestId || null,
-        code: typeof error?.code === "string" ? error.code : null,
-        message: error?.message || "unknown",
-      });
+      if (shouldLogAuthoritativeJoinFailure(error)) {
+        klog("ws_join_authoritative_failed", {
+          tableId,
+          userId,
+          requestId: requestId || null,
+          code: typeof error?.code === "string" ? error.code : null,
+          message: error?.message || "unknown",
+        });
+      }
       return normalizeJoinError(error);
     }
   };

--- a/ws-server/poker/persistence/authoritative-join-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.mjs
@@ -132,11 +132,6 @@ export function createAuthoritativeJoinExecutor({
   loadLockedStateHelpersFn = loadLockedStateHelpers,
 } = {}) {
   return async function executeAuthoritativeJoin({ tableId, userId, requestId, seatNo = null, autoSeat = false, preferredSeatNo = null, buyIn = null }) {
-    klog("ws_authoritative_adapter_start", {
-      tableId,
-      userId,
-      requestId: requestId || null
-    });
     const override = resolveJoinTestOverride(env);
     if (override) {
       return override;
@@ -236,23 +231,8 @@ export function createAuthoritativeJoinExecutor({
         }
         return normalized;
       }
-      klog("ws_authoritative_adapter_success", {
-        seatNo: normalized.seatNo,
-        stack: normalized.stack,
-        rejoin: normalized.rejoin === true,
-        snapshotVersion: Number(normalized?.snapshot?.stateVersion) || null,
-        seatsCount: Array.isArray(normalized?.snapshot?.seats) ? normalized.snapshot.seats.length : 0,
-        stacksCount: normalized?.snapshot?.stacks && typeof normalized.snapshot.stacks === "object" && !Array.isArray(normalized.snapshot.stacks)
-          ? Object.keys(normalized.snapshot.stacks).length
-          : 0,
-        seededBotsCount: Array.isArray(normalized?.seededBots) ? normalized.seededBots.length : 0
-      });
       return normalized;
     } catch (error) {
-      klog("ws_authoritative_adapter_error", {
-        code: typeof error?.code === "string" ? error.code : "authoritative_join_failed",
-        message: error?.message || "unknown"
-      });
       klog("ws_join_authoritative_failed", {
         tableId,
         userId,

--- a/ws-server/poker/persistence/authoritative-leave-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-leave-adapter.mjs
@@ -151,7 +151,8 @@ export function createAuthoritativeLeaveExecutor({
           runPostLeaveBotAutoplay: false,
           hasConnectedHumanPresence,
           klog,
-          klogVerbose
+          klogVerbose,
+          verboseLogsEnabled: verboseBotAutoplayLogs
         });
         return normalizeValidatedResult({ result, tableId, userId, requestId, klog });
       } catch (error) {

--- a/ws-server/poker/persistence/authoritative-leave-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-leave-adapter.mjs
@@ -113,6 +113,11 @@ export function createAuthoritativeLeaveExecutor({
   beginSql = beginSqlDefault
 } = {}) {
   const maxRetryAttempts = 2;
+  const verboseBotAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
+  const klogVerbose = (kind, createPayload) => {
+    if (!verboseBotAutoplayLogs) return;
+    klog(kind, createPayload());
+  };
   return async function executeAuthoritativeLeave({ tableId, userId, requestId }) {
     const override = resolveLeaveTestOverride(env);
     if (override) {
@@ -145,7 +150,8 @@ export function createAuthoritativeLeaveExecutor({
           includeState: true,
           runPostLeaveBotAutoplay: false,
           hasConnectedHumanPresence,
-          klog
+          klog,
+          klogVerbose
         });
         return normalizeValidatedResult({ result, tableId, userId, requestId, klog });
       } catch (error) {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -875,7 +875,7 @@ test("accepted bot autoplay preserves a concrete shared apply failure as an unch
       throw new Error("PR A must not restore this invariant failure");
     },
     broadcastResyncRequired: () => {},
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: () => {}
   });
 
@@ -929,7 +929,7 @@ test("accepted bot autoplay showdown uses trusted private hole cards even for pu
       return { ok: true };
     },
     broadcastResyncRequired: () => {},
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
   const result = await run({ tableId: "t-showdown", trigger: "act", requestId: "r-showdown" });
@@ -984,7 +984,7 @@ test("accepted bot autoplay accepts fallback supplement when primary showdown ha
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1040,7 +1040,7 @@ test("accepted bot autoplay preserves fresh showdown gameplay fields when fallba
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1098,7 +1098,7 @@ test("accepted bot autoplay reloads trusted private showdown hole cards after bo
       return { ok: true };
     },
     broadcastResyncRequired: () => {},
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1151,7 +1151,7 @@ test("accepted bot autoplay merges partial loop-private showdown cards with pers
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1202,7 +1202,7 @@ test("accepted bot autoplay ignores malformed fallback showdown hole-card arrays
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1213,7 +1213,7 @@ test("accepted bot autoplay ignores malformed fallback showdown hole-card arrays
   assert.equal(calls.resync, 0);
   const focusedLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing");
   assert.ok(focusedLog);
-  assert.deepEqual(focusedLog.payload.missingHoleCardsUserIds, ["human_1"]);
+  assert.equal(focusedLog.payload.missingHoleCardsCount, 1);
 });
 
 test("accepted bot autoplay emits focused showdown-input log and restores on missing trusted hole cards", async () => {
@@ -1255,7 +1255,7 @@ test("accepted bot autoplay emits focused showdown-input log and restores on mis
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1266,11 +1266,11 @@ test("accepted bot autoplay emits focused showdown-input log and restores on mis
   assert.equal(calls.resync, 0);
   const focusedLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_input_missing");
   assert.ok(focusedLog);
-  assert.deepEqual(focusedLog.payload.missingHoleCardsUserIds, ["human_1"]);
+  assert.equal(focusedLog.payload.missingHoleCardsCount, 1);
   const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
   assert.ok(preflightLog);
-  assert.deepEqual(preflightLog.payload.eligibleUserIds, ["human_1", "bot_2"]);
-  assert.deepEqual(preflightLog.payload.showdownComparedUserIds, ["bot_2"]);
+  assert.equal(preflightLog.payload.eligibleCount, 2);
+  assert.equal(preflightLog.payload.showdownComparedCount, 1);
   assert.equal(preflightLog.payload.communityLen, 5);
 });
 
@@ -1321,7 +1321,7 @@ test("accepted bot autoplay showdown comparison ignores mid-hand joiners outside
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1331,8 +1331,8 @@ test("accepted bot autoplay showdown comparison ignores mid-hand joiners outside
   assert.equal(calls.resync, 0);
   const preflightLog = logs.find((entry) => entry.event === "ws_bot_autoplay_showdown_preflight");
   assert.ok(preflightLog);
-  assert.deepEqual(preflightLog.payload.eligibleUserIds, ["human_1", "bot_2"]);
-  assert.deepEqual(preflightLog.payload.showdownComparedUserIds, ["human_1", "bot_2"]);
+  assert.equal(preflightLog.payload.eligibleCount, 2);
+  assert.equal(preflightLog.payload.showdownComparedCount, 2);
 });
 
 test("accepted bot autoplay rejects cross-hand fallback for degraded showdown runtime state", async () => {
@@ -1374,7 +1374,7 @@ test("accepted bot autoplay rejects cross-hand fallback for degraded showdown ru
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1427,7 +1427,7 @@ test("accepted bot autoplay does not treat untrusted fallback handId drift as tr
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1474,7 +1474,7 @@ test("accepted bot autoplay prefers trusted runtime private showdown source when
     persistMutatedState: async () => ({ ok: true }),
     restoreTableFromPersisted: async () => ({ ok: true }),
     broadcastResyncRequired: () => {},
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1526,7 +1526,7 @@ test("accepted bot autoplay resolves single-winner terminal hands without showdo
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
-    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl },
+    env: { WS_BOT_AUTOPLAY_MODULE_PATH: moduleUrl, WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
 
@@ -1593,6 +1593,7 @@ test("accepted bot autoplay handles mixed human+bot runtime path through showdow
     broadcastResyncRequired: () => {
       calls.resync += 1;
     },
+    env: { WS_BOT_AUTOPLAY_VERBOSE_LOGS: "1" },
     klog: (event, payload) => logs.push({ event, payload })
   });
   let guard = 0;

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -632,17 +632,17 @@ function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUser
       holeCardsByUserId,
       trustedStateSource: typeof options?.trustedStateSource === "string" ? options.trustedStateSource : "trusted_private"
     });
-    if (typeof klog === "function") {
+    if (options?.verboseLogs === true && typeof klog === "function") {
       klog("ws_bot_autoplay_showdown_preflight", {
         handId: typeof stateToMaterialize?.handId === "string" ? stateToMaterialize.handId : null,
         phase: typeof stateToMaterialize?.phase === "string" ? stateToMaterialize.phase : null,
         communityLen: showdownInputs.communityLen,
-        eligibleUserIds: showdownInputs.eligibleUserIds,
-        showdownComparedUserIds: showdownInputs.showdownComparedUserIds,
-        missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds,
-        invalidHoleCardsUserIds: showdownInputs.invalidHoleCardsUserIds,
-        invalidSeatUserIds: showdownInputs.invalidSeatUserIds,
-        eligibleMissingFromShowdownUserIds: showdownInputs.eligibleMissingFromShowdownUserIds,
+        eligibleCount: showdownInputs.eligibleCount,
+        showdownComparedCount: showdownInputs.showdownComparedCount,
+        missingHoleCardsCount: showdownInputs.missingHoleCardsUserIds.length,
+        invalidHoleCardsCount: showdownInputs.invalidHoleCardsUserIds.length,
+        invalidSeatCount: showdownInputs.invalidSeatUserIds.length,
+        eligibleMissingFromShowdownCount: showdownInputs.eligibleMissingFromShowdownUserIds.length,
         trustedStateSource: showdownInputs.trustedStateSource
       });
     }
@@ -656,12 +656,10 @@ function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUser
           communityLen: showdownInputs.communityLen,
           eligibleCount: showdownInputs.eligibleCount,
           showdownComparedCount: showdownInputs.showdownComparedCount,
-          eligibleUserIds: showdownInputs.eligibleUserIds,
-          showdownComparedUserIds: showdownInputs.showdownComparedUserIds,
-          missingHoleCardsUserIds: showdownInputs.missingHoleCardsUserIds,
-          invalidHoleCardsUserIds: showdownInputs.invalidHoleCardsUserIds,
-          invalidSeatUserIds: showdownInputs.invalidSeatUserIds,
-          eligibleMissingFromShowdownUserIds: showdownInputs.eligibleMissingFromShowdownUserIds,
+          missingHoleCardsCount: showdownInputs.missingHoleCardsUserIds.length,
+          invalidHoleCardsCount: showdownInputs.invalidHoleCardsUserIds.length,
+          invalidSeatCount: showdownInputs.invalidSeatUserIds.length,
+          eligibleMissingFromShowdownCount: showdownInputs.eligibleMissingFromShowdownUserIds.length,
           trustedStateSource: showdownInputs.trustedStateSource
         });
       }
@@ -711,10 +709,6 @@ function buildDiagnosticSnapshot(state) {
   const seats = isCurrentHandPhase(state?.phase) && Array.isArray(state?.handSeats) && state.handSeats.length > 0
     ? state.handSeats
     : (Array.isArray(state?.seats) ? state.seats : []);
-  const seatUserIds = seats
-    .filter((seat) => typeof seat?.userId === "string" && seat.userId.trim())
-    .sort((a, b) => Number(a?.seatNo ?? 0) - Number(b?.seatNo ?? 0))
-    .map((seat) => seat.userId.trim());
   const stacks = state?.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks) ? state.stacks : {};
   const communityCards = Array.isArray(state?.community) ? state.community : [];
   return {
@@ -729,8 +723,6 @@ function buildDiagnosticSnapshot(state) {
     communityDealt: Number.isFinite(Number(state?.communityDealt)) ? Number(state.communityDealt) : communityCards.length,
     communityLen: communityCards.length,
     seatsCount: seats.length,
-    seatUserIds,
-    stacksKeys: Object.keys(stacks),
     stackCount: Object.keys(stacks).length
   };
 }
@@ -914,6 +906,7 @@ export function createAcceptedBotStepExecutor({
             {
               ...options,
               runtimeFlavor,
+              verboseLogs: verboseAutoplayLogs,
               trustedStateSource
             }
           );

--- a/ws-server/poker/runtime/table-janitor.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-janitor.behavior.test.mjs
@@ -320,7 +320,8 @@ test("runTableJanitor keeps runtime/db mismatch traceable while routing cleanup"
   assert.equal(result.status, "cleaned_closed");
   assert.equal(calls.length, 1);
   assert.equal(calls[0].tableId, "t_runtime_mismatch");
-  assert.equal(logs[0].kind, "ws_table_janitor_classified");
+  assert.equal(logs[0].kind, "ws_table_janitor_result");
+  assert.equal(logs[0].data.classification, "open_inert_table");
   assert.equal(logs[0].data.reasonCode, "open_table_without_active_humans");
 });
 

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -510,18 +510,6 @@ export async function runTableJanitor({
   const action = typeof normalizedClassification?.action === "string" && normalizedClassification.action
     ? normalizedClassification.action
     : "noop";
-  klog("ws_table_janitor_classified", {
-    tableId: normalizedClassification.tableId || null,
-    trigger,
-    requestId: requestId || null,
-    classification: normalizedClassification.classification || null,
-    action,
-    reasonCode: normalizedClassification.reasonCode || null,
-    userId: normalizedClassification.userId || null,
-    healthy: normalizedClassification.healthy === true,
-    concerns: Array.isArray(normalizedClassification.concerns) ? normalizedClassification.concerns : []
-  });
-
   if (action === "noop") {
     const result = {
       ok: true,
@@ -530,16 +518,6 @@ export async function runTableJanitor({
       status: "healthy_noop",
       reasonCode: normalizedClassification.reasonCode || null
     };
-    klog("ws_table_janitor_result", {
-      tableId: normalizedClassification.tableId || null,
-      trigger,
-      requestId: requestId || null,
-      action,
-      status: result.status,
-      ok: true,
-      changed: false,
-      reasonCode: normalizedClassification.reasonCode || null
-    });
     return result;
   }
 
@@ -556,6 +534,7 @@ export async function runTableJanitor({
       tableId: normalizedClassification.tableId || null,
       trigger,
       requestId: requestId || null,
+      classification: normalizedClassification.classification || null,
       action,
       status: result.status,
       ok: false,
@@ -578,6 +557,7 @@ export async function runTableJanitor({
     tableId: normalizedClassification.tableId || null,
     trigger,
     requestId: requestId || null,
+    classification: normalizedClassification.classification || null,
     action,
     status: result?.status || null,
     ok: result?.ok === true,

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -495,7 +495,8 @@ export async function runTableJanitor({
   trigger = "table_janitor",
   requestId = null,
   primitives = {},
-  klog = () => {}
+  klog = () => {},
+  klogVerbose = () => {}
 } = {}) {
   const normalizedClassification = classification && typeof classification === "object"
     ? classification
@@ -518,6 +519,17 @@ export async function runTableJanitor({
       status: "healthy_noop",
       reasonCode: normalizedClassification.reasonCode || null
     };
+    klogVerbose("ws_table_janitor_result", () => ({
+      tableId: normalizedClassification.tableId || null,
+      trigger,
+      requestId: requestId || null,
+      classification: normalizedClassification.classification || null,
+      action,
+      status: result.status,
+      ok: true,
+      changed: false,
+      reasonCode: normalizedClassification.reasonCode || null
+    }));
     return result;
   }
 

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -565,7 +565,7 @@ export async function runTableJanitor({
     reasonCode: normalizedClassification.reasonCode || null,
     classification: normalizedClassification
   });
-  klog("ws_table_janitor_result", {
+  const createResultLogPayload = () => ({
     tableId: normalizedClassification.tableId || null,
     trigger,
     requestId: requestId || null,
@@ -577,5 +577,14 @@ export async function runTableJanitor({
     reasonCode: normalizedClassification.reasonCode || null,
     code: result?.code || null
   });
+  const routineSeatMissingNoop = result?.ok === true
+    && result?.changed !== true
+    && result?.closed !== true
+    && result?.status === "seat_missing";
+  if (routineSeatMissingNoop) {
+    klogVerbose("ws_table_janitor_result", createResultLogPayload);
+  } else {
+    klog("ws_table_janitor_result", createResultLogPayload());
+  }
   return result;
 }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1410,33 +1410,69 @@ async function restoreTableFromPersisted(tableId) {
   if (typeof loadPersistedTableBootstrap !== "function") {
     return { ok: false, reason: "persisted_bootstrap_disabled" };
   }
+  const restoreStartedAtMs = Date.now();
+  klogVerbose("ws_restore_start", () => ({
+    tableId,
+    stage: "load",
+    ok: null,
+    durationMs: 0
+  }));
   try {
     const restored = await loadPersistedTableBootstrap({ tableId });
     if (!restored?.ok || !restored?.table) {
+      const reason = restored?.code || "restore_failed";
       klogSafe("ws_restore_failed", {
         tableId,
         stage: "load",
-        reason: restored?.code || "restore_failed"
+        reason
       });
-      return { ok: false, reason: restored?.code || "restore_failed" };
+      klogVerbose("ws_restore_outcome", () => ({
+        tableId,
+        stage: "load",
+        ok: false,
+        reason,
+        durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
+      }));
+      return { ok: false, reason };
     }
     persistedStateWriter?.forgetHoleCardAcknowledgement(tableId);
     const applied = tableManager.restoreTableFromPersisted(tableId, restored.table);
     if (!applied?.ok) {
+      const reason = applied?.reason || applied?.code || "restore_failed";
       klogSafe("ws_restore_failed", {
         tableId,
         stage: "apply",
-        reason: applied?.reason || applied?.code || "restore_failed"
+        reason
       });
+      klogVerbose("ws_restore_outcome", () => ({
+        tableId,
+        stage: "apply",
+        ok: false,
+        reason,
+        durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
+      }));
       return applied;
     }
     maybeScheduleSettledRollover(tableId);
+    klogVerbose("ws_restore_outcome", () => ({
+      tableId,
+      stage: "apply",
+      ok: true,
+      durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
+    }));
     return {
       ...applied,
       restoredTable: restored.table
     };
   } catch (error) {
     klogSafe("ws_state_restore_failed", { tableId, message: error?.message || "unknown" });
+    klogVerbose("ws_restore_outcome", () => ({
+      tableId,
+      stage: "exception",
+      ok: false,
+      reason: "restore_error",
+      durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
+    }));
     return { ok: false, reason: "restore_error" };
   }
 }
@@ -1734,6 +1770,12 @@ function scheduleSettledRolloverTimer({ tableId, generationKey, dueAt, attempt =
   clearSettledRolloverTimer(tableId);
   const nowMs = Date.now();
   const delayMs = Math.max(0, dueAt - nowMs);
+  klogVerbose("ws_settled_rollover_scheduled", () => ({
+    tableId,
+    delayMs,
+    attempt,
+    mode
+  }));
   const timer = setTimeout(() => {
     settledRolloverTimerByTableId.delete(tableId);
     void enqueueTableCommand({
@@ -1766,10 +1808,24 @@ function scheduleSettledRolloverRetry({ tableId, generationKey, attempt }) {
 }
 
 async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }) {
+  const rolloverStartedAtMs = Date.now();
+  const finishSettledRollover = (result) => {
+    klogVerbose("ws_settled_rollover_outcome", () => ({
+      tableId,
+      attempt,
+      ok: result?.ok !== false,
+      changed: result?.changed === true,
+      closed: result?.closed === true,
+      reason: result?.reason || result?.code || result?.status || (result?.changed === true ? "changed" : "unchanged"),
+      durationMs: Math.max(0, Date.now() - rolloverStartedAtMs)
+    }));
+    return result;
+  };
   let pokerState = tableManager.persistedPokerState(tableId);
   if (settledRolloverGenerationKey(tableId, pokerState) !== generationKey) {
-    return { ok: true, changed: false, reason: "settled_generation_changed" };
+    return finishSettledRollover({ ok: true, changed: false, reason: "settled_generation_changed" });
   }
+  klogVerbose("ws_settled_rollover_start", () => ({ tableId, attempt }));
   if (!isGuestTableId(tableId) && hasSupabaseDbUrl) {
     const finalizeDeferredLeaves = await loadDeferredLeaveFinalizer();
     const finalized = await finalizeDeferredLeaves({ tableId });
@@ -1782,7 +1838,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
       if (finalized?.retryable !== false) {
         scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
       }
-      return finalized;
+      return finishSettledRollover(finalized);
     }
     if (finalized.changed === true || finalized.closed === true) {
       const synced = await syncCleanupRuntimeState({
@@ -1792,31 +1848,32 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
       });
       if (!synced?.ok) {
         scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
-        return { ok: false, changed: true, code: "runtime_restore_failed", retryable: true };
+        return finishSettledRollover({ ok: false, changed: true, code: "runtime_restore_failed", retryable: true });
       }
-      if (finalized.closed === true) return finalized;
+      if (finalized.closed === true) return finishSettledRollover(finalized);
       pokerState = tableManager.persistedPokerState(tableId);
       if (!pokerState || pokerState.phase !== "SETTLED") {
-        return { ok: true, changed: true, reason: "deferred_leave_state_changed" };
+        return finishSettledRollover({ ok: true, changed: true, reason: "deferred_leave_state_changed" });
       }
     }
   }
   if (!tableManager.hasActiveHumanMember(tableId)) {
     if (tableManager.hasConnectedHumanPresence(tableId)) {
       klogSafe("ws_settled_rollover_close_skipped_human_presence", { tableId, phase: pokerState?.phase || null });
-      return { ok: true, changed: false, deferred: true, reason: "human_presence_present" };
+      return finishSettledRollover({ ok: true, changed: false, deferred: true, reason: "human_presence_present" });
     }
-    return applyInactiveCleanupAndBroadcast({
+    const cleanupResult = await applyInactiveCleanupAndBroadcast({
       tableId,
       requestId: `ws-settled-rollover-close:${tableId}`,
       logPrefix: "ws_settled_rollover_close"
     });
+    return finishSettledRollover(cleanupResult);
   }
 
   if (isGuestTableId(tableId)) {
     const guestRollover = tableManager.rolloverSettledHand({ tableId, nowMs: Date.now(), economyMode: "none" });
     if (!guestRollover?.ok || !guestRollover.changed) {
-      return guestRollover;
+      return finishSettledRollover(guestRollover);
     }
     broadcastStateSnapshots(tableId);
     try {
@@ -1824,12 +1881,12 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     } catch (error) {
       klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
     }
-    return guestRollover;
+    return finishSettledRollover(guestRollover);
   }
 
   const prepared = tableManager.prepareSettledHandRollover({ tableId, nowMs: Date.now() });
   if (!prepared?.ok || !prepared.changed) {
-    return prepared;
+    return finishSettledRollover(prepared);
   }
 
   const candidatePokerState = prepared.nextCoreState?.pokerState;
@@ -1870,12 +1927,12 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     if (!persisted?.alreadyApplied) {
       scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
     }
-    return {
+    return finishSettledRollover({
       ok: Boolean(persisted?.alreadyApplied),
       changed: false,
       reason: persisted?.alreadyApplied ? "already_applied_restored" : (persisted?.reason || "persist_failed"),
       stateVersion: prepared.stateVersion
-    };
+    });
   }
 
   const rollover = tableManager.commitSettledHandRollover({
@@ -1895,7 +1952,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     } catch (error) {
       klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
     }
-    return rollover;
+    return finishSettledRollover(rollover);
   }
 
   tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
@@ -1905,7 +1962,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
   } catch (error) {
     klogSafe("ws_settled_rollover_bot_autoplay_failed", { tableId, message: error?.message || "unknown" });
   }
-  return rollover;
+  return finishSettledRollover(rollover);
 }
 
 function maybeScheduleSettledRollover(tableId) {
@@ -2021,7 +2078,8 @@ const disconnectCleanupRuntime = createDisconnectCleanupRuntime({
       trigger: "disconnect_cleanup",
       requestId,
       primitives: tableJanitorPrimitives,
-      klog: klogSafe
+      klog: klogSafe,
+      klogVerbose
     });
   },
   listActiveSocketsForUser: (userId) => sessionStore.connectionsForUser(userId),
@@ -2538,7 +2596,8 @@ async function runEvaluatedTableJanitor({ tableId, trigger, requestId }) {
     trigger,
     requestId,
     primitives: tableJanitorPrimitives,
-    klog: klogSafe
+    klog: klogSafe,
+    klogVerbose
   });
   rememberNonRetryableTerminalJanitorFailure({
     trigger,
@@ -3268,7 +3327,8 @@ wss.on("connection", (ws) => {
           persistedBootstrapEnabled,
           loadAuthoritativeJoinExecutor,
           scheduleBotStep,
-          klog: klogSafe
+          klog: klogSafe,
+          klogVerbose
         })
       });
       maybeScheduleSettledRollover(frame.__resolvedTableId);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1410,7 +1410,7 @@ async function restoreTableFromPersisted(tableId) {
   if (typeof loadPersistedTableBootstrap !== "function") {
     return { ok: false, reason: "persisted_bootstrap_disabled" };
   }
-  const restoreStartedAtMs = Date.now();
+  const restoreStartedAtMs = verbosePokerLogs ? Date.now() : null;
   klogVerbose("ws_restore_start", () => ({
     tableId,
     stage: "load",
@@ -1808,7 +1808,7 @@ function scheduleSettledRolloverRetry({ tableId, generationKey, attempt }) {
 }
 
 async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }) {
-  const rolloverStartedAtMs = Date.now();
+  const rolloverStartedAtMs = verbosePokerLogs ? Date.now() : null;
   const finishSettledRollover = (result) => {
     klogVerbose("ws_settled_rollover_outcome", () => ({
       tableId,
@@ -3328,7 +3328,8 @@ wss.on("connection", (ws) => {
           loadAuthoritativeJoinExecutor,
           scheduleBotStep,
           klog: klogSafe,
-          klogVerbose
+          klogVerbose,
+          verboseLogsEnabled: verbosePokerLogs
         })
       });
       maybeScheduleSettledRollover(frame.__resolvedTableId);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1411,20 +1411,23 @@ async function restoreTableFromPersisted(tableId) {
     return { ok: false, reason: "persisted_bootstrap_disabled" };
   }
   try {
-    klogSafe("ws_restore_load_start", { tableId });
     const restored = await loadPersistedTableBootstrap({ tableId });
-    klogSafe("ws_restore_load_result", {
-      ok: restored?.ok === true,
-      hasTable: Boolean(restored?.table),
-      version: restored?.table?.coreState?.version ?? null
-    });
     if (!restored?.ok || !restored?.table) {
+      klogSafe("ws_restore_failed", {
+        tableId,
+        stage: "load",
+        reason: restored?.code || "restore_failed"
+      });
       return { ok: false, reason: restored?.code || "restore_failed" };
     }
     persistedStateWriter?.forgetHoleCardAcknowledgement(tableId);
     const applied = tableManager.restoreTableFromPersisted(tableId, restored.table);
-    klogSafe("ws_restore_apply_result", { ok: applied?.ok === true });
     if (!applied?.ok) {
+      klogSafe("ws_restore_failed", {
+        tableId,
+        stage: "apply",
+        reason: applied?.reason || applied?.code || "restore_failed"
+      });
       return applied;
     }
     maybeScheduleSettledRollover(tableId);
@@ -1527,17 +1530,14 @@ async function syncCleanupRuntimeState({ tableId, result, logPrefix, onRestore =
     return { ok: true, changed: false, evicted: false, restored: false };
   }
   if (shouldEvictClosedRuntimeTable(tableId, result)) {
-    klogSafe(`${logPrefix}_evict_closed_start`, { tableId, status: result?.status || null });
     evictClosedRuntimeTable({ tableId, logPrefix, status: result?.status || null });
     return { ok: true, changed: true, evicted: true, restored: false };
   }
-  klogSafe(`${logPrefix}_restore_start`, { tableId, status: result?.status || null });
   const restored = await restoreTableFromPersisted(tableId);
   if (!restored?.ok) {
     klogSafe(`${logPrefix}_restore_failed`, { tableId, reason: restored?.reason || "unknown" });
     return { ok: false, changed: true, evicted: false, restored: false };
   }
-  klogSafe(`${logPrefix}_restore_success`, { tableId, status: result?.status || null });
   broadcastStateSnapshots(tableId);
   broadcastTableState(tableId);
   if (typeof onRestore === "function") {
@@ -1637,7 +1637,6 @@ async function executeUserInactiveCleanupPrimitive({
         });
         return result;
       }
-      klogSafe(`${logPrefix}_noop`, { tableId, userId, status: result?.status || null });
       return result;
     }
   });
@@ -1736,7 +1735,6 @@ function scheduleSettledRolloverTimer({ tableId, generationKey, dueAt, attempt =
   clearSettledRolloverTimer(tableId);
   const nowMs = Date.now();
   const delayMs = Math.max(0, dueAt - nowMs);
-  klogSafe("ws_settled_rollover_scheduled", { tableId, dueAt, delayMs, attempt, mode });
   const timer = setTimeout(() => {
     settledRolloverTimerByTableId.delete(tableId);
     void enqueueTableCommand({
@@ -1773,7 +1771,6 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
   if (settledRolloverGenerationKey(tableId, pokerState) !== generationKey) {
     return { ok: true, changed: false, reason: "settled_generation_changed" };
   }
-  klogSafe("ws_settled_rollover_start", { tableId, attempt });
   if (!isGuestTableId(tableId) && hasSupabaseDbUrl) {
     const finalizeDeferredLeaves = await loadDeferredLeaveFinalizer();
     const finalized = await finalizeDeferredLeaves({ tableId });
@@ -1833,7 +1830,6 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
 
   const prepared = tableManager.prepareSettledHandRollover({ tableId, nowMs: Date.now() });
   if (!prepared?.ok || !prepared.changed) {
-    klogSafe("ws_settled_rollover_noop", { tableId, reason: prepared?.reason || "unchanged" });
     return prepared;
   }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1535,7 +1535,6 @@ async function syncCleanupRuntimeState({ tableId, result, logPrefix, onRestore =
   }
   const restored = await restoreTableFromPersisted(tableId);
   if (!restored?.ok) {
-    klogSafe(`${logPrefix}_restore_failed`, { tableId, reason: restored?.reason || "unknown" });
     return { ok: false, changed: true, evicted: false, restored: false };
   }
   broadcastStateSnapshots(tableId);


### PR DESCRIPTION
## Summary

- removes routine join/rejoin/attach, leave, quick-seat, guest-session, rollover and lobby UI success-path noise
- keeps compact, lazily-built diagnostics behind the existing `WS_POKER_VERBOSE_LOGS` and `WS_BOT_AUTOPLAY_VERBOSE_LOGS` switches; no severity framework or new flag is introduced
- starts diagnostic timing only when the corresponding verbose switch is enabled, so disabled logging performs neither payload construction nor diagnostic `Date.now()` calls
- routes routine successful `disconnect_cleanup` results with `status:"seat_missing"`, `changed:false` and `closed:false` through existing lazy `WS_POKER_VERBOSE_LOGS` instead of production logging
- keeps production `ws_table_janitor_result` for failures, changes, closes, missing primitives and other non-routine outcomes
- adds verbose join start/outcome, compact restore start/outcome, healthy janitor noop result, settled-rollover lifecycle/outcome and unified post-leave autoplay lifecycle diagnostics
- preserves one focused production event when `tableManager.join()` rejects and enriches `ws_join_restore_invalid` with safe validation booleans
- restores browser-local `poker_lobby_ws_connected`
- retains focused technical join/restore failures, recovery, cashout, settlement, accounting, persistence and deployment diagnostics
- removes user-ID/key arrays and avoids full snapshots or large payloads

Refs #765

## Runtime impact

No poker protocol, game-state, persistence, settlement, cleanup, ledger or accounting behavior is changed. Verbose payloads and their diagnostic duration measurements are constructed only when the relevant existing verbose flag is enabled.

Potential breaking impact: operational searches or scripts that depend on removed success-path event names, routine successful missing-seat janitor outcomes, or caller-specific cleanup restore failures must use protocol outcomes, persisted state, compact verbose events, `ws_restore_failed`, or retained terminal/failure events instead. Expected join rejections such as `table_closed`, `table_full`, `seat_taken`, invalid join input and `insufficient_funds` do not emit the general authoritative failure event; a focused attach-failure event remains for failed `tableManager.join()` results. No application-facing breaking change is expected.

## Validation

- `npm test`
- `npm run syntax` — 213 files passed
- `npm run check:csp-inline` — 52 served documents passed
- targeted authoritative join, table janitor, shared leave, authoritative leave adapter and server behavior suites
- direct Node syntax checks for all changed JavaScript/MJS files
- `git diff --check`

All checks pass at `84457a992e98629cbd6746e50cdf5422b5d09718`. No new test cases were added; existing assertions were updated only where they intentionally depended on the logging contract.

## Exact-SHA Preview verification

- workflow run: https://github.com/krzysztofcal/arcadePlatform/actions/runs/30247456466
- deployed metadata: `releaseSha=84457a992e98629cbd6746e50cdf5422b5d09718`, `environment=preview`
- `ws_artifact_start` reports the exact SHA and preview environment
- local and public `/healthz`: `ok`
- bounded post-restart scan: no `ws_table_janitor_*failed`, persistence/accounting/invariant failures, uncaught/unhandled errors, or production clean-noop janitor results observed

The earlier functional gameplay smoke passed on the preceding exact SHA; this final deployment changes only routing of routine successful missing-seat diagnostics.