### PR TITLE
fix(poker): preserve authoritative join validation reasons

### DIFF
--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -89,9 +89,12 @@ function isStorageStateValid(validateStateForStorage, state) {
   return validateStateForStorage(normalizeStateForStorageValidation(state));
 }
 
-function makeError(code) {
+function makeError(code, validationReason = null) {
   const error = new Error(code);
   error.code = code;
+  if (typeof validationReason === "string" && /^[a-z0-9]+(?:_[a-z0-9]+)*$/.test(validationReason)) {
+    error.validationReason = validationReason;
+  }
   return error;
 }
 
@@ -138,17 +141,17 @@ function writeLockedStateResult(result) {
   }
   const version = Number(result.newVersion);
   if (!Number.isInteger(version) || version <= 0) {
-    throw makeError("authoritative_state_invalid");
+    throw makeError("authoritative_state_invalid", "locked_state_write_version_invalid");
   }
   return { version };
 }
 
 function requirePostMutationVersion({ previousVersion, nextVersion }) {
   if (!Number.isInteger(nextVersion) || nextVersion <= 0) {
-    throw makeError("authoritative_state_invalid");
+    throw makeError("authoritative_state_invalid", "post_mutation_version_invalid");
   }
   if (Number.isInteger(previousVersion) && nextVersion <= previousVersion) {
-    throw makeError("authoritative_state_invalid");
+    throw makeError("authoritative_state_invalid", "post_mutation_version_not_advanced");
   }
   return nextVersion;
 }
@@ -442,15 +445,24 @@ function assertAuthoritativeJoinStateComplete({ seatRows, state, version, userId
   );
   const stateStacks = state?.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks) ? state.stacks : {};
 
-  if (!Number.isInteger(version) || version <= 0) throw makeError("authoritative_state_invalid");
+  if (!Number.isInteger(version) || version <= 0) {
+    throw makeError("authoritative_state_invalid", "authoritative_snapshot_version_invalid");
+  }
   if (!persistedSeatKeys.has(`${userId}:${seatNo}`) || Number(stateStacks[userId]) !== Number(stack)) {
-    throw makeError("authoritative_state_invalid");
+    const validationReason = !persistedSeatKeys.has(`${userId}:${seatNo}`)
+      ? "human_seat_missing_from_authoritative_snapshot"
+      : "human_stack_mismatch_in_authoritative_snapshot";
+    throw makeError("authoritative_state_invalid", validationReason);
   }
   for (const persistedSeatKey of persistedSeatKeys) {
-    if (!stateSeatKeys.has(persistedSeatKey)) throw makeError("authoritative_state_invalid");
+    if (!stateSeatKeys.has(persistedSeatKey)) {
+      throw makeError("authoritative_state_invalid", "persisted_seat_missing_from_authoritative_snapshot");
+    }
   }
   for (const [stackUserId, persistedStack] of activeStackEntries(seatRows)) {
-    if (Number(stateStacks[stackUserId]) !== persistedStack) throw makeError("authoritative_state_invalid");
+    if (Number(stateStacks[stackUserId]) !== persistedStack) {
+      throw makeError("authoritative_state_invalid", "persisted_stack_mismatch_in_authoritative_snapshot");
+    }
   }
 
   const activeRows = activeSeatRows(seatRows);
@@ -459,7 +471,9 @@ function assertAuthoritativeJoinStateComplete({ seatRows, state, version, userId
     ? computeTargetBotCount({ maxPlayers, humanCount, maxBots: botCfg.maxPerTable })
     : 0;
   const activeBotCount = activeRows.filter((row) => row?.is_bot).length;
-  if (activeBotCount < expectedBotCount) throw makeError("authoritative_state_invalid");
+  if (activeBotCount < expectedBotCount) {
+    throw makeError("authoritative_state_invalid", "seeded_bot_projection_incomplete");
+  }
 }
 
 async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, stack, loadStateForUpdate, updateStateLocked, validateStateForStorage, maxPlayers, botCfg }) {
@@ -472,7 +486,7 @@ async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, stack, loadS
   });
   const nextStateForStorage = sanitizeStateForStorage(nextState);
   if (!isStorageStateValid(validateStateForStorage, nextStateForStorage)) {
-    throw makeError("state_invalid");
+    throw makeError("state_invalid", "storage_state_validation_failed");
   }
   const updated = writeLockedStateResult(await updateStateLocked(tx, { tableId, nextState: nextStateForStorage }));
   const version = requirePostMutationVersion({ previousVersion: stateRow.version, nextVersion: updated.version });
@@ -585,7 +599,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         const persisted = await readPersistedSeatStack({ tx, tableId, userId });
         if (stateAlreadyRepresentsActiveSeatRows(stateRow.state, seatRows, userId)) {
           if (!Number.isInteger(stateRow.version) || stateRow.version <= 0) {
-            throw makeError("authoritative_state_invalid");
+            throw makeError("authoritative_state_invalid", "rejoin_state_version_invalid");
           }
           await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
           return {
@@ -612,7 +626,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         });
         const nextStateForStorage = sanitizeStateForStorage(nextState);
         if (!isStorageStateValid(validateStateForStorage, nextStateForStorage)) {
-          throw makeError("state_invalid");
+          throw makeError("state_invalid", "storage_state_validation_failed");
         }
         const updatedState = writeLockedStateResult(await updateStateLocked(tx, { tableId, nextState: nextStateForStorage }));
         const snapshotVersion = requirePostMutationVersion({ previousVersion: stateRow.version, nextVersion: updatedState.version });

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -77,6 +77,14 @@ function evaluateRestoredAuthoritativeState({ restoredTable, userId, seatNo, see
   };
 }
 
+function restoredAuthoritativeValidationReason(validation) {
+  if (validation?.expectedVersionValid !== true) return "restore_expected_version_invalid";
+  if (validation?.humanSeatValid !== true) return "restore_human_seat_missing";
+  if (validation?.humanStackValid !== true) return "restore_human_stack_missing";
+  if (validation?.seededBotProjectionValid !== true) return "restore_seeded_bot_projection_invalid";
+  return "restore_validation_failed";
+}
+
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
 
 export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {}, klogVerbose = () => {}, verboseLogsEnabled = false }) {
@@ -187,10 +195,12 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       expectedStateVersion: expectedVersionRaw
     });
     if (!restoreValidation.ok) {
+      const validationReason = restoredAuthoritativeValidationReason(restoreValidation);
       klog("ws_join_restore_invalid", {
         tableId,
         requestId: frame.requestId ?? null,
         reason: "validation_failed",
+        validationReason,
         restoredVersion: Number.isInteger(restoredVersion) ? restoredVersion : null,
         expectedVersion: Number.isInteger(expectedVersion) ? expectedVersion : null,
         expectedVersionValid: restoreValidation.expectedVersionValid,

--- a/ws-server/poker/persistence/authoritative-join-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.behavior.test.mjs
@@ -175,7 +175,7 @@ test("authoritative join adapter rejects malformed success payload", async () =>
   });
 
   const result = await execute({ tableId: "t1", userId: "u1", requestId: "r3", buyIn: 100 });
-  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid" });
+  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid", validationReason: "invalid_stack" });
 });
 
 test("authoritative join adapter rejects partial human-only success snapshot", async () => {
@@ -205,7 +205,7 @@ test("authoritative join adapter rejects partial human-only success snapshot", a
   });
 
   const result = await execute({ tableId: "t1", userId: "u1", requestId: "r-partial" });
-  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid" });
+  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid", validationReason: "invalid_snapshot_version" });
 });
 
 test("authoritative join adapter rejects successful fresh-join snapshot when stateVersion stays at 0", async () => {
@@ -227,7 +227,7 @@ test("authoritative join adapter rejects successful fresh-join snapshot when sta
   });
 
   const result = await execute({ tableId: "t1", userId: "u1", requestId: "r-version-zero" });
-  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid" });
+  assert.deepEqual(result, { ok: false, code: "authoritative_state_invalid", validationReason: "invalid_snapshot_version" });
 });
 
 test("authoritative join adapter accepts successful fresh-join snapshot once stateVersion moves positive", async () => {

--- a/ws-server/poker/persistence/authoritative-join-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.mjs
@@ -50,8 +50,11 @@ function resolveJoinTestOverride(env = process.env) {
 
 function normalizeJoinError(error) {
   const code = typeof error?.code === "string" ? error.code : "authoritative_join_failed";
+  const validationReason = typeof error?.validationReason === "string" && /^[a-z0-9]+(?:_[a-z0-9]+)*$/.test(error.validationReason)
+    ? error.validationReason
+    : null;
   if (["table_not_found", "table_closed", "table_not_open", "seat_taken", "table_full", "table_full_bot_leaving", "state_missing", "poker_state_missing", "state_invalid", "duplicate_seat", "invalid_seat_no", "invalid_buy_in", "request_pending", "insufficient_funds", "system_account_missing", "chips_apply_failed", "chips_apply_mismatch", "missing_idempotency_key", "invalid_escrow_only_entries", "authoritative_state_invalid"].includes(code)) {
-    return { ok: false, code };
+    return validationReason ? { ok: false, code, validationReason } : { ok: false, code };
   }
   return { ok: false, code: "authoritative_join_failed" };
 }
@@ -85,18 +88,20 @@ function noopPostTransaction() {
   return { ok: true };
 }
 
-function normalizeSuccess(result, { tableId, userId, requestId, klog }) {
+function invalidAuthoritativeState(validationReason) {
+  return { ok: false, code: "authoritative_state_invalid", validationReason };
+}
+
+function normalizeSuccess(result, { tableId, userId, requestId }) {
   if (!result?.ok) return result;
   const seatNo = Number(result?.seatNo);
   if (!Number.isInteger(seatNo) || seatNo < 1) {
-    klog("ws_join_authoritative_failed", { tableId, userId, requestId: requestId || null, code: "authoritative_state_invalid", message: "invalid_seat" });
-    return { ok: false, code: "authoritative_state_invalid" };
+    return invalidAuthoritativeState("invalid_seat_number");
   }
   const stack = Number(result?.stack);
   const rejoin = result?.rejoin === true;
   if (!Number.isInteger(stack) || stack <= 0) {
-    klog("ws_join_authoritative_failed", { tableId, userId, requestId: requestId || null, code: "authoritative_state_invalid", message: "invalid_stack" });
-    return { ok: false, code: "authoritative_state_invalid" };
+    return invalidAuthoritativeState("invalid_stack");
   }
   const seededBots = Array.isArray(result?.seededBots) ? result.seededBots : [];
   const snapshot = result?.snapshot && typeof result.snapshot === "object" ? result.snapshot : null;
@@ -112,21 +117,30 @@ function normalizeSuccess(result, { tableId, userId, requestId, klog }) {
       })
       .filter(Boolean)
   );
-  if (!snapshot || !Number.isInteger(snapshotVersion) || snapshotVersion <= 0) {
-    klog("ws_join_authoritative_failed", { tableId, userId, requestId: requestId || null, code: "authoritative_state_invalid", message: "invalid_snapshot_version" });
-    return { ok: false, code: "authoritative_state_invalid" };
+  if (!snapshot) {
+    return invalidAuthoritativeState("missing_snapshot");
   }
-  if (!snapshotSeatKeys.has(`${userId}:${seatNo}`) || Number(snapshotStacks[userId]) <= 0 || (!rejoin && Number(snapshotStacks[userId]) !== stack)) {
-    klog("ws_join_authoritative_failed", { tableId, userId, requestId: requestId || null, code: "authoritative_state_invalid", message: "missing_human_snapshot_state" });
-    return { ok: false, code: "authoritative_state_invalid" };
+  if (!Number.isInteger(snapshotVersion) || snapshotVersion <= 0) {
+    return invalidAuthoritativeState("invalid_snapshot_version");
+  }
+  if (!snapshotSeatKeys.has(`${userId}:${seatNo}`)) {
+    return invalidAuthoritativeState("missing_human_snapshot_seat");
+  }
+  if (Number(snapshotStacks[userId]) <= 0) {
+    return invalidAuthoritativeState("missing_human_snapshot_stack");
+  }
+  if (!rejoin && Number(snapshotStacks[userId]) !== stack) {
+    return invalidAuthoritativeState("human_snapshot_stack_mismatch");
   }
   for (const bot of seededBots) {
     const botUserId = typeof bot?.userId === "string" ? bot.userId : "";
     const botSeatNo = Number(bot?.seatNo);
     const botStack = Number(bot?.stack);
-    if (!botUserId || !Number.isInteger(botSeatNo) || botSeatNo < 1 || !snapshotSeatKeys.has(`${botUserId}:${botSeatNo}`) || Number(snapshotStacks[botUserId]) !== botStack) {
-      klog("ws_join_authoritative_failed", { tableId, userId, requestId: requestId || null, code: "authoritative_state_invalid", message: "missing_seeded_bot_snapshot_state" });
-      return { ok: false, code: "authoritative_state_invalid" };
+    if (!botUserId || !Number.isInteger(botSeatNo) || botSeatNo < 1 || !snapshotSeatKeys.has(`${botUserId}:${botSeatNo}`)) {
+      return invalidAuthoritativeState("missing_seeded_bot_snapshot_seat");
+    }
+    if (Number(snapshotStacks[botUserId]) !== botStack) {
+      return invalidAuthoritativeState("missing_seeded_bot_snapshot_stack");
     }
   }
   return {
@@ -240,12 +254,15 @@ export function createAuthoritativeJoinExecutor({
       if (buyIn !== null && buyIn !== undefined) sharedArgs.buyIn = buyIn;
 
       const result = await joinModule.executePokerJoinAuthoritative(sharedArgs);
-      const normalized = normalizeSuccess(result, { tableId, userId, requestId, klog });
+      const normalized = normalizeSuccess(result, { tableId, userId, requestId });
       if (!normalized?.ok) {
         if (normalized?.code === "authoritative_state_invalid") {
-          klog("ws_authoritative_adapter_invalid_snapshot", {
-            snapshotVersion: Number(result?.snapshot?.stateVersion) || null,
-            reason: "authoritative_state_invalid"
+          klog("ws_join_authoritative_failed", {
+            tableId,
+            userId,
+            requestId: requestId || null,
+            code: normalized.code,
+            validationReason: normalized.validationReason || "unknown_validation_failure"
           });
         }
         return normalized;
@@ -253,12 +270,13 @@ export function createAuthoritativeJoinExecutor({
       return normalized;
     } catch (error) {
       if (shouldLogAuthoritativeJoinFailure(error)) {
+        const normalized = normalizeJoinError(error);
         klog("ws_join_authoritative_failed", {
           tableId,
           userId,
           requestId: requestId || null,
-          code: typeof error?.code === "string" ? error.code : null,
-          message: error?.message || "unknown",
+          code: normalized.code,
+          validationReason: normalized.validationReason || null
         });
       }
       return normalizeJoinError(error);

--- a/ws-server/poker/persistence/authoritative-join-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.mjs
@@ -139,8 +139,11 @@ function normalizeSuccess(result, { tableId, userId, requestId }) {
     if (!botUserId || !Number.isInteger(botSeatNo) || botSeatNo < 1 || !snapshotSeatKeys.has(`${botUserId}:${botSeatNo}`)) {
       return invalidAuthoritativeState("missing_seeded_bot_snapshot_seat");
     }
-    if (Number(snapshotStacks[botUserId]) !== botStack) {
+    if (!Object.prototype.hasOwnProperty.call(snapshotStacks, botUserId)) {
       return invalidAuthoritativeState("missing_seeded_bot_snapshot_stack");
+    }
+    if (Number(snapshotStacks[botUserId]) !== botStack) {
+      return invalidAuthoritativeState("seeded_bot_snapshot_stack_mismatch");
     }
   }
   return {


### PR DESCRIPTION
## Summary

- preserves a stable lowercase `validationReason` on every known shared-domain path that produces `authoritative_state_invalid`
- distinguishes locked-write version errors, invalid/non-advancing post-mutation versions, authoritative seat/stack projection failures and incomplete seeded-bot projection
- distinguishes a missing seeded-bot stack entry from an existing mismatched stack value
- carries safe validation metadata through adapter normalization while keeping the public join rejection code unchanged
- replaces the duplicated adapter invalid-snapshot event with one `ws_join_authoritative_failed` event containing `code` and `validationReason`
- adds a compact validation reason to the existing `ws_join_restore_invalid` event
- tags storage-state validation failures without logging snapshots, cards, maps, SQL or arbitrary runtime messages

Closes #767

## Root cause

The shared join domain reduced several independent validation branches to the same error code, and `normalizeJoinError()` discarded any diagnostic metadata. Adapter-side contract checks also logged free-form messages and returned only the generic code, followed by a second invalid-snapshot event. Operators could therefore see `authoritative_state_invalid` but could not identify the failed invariant.

## Runtime and protocol impact

The client-facing/protocol rejection remains `authoritative_state_invalid`. No validation condition, transaction, persistence, ledger, settlement, retry or gameplay behavior changes. `validationReason` is internal adapter/logging context only.

Potential breaking observability impact: `ws_authoritative_adapter_invalid_snapshot` is removed; searches should use the consolidated `ws_join_authoritative_failed` event and its `validationReason` field.

## Validation

- full `npm test`
- `npm run syntax` — 213 files
- `npm run check:csp-inline` — 52 served documents
- targeted shared join, authoritative join adapter and join handler suites
- `git diff --check`

No new tests were created. Three existing adapter assertions were updated for the enriched internal result contract.

## Preview verification

Because this changes `ws-server/**`, deploy exact SHA `0e0c42770bbf0b15c645ecb4283bce527b19ca95` with **WS Preview Deploy**, verify both `/healthz` endpoints, perform a normal join/rejoin smoke, and confirm normal success emits no new production log. If an existing safe fixture triggers a known invalid authoritative result, verify one `ws_join_authoritative_failed` with a stable `validationReason` and no duplicate invalid-snapshot event.