### PR TITLE
feat: repair bot claims on Preview tables

### DIFF
--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -25,6 +25,11 @@ ws-preview.kcswh.pl {
     reverse_proxy 127.0.0.1:3001
   }
 
+  @botClaimsRecoveryAdmin path /internal/admin/bot-claims-recovery
+  handle @botClaimsRecoveryAdmin {
+    reverse_proxy 127.0.0.1:3001
+  }
+
   @ws path /ws*
   handle @ws {
     reverse_proxy 127.0.0.1:3001

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1688,7 +1688,7 @@
     setStatus(t("loading", "Loading..."), "info");
     try {
       var keyScope = "bot-claims-recovery-" + tableId;
-      await apiFetch("/.netlify/functions/admin-table-bot-claims-recovery", {
+      var result = await apiFetch("/.netlify/functions/admin-table-bot-claims-recovery", {
         method: "POST",
         body: JSON.stringify({
           mode: "execute",
@@ -1700,6 +1700,12 @@
           reason: reason,
         }),
       });
+      if (!result || result.ok !== true || result.changed !== true || result.closed !== true){
+        var outcomeError = new Error(result && result.reason ? String(result.reason) : "recovery_not_completed");
+        outcomeError.status = 409;
+        outcomeError.code = result && result.reason ? result.reason : "recovery_not_completed";
+        throw outcomeError;
+      }
       resetDraftIdempotencyKey(keyScope);
       state.tables.recovery = null;
       setStatus("Bot claims repaired and table closed.", "success");

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -24,6 +24,7 @@
       pagination: null,
       selectedTableId: null,
       detail: null,
+      recovery: null,
       loaded: false,
     },
     ledger: {
@@ -842,8 +843,35 @@
     html.push('<button class="admin-btn admin-btn--ghost" type="button" data-table-action="stale_seat_cleanup" data-table-id="' + escapeHtml(table.tableId || "") + '">Stale-seat cleanup</button>');
     html.push('<button class="admin-btn admin-btn--ghost" type="button" data-table-action="reconcile" data-table-id="' + escapeHtml(table.tableId || "") + '">Reconcile</button>');
     html.push('<button class="admin-btn admin-btn--danger" type="button" data-table-action="force_close" data-table-id="' + escapeHtml(table.tableId || "") + '">Force close</button>');
+    if (table.persistedStatus === "OPEN" && table.phase === "SETTLED" && janitor.healthy === false){
+      html.push('<button class="admin-btn admin-btn--ghost" type="button" data-table-action="analyze_bot_recovery" data-table-id="' + escapeHtml(table.tableId || "") + '">Analyze bot recovery</button>');
+    }
     html.push("</div>");
     html.push('<p class="admin-note' + (janitor.healthy === false ? " admin-note--danger" : "") + '">Recommended action: ' + escapeHtml(janitor.action || "noop") + (janitor.reasonCode ? " · " + escapeHtml(janitor.reasonCode) : "") + "</p>");
+    var recovery = state.tables.recovery;
+    if (recovery && recovery.tableId === table.tableId){
+      if (recovery.eligible === true){
+        html.push('<div class="admin-surface"><h3 class="admin-section-title">Bot claims recovery</h3>');
+        html.push('<div class="admin-kv">');
+        html.push(renderKvRow("Environment", recovery.environment || "ws-preview"));
+        html.push(renderKvRow("Table", table.tableId));
+        html.push(renderKvRow("Claim total", formatAmount(recovery.claimTotal)));
+        html.push(renderKvRow("Escrow", formatAmount(recovery.escrow)));
+        html.push(renderKvRow("Signed delta", formatSignedAmount(recovery.delta)));
+        html.push(renderKvRow("Human stack preserved", recovery.humanStack == null ? "none" : formatAmount(recovery.humanStack)));
+        html.push("</div>");
+        html.push('<div><h4 class="admin-section-title">Bot stacks before / after</h4>' + renderMiniList((recovery.bots || []).map(function(bot){
+          return {
+            title: "Seat " + escapeHtml(bot.seatNo),
+            meta: escapeHtml(formatAmount(bot.before) + " → " + formatAmount(bot.after)),
+          };
+        })) + "</div>");
+        html.push('<p class="admin-note admin-note--danger">This assigns the unexplained difference only to bot economy and permanently closes the table.</p>');
+        html.push('<button class="admin-btn admin-btn--danger" type="button" data-table-action="execute_bot_recovery" data-table-id="' + escapeHtml(table.tableId) + '">Repair bot claims and close</button></div>');
+      } else {
+        html.push('<p class="admin-note admin-note--danger">Bot recovery is not eligible: ' + escapeHtml(recovery.reason || "unknown") + "</p>");
+      }
+    }
     html.push('<div><h3 class="admin-section-title">Seats</h3>' + renderMiniList((detail.seats || []).map(function(seat){
       var label = (seat.userId || "user") + " · seat " + (seat.seatNo || "—") + " · " + (seat.isBot ? "bot" : "human");
       return {
@@ -1545,6 +1573,9 @@
     try {
       var payload = await apiFetch("/.netlify/functions/admin-table-details?tableId=" + encodeURIComponent(tableId), { method: "GET" });
       state.tables.detail = payload;
+      if (!state.tables.recovery || state.tables.recovery.tableId !== tableId){
+        state.tables.recovery = null;
+      }
       renderTableDetail();
       setStatus("", "");
     } catch (err){
@@ -1616,6 +1647,73 @@
       loadOps();
     } catch (err){
       handleApiError(err, "Could not run table action.");
+    }
+  }
+
+  async function analyzeBotRecovery(tableId){
+    setStatus(t("loading", "Loading..."), "info");
+    try {
+      var result = await apiFetch("/.netlify/functions/admin-table-bot-claims-recovery", {
+        method: "POST",
+        body: JSON.stringify({ mode: "preflight", tableId: tableId }),
+      });
+      state.tables.recovery = Object.assign({ tableId: tableId }, result);
+      renderTableDetail();
+      setStatus(result.eligible === true ? "Bot recovery analysis completed." : "Table is not eligible for bot recovery.", result.eligible === true ? "success" : "error");
+    } catch (err){
+      state.tables.recovery = null;
+      handleApiError(err, "Could not analyze bot recovery.");
+    }
+  }
+
+  async function executeBotRecovery(tableId){
+    var recovery = state.tables.recovery;
+    if (!recovery || recovery.tableId !== tableId || recovery.eligible !== true){
+      setStatus("Run bot recovery analysis first.", "error");
+      return;
+    }
+    if (typeof window.confirm === "function" && !window.confirm("Repair bot claims and permanently close table " + tableId + "?")){
+      return;
+    }
+    var confirmation = typeof window.prompt === "function"
+      ? window.prompt("Type REPAIR BOT CLAIMS AND CLOSE to confirm.", "")
+      : "";
+    if (String(confirmation || "").trim() !== "REPAIR BOT CLAIMS AND CLOSE"){
+      setStatus("Bot recovery cancelled.", "info");
+      return;
+    }
+    var reasonNode = doc.getElementById("adminTableReason");
+    var reason = reasonNode && typeof reasonNode.value === "string" ? reasonNode.value.trim() : "";
+    if (!reason) reason = "approved Preview bot claims recovery";
+    setStatus(t("loading", "Loading..."), "info");
+    try {
+      var keyScope = "bot-claims-recovery-" + tableId;
+      await apiFetch("/.netlify/functions/admin-table-bot-claims-recovery", {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "execute",
+          tableId: tableId,
+          expectedStateVersion: recovery.stateVersion,
+          expectedInputHash: recovery.inputHash,
+          idempotencyKey: getDraftIdempotencyKey(keyScope),
+          confirmation: "REPAIR BOT CLAIMS AND CLOSE",
+          reason: reason,
+        }),
+      });
+      resetDraftIdempotencyKey(keyScope);
+      state.tables.recovery = null;
+      setStatus("Bot claims repaired and table closed.", "success");
+      await loadTableDetail(tableId, true);
+      await loadTables();
+      await loadOps();
+    } catch (err){
+      if (err && (err.code === "state_version_changed" || err.code === "recovery_input_changed")){
+        state.tables.recovery = null;
+        renderTableDetail();
+        handleApiError(err, "Table changed. Analyze bot recovery again.");
+        return;
+      }
+      handleApiError(err, "Could not repair bot claims.");
     }
   }
 
@@ -1972,6 +2070,16 @@
     if (action === "evaluate"){
       setActiveTab("tables");
       evaluateTable(tableId);
+      return;
+    }
+    if (action === "analyze_bot_recovery"){
+      setActiveTab("tables");
+      analyzeBotRecovery(tableId);
+      return;
+    }
+    if (action === "execute_bot_recovery"){
+      setActiveTab("tables");
+      executeBotRecovery(tableId);
       return;
     }
     setActiveTab("tables");

--- a/netlify/functions/admin-table-bot-claims-recovery.mjs
+++ b/netlify/functions/admin-table-bot-claims-recovery.mjs
@@ -71,17 +71,18 @@ function parseBody(body, adminUserId) {
     throw recoveryError("invalid_confirmation");
   }
   const clientKey = parseIdempotencyKey(payload.idempotencyKey);
-  if (clientKey.length > 64) throw recoveryError("invalid_idempotency_key");
   const reason = parseOptionalText(payload.reason, { maxLength: 240 });
   if (reason.length < 3) throw recoveryError("missing_reason");
   const tableId = parseUuid(payload.tableId, "invalid_table_id");
+  const requestId = `admin-recovery:${tableId}:${clientKey}`;
+  if (requestId.length > 140) throw recoveryError("invalid_idempotency_key");
   return {
     mode,
     tableId,
     adminUserId,
     expectedStateVersion,
     expectedInputHash,
-    requestId: `admin-recovery:${tableId}:${clientKey}`,
+    requestId,
     reason,
   };
 }

--- a/netlify/functions/admin-table-bot-claims-recovery.mjs
+++ b/netlify/functions/admin-table-bot-claims-recovery.mjs
@@ -1,0 +1,230 @@
+import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.mjs";
+import { parseIdempotencyKey, parseJsonBody, parseOptionalText, parseUuid } from "./_shared/admin-ops.mjs";
+import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
+import { buildStageIdentity } from "./admin-stage-identity.mjs";
+
+const WS_PREVIEW_ORIGIN = "https://ws-preview.kcswh.pl";
+const CONFIRMATION = "REPAIR BOT CLAIMS AND CLOSE";
+
+function jsonResponse(statusCode, headers, body) {
+  return {
+    statusCode,
+    headers: { ...headers, "cache-control": "no-store" },
+    body: JSON.stringify(body),
+  };
+}
+
+function recoveryError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function exactKeys(payload, expected) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+  const keys = Object.keys(payload).sort();
+  const sortedExpected = [...expected].sort();
+  return keys.length === sortedExpected.length && keys.every((key, index) => key === sortedExpected[index]);
+}
+
+function parseBody(body, adminUserId) {
+  const payload = parseJsonBody(body);
+  const mode = typeof payload.mode === "string" ? payload.mode.trim() : "";
+  if (mode === "preflight" && exactKeys(payload, ["mode", "tableId"])) {
+    return {
+      mode,
+      tableId: parseUuid(payload.tableId, "invalid_table_id"),
+      adminUserId,
+    };
+  }
+  if (mode !== "execute" || !exactKeys(payload, [
+    "confirmation",
+    "expectedInputHash",
+    "expectedStateVersion",
+    "idempotencyKey",
+    "mode",
+    "reason",
+    "tableId",
+  ])) {
+    throw recoveryError("invalid_request");
+  }
+  const expectedStateVersion = Number(payload.expectedStateVersion);
+  if (!Number.isSafeInteger(expectedStateVersion) || expectedStateVersion < 0) {
+    throw recoveryError("invalid_state_version");
+  }
+  const expectedInputHash = typeof payload.expectedInputHash === "string"
+    ? payload.expectedInputHash.trim()
+    : "";
+  if (!/^[a-f0-9]{64}$/i.test(expectedInputHash)) throw recoveryError("invalid_input_hash");
+  if (String(payload.confirmation || "").trim() !== CONFIRMATION) {
+    throw recoveryError("invalid_confirmation");
+  }
+  const clientKey = parseIdempotencyKey(payload.idempotencyKey);
+  if (clientKey.length > 64) throw recoveryError("invalid_idempotency_key");
+  const reason = parseOptionalText(payload.reason, { maxLength: 240 });
+  if (reason.length < 3) throw recoveryError("missing_reason");
+  const tableId = parseUuid(payload.tableId, "invalid_table_id");
+  return {
+    mode,
+    tableId,
+    adminUserId,
+    expectedStateVersion,
+    expectedInputHash,
+    requestId: `admin-recovery:${tableId}:${clientKey}`,
+    reason,
+  };
+}
+
+function resolvePreviewBaseUrl(env) {
+  const raw = typeof env?.POKER_WS_INTERNAL_BASE_URL === "string"
+    ? env.POKER_WS_INTERNAL_BASE_URL.trim()
+    : "";
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (
+      url.origin !== WS_PREVIEW_ORIGIN
+      || (url.pathname !== "/" && url.pathname !== "")
+      || url.username
+      || url.password
+      || url.search
+      || url.hash
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function isValidRecoveryResponse(value, mode) {
+  if (!value || typeof value !== "object" || value.environment !== "ws-preview") return false;
+  if (typeof value.ok !== "boolean" || typeof value.eligible !== "boolean") return false;
+  if (value.bots != null && !Array.isArray(value.bots)) return false;
+  if (value.eligible === true) {
+    if (!Number.isSafeInteger(value.stateVersion) || !/^[a-f0-9]{64}$/i.test(String(value.inputHash || ""))) {
+      return false;
+    }
+  }
+  if (mode === "execute" && value.ok === true && value.closed !== true) return false;
+  return true;
+}
+
+async function proxyRecovery({ payload, env, fetchImpl }) {
+  const baseUrl = resolvePreviewBaseUrl(env);
+  const token = typeof env?.POKER_WS_INTERNAL_TOKEN === "string"
+    ? env.POKER_WS_INTERNAL_TOKEN.trim()
+    : "";
+  if (!baseUrl || !token || typeof fetchImpl !== "function") {
+    throw recoveryError("ws_preview_unavailable", 503);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  if (typeof timer?.unref === "function") timer.unref();
+  try {
+    const response = await fetchImpl(`${baseUrl}/internal/admin/bot-claims-recovery`, {
+      method: "POST",
+      cache: "no-store",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {}
+    if (!response.ok) {
+      const exposed = new Set([
+        "active_table_presence",
+        "foreign_human_history",
+        "other_request_pending",
+        "participant_identity_unknown",
+        "preview_only",
+        "recovery_input_changed",
+        "request_pending",
+        "state_version_changed",
+      ]);
+      const upstreamCode = typeof body?.error === "string" ? body.error : "ws_preview_unavailable";
+      throw recoveryError(exposed.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable", response.status);
+    }
+    if (!isValidRecoveryResponse(body, payload.mode)) {
+      throw recoveryError("ws_preview_invalid_response", 502);
+    }
+    return body;
+  } catch (error) {
+    if (error?.name === "AbortError") throw recoveryError("ws_preview_timeout", 504);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createAdminTableBotClaimsRecoveryHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const requireAdmin = deps.requireAdminUser || requireAdminUser;
+  const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
+  const fetchImpl = deps.fetchImpl || globalThis.fetch;
+  return async function handler(event) {
+    if (env.CHIPS_ENABLED !== "1") return jsonResponse(404, baseHeaders(), { error: "not_found" });
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) return jsonResponse(403, baseHeaders(), { error: "forbidden_origin" });
+    if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: { ...cors, "cache-control": "no-store" }, body: "" };
+    if (event.httpMethod !== "POST") return jsonResponse(405, cors, { error: "method_not_allowed" });
+
+    try {
+      const admin = await requireAdmin(event, env);
+      const identity = buildIdentity();
+      if (
+        identity?.environmentContext !== "deploy-preview"
+        || identity?.databaseTarget !== "stage"
+        || identity?.stageProjectRefMatches !== true
+        || identity?.databaseMatchesSupabaseProjectRef !== true
+        || identity?.serviceRoleStageProjectRefMatches !== true
+      ) {
+        return jsonResponse(403, cors, { error: "preview_only" });
+      }
+      const payload = parseBody(event.body, admin.userId);
+      const result = await proxyRecovery({ payload, env, fetchImpl });
+      klog("admin_bot_claims_recovery_outcome", {
+        adminUserId: admin.userId,
+        tableId: payload.tableId,
+        mode: payload.mode,
+        ok: result.ok === true,
+        eligible: result.eligible === true,
+        closed: result.closed === true,
+        reason: result.reason || null,
+        stateVersion: result.stateVersion ?? null,
+        finalStateVersion: result.finalStateVersion ?? null,
+        delta: result.delta ?? null,
+      });
+      return jsonResponse(200, cors, result);
+    } catch (error) {
+      if (error?.status === 401 || (error?.status === 403 && error?.code === "admin_required")) {
+        const response = adminAuthErrorResponse(error, cors);
+        return { ...response, headers: { ...response.headers, "cache-control": "no-store" } };
+      }
+      const status = Number(error?.status) || 500;
+      const code = error?.code || "server_error";
+      klog("admin_bot_claims_recovery_failed", { status, code });
+      return jsonResponse(status, cors, { error: code });
+    }
+  };
+}
+
+const handler = createAdminTableBotClaimsRecoveryHandler();
+
+export {
+  CONFIRMATION,
+  createAdminTableBotClaimsRecoveryHandler,
+  handler,
+  isValidRecoveryResponse,
+  parseBody,
+  proxyRecovery,
+  resolvePreviewBaseUrl,
+};

--- a/netlify/functions/admin-table-bot-claims-recovery.mjs
+++ b/netlify/functions/admin-table-bot-claims-recovery.mjs
@@ -5,6 +5,16 @@ import { buildStageIdentity } from "./admin-stage-identity.mjs";
 
 const WS_PREVIEW_ORIGIN = "https://ws-preview.kcswh.pl";
 const CONFIRMATION = "REPAIR BOT CLAIMS AND CLOSE";
+const EXPOSED_RECOVERY_ERRORS = new Set([
+  "active_table_presence",
+  "foreign_human_history",
+  "other_request_pending",
+  "participant_identity_unknown",
+  "preview_only",
+  "recovery_input_changed",
+  "request_pending",
+  "state_version_changed",
+]);
 
 function jsonResponse(statusCode, headers, body) {
   return {
@@ -108,7 +118,12 @@ function isValidRecoveryResponse(value, mode) {
       return false;
     }
   }
-  if (mode === "execute" && value.ok === true && value.closed !== true) return false;
+  if (
+    mode === "execute"
+    && (typeof value.changed !== "boolean" || typeof value.closed !== "boolean")
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -139,21 +154,24 @@ async function proxyRecovery({ payload, env, fetchImpl }) {
       body = await response.json();
     } catch {}
     if (!response.ok) {
-      const exposed = new Set([
-        "active_table_presence",
-        "foreign_human_history",
-        "other_request_pending",
-        "participant_identity_unknown",
-        "preview_only",
-        "recovery_input_changed",
-        "request_pending",
-        "state_version_changed",
-      ]);
       const upstreamCode = typeof body?.error === "string" ? body.error : "ws_preview_unavailable";
-      throw recoveryError(exposed.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable", response.status);
+      throw recoveryError(
+        EXPOSED_RECOVERY_ERRORS.has(upstreamCode) ? upstreamCode : "ws_preview_unavailable",
+        response.status,
+      );
     }
     if (!isValidRecoveryResponse(body, payload.mode)) {
       throw recoveryError("ws_preview_invalid_response", 502);
+    }
+    if (
+      payload.mode === "execute"
+      && (body.ok !== true || body.changed !== true || body.closed !== true)
+    ) {
+      const outcomeCode = typeof body.reason === "string" ? body.reason : "";
+      throw recoveryError(
+        EXPOSED_RECOVERY_ERRORS.has(outcomeCode) ? outcomeCode : "recovery_not_completed",
+        409,
+      );
     }
     return body;
   } catch (error) {

--- a/shared/poker-domain/bot-claims-recovery.mjs
+++ b/shared/poker-domain/bot-claims-recovery.mjs
@@ -1,0 +1,578 @@
+import { createHash } from "node:crypto";
+import { postTransaction } from "../../netlify/functions/_shared/chips-ledger.mjs";
+import {
+  ensurePokerRequest,
+  storePokerRequestResult,
+} from "../../netlify/functions/_shared/poker-idempotency.mjs";
+import {
+  executeTerminalPokerCloseInTx,
+  loadBotFundingRows,
+} from "./terminal-close.mjs";
+
+const RECOVERY_KIND = "ADMIN_BOT_CLAIMS_RECOVERY";
+const RECOVERY_CLOSE_REASON = "ADMIN_BOT_CLAIMS_RECOVERY";
+const GAMEPLAY_REQUEST_KINDS = new Set(["ACT", "JOIN", "LEAVE", "REBUY"]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeJsonObject(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeNonNegativeInt(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function addSafe(left, right) {
+  const result = left + right;
+  return Number.isSafeInteger(result) && result >= 0 ? result : null;
+}
+
+function fail(reason, extra = {}) {
+  return {
+    ok: false,
+    eligible: false,
+    changed: false,
+    closed: false,
+    retryable: false,
+    code: "bot_claims_recovery_ineligible",
+    reason,
+    ...extra,
+  };
+}
+
+function conflict(reason) {
+  const error = new Error(reason);
+  error.code = reason;
+  error.status = 409;
+  return error;
+}
+
+function parseStateSeat(row) {
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const userId = normalizeString(row.userId ?? row.user_id);
+  const seatNo = normalizeNonNegativeInt(row.seatNo ?? row.seat_no ?? row.seat);
+  if (!userId || seatNo == null || seatNo < 1) return null;
+  const rawIsBot = row.isBot ?? row.is_bot;
+  return {
+    userId,
+    seatNo,
+    isBot: rawIsBot === true ? true : rawIsBot === false ? false : null,
+  };
+}
+
+function normalizeSettlementPayoutIds(meta) {
+  const parsed = normalizeJsonObject(meta);
+  const payouts = normalizeJsonObject(parsed?.payoutByUserId);
+  return payouts ? Object.keys(payouts).map(normalizeString).filter(Boolean) : [];
+}
+
+function terminalCashoutEvidence(transaction, stateVersion) {
+  const metadata = normalizeJsonObject(transaction?.metadata) || {};
+  const reason = normalizeString(metadata.reason).toUpperCase();
+  const key = normalizeString(transaction?.idempotency_key);
+  const isTerminal =
+    reason === "HUMAN_TERMINAL_CASH_OUT"
+    || reason === "BOT_TERMINAL_CASH_OUT"
+    || key.startsWith("poker:human-terminal-cashout:v1:")
+    || key.startsWith("poker:bot-terminal-cashout:v1:");
+  if (!isTerminal) return { terminal: false, blocking: false };
+  const fromVersion = normalizeNonNegativeInt(metadata.fromStateVersion);
+  const toVersion = normalizeNonNegativeInt(metadata.toStateVersion);
+  if (fromVersion == null || toVersion == null) {
+    return { terminal: true, blocking: true };
+  }
+  return {
+    terminal: true,
+    blocking: toVersion >= stateVersion || fromVersion >= stateVersion,
+  };
+}
+
+function buildInputHash({ escrowBefore, seats }) {
+  const seatProjection = seats
+    .map((seat) => ({
+      userId: normalizeString(seat.user_id),
+      seatNo: normalizeNonNegativeInt(seat.seat_no),
+      isBot: seat.is_bot === true,
+    }))
+    .sort((left, right) => left.seatNo - right.seatNo || left.userId.localeCompare(right.userId));
+  return createHash("sha256")
+    .update(JSON.stringify({ escrowBefore, seats: seatProjection }))
+    .digest("hex");
+}
+
+function collectParticipantEvidence({
+  adminUserId,
+  table,
+  state,
+  seats,
+  actions,
+  requests,
+  ledgerTransactions,
+  ledgerUserIds,
+  fundingRecords,
+}) {
+  const participants = new Set();
+  const humanEvidence = new Set();
+  const botEvidence = new Set();
+  let conflicting = false;
+  const addParticipant = (value) => {
+    const userId = normalizeString(value);
+    if (userId) participants.add(userId);
+  };
+  const addHuman = (value) => {
+    const userId = normalizeString(value);
+    if (!userId) return;
+    participants.add(userId);
+    humanEvidence.add(userId);
+  };
+  const addBot = (value) => {
+    const userId = normalizeString(value);
+    if (!userId) return;
+    participants.add(userId);
+    botEvidence.add(userId);
+  };
+
+  addHuman(table?.created_by);
+  for (const seat of seats) {
+    if (seat?.is_bot === true) addParticipant(seat.user_id);
+    else if (seat?.is_bot === false) addHuman(seat.user_id);
+    else conflicting = true;
+  }
+  for (const stateSeatRaw of Array.isArray(state?.seats) ? state.seats : []) {
+    const stateSeat = parseStateSeat(stateSeatRaw);
+    if (!stateSeat) {
+      conflicting = true;
+      continue;
+    }
+    if (stateSeat.isBot === true) addParticipant(stateSeat.userId);
+    else if (stateSeat.isBot === false) addHuman(stateSeat.userId);
+    else addParticipant(stateSeat.userId);
+  }
+  for (const userId of Object.keys(normalizeJsonObject(state?.stacks) || {})) addParticipant(userId);
+
+  for (const record of fundingRecords) {
+    if (record?.kind === "seed") addBot(record.botUserId);
+    if (record?.kind === "replacement") {
+      addBot(record.oldBotUserId);
+      addBot(record.replacementBotUserId);
+    }
+  }
+  for (const action of actions) {
+    const actionType = normalizeString(action?.action_type).toUpperCase();
+    if (!actionType.startsWith("ADMIN_")) addParticipant(action?.user_id);
+    if (actionType === "HAND_SETTLED") {
+      for (const userId of normalizeSettlementPayoutIds(action?.meta)) addParticipant(userId);
+    }
+  }
+  for (const request of requests) {
+    if (GAMEPLAY_REQUEST_KINDS.has(normalizeString(request?.kind).toUpperCase())) {
+      addParticipant(request?.user_id);
+    }
+  }
+  for (const transaction of ledgerTransactions) {
+    const metadata = normalizeJsonObject(transaction?.metadata) || {};
+    const reason = normalizeString(metadata.reason).toUpperCase();
+    if (transaction?.user_id) addHuman(transaction.user_id);
+    if (reason === "BOT_SEED_BUY_IN") addBot(metadata.botUserId);
+    if (reason === "BOT_REPLACEMENT_BUY_IN") {
+      addBot(metadata.oldBotUserId);
+      addBot(metadata.replacementBotUserId);
+    }
+    if (reason === "BOT_TERMINAL_CASH_OUT") addBot(metadata.botUserId);
+  }
+  for (const userId of ledgerUserIds) addHuman(userId);
+
+  for (const userId of participants) {
+    if (!UUID_RE.test(userId)) conflicting = true;
+    if (humanEvidence.has(userId) && botEvidence.has(userId)) conflicting = true;
+  }
+  if (conflicting) return fail("identity_evidence_conflict");
+
+  const foreignHumans = [...humanEvidence].filter((userId) => userId !== adminUserId);
+  if (foreignHumans.length > 0) return fail("foreign_human_history");
+
+  const unknown = [...participants].filter((userId) => userId !== adminUserId && !botEvidence.has(userId));
+  if (unknown.length > 0) return fail("participant_identity_unknown");
+
+  return {
+    ok: true,
+    participants,
+    botUserIds: botEvidence,
+    hasAdminHuman: humanEvidence.has(adminUserId),
+  };
+}
+
+export function projectBotClaimsRepair({ state, seats, escrowBefore, adminUserId, identityEvidence }) {
+  const stacks = normalizeJsonObject(state?.stacks);
+  if (!stacks || !identityEvidence?.ok) return fail("stack_or_identity_invalid");
+  const normalizedEscrow = normalizeNonNegativeInt(escrowBefore);
+  if (normalizedEscrow == null) return fail("escrow_invalid");
+
+  const normalizedStacks = new Map();
+  let claimTotal = 0;
+  for (const [userIdRaw, amountRaw] of Object.entries(stacks)) {
+    const userId = normalizeString(userIdRaw);
+    const amount = normalizeNonNegativeInt(amountRaw);
+    if (!userId || amount == null || normalizedStacks.has(userId)) return fail("stack_state_invalid");
+    normalizedStacks.set(userId, amount);
+    claimTotal = addSafe(claimTotal, amount);
+    if (claimTotal == null) return fail("claims_overflow");
+  }
+
+  const seatByUserId = new Map();
+  for (const seat of seats) {
+    const userId = normalizeString(seat?.user_id);
+    const seatNo = normalizeNonNegativeInt(seat?.seat_no);
+    if (!userId || seatNo == null || seatNo < 1 || seatByUserId.has(userId)) return fail("seat_state_invalid");
+    seatByUserId.set(userId, { userId, seatNo, isBot: seat.is_bot === true });
+  }
+
+  const bots = [];
+  let humanStack = null;
+  for (const [userId, amount] of normalizedStacks) {
+    const seat = seatByUserId.get(userId);
+    if (!seat) return fail("claimant_seat_missing");
+    if (userId === adminUserId) {
+      if (seat.isBot || humanStack != null) return fail("human_claim_invalid");
+      humanStack = amount;
+      continue;
+    }
+    if (!seat.isBot || !identityEvidence.botUserIds.has(userId)) return fail("bot_claimant_unconfirmed");
+    bots.push({ userId, seatNo: seat.seatNo, before: amount, after: amount });
+  }
+  bots.sort((left, right) => left.seatNo - right.seatNo || left.userId.localeCompare(right.userId));
+
+  const delta = normalizedEscrow - claimTotal;
+  if (!Number.isSafeInteger(delta)) return fail("delta_invalid");
+  if (delta > 0) {
+    if (bots.length === 0) return fail("missing_bot_for_positive_delta");
+    const corrected = addSafe(bots[0].after, delta);
+    if (corrected == null) return fail("claims_overflow");
+    bots[0].after = corrected;
+  } else if (delta < 0) {
+    let remaining = Math.abs(delta);
+    for (const bot of bots) {
+      const deduction = Math.min(bot.after, remaining);
+      bot.after -= deduction;
+      remaining -= deduction;
+      if (remaining === 0) break;
+    }
+    if (remaining !== 0) return fail("insufficient_bot_stacks");
+  }
+
+  const correctedStacks = { ...stacks };
+  for (const bot of bots) correctedStacks[bot.userId] = bot.after;
+  if (humanStack != null && correctedStacks[adminUserId] !== humanStack) return fail("human_stack_changed");
+  const correctedTotal = Object.values(correctedStacks).reduce((sum, amount) => sum + Number(amount), 0);
+  if (!Number.isSafeInteger(correctedTotal) || correctedTotal !== normalizedEscrow) {
+    return fail("corrected_claims_mismatch");
+  }
+
+  return {
+    ok: true,
+    eligible: true,
+    claimTotal,
+    escrow: normalizedEscrow,
+    delta,
+    humanStack,
+    correctedStacks,
+    bots,
+  };
+}
+
+async function loadRecoverySnapshotTx(tx, { tableId, lock }) {
+  const lockClause = lock ? " for update" : "";
+  const tableRows = await tx.unsafe(
+    `select id, status, created_by from public.poker_tables where id = $1 limit 1${lockClause};`,
+    [tableId],
+  );
+  const stateRows = await tx.unsafe(
+    `select version, state from public.poker_state where table_id = $1 limit 1${lockClause};`,
+    [tableId],
+  );
+  const seatRows = await tx.unsafe(
+    `select user_id, seat_no, status, is_bot, stack from public.poker_seats where table_id = $1 order by seat_no asc${lockClause};`,
+    [tableId],
+  );
+  const escrowRows = await tx.unsafe(
+    `select id, account_type, system_key, status, balance from public.chips_accounts where system_key = $1 limit 1${lockClause};`,
+    [`POKER_TABLE:${tableId}`],
+  );
+  return {
+    table: tableRows?.[0] || null,
+    stateRow: stateRows?.[0] || null,
+    seats: Array.isArray(seatRows) ? seatRows : [],
+    escrow: escrowRows?.[0] || null,
+  };
+}
+
+async function loadRecoveryEvidenceTx(tx, { tableId, escrowAccountId }) {
+  const [actions, requests, transactions, ledgerUsers, funding] = await Promise.all([
+    tx.unsafe(
+      "select user_id, action_type, meta from public.poker_actions where table_id = $1 order by created_at asc, id asc;",
+      [tableId],
+    ),
+    tx.unsafe(
+      "select user_id, request_id, kind, result_json from public.poker_requests where table_id = $1 order by created_at asc;",
+      [tableId],
+    ),
+    tx.unsafe(
+      `select id, user_id, tx_type, idempotency_key, metadata
+       from public.chips_transactions
+       where reference = $1 or coalesce(metadata->>'tableId', '') = $2
+       order by created_at asc, id asc;`,
+      [`table:${tableId}`, tableId],
+    ),
+    tx.unsafe(
+      `select distinct a.user_id
+       from public.chips_transactions t
+       join public.chips_entries e on e.transaction_id = t.id
+       join public.chips_accounts a on a.id = e.account_id
+       where (t.reference = $1 or coalesce(t.metadata->>'tableId', '') = $2)
+         and a.account_type = 'USER'
+         and a.user_id is not null;`,
+      [`table:${tableId}`, tableId],
+    ),
+    loadBotFundingRows(tx, { tableId, escrowAccountId }),
+  ]);
+  return {
+    actions: Array.isArray(actions) ? actions : [],
+    requests: Array.isArray(requests) ? requests : [],
+    transactions: Array.isArray(transactions) ? transactions : [],
+    ledgerUserIds: (Array.isArray(ledgerUsers) ? ledgerUsers : []).map((row) => row.user_id).filter(Boolean),
+    funding,
+  };
+}
+
+async function evaluateRecoveryTx(tx, {
+  tableId,
+  adminUserId,
+  lock,
+  snapshot: suppliedSnapshot = null,
+  allowedPendingRequest = null,
+}) {
+  const snapshot = suppliedSnapshot || await loadRecoverySnapshotTx(tx, { tableId, lock });
+  const table = snapshot.table;
+  const stateVersion = normalizeNonNegativeInt(snapshot.stateRow?.version);
+  const state = normalizeJsonObject(snapshot.stateRow?.state);
+  if (!table || stateVersion == null || !state) return fail("table_or_state_missing");
+  if (normalizeString(table.status).toUpperCase() !== "OPEN") return fail("table_not_open");
+  if (normalizeString(state.phase).toUpperCase() !== "SETTLED") return fail("phase_not_settled");
+
+  const pot = Object.prototype.hasOwnProperty.call(state, "pot") ? normalizeNonNegativeInt(state.pot) : 0;
+  const potTotal = Object.prototype.hasOwnProperty.call(state, "potTotal") ? normalizeNonNegativeInt(state.potTotal) : pot;
+  if (pot == null || potTotal == null || pot !== potTotal || potTotal !== 0) return fail("pot_not_zero");
+
+  const escrowBefore = normalizeNonNegativeInt(snapshot.escrow?.balance);
+  if (
+    !UUID_RE.test(normalizeString(snapshot.escrow?.id))
+    || normalizeString(snapshot.escrow?.account_type).toUpperCase() !== "ESCROW"
+    || normalizeString(snapshot.escrow?.status).toLowerCase() !== "active"
+    || escrowBefore == null
+  ) {
+    return fail("escrow_invalid");
+  }
+
+  const evidence = await loadRecoveryEvidenceTx(tx, {
+    tableId,
+    escrowAccountId: snapshot.escrow.id,
+  });
+  if (!evidence.funding?.ok) return fail(evidence.funding?.reason || "bot_funding_invalid");
+
+  const pendingRequests = evidence.requests.filter((request) => request.result_json == null);
+  const otherPendingRequests = pendingRequests.filter(
+    (pending) => !(
+      allowedPendingRequest
+      && normalizeString(pending.request_id) === allowedPendingRequest.requestId
+      && normalizeString(pending.user_id) === allowedPendingRequest.userId
+      && normalizeString(pending.kind) === allowedPendingRequest.kind
+    ),
+  );
+  if (otherPendingRequests.length > 0) return fail("other_request_pending");
+  const blockingTerminalCashouts = evidence.transactions.filter(
+    (transaction) => terminalCashoutEvidence(transaction, stateVersion).blocking,
+  );
+  if (blockingTerminalCashouts.length > 0) return fail("terminal_close_already_persisted");
+
+  const identities = collectParticipantEvidence({
+    adminUserId,
+    table,
+    state,
+    seats: snapshot.seats,
+    actions: evidence.actions,
+    requests: evidence.requests,
+    ledgerTransactions: evidence.transactions,
+    ledgerUserIds: evidence.ledgerUserIds,
+    fundingRecords: evidence.funding.records,
+  });
+  if (!identities.ok) return identities;
+
+  const projection = projectBotClaimsRepair({
+    state,
+    seats: snapshot.seats,
+    escrowBefore,
+    adminUserId,
+    identityEvidence: identities,
+  });
+  if (!projection.ok) return projection;
+
+  return {
+    ...projection,
+    stateVersion,
+    inputHash: buildInputHash({ escrowBefore, seats: snapshot.seats }),
+    state,
+  };
+}
+
+function toSafeResult(result) {
+  return {
+    ok: result.ok === true,
+    eligible: result.eligible === true,
+    reason: result.reason || null,
+    stateVersion: result.stateVersion ?? null,
+    finalStateVersion: result.finalStateVersion ?? null,
+    inputHash: result.inputHash || null,
+    claimTotal: result.claimTotal ?? null,
+    escrow: result.escrow ?? null,
+    delta: result.delta ?? null,
+    humanStack: result.humanStack ?? null,
+    bots: Array.isArray(result.bots)
+      ? result.bots.map(({ seatNo, before, after }) => ({ seatNo, before, after }))
+      : [],
+    changed: result.changed === true,
+    closed: result.closed === true,
+    replayed: result.replayed === true,
+    recoveryReason: result.recoveryReason || null,
+  };
+}
+
+export async function preflightBotClaimsRecovery({ beginSql, tableId, adminUserId }) {
+  if (typeof beginSql !== "function") throw new Error("bot_claims_recovery_begin_sql_missing");
+  return beginSql(async (tx) => {
+    const evaluated = await evaluateRecoveryTx(tx, { tableId, adminUserId, lock: false });
+    return toSafeResult(evaluated);
+  });
+}
+
+export async function executeBotClaimsRecovery({
+  beginSql,
+  tableId,
+  adminUserId,
+  requestId,
+  expectedStateVersion,
+  expectedInputHash,
+  reason,
+  klog = () => {},
+}) {
+  if (typeof beginSql !== "function") throw new Error("bot_claims_recovery_begin_sql_missing");
+  return beginSql(async (tx) => {
+    const snapshot = await loadRecoverySnapshotTx(tx, { tableId, lock: true });
+    if (!snapshot.table || !snapshot.stateRow || !snapshot.escrow) throw conflict("table_or_state_missing");
+
+    const request = await ensurePokerRequest(tx, {
+      tableId,
+      userId: adminUserId,
+      requestId,
+      kind: RECOVERY_KIND,
+      pendingStaleSec: 30,
+    });
+    if (request.status === "stored") return { ...request.result, replayed: true };
+    if (request.status === "pending") throw conflict("request_pending");
+
+    const evaluated = await evaluateRecoveryTx(tx, {
+      tableId,
+      adminUserId,
+      lock: true,
+      snapshot,
+      allowedPendingRequest: {
+        requestId,
+        userId: adminUserId,
+        kind: RECOVERY_KIND,
+      },
+    });
+    if (!evaluated.ok) throw conflict(evaluated.reason);
+    if (evaluated.stateVersion !== expectedStateVersion) throw conflict("state_version_changed");
+    if (expectedInputHash && evaluated.inputHash !== expectedInputHash) throw conflict("recovery_input_changed");
+
+    const correctedVersion = evaluated.stateVersion + 1;
+    if (!Number.isSafeInteger(correctedVersion)) throw conflict("state_version_invalid");
+    const correctedState = { ...evaluated.state, stacks: evaluated.correctedStacks };
+    const updatedRows = await tx.unsafe(
+      `update public.poker_state
+       set version = version + 1, state = $3::jsonb, updated_at = now()
+       where table_id = $1 and version = $2
+       returning version;`,
+      [tableId, evaluated.stateVersion, JSON.stringify(correctedState)],
+    );
+    if (Number(updatedRows?.[0]?.version) !== correctedVersion) throw conflict("state_version_changed");
+
+    const closed = await executeTerminalPokerCloseInTx({
+      tx,
+      tableId,
+      postTransaction,
+      createdBy: adminUserId,
+      closeReason: RECOVERY_CLOSE_REASON,
+      successStatus: "bot_claims_recovered_closed",
+      klog,
+    });
+    if (closed?.ok !== true || closed?.closed !== true || closed?.changed !== true) {
+      throw conflict(closed?.reason || closed?.code || "terminal_close_failed");
+    }
+
+    const postRows = await tx.unsafe(
+      `select
+         t.status as table_status,
+         s.version as state_version,
+         s.state as state,
+         a.balance as escrow_balance,
+         (select count(*) from public.poker_seats ps where ps.table_id = $1 and ps.status <> 'INACTIVE') as active_seats
+       from public.poker_tables t
+       join public.poker_state s on s.table_id = t.id
+       join public.chips_accounts a on a.system_key = $2
+       where t.id = $1
+       limit 1;`,
+      [tableId, `POKER_TABLE:${tableId}`],
+    );
+    const post = postRows?.[0] || {};
+    const postState = normalizeJsonObject(post.state);
+    if (
+      normalizeString(post.table_status).toUpperCase() !== "CLOSED"
+      || normalizeNonNegativeInt(post.escrow_balance) !== 0
+      || normalizeNonNegativeInt(post.active_seats) !== 0
+      || normalizeString(postState?.phase).toUpperCase() !== "HAND_DONE"
+      || Object.keys(normalizeJsonObject(postState?.stacks) || {}).length !== 0
+    ) {
+      throw conflict("recovery_postcondition_failed");
+    }
+
+    const result = toSafeResult({
+      ...evaluated,
+      changed: true,
+      closed: true,
+      finalStateVersion: normalizeNonNegativeInt(post.state_version),
+      recoveryReason: normalizeString(reason),
+    });
+    await storePokerRequestResult(tx, {
+      tableId,
+      userId: adminUserId,
+      requestId,
+      kind: RECOVERY_KIND,
+      result,
+    });
+    return result;
+  });
+}
+
+export { RECOVERY_KIND };

--- a/shared/poker-domain/bot-claims-recovery.mjs
+++ b/shared/poker-domain/bot-claims-recovery.mjs
@@ -144,7 +144,7 @@ function collectParticipantEvidence({
     botEvidence.add(userId);
   };
 
-  addHuman(table?.created_by);
+  const creatorUserId = normalizeString(table?.created_by);
   for (const seat of seats) {
     if (seat?.is_bot === true) addParticipant(seat.user_id);
     else if (seat?.is_bot === false) addHuman(seat.user_id);
@@ -171,14 +171,18 @@ function collectParticipantEvidence({
   }
   for (const action of actions) {
     const actionType = normalizeString(action?.action_type).toUpperCase();
-    if (!actionType.startsWith("ADMIN_")) addParticipant(action?.user_id);
+    if (!actionType.startsWith("ADMIN_")) {
+      if (normalizeString(action?.user_id) === creatorUserId) addHuman(action.user_id);
+      else addParticipant(action?.user_id);
+    }
     if (actionType === "HAND_SETTLED") {
       for (const userId of normalizeSettlementPayoutIds(action?.meta)) addParticipant(userId);
     }
   }
   for (const request of requests) {
     if (GAMEPLAY_REQUEST_KINDS.has(normalizeString(request?.kind).toUpperCase())) {
-      addParticipant(request?.user_id);
+      if (normalizeString(request?.user_id) === creatorUserId) addHuman(request.user_id);
+      else addParticipant(request?.user_id);
     }
   }
   for (const transaction of ledgerTransactions) {
@@ -474,6 +478,7 @@ export async function executeBotClaimsRecovery({
   expectedStateVersion,
   expectedInputHash,
   reason,
+  hasActivePresence,
   klog = () => {},
 }) {
   if (typeof beginSql !== "function") throw new Error("bot_claims_recovery_begin_sql_missing");
@@ -505,6 +510,9 @@ export async function executeBotClaimsRecovery({
     if (!evaluated.ok) throw conflict(evaluated.reason);
     if (evaluated.stateVersion !== expectedStateVersion) throw conflict("state_version_changed");
     if (expectedInputHash && evaluated.inputHash !== expectedInputHash) throw conflict("recovery_input_changed");
+    if (typeof hasActivePresence === "function" && hasActivePresence()) {
+      throw conflict("active_table_presence");
+    }
 
     const correctedVersion = evaluated.stateVersion + 1;
     if (!Number.isSafeInteger(correctedVersion)) throw conflict("state_version_invalid");
@@ -575,4 +583,7 @@ export async function executeBotClaimsRecovery({
   });
 }
 
-export { RECOVERY_KIND };
+export {
+  RECOVERY_KIND,
+  collectParticipantEvidence,
+};

--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -2,7 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { executeInactiveCleanup } from "./inactive-cleanup.mjs";
 import { executeTerminalPokerCloseInTx } from "./terminal-close.mjs";
-import { projectBotClaimsRepair } from "./bot-claims-recovery.mjs";
+import {
+  collectParticipantEvidence,
+  projectBotClaimsRepair,
+} from "./bot-claims-recovery.mjs";
 
 function createCleanupHarness({
   seatRows,
@@ -739,4 +742,51 @@ test("bot claims recovery rejects an unconfirmed non-admin claimant", () => {
 
   assert.equal(result.ok, false);
   assert.equal(result.reason, "bot_claimant_unconfirmed");
+});
+
+test("bot-only recovery does not treat an unrelated table creator as a participant", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const creatorUserId = "00000000-0000-4000-8000-000000000005";
+  const botUserId = "00000000-0000-4000-8000-000000000002";
+  const result = collectParticipantEvidence({
+    adminUserId,
+    table: { created_by: creatorUserId },
+    state: {
+      stacks: { [botUserId]: 100 },
+      seats: [{ userId: botUserId, seatNo: 1, isBot: true }],
+    },
+    seats: [{ user_id: botUserId, seat_no: 1, is_bot: true }],
+    actions: [],
+    requests: [],
+    ledgerTransactions: [],
+    ledgerUserIds: [],
+    fundingRecords: [{ kind: "seed", botUserId }],
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.participants.has(creatorUserId), false);
+  assert.equal(result.botUserIds.has(botUserId), true);
+});
+
+test("table creator confirmed by gameplay evidence remains a human participant", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const creatorUserId = "00000000-0000-4000-8000-000000000005";
+  const botUserId = "00000000-0000-4000-8000-000000000002";
+  const result = collectParticipantEvidence({
+    adminUserId,
+    table: { created_by: creatorUserId },
+    state: {
+      stacks: { [botUserId]: 100 },
+      seats: [{ userId: botUserId, seatNo: 1, isBot: true }],
+    },
+    seats: [{ user_id: botUserId, seat_no: 1, is_bot: true }],
+    actions: [{ user_id: creatorUserId, action_type: "CHECK", meta: null }],
+    requests: [],
+    ledgerTransactions: [],
+    ledgerUserIds: [],
+    fundingRecords: [{ kind: "seed", botUserId }],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "foreign_human_history");
 });

--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { executeInactiveCleanup } from "./inactive-cleanup.mjs";
 import { executeTerminalPokerCloseInTx } from "./terminal-close.mjs";
+import { projectBotClaimsRepair } from "./bot-claims-recovery.mjs";
 
 function createCleanupHarness({
   seatRows,
@@ -654,4 +655,88 @@ test("inactive cleanup keeps fresh table open during close grace period", async 
   assert.equal(result.code, "grace_period");
   assert.equal(result.retryable, true);
   assert.equal(harness.tableState.tableStatus, "OPEN");
+});
+
+test("bot claims recovery assigns a positive delta to the lowest-seat confirmed bot", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const botLow = "00000000-0000-4000-8000-000000000002";
+  const botHigh = "00000000-0000-4000-8000-000000000003";
+  const result = projectBotClaimsRepair({
+    state: { stacks: { [adminUserId]: 50, [botHigh]: 30, [botLow]: 20 } },
+    seats: [
+      { user_id: adminUserId, seat_no: 1, is_bot: false },
+      { user_id: botHigh, seat_no: 3, is_bot: true },
+      { user_id: botLow, seat_no: 2, is_bot: true },
+    ],
+    escrowBefore: 115,
+    adminUserId,
+    identityEvidence: { ok: true, botUserIds: new Set([botLow, botHigh]) },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.delta, 15);
+  assert.equal(result.humanStack, 50);
+  assert.deepEqual(result.bots.map(({ seatNo, before, after }) => ({ seatNo, before, after })), [
+    { seatNo: 2, before: 20, after: 35 },
+    { seatNo: 3, before: 30, after: 30 },
+  ]);
+});
+
+test("bot claims recovery drains a negative delta in seat order without changing the human", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const botLow = "00000000-0000-4000-8000-000000000002";
+  const botHigh = "00000000-0000-4000-8000-000000000003";
+  const result = projectBotClaimsRepair({
+    state: { stacks: { [adminUserId]: 50, [botLow]: 20, [botHigh]: 30 } },
+    seats: [
+      { user_id: adminUserId, seat_no: 1, is_bot: false },
+      { user_id: botLow, seat_no: 2, is_bot: true },
+      { user_id: botHigh, seat_no: 3, is_bot: true },
+    ],
+    escrowBefore: 65,
+    adminUserId,
+    identityEvidence: { ok: true, botUserIds: new Set([botLow, botHigh]) },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.delta, -35);
+  assert.equal(result.correctedStacks[adminUserId], 50);
+  assert.equal(result.correctedStacks[botLow], 0);
+  assert.equal(result.correctedStacks[botHigh], 15);
+});
+
+test("bot claims recovery fails closed when confirmed bot stacks cannot cover the deficit", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const botUserId = "00000000-0000-4000-8000-000000000002";
+  const result = projectBotClaimsRepair({
+    state: { stacks: { [adminUserId]: 50, [botUserId]: 10 } },
+    seats: [
+      { user_id: adminUserId, seat_no: 1, is_bot: false },
+      { user_id: botUserId, seat_no: 2, is_bot: true },
+    ],
+    escrowBefore: 40,
+    adminUserId,
+    identityEvidence: { ok: true, botUserIds: new Set([botUserId]) },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "insufficient_bot_stacks");
+});
+
+test("bot claims recovery rejects an unconfirmed non-admin claimant", () => {
+  const adminUserId = "00000000-0000-4000-8000-000000000001";
+  const foreignHumanId = "00000000-0000-4000-8000-000000000004";
+  const result = projectBotClaimsRepair({
+    state: { stacks: { [adminUserId]: 50, [foreignHumanId]: 10 } },
+    seats: [
+      { user_id: adminUserId, seat_no: 1, is_bot: false },
+      { user_id: foreignHumanId, seat_no: 2, is_bot: false },
+    ],
+    escrowBefore: 60,
+    adminUserId,
+    identityEvidence: { ok: true, botUserIds: new Set() },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "bot_claimant_unconfirmed");
 });

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -20,6 +20,11 @@ test("admin table recovery requires explicit analysis before the confirmed repai
   assert.match(source, /REPAIR BOT CLAIMS AND CLOSE/);
   assert.match(source, /expectedStateVersion: recovery\.stateVersion/);
   assert.match(source, /expectedInputHash: recovery\.inputHash/);
+  assert.match(source, /result\.ok !== true \|\| result\.changed !== true \|\| result\.closed !== true/);
+  assert.ok(
+    source.indexOf("result.ok !== true") < source.indexOf("resetDraftIdempotencyKey(keyScope)"),
+    "recovery outcome must be verified before clearing its idempotency key",
+  );
 });
 
 function createClassList(node) {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -12,6 +12,16 @@ const source = await readFile(path.join(repoRoot, "js", "admin-page.js"), "utf8"
 
 const flush = () => new Promise((resolve) => setImmediate(resolve));
 
+test("admin table recovery requires explicit analysis before the confirmed repair action", () => {
+  assert.match(source, /Analyze bot recovery/);
+  assert.match(source, /Repair bot claims and close/);
+  assert.match(source, /mode: "preflight"/);
+  assert.match(source, /mode: "execute"/);
+  assert.match(source, /REPAIR BOT CLAIMS AND CLOSE/);
+  assert.match(source, /expectedStateVersion: recovery\.stateVersion/);
+  assert.match(source, /expectedInputHash: recovery\.inputHash/);
+});
+
 function createClassList(node) {
   function read() {
     return String(node.className || "").split(/\s+/).filter(Boolean);

--- a/tests/admin-table-actions.behavior.test.mjs
+++ b/tests/admin-table-actions.behavior.test.mjs
@@ -201,3 +201,46 @@ test("bot claims recovery proxies an explicitly confirmed execute request", asyn
   assert.equal(upstream.adminUserId, "00000000-0000-4000-8000-000000000010");
   assert.match(upstream.requestId, /^admin-recovery:/);
 });
+
+test("bot claims recovery maps an incomplete execute outcome to HTTP conflict", async () => {
+  const handler = createAdminTableBotClaimsRecoveryHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "internal-test-token",
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: () => ({
+      environmentContext: "deploy-preview",
+      databaseTarget: "stage",
+      stageProjectRefMatches: true,
+      databaseMatchesSupabaseProjectRef: true,
+      serviceRoleStageProjectRefMatches: true,
+    }),
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: false,
+        eligible: false,
+        changed: false,
+        closed: false,
+        environment: "ws-preview",
+        reason: "active_table_presence",
+        bots: [],
+      }),
+    }),
+  });
+  const response = await handler(createPostEvent({
+    mode: "execute",
+    tableId: "00000000-0000-4000-8000-000000000111",
+    expectedStateVersion: 78,
+    expectedInputHash: "a".repeat(64),
+    idempotencyKey: "client-recovery-active",
+    confirmation: "REPAIR BOT CLAIMS AND CLOSE",
+    reason: "approved Preview repair",
+  }));
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), { error: "active_table_presence" });
+});

--- a/tests/admin-table-actions.behavior.test.mjs
+++ b/tests/admin-table-actions.behavior.test.mjs
@@ -153,6 +153,9 @@ test("bot claims recovery remains fail-closed outside exact Preview stage identi
 
 test("bot claims recovery proxies an explicitly confirmed execute request", async () => {
   let upstream = null;
+  const tableId = "00000000-0000-4000-8000-000000000111";
+  const uiGeneratedKey = `bot-claims-recovery-${tableId}-mabc1234-r4nd0m12`;
+  assert.ok(uiGeneratedKey.length > 64);
   const handler = createAdminTableBotClaimsRecoveryHandler({
     env: {
       CHIPS_ENABLED: "1",
@@ -188,10 +191,10 @@ test("bot claims recovery proxies an explicitly confirmed execute request", asyn
   });
   const response = await handler(createPostEvent({
     mode: "execute",
-    tableId: "00000000-0000-4000-8000-000000000111",
+    tableId,
     expectedStateVersion: 78,
     expectedInputHash: "a".repeat(64),
-    idempotencyKey: "client-recovery-1",
+    idempotencyKey: uiGeneratedKey,
     confirmation: "REPAIR BOT CLAIMS AND CLOSE",
     reason: "approved Preview repair",
   }));
@@ -200,6 +203,7 @@ test("bot claims recovery proxies an explicitly confirmed execute request", asyn
   assert.equal(upstream.mode, "execute");
   assert.equal(upstream.adminUserId, "00000000-0000-4000-8000-000000000010");
   assert.match(upstream.requestId, /^admin-recovery:/);
+  assert.ok(upstream.requestId.length <= 140);
 });
 
 test("bot claims recovery maps an incomplete execute outcome to HTTP conflict", async () => {

--- a/tests/admin-table-actions.behavior.test.mjs
+++ b/tests/admin-table-actions.behavior.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 const { createAdminTableEvaluateHandler } = await import("../netlify/functions/admin-table-evaluate.mjs");
 const { createAdminTableCleanupHandler } = await import("../netlify/functions/admin-table-cleanup.mjs");
 const { createAdminTableForceCloseHandler } = await import("../netlify/functions/admin-table-force-close.mjs");
+const { createAdminTableBotClaimsRecoveryHandler } = await import("../netlify/functions/admin-table-bot-claims-recovery.mjs");
 
 function createGetEvent(queryStringParameters = {}) {
   return {
@@ -127,4 +128,76 @@ test("admin-table-force-close forwards dangerous action only after validation", 
   assert.equal(seen.requestedAction, "force_close");
   assert.match(seen.idempotencyKey, /^admin-force-close:/);
   assert.equal(body.result.status, "force_closed");
+});
+
+test("bot claims recovery remains fail-closed outside exact Preview stage identity", async () => {
+  const handler = createAdminTableBotClaimsRecoveryHandler({
+    env: { CHIPS_ENABLED: "1" },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: () => ({
+      environmentContext: "production",
+      databaseTarget: "production",
+      stageProjectRefMatches: false,
+      databaseMatchesSupabaseProjectRef: true,
+      serviceRoleStageProjectRefMatches: false,
+    }),
+  });
+  const response = await handler(createPostEvent({
+    mode: "preflight",
+    tableId: "00000000-0000-4000-8000-000000000111",
+  }));
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), { error: "preview_only" });
+});
+
+test("bot claims recovery proxies an explicitly confirmed execute request", async () => {
+  let upstream = null;
+  const handler = createAdminTableBotClaimsRecoveryHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "internal-test-token",
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: () => ({
+      environmentContext: "deploy-preview",
+      databaseTarget: "stage",
+      stageProjectRefMatches: true,
+      databaseMatchesSupabaseProjectRef: true,
+      serviceRoleStageProjectRefMatches: true,
+    }),
+    fetchImpl: async (_url, options) => {
+      upstream = JSON.parse(options.body);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          eligible: true,
+          changed: true,
+          closed: true,
+          environment: "ws-preview",
+          stateVersion: 78,
+          finalStateVersion: 80,
+          inputHash: "a".repeat(64),
+          bots: [],
+        }),
+      };
+    },
+  });
+  const response = await handler(createPostEvent({
+    mode: "execute",
+    tableId: "00000000-0000-4000-8000-000000000111",
+    expectedStateVersion: 78,
+    expectedInputHash: "a".repeat(64),
+    idempotencyKey: "client-recovery-1",
+    confirmation: "REPAIR BOT CLAIMS AND CLOSE",
+    reason: "approved Preview repair",
+  }));
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(upstream.mode, "execute");
+  assert.equal(upstream.adminUserId, "00000000-0000-4000-8000-000000000010");
+  assert.match(upstream.requestId, /^admin-recovery:/);
 });

--- a/ws-server/poker/persistence/bot-claims-recovery-adapter.mjs
+++ b/ws-server/poker/persistence/bot-claims-recovery-adapter.mjs
@@ -5,6 +5,15 @@ async function beginSqlDefault(fn, { env = process.env } = {}) {
 
 const DEFAULT_RECOVERY_MODULE_URL = new URL("../../shared/poker-domain/bot-claims-recovery.mjs", import.meta.url).href;
 
+export async function loadBotClaimsRecoveryExecutorIfInactive({
+  hasActivePresence,
+  loadExecutor,
+}) {
+  if (typeof hasActivePresence !== "function" || hasActivePresence()) return null;
+  const executor = await loadExecutor();
+  return hasActivePresence() ? null : executor;
+}
+
 export function createBotClaimsRecoveryExecutor({
   env = process.env,
   klog = () => {},
@@ -25,6 +34,7 @@ export function createBotClaimsRecoveryExecutor({
       expectedStateVersion: input.expectedStateVersion,
       expectedInputHash: input.expectedInputHash,
       reason: input.reason,
+      hasActivePresence: input.hasActivePresence,
       klog,
     });
   };

--- a/ws-server/poker/persistence/bot-claims-recovery-adapter.mjs
+++ b/ws-server/poker/persistence/bot-claims-recovery-adapter.mjs
@@ -1,0 +1,31 @@
+async function beginSqlDefault(fn, { env = process.env } = {}) {
+  const bootstrapDb = await import("../bootstrap/persisted-bootstrap-db.mjs");
+  return bootstrapDb.beginSqlWs(fn, { env });
+}
+
+const DEFAULT_RECOVERY_MODULE_URL = new URL("../../shared/poker-domain/bot-claims-recovery.mjs", import.meta.url).href;
+
+export function createBotClaimsRecoveryExecutor({
+  env = process.env,
+  klog = () => {},
+  loadRecoveryModule = () => import(DEFAULT_RECOVERY_MODULE_URL),
+  beginSql = beginSqlDefault,
+} = {}) {
+  return async function runBotClaimsRecovery(input) {
+    const recovery = await loadRecoveryModule();
+    const method = input?.mode === "execute"
+      ? recovery.executeBotClaimsRecovery
+      : recovery.preflightBotClaimsRecovery;
+    if (typeof method !== "function") throw new Error("bot_claims_recovery_unavailable");
+    return method({
+      beginSql: (fn) => beginSql(fn, { env }),
+      tableId: input.tableId,
+      adminUserId: input.adminUserId,
+      requestId: input.requestId,
+      expectedStateVersion: input.expectedStateVersion,
+      expectedInputHash: input.expectedInputHash,
+      reason: input.reason,
+      klog,
+    });
+  };
+}

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -19,12 +19,31 @@ import {
   markTransportPingSent
 } from "./poker/runtime/transport-watchdog.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
+import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 
 const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
   import.meta.url
 ).href;
+
+test("bot claims recovery stops when a socket appears while the executor is loading", async () => {
+  let activePresence = false;
+  let loadCalls = 0;
+  const executor = await loadBotClaimsRecoveryExecutorIfInactive({
+    hasActivePresence: () => activePresence,
+    loadExecutor: async () => {
+      loadCalls += 1;
+      activePresence = true;
+      return () => {
+        throw new Error("recovery must not execute");
+      };
+    },
+  });
+
+  assert.equal(loadCalls, 1);
+  assert.equal(executor, null);
+});
 
 test("transport watchdog keeps one pending probe and terminates at the timeout boundary", () => {
   const connState = createConnState();

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -49,6 +49,7 @@ import { handleRebuyCommand } from "./poker/handlers/rebuy.mjs";
 import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs";
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
+import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
@@ -2964,8 +2965,15 @@ async function handleInternalBotClaimsRecovery(req, res) {
       commandName: `admin_bot_claims_recovery_${mode}`,
       dedupeKey: mode === "execute" ? `admin_bot_claims_recovery:${payload.requestId.trim()}` : null,
       run: async () => {
-        const hasActiveSocket = [...wss.clients].some((socket) => tableSocketMatches(socket, tableId));
-        if (hasActiveSocket || tableManager.hasConnectedHumanPresence(tableId)) {
+        const hasActivePresence = () => (
+          [...wss.clients].some((socket) => tableSocketMatches(socket, tableId))
+          || tableManager.hasConnectedHumanPresence(tableId)
+        );
+        const executeRecovery = await loadBotClaimsRecoveryExecutorIfInactive({
+          hasActivePresence,
+          loadExecutor: loadBotClaimsRecoveryExecutor,
+        });
+        if (!executeRecovery) {
           return {
             ok: false,
             eligible: false,
@@ -2974,7 +2982,6 @@ async function handleInternalBotClaimsRecovery(req, res) {
             reason: "active_table_presence"
           };
         }
-        const executeRecovery = await loadBotClaimsRecoveryExecutor();
         const recoveryResult = await executeRecovery({
           mode,
           tableId,
@@ -2982,7 +2989,8 @@ async function handleInternalBotClaimsRecovery(req, res) {
           requestId: validExecute ? payload.requestId.trim() : null,
           expectedStateVersion: validExecute ? payload.expectedStateVersion : null,
           expectedInputHash: validExecute ? payload.expectedInputHash.trim() : null,
-          reason: validExecute ? payload.reason.trim() : null
+          reason: validExecute ? payload.reason.trim() : null,
+          hasActivePresence
         });
         if (mode === "execute" && recoveryResult?.closed === true) {
           evictClosedRuntimeTable({

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -320,6 +320,7 @@ let authoritativeRebuyExecutorPromise = null;
 let inactiveCleanupExecutorPromise = null;
 let deferredLeaveFinalizerPromise = null;
 let acceptedBotAutoplayExecutorPromise = null;
+let botClaimsRecoveryExecutorPromise = null;
 let beginSqlWsLoaderPromise = null;
 const timeoutFailureTrackerByTableId = new Map();
 const settledRolloverTimerByTableId = new Map();
@@ -339,6 +340,14 @@ async function loadAuthoritativeLeaveExecutor() {
       }));
   }
   return authoritativeLeaveExecutorPromise;
+}
+
+async function loadBotClaimsRecoveryExecutor() {
+  if (!botClaimsRecoveryExecutorPromise) {
+    botClaimsRecoveryExecutorPromise = import("./poker/persistence/bot-claims-recovery-adapter.mjs")
+      .then((module) => module.createBotClaimsRecoveryExecutor({ env: process.env, klog: klogSafe }));
+  }
+  return botClaimsRecoveryExecutorPromise;
 }
 
 async function loadAuthoritativeJoinExecutor() {
@@ -2895,6 +2904,120 @@ async function handleInternalBotReactionConfig(req, res) {
   }
 }
 
+async function handleInternalBotClaimsRecovery(req, res) {
+  if (req.method !== "POST") {
+    sendInternalJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!internalRuntimeToken) {
+    sendInternalJson(res, 503, { error: "internal_runtime_token_missing" });
+    return;
+  }
+  const authHeader = typeof req.headers?.authorization === "string" ? req.headers.authorization.trim() : "";
+  if (authHeader !== `Bearer ${internalRuntimeToken}`) {
+    sendInternalJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  if (loadReleaseMetadata().environment !== "preview") {
+    sendInternalJson(res, 403, { error: "preview_only" });
+    return;
+  }
+
+  try {
+    const payload = await readJsonBody(req, { maxBytes: 4_096 });
+    const mode = typeof payload?.mode === "string" ? payload.mode.trim() : "";
+    const tableId = typeof payload?.tableId === "string" ? payload.tableId.trim() : "";
+    const adminUserId = typeof payload?.adminUserId === "string" ? payload.adminUserId.trim() : "";
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    const preflightKeys = ["adminUserId", "mode", "tableId"];
+    const executeKeys = [
+      "adminUserId",
+      "expectedInputHash",
+      "expectedStateVersion",
+      "mode",
+      "reason",
+      "requestId",
+      "tableId"
+    ];
+    const validPreflight = mode === "preflight"
+      && hasExactKeys(payload, preflightKeys)
+      && Object.keys(payload).length === preflightKeys.length;
+    const validExecute = mode === "execute"
+      && hasExactKeys(payload, executeKeys)
+      && Object.keys(payload).length === executeKeys.length
+      && Number.isSafeInteger(payload.expectedStateVersion)
+      && payload.expectedStateVersion >= 0
+      && /^[a-f0-9]{64}$/i.test(String(payload.expectedInputHash || ""))
+      && typeof payload.requestId === "string"
+      && payload.requestId.trim().length >= 8
+      && payload.requestId.trim().length <= 140
+      && typeof payload.reason === "string"
+      && payload.reason.trim().length >= 3
+      && payload.reason.trim().length <= 240;
+    if ((!validPreflight && !validExecute) || !UUID_RE.test(tableId) || !UUID_RE.test(adminUserId)) {
+      sendInternalJson(res, 400, { error: "invalid_request" });
+      return;
+    }
+
+    const result = await enqueueTableCommand({
+      tableId,
+      commandName: `admin_bot_claims_recovery_${mode}`,
+      dedupeKey: mode === "execute" ? `admin_bot_claims_recovery:${payload.requestId.trim()}` : null,
+      run: async () => {
+        const hasActiveSocket = [...wss.clients].some((socket) => tableSocketMatches(socket, tableId));
+        if (hasActiveSocket || tableManager.hasConnectedHumanPresence(tableId)) {
+          return {
+            ok: false,
+            eligible: false,
+            changed: false,
+            closed: false,
+            reason: "active_table_presence"
+          };
+        }
+        const executeRecovery = await loadBotClaimsRecoveryExecutor();
+        const recoveryResult = await executeRecovery({
+          mode,
+          tableId,
+          adminUserId,
+          requestId: validExecute ? payload.requestId.trim() : null,
+          expectedStateVersion: validExecute ? payload.expectedStateVersion : null,
+          expectedInputHash: validExecute ? payload.expectedInputHash.trim() : null,
+          reason: validExecute ? payload.reason.trim() : null
+        });
+        if (mode === "execute" && recoveryResult?.closed === true) {
+          evictClosedRuntimeTable({
+            tableId,
+            logPrefix: "ws_bot_claims_recovery",
+            status: "bot_claims_recovered_closed"
+          });
+        }
+        return recoveryResult;
+      }
+    });
+    klogSafe("ws_bot_claims_recovery_outcome", {
+      tableId,
+      mode,
+      ok: result?.ok === true,
+      eligible: result?.eligible === true,
+      changed: result?.changed === true,
+      closed: result?.closed === true,
+      reason: result?.reason || null,
+      stateVersion: result?.stateVersion ?? null,
+      finalStateVersion: result?.finalStateVersion ?? null,
+      delta: result?.delta ?? null,
+      botCount: Array.isArray(result?.bots) ? result.bots.length : 0,
+      humanPreserved: result?.humanStack != null
+    });
+    sendInternalJson(res, 200, { ...result, environment: "ws-preview" });
+  } catch (error) {
+    const code = error?.code || (error instanceof SyntaxError ? "invalid_json" : "internal_server_error");
+    const statusCode = Number(error?.status)
+      || (code === "body_too_large" || code === "invalid_json" ? 400 : 500);
+    klogSafe("ws_bot_claims_recovery_failed", { code, statusCode });
+    sendInternalJson(res, statusCode, { error: code });
+  }
+}
+
 async function handleInternalLobbyMaterialize(req, res) {
   if (req.method !== "POST") {
     res.writeHead(405, { "content-type": "application/json" });
@@ -2971,6 +3094,11 @@ async function handleHttpRequest(req, res) {
 
   if (req.url === "/internal/admin/bot-reaction") {
     await handleInternalBotReactionConfig(req, res);
+    return;
+  }
+
+  if (req.url === "/internal/admin/bot-claims-recovery") {
+    await handleInternalBotClaimsRecovery(req, res);
     return;
   }
 

--- a/ws-server/shared/poker-domain/bot-claims-recovery.mjs
+++ b/ws-server/shared/poker-domain/bot-claims-recovery.mjs
@@ -1,0 +1,4 @@
+export {
+  executeBotClaimsRecovery,
+  preflightBotClaimsRecovery,
+} from "../../../shared/poker-domain/bot-claims-recovery.mjs";

--- a/ws-tests/infra-vps-caddy.guard.test.mjs
+++ b/ws-tests/infra-vps-caddy.guard.test.mjs
@@ -33,10 +33,12 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
 
   assert.match(preview, /@healthz path \/healthz/);
   assert.match(preview, /@botReactionAdmin path \/internal\/admin\/bot-reaction/);
+  assert.match(preview, /@botClaimsRecoveryAdmin path \/internal\/admin\/bot-claims-recovery/);
   assert.match(preview, /@ws path \/ws\*/);
   assert.match(preview, /reverse_proxy 127\.0\.0\.1:3001/);
   assert.match(preview, /respond "OK" 200/);
   assert.doesNotMatch(prod, /internal\/admin\/bot-reaction/);
+  assert.doesNotMatch(prod, /internal\/admin\/bot-claims-recovery/);
 });
 
 test("WS PR harness runs the unified infra VPS Caddy guard", () => {


### PR DESCRIPTION
Closes #773

## Summary
- add an explicit read-only `Analyze bot recovery` preflight and confirmed `Repair bot claims and close` admin action
- limit the operation to exact Preview/stage identity and an allowlisted admin through the authenticated Netlify-to-WS Preview path
- serialize against table runtime work with `enqueueTableCommand()` and reject active sockets or connected human presence
- revalidate OPEN/SETTLED/zero-pot eligibility, pending requests, terminal-close evidence and known participant identities under DB locks
- deterministically assign only the claims/escrow delta to confirmed bot stacks, preserve the admin human stack, then invoke the existing terminal close in the same transaction
- reuse `poker_requests` for durable idempotency; any failure rolls back the correction, cash-outs, ledger movements and close

## Safety
- Preview/stage only; production is rejected in both Netlify and WS layers
- no escrow top-up, settlement rewrite, historical ledger mutation or terminal-invariant bypass
- ordinary historical buy-ins and leave cash-outs remain allowed; terminal cash-out evidence for the current generation blocks recovery
- payloads and logs expose only bounded aggregates, never cards or full state

## Verification
- `npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- targeted recovery/admin behavior suites: 34 passed
- `git diff --check`
- read-only preflight against the current corrupted Preview table: eligible; claims 500 CH, escrow 304 CH, delta -196 CH, human stack preserved at 100 CH; the historical normal leave cash-out of 296 CH did not block eligibility

No recovery mutation was performed during development verification.

## Breaking impact
Intentional and Preview-only: an allowlisted administrator can explicitly reassign an unexplained claims/escrow difference exclusively within confirmed bot economy and close a qualifying corrupted table. Normal gameplay, production, human claims, settlement rules and terminal accounting invariants are unchanged.