### PR TITLE
fix: stabilize authoritative join bot target

### DIFF
--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -206,7 +206,7 @@ async function loadSeatRows(tx, tableId) {
   return Array.isArray(rows) ? rows : [];
 }
 
-async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, humanUserId, postTransaction, klog = () => {}, random = Math.random }) {
+async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, humanUserId, postTransaction, targetBotCount = null, klog = () => {}, random = Math.random }) {
   if (!cfg?.enabled || typeof postTransaction !== "function") return [];
   const stakesParsed = parseStakes(tableStakes);
   if (!stakesParsed.ok) {
@@ -219,7 +219,9 @@ async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, huma
   const humanCount = activeSeats.filter((row) => !row?.is_bot).length;
   if (!shouldSeedBotsOnJoin({ humanCount })) return [];
 
-  const targetBots = computeTargetBotCount({ maxPlayers, humanCount, minBots: cfg.minPerTable, maxBots: cfg.maxPerTable, random });
+  const targetBots = Number.isInteger(targetBotCount)
+    ? targetBotCount
+    : computeTargetBotCount({ maxPlayers, humanCount, minBots: cfg.minPerTable, maxBots: cfg.maxPerTable, random });
   if (!Number.isInteger(targetBots) || targetBots <= 0) return [];
 
   const existingBotCount = activeSeats.filter((row) => row?.is_bot).length;

--- a/shared/poker-domain/join.behavior.test.mjs
+++ b/shared/poker-domain/join.behavior.test.mjs
@@ -1003,7 +1003,14 @@ test("authoritative join rejects explicit and preferred seat numbers below 1", a
   );
 });
 
-test("first human authoritative join seeds exactly two bots and persists bot seat fields", async () => withBotEnv(async () => {
+test("first human authoritative join validates the same randomized bot target that it seeds", async () => withBotEnv(async () => {
+  process.env.POKER_BOTS_MAX_PER_TABLE = "5";
+  const originalRandom = Math.random;
+  let randomCalls = 0;
+  Math.random = () => {
+    randomCalls += 1;
+    return randomCalls === 1 ? 0 : 0.999999;
+  };
   const store = {
     table: { id: "t-bots", status: "OPEN", max_players: 6, stakes: '{"sb":1,"bb":2}' },
     seatRows: [],
@@ -1011,7 +1018,8 @@ test("first human authoritative join seeds exactly two bots and persists bot sea
     ledgerCalls: []
   };
 
-  const result = await executePokerJoinAuthoritative(withLockedState({
+  try {
+    const result = await executePokerJoinAuthoritative(withLockedState({
     beginSql: async (fn) => fn({
       unsafe: async (sql, params = []) => {
         if (sql.includes("from public.poker_tables")) return [store.table];
@@ -1068,20 +1076,24 @@ test("first human authoritative join seeds exactly two bots and persists bot sea
     }
   }));
 
-  assert.equal(result.ok, true);
-  assert.equal(result.seededBots.length, 2);
-  assert.equal(result.snapshot.seats.length, 3);
-  assert.deepEqual(result.snapshot.seats.map((seat) => seat.seatNo), [1, 2, 3]);
-  assert.deepEqual(result.snapshot.seats.filter((seat) => seat.isBot).map((seat) => ({ seatNo: seat.seatNo, botProfile: seat.botProfile, leaveAfterHand: seat.leaveAfterHand === true })), [
-    { seatNo: 2, botProfile: "NORMAL", leaveAfterHand: false },
-    { seatNo: 3, botProfile: "NORMAL", leaveAfterHand: false }
-  ]);
-  assert.equal(result.snapshot.stacks.human_1, 100);
-  assert.deepEqual(Object.values(result.snapshot.stacks), [100, 100, 100]);
-  assert.equal(result.snapshot.stateVersion, 4);
-  assert.equal(store.stateRow.version, 4);
-  assert.equal(store.seatRows.filter((seat) => seat.is_bot).length, 2);
-  assert.equal(store.ledgerCalls.length, 3);
+    assert.equal(result.ok, true);
+    assert.equal(result.seededBots.length, 2);
+    assert.equal(result.snapshot.seats.length, 3);
+    assert.deepEqual(result.snapshot.seats.map((seat) => seat.seatNo), [1, 2, 3]);
+    assert.deepEqual(result.snapshot.seats.filter((seat) => seat.isBot).map((seat) => ({ seatNo: seat.seatNo, botProfile: seat.botProfile, leaveAfterHand: seat.leaveAfterHand === true })), [
+      { seatNo: 2, botProfile: "NORMAL", leaveAfterHand: false },
+      { seatNo: 3, botProfile: "NORMAL", leaveAfterHand: false }
+    ]);
+    assert.equal(result.snapshot.stacks.human_1, 100);
+    assert.deepEqual(Object.values(result.snapshot.stacks), [100, 100, 100]);
+    assert.equal(result.snapshot.stateVersion, 4);
+    assert.equal(store.stateRow.version, 4);
+    assert.equal(store.seatRows.filter((seat) => seat.is_bot).length, 2);
+    assert.equal(store.ledgerCalls.length, 3);
+    assert.equal(randomCalls, 1);
+  } finally {
+    Math.random = originalRandom;
+  }
 }));
 
 test("authoritative join replay does not duplicate bots and only fills missing bot seat", async () => withBotEnv(async () => {

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -435,8 +435,7 @@ function assertAuthoritativeJoinStateComplete({
   version,
   userId,
   seatNo,
-  maxPlayers,
-  botCfg,
+  targetBotCount,
   previousStacks,
   fundedStacks,
   displacedUserIds
@@ -497,17 +496,14 @@ function assertAuthoritativeJoinStateComplete({
   }
 
   const activeRows = activeSeatRows(seatRows);
-  const humanCount = activeRows.filter((row) => !row?.is_bot).length;
-  const expectedBotCount = botCfg?.enabled && shouldSeedBotsOnJoin({ humanCount })
-    ? computeTargetBotCount({ maxPlayers, humanCount, maxBots: botCfg.maxPerTable })
-    : 0;
+  const expectedBotCount = Number.isInteger(targetBotCount) ? targetBotCount : 0;
   const activeBotCount = activeRows.filter((row) => row?.is_bot).length;
   if (activeBotCount < expectedBotCount) {
     throw makeError("authoritative_state_invalid", "seeded_bot_projection_incomplete");
   }
 }
 
-async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackEntries, loadStateForUpdate, updateStateLocked, validateStateForStorage, maxPlayers, botCfg }) {
+async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackEntries, loadStateForUpdate, updateStateLocked, validateStateForStorage, targetBotCount }) {
   const stateRow = normalizeLockedStateResult(await loadStateForUpdate(tx, tableId));
   const seatRows = await loadSeatRows(tx, tableId);
   const merged = applyAuthoritativeSeatRowsToState(stateRow.state, {
@@ -528,8 +524,7 @@ async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackE
     version,
     userId,
     seatNo,
-    maxPlayers,
-    botCfg,
+    targetBotCount,
     previousStacks: merged.previousStacks,
     fundedStacks: merged.fundedStacks,
     displacedUserIds: merged.displacedUserIds
@@ -819,6 +814,15 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       }
 
       const botCfg = getBotConfig(process.env);
+      const humanCountAfterJoin = activeSeatRows(seatRows).filter((row) => !row?.is_bot).length + 1;
+      const targetBotCount = botCfg.enabled && shouldSeedBotsOnJoin({ humanCount: humanCountAfterJoin })
+        ? computeTargetBotCount({
+          maxPlayers,
+          humanCount: humanCountAfterJoin,
+          minBots: botCfg.minPerTable,
+          maxBots: botCfg.maxPerTable
+        })
+        : 0;
       const seededBots = await seedBotsForJoin({
       tx,
       tableId,
@@ -827,6 +831,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       cfg: botCfg,
       humanUserId: userId,
       postTransaction: runPostTransaction,
+      targetBotCount,
       klog
       });
       const updatedStateRow = await syncStateSeatAndStack({
@@ -841,8 +846,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       loadStateForUpdate,
       updateStateLocked,
       validateStateForStorage,
-      maxPlayers,
-      botCfg
+      targetBotCount
       });
       await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
       return {


### PR DESCRIPTION
## Summary

- computes the bot target once per fresh authoritative join
- passes that exact target through `seedBotsForJoin()` and authoritative state validation
- removes the second randomized target calculation that caused false `seeded_bot_projection_incomplete` failures
- retains fail-closed validation when the selected target was not actually seeded and projected

## Root cause

The seeding path and its post-write validator independently called randomized `computeTargetBotCount()`. A correctly seeded join could therefore be rolled back when validation happened to sample a larger target.

The Preview incident produced two fully rolled-back failures followed by a successful retry solely because the random samples changed.

Fixes #779

## Validation

- `npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- `node --test shared/poker-domain/join.behavior.test.mjs`
- `node --test ws-tests/ws-join-runtime.behavior.test.mjs ws-tests/ws-preview-deploy.workflow.guard.test.mjs ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs`
- `git diff --check`

The focused regression makes a hypothetical second random draw select a larger target and verifies that the join uses only the first selected target.

## Breaking impact

No intended protocol, persistence, ledger, escrow, or settlement breaking change. The change removes a nondeterministic false rejection while preserving the existing transaction and rollback boundaries.

A manual WS Preview Deploy for the exact PR SHA is required before merge.
