### PR TITLE
feat: classify poker WS logs by severity

### DIFF
--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -355,6 +355,19 @@ export function buildPokerLogPayload(eventName, data = null) {
   };
 }
 
+export function serializePokerLogPayload(eventName, data = null) {
+  try {
+    return JSON.stringify(buildPokerLogPayload(eventName, data));
+  } catch {
+    const policy = resolvePokerLogPolicy(eventName);
+    return JSON.stringify({
+      serializationError: true,
+      severity: policy.severity,
+      category: policy.category
+    });
+  }
+}
+
 export function listClassifiedPokerLogEvents() {
   return [...policyByEventName.keys()].sort();
 }

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -356,10 +356,16 @@ export function buildPokerLogPayload(eventName, data = null) {
 }
 
 export function serializePokerLogPayload(eventName, data = null) {
+  let policy = { severity: "UNSPECIFIED", category: null };
   try {
-    return JSON.stringify(buildPokerLogPayload(eventName, data));
+    const context = data && typeof data === "object" && !Array.isArray(data) ? data : {};
+    policy = resolvePokerLogPolicy(eventName, context);
+    return JSON.stringify({
+      ...context,
+      severity: policy.severity,
+      category: policy.category
+    });
   } catch {
-    const policy = resolvePokerLogPolicy(eventName);
     return JSON.stringify({
       serializationError: true,
       severity: policy.severity,

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -1,0 +1,365 @@
+const POKER_LOG_SEVERITIES = Object.freeze(["DEBUG", "INFO", "WARN", "ERROR"]);
+const POKER_LOG_CATEGORIES = Object.freeze([
+  "runtime",
+  "transport",
+  "session",
+  "table_lifecycle",
+  "gameplay",
+  "autoplay",
+  "persistence",
+  "recovery",
+  "janitor",
+  "settlement",
+  "accounting",
+  "ledger",
+  "http",
+  "admin",
+  "deployment"
+]);
+
+const severitySet = new Set(POKER_LOG_SEVERITIES);
+const categorySet = new Set(POKER_LOG_CATEGORIES);
+const policyByEventName = new Map();
+
+function register(severity, category, eventNames) {
+  if (!severitySet.has(severity) || !categorySet.has(category)) {
+    throw new Error("invalid_poker_log_policy");
+  }
+  for (const eventName of eventNames) {
+    if (policyByEventName.has(eventName)) {
+      throw new Error(`duplicate_poker_log_policy:${eventName}`);
+    }
+    policyByEventName.set(eventName, Object.freeze({ severity, category, classified: true }));
+  }
+}
+
+register("DEBUG", "autoplay", [
+  "poker_leave_bot_autoplay_loop",
+  "ws_bot_autoplay_action_chosen",
+  "ws_bot_autoplay_apply_result",
+  "ws_bot_autoplay_apply_start",
+  "ws_bot_autoplay_decision",
+  "ws_bot_autoplay_loop_start",
+  "ws_bot_autoplay_loop_stop",
+  "ws_bot_autoplay_persist_result",
+  "ws_bot_autoplay_persist_start",
+  "ws_bot_autoplay_reaction_delay",
+  "ws_bot_autoplay_showdown_preflight",
+  "ws_bot_autoplay_state_after_step",
+  "ws_bot_autoplay_turn_snapshot",
+  "ws_observed_bot_turn_autoplay_scheduled"
+]);
+
+register("DEBUG", "janitor", [
+  "ws_open_table_reconciler_batch_selected",
+  "ws_table_janitor_evaluation_coalesced"
+]);
+
+register("DEBUG", "persistence", [
+  "ws_state_persist_result",
+  "ws_state_persist_start",
+  "ws_state_update_result",
+  "ws_state_update_start"
+]);
+
+register("DEBUG", "recovery", [
+  "ws_restore_outcome",
+  "ws_restore_start"
+]);
+
+register("DEBUG", "settlement", [
+  "ws_settled_reveal_pending_check",
+  "ws_settled_rollover_outcome",
+  "ws_settled_rollover_scheduled",
+  "ws_settled_rollover_start"
+]);
+
+register("DEBUG", "table_lifecycle", [
+  "poker_leave_already_left_noop",
+  "poker_leave_autoplay_skipped",
+  "poker_rebuy_replayed",
+  "ws_guest_table_cleanup_cancelled",
+  "ws_guest_table_cleanup_scheduled",
+  "ws_join_authoritative_result",
+  "ws_join_authoritative_start"
+]);
+
+register("INFO", "accounting", [
+  "poker_leave_cashout",
+  "poker_terminal_accounting_closed"
+]);
+
+register("INFO", "admin", [
+  "ws_bot_claims_recovery_outcome",
+  "ws_preview_bot_reaction_updated"
+]);
+
+register("INFO", "deployment", [
+  "ws_artifact_start",
+  "ws_listening"
+]);
+
+register("INFO", "persistence", [
+  "ws_hand_settlement_audit_written",
+  "ws_hole_cards_persist_written"
+]);
+
+register("INFO", "session", [
+  "ws_invalidated_prior_socket",
+  "ws_session_rebound"
+]);
+
+register("INFO", "settlement", [
+  "poker_hand_settled"
+]);
+
+register("INFO", "table_lifecycle", [
+  "poker_deferred_leaves_finalized",
+  "poker_leave_advanced",
+  "poker_leave_retained_live_hand",
+  "poker_rebuy_committed",
+  "ws_guest_table_evicted"
+]);
+
+register("WARN", "autoplay", [
+  "ws_bot_autoplay_failure_summary",
+  "ws_bot_autoplay_fallback_action",
+  "ws_bot_timeout_safety_autoplay"
+]);
+
+register("WARN", "janitor", [
+  "poker_inactive_cleanup_live_hand_preserved",
+  "poker_inactive_cleanup_stale_live_hand_closing",
+  "poker_inactive_cleanup_table_close_skipped_human_presence",
+  "ws_disconnect_cleanup_deferred",
+  "ws_disconnect_cleanup_protected",
+  "ws_disconnect_cleanup_retry",
+  "ws_table_janitor_terminal_failure_suppression_activated",
+  "ws_table_janitor_terminal_failure_suppression_summary"
+]);
+
+register("WARN", "persistence", [
+  "ws_hole_cards_persist_skipped"
+]);
+
+register("WARN", "recovery", [
+  "poker_settlement_backfilled",
+  "ws_join_authoritative_ledger_fallback",
+  "ws_turn_timeout_quarantine_force_hand_done_skipped",
+  "ws_turn_timeout_quarantine_recovered",
+  "ws_turn_timeout_table_quarantined"
+]);
+
+register("WARN", "session", [
+  "ws_invalidate_before_close",
+  "ws_invalidating_stale_socket",
+  "ws_stale_session_socket_rejected",
+  "ws_transport_watchdog_terminated"
+]);
+
+register("WARN", "settlement", [
+  "ws_settled_rollover_close_skipped_human_presence"
+]);
+
+register("WARN", "table_lifecycle", [
+  "poker_leave_conflict",
+  "poker_leave_request_retained",
+  "poker_leave_table_close_skipped_human_presence",
+  "shared_join_reclaimed_inactive_seat_conflict",
+  "shared_join_seat_retry",
+  "ws_join_authoritative_buyin_duplicate_idempotency"
+]);
+
+register("ERROR", "accounting", [
+  "poker_terminal_accounting_invariant_failed"
+]);
+
+register("ERROR", "autoplay", [
+  "poker_act_bot_autoplay_step_error",
+  "ws_act_bot_autoplay_failed",
+  "ws_bot_autoplay_command_failed",
+  "ws_bot_autoplay_executor_unavailable",
+  "ws_bot_autoplay_failed",
+  "ws_bot_autoplay_no_fallback_action",
+  "ws_bot_autoplay_showdown_input_missing",
+  "ws_bot_autoplay_step_broadcast_failed",
+  "ws_bot_autoplay_unavailable",
+  "ws_join_bootstrap_bot_autoplay_failed",
+  "ws_leave_schedule_bot_step_failed",
+  "ws_observed_bot_turn_autoplay_failed",
+  "ws_rebuy_schedule_bot_step_failed",
+  "ws_settled_rollover_bot_autoplay_failed",
+  "ws_start_hand_bot_autoplay_failed",
+  "ws_timeout_bot_autoplay_failed"
+]);
+
+register("ERROR", "janitor", [
+  "poker_inactive_cleanup_stack_ambiguous",
+  "ws_inactive_cleanup_failed",
+  "ws_inactive_cleanup_unavailable",
+  "ws_open_table_reconciler_list_failed",
+  "ws_stale_seat_cleanup_list_failed",
+  "ws_table_janitor_snapshot_failed",
+  "ws_zombie_cleanup_list_failed"
+]);
+
+register("ERROR", "ledger", [
+  "chips_apply_mismatch"
+]);
+
+register("ERROR", "persistence", [
+  "ws_accepted_action_audit_failed",
+  "ws_durable_action_read_error",
+  "ws_hand_settlement_audit_failed",
+  "ws_hole_cards_persist_failed",
+  "ws_persisted_state_write_error",
+  "ws_state_persist_failed",
+  "ws_state_update_invalid",
+  "ws_touch_persisted_seat_failed"
+]);
+
+register("ERROR", "recovery", [
+  "ws_bot_claims_recovery_failed",
+  "ws_deferred_leave_finalization_failed",
+  "ws_join_restore_invalid",
+  "ws_leave_restore_rejected",
+  "ws_persisted_bootstrap_live_hand_rejected",
+  "ws_rebuy_runtime_restore_failed",
+  "ws_restore_failed",
+  "ws_state_restore_failed",
+  "ws_turn_timeout_quarantine_cleanup_failed",
+  "ws_turn_timeout_quarantine_force_hand_done_failed",
+  "ws_turn_timeout_quarantine_restore_failed"
+]);
+
+register("ERROR", "runtime", [
+  "ws_error",
+  "ws_message_processing_error",
+  "ws_table_command_failed",
+  "ws_table_command_queue_unhandled",
+  "ws_uncaught_exception",
+  "ws_unhandled_rejection"
+]);
+
+register("ERROR", "http", [
+  "ws_http_request_failed"
+]);
+
+register("ERROR", "admin", [
+  "ws_preview_bot_reaction_failed"
+]);
+
+register("ERROR", "session", [
+  "ws_invalidated_prior_socket_error"
+]);
+
+register("ERROR", "settlement", [
+  "poker_showdown_no_eligible",
+  "ws_settled_reveal_pending_check_failed",
+  "ws_settled_rollover_deferred_leave_failed",
+  "ws_settled_rollover_persist_failed"
+]);
+
+register("ERROR", "table_lifecycle", [
+  "poker_join_bot_seed_failed",
+  "poker_join_bot_seed_skip_invalid_stakes",
+  "poker_leave_invalid_reducer_state",
+  "poker_leave_post_hand_stack_ambiguous",
+  "poker_leave_reducer_throw",
+  "poker_leave_stack_ambiguous",
+  "poker_leave_stack_missing",
+  "poker_leave_stack_negative",
+  "ws_join_attach_failed",
+  "ws_join_authoritative_failed",
+  "ws_join_authoritative_unavailable",
+  "ws_leave_authoritative_failed",
+  "ws_leave_authoritative_unavailable",
+  "ws_rebuy_authoritative_failed",
+  "ws_rebuy_authoritative_unavailable"
+]);
+
+register("ERROR", "transport", [
+  "ws_transport_watchdog_terminate_failed"
+]);
+
+register("WARN", "gameplay", [
+  "ws_table_snapshot_empty_legal_actions",
+  "ws_table_snapshot_timeout_apply_skipped"
+]);
+
+register("ERROR", "gameplay", [
+  "ws_table_snapshot_error"
+]);
+
+const cleanupPrefixCategories = Object.freeze({
+  ws_bot_claims_recovery: "recovery",
+  ws_disconnect_cleanup: "janitor",
+  ws_settled_rollover_close: "janitor",
+  ws_settled_rollover_deferred_leave: "janitor",
+  ws_stale_seat_cleanup: "janitor",
+  ws_table_inactive_cleanup: "janitor",
+  ws_turn_timeout_quarantine_cleanup: "recovery",
+  ws_zombie_cleanup: "janitor"
+});
+
+const cleanupSuffixSeverities = Object.freeze({
+  evict_closed_success: "INFO",
+  retry: "WARN",
+  schedule_bot_step_failed: "ERROR",
+  settled_reveal_deferred: "WARN"
+});
+
+function resolveDynamicCleanupPolicy(eventName) {
+  for (const [prefix, category] of Object.entries(cleanupPrefixCategories)) {
+    const marker = `${prefix}_`;
+    if (!eventName.startsWith(marker)) continue;
+    const suffix = eventName.slice(marker.length);
+    const severity = cleanupSuffixSeverities[suffix];
+    if (severity) return { severity, category, classified: true };
+  }
+  return null;
+}
+
+function resolveJanitorResultPolicy(data) {
+  if (data?.ok !== true) return { severity: "ERROR", category: "janitor", classified: true };
+  if (data?.changed === true || data?.closed === true) {
+    return { severity: "INFO", category: "janitor", classified: true };
+  }
+  if (data?.status === "healthy_noop" || data?.status === "seat_missing") {
+    return { severity: "DEBUG", category: "janitor", classified: true };
+  }
+  return { severity: "WARN", category: "janitor", classified: true };
+}
+
+function normalizeEventName(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function resolvePokerLogPolicy(eventName, data = null) {
+  const normalizedEventName = normalizeEventName(eventName);
+  if (normalizedEventName === "ws_table_janitor_result") {
+    return resolveJanitorResultPolicy(data);
+  }
+  return policyByEventName.get(normalizedEventName)
+    || resolveDynamicCleanupPolicy(normalizedEventName)
+    || { severity: "UNSPECIFIED", category: null, classified: false };
+}
+
+export function buildPokerLogPayload(eventName, data = null) {
+  const context = data && typeof data === "object" && !Array.isArray(data) ? data : {};
+  const policy = resolvePokerLogPolicy(eventName, context);
+  return {
+    ...context,
+    severity: policy.severity,
+    category: policy.category
+  };
+}
+
+export function listClassifiedPokerLogEvents() {
+  return [...policyByEventName.keys()].sort();
+}
+
+export {
+  POKER_LOG_CATEGORIES,
+  POKER_LOG_SEVERITIES
+};

--- a/ws-server/poker/persistence/sql-admin.mjs
+++ b/ws-server/poker/persistence/sql-admin.mjs
@@ -1,4 +1,5 @@
 import postgres from "postgres";
+import { buildPokerLogPayload } from "../observability/poker-log-policy.mjs";
 
 const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL || "";
 const DB_MAX_RAW = Number(process.env.SUPABASE_DB_MAX || process.env.POKER_DB_MAX || 5);
@@ -8,8 +9,8 @@ const POSTGRES_OPTIONS = { max: DB_MAX, idle_timeout: 30, connect_timeout: 10, p
 const sql = SUPABASE_DB_URL ? postgres(SUPABASE_DB_URL, POSTGRES_OPTIONS) : null;
 
 function klog(kind, data) {
-  const payload = data && typeof data === "object" ? ` ${JSON.stringify(data)}` : "";
-  process.stdout.write(`[klog] ${kind}${payload}\n`);
+  const payload = buildPokerLogPayload(kind, data);
+  process.stdout.write(`[klog] ${kind} ${JSON.stringify(payload)}\n`);
 }
 
 async function beginSql(fn) {

--- a/ws-server/poker/persistence/sql-admin.mjs
+++ b/ws-server/poker/persistence/sql-admin.mjs
@@ -1,5 +1,5 @@
 import postgres from "postgres";
-import { buildPokerLogPayload } from "../observability/poker-log-policy.mjs";
+import { serializePokerLogPayload } from "../observability/poker-log-policy.mjs";
 
 const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL || "";
 const DB_MAX_RAW = Number(process.env.SUPABASE_DB_MAX || process.env.POKER_DB_MAX || 5);
@@ -9,8 +9,7 @@ const POSTGRES_OPTIONS = { max: DB_MAX, idle_timeout: 30, connect_timeout: 10, p
 const sql = SUPABASE_DB_URL ? postgres(SUPABASE_DB_URL, POSTGRES_OPTIONS) : null;
 
 function klog(kind, data) {
-  const payload = buildPokerLogPayload(kind, data);
-  process.stdout.write(`[klog] ${kind} ${JSON.stringify(payload)}\n`);
+  process.stdout.write(`[klog] ${kind} ${serializePokerLogPayload(kind, data)}\n`);
 }
 
 async function beginSql(fn) {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import net from "node:net";
+import { fileURLToPath } from "node:url";
 import WebSocket from "ws";
 import { makeBotUserId } from "../shared/poker-domain/bots.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "./poker/shared/poker-primitives.mjs";
@@ -18,6 +19,13 @@ import {
   decideTransportWatchdogAction,
   markTransportPingSent
 } from "./poker/runtime/transport-watchdog.mjs";
+import {
+  buildPokerLogPayload,
+  listClassifiedPokerLogEvents,
+  POKER_LOG_CATEGORIES,
+  POKER_LOG_SEVERITIES,
+  resolvePokerLogPolicy
+} from "./poker/observability/poker-log-policy.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
@@ -26,6 +34,125 @@ const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
   import.meta.url
 ).href;
+
+async function listProductionModuleFiles(rootPath) {
+  const stat = await fs.stat(rootPath);
+  if (stat.isFile()) return [rootPath];
+  const files = [];
+  for (const entry of await fs.readdir(rootPath, { withFileTypes: true })) {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "fixtures") continue;
+      files.push(...await listProductionModuleFiles(entryPath));
+      continue;
+    }
+    if (
+      entry.isFile()
+      && entry.name.endsWith(".mjs")
+      && !entry.name.endsWith(".test.mjs")
+      && !entry.name.endsWith(".fixture.mjs")
+    ) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+test("poker log policy classifies every production WS poker event", async () => {
+  const wsRoot = path.dirname(fileURLToPath(import.meta.url));
+  const sourceRoots = [
+    path.join(wsRoot, "server.mjs"),
+    path.join(wsRoot, "poker"),
+    path.join(wsRoot, "..", "shared", "poker-domain")
+  ];
+  const sourceFiles = (await Promise.all(sourceRoots.map(listProductionModuleFiles))).flat();
+  const literalEvents = new Set();
+  const dynamicPrefixes = new Set();
+  const dynamicSuffixes = new Set();
+  let hasAutoplayFallbackChoice = false;
+
+  for (const sourceFile of sourceFiles) {
+    const source = await fs.readFile(sourceFile, "utf8");
+    const literalPattern = /\b(?:klog|klogSafe|klogVerbose|klogBotAutoplayVerbose|logVerbose)\(\s*["']((?:ws|poker|shared|chips)_[a-z0-9_]+)["']/g;
+    let match;
+    while ((match = literalPattern.exec(source))) {
+      literalEvents.add(match[1]);
+    }
+    const prefixPattern = /logPrefix:\s*"([a-z0-9_]+)"/g;
+    while ((match = prefixPattern.exec(source))) {
+      dynamicPrefixes.add(match[1]);
+    }
+    const suffixPattern = /\$\{logPrefix\}_([a-z0-9_]+)/g;
+    while ((match = suffixPattern.exec(source))) {
+      dynamicSuffixes.add(match[1]);
+    }
+    if (
+      source.includes('"ws_bot_autoplay_fallback_action"')
+      && source.includes('"ws_bot_autoplay_no_fallback_action"')
+    ) {
+      hasAutoplayFallbackChoice = true;
+      literalEvents.add("ws_bot_autoplay_fallback_action");
+      literalEvents.add("ws_bot_autoplay_no_fallback_action");
+    }
+  }
+
+  const missing = [...literalEvents]
+    .filter((eventName) => !resolvePokerLogPolicy(eventName, { ok: true, changed: true }).classified)
+    .sort();
+  assert.deepEqual(missing, []);
+  assert.equal(hasAutoplayFallbackChoice, true);
+
+  for (const prefix of dynamicPrefixes) {
+    for (const suffix of dynamicSuffixes) {
+      assert.equal(
+        resolvePokerLogPolicy(`${prefix}_${suffix}`, { ok: true, changed: true }).classified,
+        true,
+        `dynamic event ${prefix}_${suffix} must be classified`
+      );
+    }
+  }
+
+  const catalogWithoutConditionalEvents = new Set(listClassifiedPokerLogEvents());
+  const sourceWithoutConditionalEvents = new Set(literalEvents);
+  sourceWithoutConditionalEvents.delete("ws_table_janitor_result");
+  assert.deepEqual(
+    [...catalogWithoutConditionalEvents].filter((eventName) => !sourceWithoutConditionalEvents.has(eventName)),
+    []
+  );
+});
+
+test("poker log policy owns envelope metadata and preserves compatibility for unknown events", () => {
+  assert.deepEqual(POKER_LOG_SEVERITIES, ["DEBUG", "INFO", "WARN", "ERROR"]);
+  assert.equal(new Set(POKER_LOG_CATEGORIES).size, POKER_LOG_CATEGORIES.length);
+
+  const artifactPayload = buildPokerLogPayload("ws_artifact_start", {
+    releaseSha: "abc123",
+    severity: "ERROR",
+    category: "ledger"
+  });
+  assert.deepEqual(artifactPayload, {
+    releaseSha: "abc123",
+    severity: "INFO",
+    category: "deployment"
+  });
+
+  assert.deepEqual(
+    resolvePokerLogPolicy("ws_table_janitor_result", { ok: true, changed: false, status: "seat_missing" }),
+    { severity: "DEBUG", category: "janitor", classified: true }
+  );
+  assert.deepEqual(
+    resolvePokerLogPolicy("ws_table_janitor_result", { ok: false, changed: false }),
+    { severity: "ERROR", category: "janitor", classified: true }
+  );
+  assert.deepEqual(
+    resolvePokerLogPolicy("future_legacy_event"),
+    { severity: "UNSPECIFIED", category: null, classified: false }
+  );
+  assert.deepEqual(
+    buildPokerLogPayload("future_legacy_event", { ok: true }),
+    { ok: true, severity: "UNSPECIFIED", category: null }
+  );
+});
 
 test("bot claims recovery stops when a socket appears while the executor is loading", async () => {
   let activePresence = false;
@@ -1674,6 +1801,8 @@ test("server logs deploy identity at artifact startup", async () => {
     assert.match(joined, /"releaseSha":"test-release-sha"/);
     assert.match(joined, /"deployRef":"agent\/test-release-ref"/);
     assert.match(joined, /"environment":"preview"/);
+    assert.match(joined, /"severity":"INFO"/);
+    assert.match(joined, /"category":"deployment"/);
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -182,6 +182,21 @@ test("poker log serialization failures use a safe classified fallback", () => {
       category: "recovery"
     }
   );
+
+  const circularJanitorPayload = {
+    ok: true,
+    changed: false,
+    status: "seat_missing"
+  };
+  circularJanitorPayload.self = circularJanitorPayload;
+  assert.deepEqual(
+    JSON.parse(serializePokerLogPayload("ws_table_janitor_result", circularJanitorPayload)),
+    {
+      serializationError: true,
+      severity: "DEBUG",
+      category: "janitor"
+    }
+  );
 });
 
 test("bot claims recovery stops when a socket appears while the executor is loading", async () => {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -24,7 +24,8 @@ import {
   listClassifiedPokerLogEvents,
   POKER_LOG_CATEGORIES,
   POKER_LOG_SEVERITIES,
-  resolvePokerLogPolicy
+  resolvePokerLogPolicy,
+  serializePokerLogPayload
 } from "./poker/observability/poker-log-policy.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
@@ -151,6 +152,35 @@ test("poker log policy owns envelope metadata and preserves compatibility for un
   assert.deepEqual(
     buildPokerLogPayload("future_legacy_event", { ok: true }),
     { ok: true, severity: "UNSPECIFIED", category: null }
+  );
+});
+
+test("poker log serialization failures use a safe classified fallback", () => {
+  const circularPayload = {};
+  circularPayload.self = circularPayload;
+  assert.deepEqual(
+    JSON.parse(serializePokerLogPayload("ws_state_persist_failed", circularPayload)),
+    {
+      serializationError: true,
+      severity: "ERROR",
+      category: "persistence"
+    }
+  );
+
+  const throwingPayload = {};
+  Object.defineProperty(throwingPayload, "value", {
+    enumerable: true,
+    get() {
+      throw new Error("getter_failed");
+    }
+  });
+  assert.deepEqual(
+    JSON.parse(serializePokerLogPayload("ws_restore_failed", throwingPayload)),
+    {
+      serializationError: true,
+      severity: "ERROR",
+      category: "recovery"
+    }
   );
 });
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -50,6 +50,7 @@ import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
+import { buildPokerLogPayload } from "./poker/observability/poker-log-policy.mjs";
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
@@ -475,8 +476,8 @@ const turnTimeoutQuarantineMs = resolvePositiveInt(process.env.WS_TIMEOUT_QUARAN
 });
 
 function klog(kind, data) {
-  const payload = data && typeof data === "object" ? ` ${JSON.stringify(data)}` : "";
-  process.stdout.write(`[klog] ${kind}${payload}\n`);
+  const payload = buildPokerLogPayload(kind, data);
+  process.stdout.write(`[klog] ${kind} ${JSON.stringify(payload)}\n`);
 }
 
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -50,7 +50,7 @@ import { createTableCommandQueue } from "./poker/runtime/table-command-queue.mjs
 import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-recovery.mjs";
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
-import { buildPokerLogPayload } from "./poker/observability/poker-log-policy.mjs";
+import { serializePokerLogPayload } from "./poker/observability/poker-log-policy.mjs";
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
@@ -476,8 +476,7 @@ const turnTimeoutQuarantineMs = resolvePositiveInt(process.env.WS_TIMEOUT_QUARAN
 });
 
 function klog(kind, data) {
-  const payload = buildPokerLogPayload(kind, data);
-  process.stdout.write(`[klog] ${kind} ${JSON.stringify(payload)}\n`);
+  process.stdout.write(`[klog] ${kind} ${serializePokerLogPayload(kind, data)}\n`);
 }
 
 

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -782,6 +782,7 @@ test("authoritative join adapter resolves in ws artifact layout without netlify 
       ["ws-server/poker/persistence/chips-ledger.mjs", "poker/persistence/chips-ledger.mjs"],
       ["ws-server/poker/persistence/sql-admin.mjs", "poker/persistence/sql-admin.mjs"],
       ["ws-server/poker/persistence/poker-state-write-locked.mjs", "poker/persistence/poker-state-write-locked.mjs"],
+      ["ws-server/poker/observability/poker-log-policy.mjs", "poker/observability/poker-log-policy.mjs"],
       ["ws-server/poker/snapshot-runtime/poker-state-utils.mjs", "poker/snapshot-runtime/poker-state-utils.mjs"],
       ["ws-server/poker/bootstrap/persisted-bootstrap-db.mjs", "poker/bootstrap/persisted-bootstrap-db.mjs"],
       ["shared/poker-domain/join.mjs", "shared/poker-domain/join.mjs"],


### PR DESCRIPTION
## Summary

- adds a central, explicit severity and category policy for every production poker event emitted by the WS runtime
- enriches the existing `[klog] <event> <json>` envelope without renaming events or changing their emission frequency
- preserves unclassified legacy compatibility as `UNSPECIFIED` while preventing known poker events from silently escaping classification
- adds a source guard for literal and existing dynamic poker event families

## Scope

This is PR A from the accepted implementation plan for #775.

It intentionally does **not** add runtime filtering, TTL overrides, admin controls, or change default log volume. Those remain separate review and rollback boundaries.

The event line prefix and stable event names are unchanged. Existing consumers continue to receive the original context fields, with additive `severity` and `category` fields.

Refs #775

## Validation

- `npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- `node --test ws-tests/ws-preview-deploy.workflow.guard.test.mjs ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs`
- `node --test --test-name-pattern='poker log policy|server logs deploy identity' ws-server/server.behavior.test.mjs`
- `git diff --check`

No browser JavaScript or CSS was changed. A manual WS Preview Deploy for the exact PR SHA is required before merge.

## Breaking impact

No intended runtime or protocol breaking change. The structured JSON payload gains two fields (`severity`, `category`); parsers that incorrectly require an exact field set should be checked during Preview verification.
