### PR TITLE
feat: add TTL-bound poker debug overrides

### DIFF
--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -118,7 +118,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     klogVerbose("ws_join_authoritative_start", () => ({
       tableId,
       requestId: frame.requestId ?? null
-    }));
+    }), { tableId });
     const authoritativeJoin = await authoritativeJoinExecutor({
       tableId,
       userId: connState.session.userId,
@@ -142,7 +142,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
         ok: false,
         reason,
         durationMs: Math.max(0, Date.now() - authoritativeJoinStartedAtMs)
-      }));
+      }), { tableId });
       sendCommandResult(ws, connState, {
         requestId: frame.requestId ?? null,
         tableId,
@@ -158,7 +158,7 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       rejoin: authoritativeJoin?.rejoin === true,
       stateVersion: Number(authoritativeJoin?.snapshot?.stateVersion) || null,
       durationMs: Math.max(0, Date.now() - authoritativeJoinStartedAtMs)
-    }));
+    }), { tableId });
     authoritativeJoinResult = authoritativeJoin;
   }
 

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -91,6 +91,9 @@ register("INFO", "accounting", [
 
 register("INFO", "admin", [
   "ws_bot_claims_recovery_outcome",
+  "ws_poker_debug_override_disabled",
+  "ws_poker_debug_override_enabled",
+  "ws_poker_debug_override_expired",
   "ws_preview_bot_reaction_updated"
 ]);
 
@@ -246,6 +249,7 @@ register("ERROR", "http", [
 ]);
 
 register("ERROR", "admin", [
+  "ws_poker_log_config_invalid",
   "ws_preview_bot_reaction_failed"
 ]);
 

--- a/ws-server/poker/observability/poker-log-runtime-control.mjs
+++ b/ws-server/poker/observability/poker-log-runtime-control.mjs
@@ -138,18 +138,15 @@ export function createPokerLogRuntimeControl({
     }
   }
 
-  function mayBuildDebugPayload(eventName) {
+  function mayBuildDebugPayload(eventName, { tableId = null } = {}) {
     const policy = eventName === "ws_table_janitor_result"
       ? { severity: "DEBUG", category: "janitor", classified: true }
       : resolvePokerLogPolicy(eventName);
     if (policy.severity !== "DEBUG") return shouldEmit(eventName);
-    pruneExpired();
-    return defaultLevel === "DEBUG"
-      || globalOverride !== null
-      || categoryOverrides.has(policy.category)
-      || tableOverrides.size > 0
-      || (legacyAutoplayDebug && policy.category === "autoplay")
-      || (legacyPokerDebug && policy.category !== "autoplay");
+    return debugEnabled({
+      category: policy.category,
+      tableId: normalizeTableId(tableId)
+    });
   }
 
   function enable({ scope, category = null, tableId = null, ttlMs, adminUserId = null }) {

--- a/ws-server/poker/observability/poker-log-runtime-control.mjs
+++ b/ws-server/poker/observability/poker-log-runtime-control.mjs
@@ -1,0 +1,250 @@
+import { POKER_LOG_CATEGORIES, resolvePokerLogPolicy } from "./poker-log-policy.mjs";
+
+const LEVELS = Object.freeze({ DEBUG: 10, INFO: 20, WARN: 30, ERROR: 40 });
+const TTL_MIN_MS = 60_000;
+const TTL_DEFAULT_MS = 15 * 60_000;
+const TTL_MAX_MS = 60 * 60_000;
+const TABLE_OVERRIDE_LIMIT = 100;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const GUEST_TABLE_RE = /^guest_[a-z0-9_-]{1,120}$/i;
+
+function normalizeLevel(value) {
+  const normalized = typeof value === "string" ? value.trim().toUpperCase() : "";
+  return Object.prototype.hasOwnProperty.call(LEVELS, normalized) ? normalized : null;
+}
+
+function normalizeCategory(value) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return POKER_LOG_CATEGORIES.includes(normalized) ? normalized : null;
+}
+
+function normalizeTableId(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return UUID_RE.test(normalized) || GUEST_TABLE_RE.test(normalized) ? normalized : null;
+}
+
+function makeError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function normalizeTtlMs(value) {
+  const ttlMs = Number(value);
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < TTL_MIN_MS || ttlMs > TTL_MAX_MS) {
+    throw makeError("invalid_ttl");
+  }
+  return ttlMs;
+}
+
+function publicOverride(entry) {
+  return {
+    scope: entry.scope,
+    ...(entry.category ? { category: entry.category } : {}),
+    ...(entry.tableId ? { tableId: entry.tableId } : {}),
+    expiresAt: new Date(entry.expiresAtMs).toISOString()
+  };
+}
+
+export function createPokerLogRuntimeControl({
+  env = process.env,
+  now = Date.now,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  tableOverrideLimit = TABLE_OVERRIDE_LIMIT,
+  audit = () => {}
+} = {}) {
+  const configuredLevel = normalizeLevel(env?.WS_POKER_LOG_LEVEL);
+  const defaultLevel = configuredLevel || "INFO";
+  const invalidConfiguredLevel = env?.WS_POKER_LOG_LEVEL != null && !configuredLevel;
+  const legacyPokerDebug = env?.WS_POKER_VERBOSE_LOGS === "1";
+  const legacyAutoplayDebug = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
+  let globalOverride = null;
+  const categoryOverrides = new Map();
+  const tableOverrides = new Map();
+  let expiryTimer = null;
+
+  function allOverrides() {
+    return [
+      ...(globalOverride ? [globalOverride] : []),
+      ...categoryOverrides.values(),
+      ...tableOverrides.values()
+    ];
+  }
+
+  function scheduleExpiry() {
+    if (expiryTimer) clearTimer(expiryTimer);
+    expiryTimer = null;
+    const nextExpiry = Math.min(...allOverrides().map((entry) => entry.expiresAtMs));
+    if (!Number.isFinite(nextExpiry)) return;
+    expiryTimer = setTimer(() => {
+      expiryTimer = null;
+      pruneExpired("timer");
+    }, Math.max(0, nextExpiry - now()));
+    expiryTimer?.unref?.();
+  }
+
+  function pruneExpired(trigger = "read") {
+    const current = now();
+    const expired = [];
+    if (globalOverride && globalOverride.expiresAtMs <= current) {
+      expired.push(globalOverride);
+      globalOverride = null;
+    }
+    for (const [category, entry] of categoryOverrides) {
+      if (entry.expiresAtMs <= current) {
+        expired.push(entry);
+        categoryOverrides.delete(category);
+      }
+    }
+    for (const [tableId, entry] of tableOverrides) {
+      if (entry.expiresAtMs <= current) {
+        expired.push(entry);
+        tableOverrides.delete(tableId);
+      }
+    }
+    for (const entry of expired) {
+      audit("ws_poker_debug_override_expired", { ...publicOverride(entry), trigger });
+    }
+    if (expired.length > 0 || !expiryTimer) scheduleExpiry();
+    return expired.length;
+  }
+
+  function debugEnabled({ category, tableId } = {}) {
+    pruneExpired();
+    if (defaultLevel === "DEBUG") return true;
+    if (legacyAutoplayDebug && category === "autoplay") return true;
+    if (legacyPokerDebug && category !== "autoplay") return true;
+    if (globalOverride) return true;
+    if (category && categoryOverrides.has(category)) return true;
+    return Boolean(tableId && tableOverrides.has(tableId));
+  }
+
+  function shouldEmit(eventName, data = null) {
+    try {
+      const policy = resolvePokerLogPolicy(eventName, data);
+      if (!policy.classified) return true;
+      if (policy.severity === "ERROR") return true;
+      if (policy.severity === "DEBUG") {
+        return debugEnabled({
+          category: policy.category,
+          tableId: normalizeTableId(data?.tableId)
+        });
+      }
+      return LEVELS[policy.severity] >= LEVELS[defaultLevel];
+    } catch {
+      return true;
+    }
+  }
+
+  function mayBuildDebugPayload(eventName) {
+    const policy = eventName === "ws_table_janitor_result"
+      ? { severity: "DEBUG", category: "janitor", classified: true }
+      : resolvePokerLogPolicy(eventName);
+    if (policy.severity !== "DEBUG") return shouldEmit(eventName);
+    pruneExpired();
+    return defaultLevel === "DEBUG"
+      || globalOverride !== null
+      || categoryOverrides.has(policy.category)
+      || tableOverrides.size > 0
+      || (legacyAutoplayDebug && policy.category === "autoplay")
+      || (legacyPokerDebug && policy.category !== "autoplay");
+  }
+
+  function enable({ scope, category = null, tableId = null, ttlMs, adminUserId = null }) {
+    const normalizedScope = typeof scope === "string" ? scope.trim().toLowerCase() : "";
+    const normalizedTtlMs = normalizeTtlMs(ttlMs);
+    const entry = {
+      scope: normalizedScope,
+      expiresAtMs: now() + normalizedTtlMs
+    };
+    let updated = false;
+    if (normalizedScope === "global") {
+      updated = Boolean(globalOverride);
+      globalOverride = entry;
+    } else if (normalizedScope === "category") {
+      const normalizedCategory = normalizeCategory(category);
+      if (!normalizedCategory) throw makeError("invalid_category");
+      entry.category = normalizedCategory;
+      updated = categoryOverrides.has(normalizedCategory);
+      categoryOverrides.set(normalizedCategory, entry);
+    } else if (normalizedScope === "table") {
+      const normalizedTableId = normalizeTableId(tableId);
+      if (!normalizedTableId) throw makeError("invalid_table_id");
+      if (!tableOverrides.has(normalizedTableId) && tableOverrides.size >= tableOverrideLimit) {
+        throw makeError("table_override_capacity", 409);
+      }
+      entry.tableId = normalizedTableId;
+      updated = tableOverrides.has(normalizedTableId);
+      tableOverrides.set(normalizedTableId, entry);
+    } else {
+      throw makeError("invalid_scope");
+    }
+    scheduleExpiry();
+    audit("ws_poker_debug_override_enabled", { ...publicOverride(entry), updated, adminUserId });
+    return snapshot();
+  }
+
+  function disable({ scope, category = null, tableId = null, adminUserId = null }) {
+    const normalizedScope = typeof scope === "string" ? scope.trim().toLowerCase() : "";
+    let removed = false;
+    let identity = { scope: normalizedScope };
+    if (normalizedScope === "global") {
+      removed = Boolean(globalOverride);
+      globalOverride = null;
+    } else if (normalizedScope === "category") {
+      const normalizedCategory = normalizeCategory(category);
+      if (!normalizedCategory) throw makeError("invalid_category");
+      identity.category = normalizedCategory;
+      removed = categoryOverrides.delete(normalizedCategory);
+    } else if (normalizedScope === "table") {
+      const normalizedTableId = normalizeTableId(tableId);
+      if (!normalizedTableId) throw makeError("invalid_table_id");
+      identity.tableId = normalizedTableId;
+      removed = tableOverrides.delete(normalizedTableId);
+    } else {
+      throw makeError("invalid_scope");
+    }
+    scheduleExpiry();
+    audit("ws_poker_debug_override_disabled", { ...identity, removed, adminUserId });
+    return snapshot();
+  }
+
+  function snapshot() {
+    pruneExpired();
+    return {
+      defaultLevel,
+      serverNow: new Date(now()).toISOString(),
+      ttl: {
+        minMs: TTL_MIN_MS,
+        defaultMs: TTL_DEFAULT_MS,
+        maxMs: TTL_MAX_MS,
+        presetsMs: [15 * 60_000, 30 * 60_000, 60 * 60_000]
+      },
+      overrides: allOverrides()
+        .sort((left, right) => left.expiresAtMs - right.expiresAtMs)
+        .map(publicOverride)
+    };
+  }
+
+  return {
+    defaultLevel,
+    invalidConfiguredLevel,
+    shouldEmit,
+    mayBuildDebugPayload,
+    enable,
+    disable,
+    snapshot,
+    pruneExpired
+  };
+}
+
+let auditLogger = () => {};
+export const pokerLogRuntimeControl = createPokerLogRuntimeControl({
+  audit: (...args) => auditLogger(...args)
+});
+
+export function setPokerLogRuntimeAuditLogger(logger) {
+  auditLogger = typeof logger === "function" ? logger : () => {};
+}

--- a/ws-server/poker/observability/poker-log-runtime-control.mjs
+++ b/ws-server/poker/observability/poker-log-runtime-control.mjs
@@ -20,7 +20,9 @@ function normalizeCategory(value) {
 
 function normalizeTableId(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
-  return UUID_RE.test(normalized) || GUEST_TABLE_RE.test(normalized) ? normalized : null;
+  return UUID_RE.test(normalized) || GUEST_TABLE_RE.test(normalized)
+    ? normalized.toLowerCase()
+    : null;
 }
 
 function makeError(code, status = 400) {

--- a/ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
+++ b/ws-server/poker/persistence/authoritative-leave-adapter.behavior.test.mjs
@@ -27,13 +27,18 @@ test("default loader resolves in artifact-shaped layout without loader-unavailab
   try {
     const stagedAdapter = path.join(stageDir, "poker/persistence/authoritative-leave-adapter.mjs");
     const stagedBootstrap = path.join(stageDir, "poker/bootstrap/persisted-bootstrap-db.mjs");
+    const stagedLogPolicy = path.join(stageDir, "poker/observability/poker-log-policy.mjs");
+    const stagedLogControl = path.join(stageDir, "poker/observability/poker-log-runtime-control.mjs");
     const stagedLeave = path.join(stageDir, "shared/poker-domain/leave.mjs");
 
     await fs.mkdir(path.dirname(stagedAdapter), { recursive: true });
     await fs.mkdir(path.dirname(stagedBootstrap), { recursive: true });
+    await fs.mkdir(path.dirname(stagedLogPolicy), { recursive: true });
     await fs.mkdir(path.dirname(stagedLeave), { recursive: true });
 
     await fs.copyFile("ws-server/poker/persistence/authoritative-leave-adapter.mjs", stagedAdapter);
+    await fs.copyFile("ws-server/poker/observability/poker-log-policy.mjs", stagedLogPolicy);
+    await fs.copyFile("ws-server/poker/observability/poker-log-runtime-control.mjs", stagedLogControl);
     await fs.writeFile(stagedBootstrap, "export async function beginSqlWs(fn) { return fn({}); }\n", "utf8");
     await fs.writeFile(stagedLeave, "export async function executePokerLeave(){ throw Object.assign(new Error('state_invalid'), { code: 'state_invalid' }); }\n", "utf8");
 

--- a/ws-server/poker/persistence/authoritative-leave-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-leave-adapter.mjs
@@ -1,3 +1,5 @@
+import { pokerLogRuntimeControl } from "../observability/poker-log-runtime-control.mjs";
+
 async function beginSqlDefault(fn, { env = process.env } = {}) {
   const bootstrapDb = await import("../bootstrap/persisted-bootstrap-db.mjs");
   return bootstrapDb.beginSqlWs(fn, { env });
@@ -113,9 +115,9 @@ export function createAuthoritativeLeaveExecutor({
   beginSql = beginSqlDefault
 } = {}) {
   const maxRetryAttempts = 2;
-  const verboseBotAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
+  const staticVerboseBotAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
   const klogVerbose = (kind, createPayload) => {
-    if (!verboseBotAutoplayLogs) return;
+    if (!staticVerboseBotAutoplayLogs && !pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
     klog(kind, createPayload());
   };
   return async function executeAuthoritativeLeave({ tableId, userId, requestId }) {
@@ -152,7 +154,8 @@ export function createAuthoritativeLeaveExecutor({
           hasConnectedHumanPresence,
           klog,
           klogVerbose,
-          verboseLogsEnabled: verboseBotAutoplayLogs
+          verboseLogsEnabled: staticVerboseBotAutoplayLogs
+            || pokerLogRuntimeControl.mayBuildDebugPayload("poker_leave_bot_autoplay_loop")
         });
         return normalizeValidatedResult({ result, tableId, userId, requestId, klog });
       } catch (error) {

--- a/ws-server/poker/persistence/authoritative-leave-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-leave-adapter.mjs
@@ -116,8 +116,11 @@ export function createAuthoritativeLeaveExecutor({
 } = {}) {
   const maxRetryAttempts = 2;
   const staticVerboseBotAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
-  const klogVerbose = (kind, createPayload) => {
-    if (!staticVerboseBotAutoplayLogs && !pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
+  const klogVerbose = (kind, createPayload, { tableId = null } = {}) => {
+    if (
+      !staticVerboseBotAutoplayLogs
+      && !pokerLogRuntimeControl.mayBuildDebugPayload(kind, { tableId })
+    ) return;
     klog(kind, createPayload());
   };
   return async function executeAuthoritativeLeave({ tableId, userId, requestId }) {
@@ -153,9 +156,9 @@ export function createAuthoritativeLeaveExecutor({
           runPostLeaveBotAutoplay: false,
           hasConnectedHumanPresence,
           klog,
-          klogVerbose,
+          klogVerbose: (kind, createPayload) => klogVerbose(kind, createPayload, { tableId }),
           verboseLogsEnabled: staticVerboseBotAutoplayLogs
-            || pokerLogRuntimeControl.mayBuildDebugPayload("poker_leave_bot_autoplay_loop")
+            || pokerLogRuntimeControl.mayBuildDebugPayload("poker_leave_bot_autoplay_loop", { tableId })
         });
         return normalizeValidatedResult({ result, tableId, userId, requestId, klog });
       } catch (error) {

--- a/ws-server/poker/persistence/poker-state-write-locked.mjs
+++ b/ws-server/poker/persistence/poker-state-write-locked.mjs
@@ -1,8 +1,9 @@
 import { normalizeJsonState } from "../snapshot-runtime/poker-state-utils.mjs";
+import { pokerLogRuntimeControl } from "../observability/poker-log-runtime-control.mjs";
 
 export async function updatePokerStateLocked(tx, { tableId, nextState }) {
   const klog = typeof tx?.klog === "function" ? tx.klog : () => {};
-  const verboseLogs = process.env.WS_POKER_VERBOSE_LOGS === "1";
+  const verboseLogs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_update_start");
   if (!tableId) return { ok: false, reason: "invalid" };
   if (!nextState || typeof nextState !== "object" || Array.isArray(nextState)) {
     klog("ws_state_update_invalid", { reason: "invalid_state_payload" });

--- a/ws-server/poker/persistence/poker-state-write-locked.mjs
+++ b/ws-server/poker/persistence/poker-state-write-locked.mjs
@@ -3,7 +3,7 @@ import { pokerLogRuntimeControl } from "../observability/poker-log-runtime-contr
 
 export async function updatePokerStateLocked(tx, { tableId, nextState }) {
   const klog = typeof tx?.klog === "function" ? tx.klog : () => {};
-  const verboseLogs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_update_start");
+  const verboseLogs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_update_start", { tableId });
   if (!tableId) return { ok: false, reason: "invalid" };
   if (!nextState || typeof nextState !== "object" || Array.isArray(nextState)) {
     klog("ws_state_update_invalid", { reason: "invalid_state_payload" });

--- a/ws-server/poker/persistence/sql-admin.mjs
+++ b/ws-server/poker/persistence/sql-admin.mjs
@@ -1,5 +1,6 @@
 import postgres from "postgres";
 import { serializePokerLogPayload } from "../observability/poker-log-policy.mjs";
+import { pokerLogRuntimeControl } from "../observability/poker-log-runtime-control.mjs";
 
 const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL || "";
 const DB_MAX_RAW = Number(process.env.SUPABASE_DB_MAX || process.env.POKER_DB_MAX || 5);
@@ -9,6 +10,7 @@ const POSTGRES_OPTIONS = { max: DB_MAX, idle_timeout: 30, connect_timeout: 10, p
 const sql = SUPABASE_DB_URL ? postgres(SUPABASE_DB_URL, POSTGRES_OPTIONS) : null;
 
 function klog(kind, data) {
+  if (!pokerLogRuntimeControl.shouldEmit(kind, data)) return;
   process.stdout.write(`[klog] ${kind} ${serializePokerLogPayload(kind, data)}\n`);
 }
 

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -769,8 +769,11 @@ export function createAcceptedBotStepExecutor({
   klog = () => {}
 } = {}) {
   const staticVerboseAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
-  const logVerbose = (kind, createPayload) => {
-    if (!staticVerboseAutoplayLogs && !pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
+  const logVerbose = (kind, createPayload, { tableId = null } = {}) => {
+    if (
+      !staticVerboseAutoplayLogs
+      && !pokerLogRuntimeControl.mayBuildDebugPayload(kind, { tableId })
+    ) return;
     klog(kind, createPayload());
   };
 
@@ -792,7 +795,7 @@ export function createAcceptedBotStepExecutor({
           ? Number(result.finalStateVersion)
           : Number(tableManager.persistedStateVersion(tableId) || 0),
         shouldContinue: result?.shouldContinue === true
-      }));
+      }), { tableId });
       return result;
     };
     let lastKnown = {
@@ -859,7 +862,7 @@ export function createAcceptedBotStepExecutor({
       ...buildDiagnosticSnapshot(state),
       stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0),
       maxActions: 1
-    }));
+    }), { tableId });
     try {
       let broadcastedStepCount = 0;
       let lastBroadcastStateVersion = null;
@@ -910,7 +913,7 @@ export function createAcceptedBotStepExecutor({
               runtimeFlavor,
               tableId,
               verboseLogs: staticVerboseAutoplayLogs
-                || pokerLogRuntimeControl.mayBuildDebugPayload("ws_bot_autoplay_showdown_preflight"),
+                || pokerLogRuntimeControl.mayBuildDebugPayload("ws_bot_autoplay_showdown_preflight", { tableId }),
               trustedStateSource
             }
           );
@@ -929,7 +932,7 @@ export function createAcceptedBotStepExecutor({
             legalActionSummary: legalSummary,
             ...buildDiagnosticSnapshot(statePublic),
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
-          }));
+          }), { tableId });
           return botLegal;
         },
         beforeBotActionStep: async ({
@@ -960,7 +963,7 @@ export function createAcceptedBotStepExecutor({
               delayMs: reactionDelayMs,
               ...buildDiagnosticSnapshot(responseFinalState),
               stateVersion: Number(loopVersion || tableManager.persistedStateVersion(tableId) || 0)
-            }));
+            }), { tableId });
             await sleep(reactionDelayMs);
           }
 
@@ -1019,14 +1022,14 @@ export function createAcceptedBotStepExecutor({
               action
             }),
             legalActionSummary: summarizeLegalActions(legalActions)
-          }));
+          }), { tableId });
           lastKnown = { ...lastKnown, stage: "action_chosen", actionType: action?.type || null, actionAmount: action?.amount ?? null };
           logVerbose("ws_bot_autoplay_action_chosen", () => ({
             ...baseLog,
             botTurnUserId: typeof lastKnown?.state?.turnUserId === "string" ? lastKnown.state.turnUserId : null,
             actionType: action?.type || null,
             amount: action?.amount ?? null
-          }));
+          }), { tableId });
           return action;
         },
         isBotTurn,
@@ -1041,7 +1044,7 @@ export function createAcceptedBotStepExecutor({
             ...buildDiagnosticSnapshot(safeState),
             legalActionSummary: lastKnown.legalActionSummary,
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
-          }));
+          }), { tableId });
           const applied = applyRuntimeAction(loopPrivateState, botAction);
           const nextState = withoutPrivateState(applied?.state);
           lastKnown = { ...lastKnown, stage: "apply_result", state: nextState };
@@ -1053,7 +1056,7 @@ export function createAcceptedBotStepExecutor({
             ...buildDiagnosticSnapshot(nextState),
             legalActionSummary: lastKnown.legalActionSummary,
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
-          }));
+          }), { tableId });
           return applied;
         },
         persistStep: async ({ botTurnUserId, botAction, botRequestId, fromState }) => {
@@ -1065,7 +1068,7 @@ export function createAcceptedBotStepExecutor({
             ...buildDiagnosticSnapshot(fromState),
             legalActionSummary: lastKnown.legalActionSummary,
             stateVersion: Number(tableManager.persistedStateVersion(tableId) || 0)
-          }));
+          }), { tableId });
           const applied = tableManager.applyAction({
             tableId,
             handId: fromState?.handId,
@@ -1084,7 +1087,7 @@ export function createAcceptedBotStepExecutor({
               amount: botAction?.amount ?? null,
               ok: false,
               reason: applied?.reason || "bot_action_rejected"
-            }));
+            }), { tableId });
             return { ok: false, reason: applied?.reason || "bot_action_rejected" };
           }
 
@@ -1110,7 +1113,7 @@ export function createAcceptedBotStepExecutor({
               amount: botAction?.amount ?? null,
               ok: false,
               reason: persisted?.reason || "persist_failed"
-            }));
+            }), { tableId });
             return { ok: false, reason: persisted?.reason || "persist_failed" };
           }
 
@@ -1124,7 +1127,7 @@ export function createAcceptedBotStepExecutor({
             amount: botAction?.amount ?? null,
             ok: true,
             stateVersion: Number(applied.stateVersion)
-          }));
+          }), { tableId });
           logVerbose("ws_bot_autoplay_state_after_step", () => ({
             ...baseLog,
             botTurnUserId: botTurnUserId || null,
@@ -1133,7 +1136,7 @@ export function createAcceptedBotStepExecutor({
             ...buildDiagnosticSnapshot(latestState),
             legalActionSummary: lastKnown.legalActionSummary,
             stateVersion: Number(applied.stateVersion)
-          }));
+          }), { tableId });
           try {
             await onBotStepPersisted({
               tableId,

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -14,6 +14,7 @@ import { computeShowdown as computeLegacyShowdown } from "../snapshot-runtime/po
 import { awardPotsAtShowdown as awardLegacyPotsAtShowdown } from "../snapshot-runtime/poker-payout.mjs";
 import { withoutPrivateState as withoutLegacyPrivateState } from "../snapshot-runtime/poker-state-utils.mjs";
 import { computeLegalActions as computeLegacyLegalActions } from "../snapshot-runtime/poker-legal-actions.mjs";
+import { pokerLogRuntimeControl } from "../observability/poker-log-runtime-control.mjs";
 
 const DEFAULT_SHARED_AUTOPLAY_MODULE_URL = new URL("../../shared/poker-domain/poker-autoplay.mjs", import.meta.url).href;
 const sharedAutoplayModulePromiseByUrl = new Map();
@@ -634,6 +635,7 @@ function materializeShowdownState(stateToMaterialize, seatOrder, holeCardsByUser
     });
     if (options?.verboseLogs === true && typeof klog === "function") {
       klog("ws_bot_autoplay_showdown_preflight", {
+        tableId: options?.tableId || null,
         handId: typeof stateToMaterialize?.handId === "string" ? stateToMaterialize.handId : null,
         phase: typeof stateToMaterialize?.phase === "string" ? stateToMaterialize.phase : null,
         communityLen: showdownInputs.communityLen,
@@ -766,9 +768,9 @@ export function createAcceptedBotStepExecutor({
   sleep = sleepMs,
   klog = () => {}
 } = {}) {
-  const verboseAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
+  const staticVerboseAutoplayLogs = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
   const logVerbose = (kind, createPayload) => {
-    if (!verboseAutoplayLogs) return;
+    if (!staticVerboseAutoplayLogs && !pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
     klog(kind, createPayload());
   };
 
@@ -906,7 +908,9 @@ export function createAcceptedBotStepExecutor({
             {
               ...options,
               runtimeFlavor,
-              verboseLogs: verboseAutoplayLogs,
+              tableId,
+              verboseLogs: staticVerboseAutoplayLogs
+                || pokerLogRuntimeControl.mayBuildDebugPayload("ws_bot_autoplay_showdown_preflight"),
               trustedStateSource
             }
           );

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -529,7 +529,7 @@ export async function runTableJanitor({
       ok: true,
       changed: false,
       reasonCode: normalizedClassification.reasonCode || null
-    }));
+    }), { tableId: normalizedClassification.tableId || null });
     return result;
   }
 
@@ -582,7 +582,9 @@ export async function runTableJanitor({
     && result?.closed !== true
     && result?.status === "seat_missing";
   if (routineSeatMissingNoop) {
-    klogVerbose("ws_table_janitor_result", createResultLogPayload);
+    klogVerbose("ws_table_janitor_result", createResultLogPayload, {
+      tableId: normalizedClassification.tableId || null
+    });
   } else {
     klog("ws_table_janitor_result", createResultLogPayload());
   }

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -27,6 +27,7 @@ import {
   resolvePokerLogPolicy,
   serializePokerLogPayload
 } from "./poker/observability/poker-log-policy.mjs";
+import { createPokerLogRuntimeControl } from "./poker/observability/poker-log-runtime-control.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
@@ -74,7 +75,7 @@ test("poker log policy classifies every production WS poker event", async () => 
 
   for (const sourceFile of sourceFiles) {
     const source = await fs.readFile(sourceFile, "utf8");
-    const literalPattern = /\b(?:klog|klogSafe|klogVerbose|klogBotAutoplayVerbose|logVerbose)\(\s*["']((?:ws|poker|shared|chips)_[a-z0-9_]+)["']/g;
+    const literalPattern = /\b(?:audit|klog|klogSafe|klogVerbose|klogBotAutoplayVerbose|logVerbose)\(\s*["']((?:ws|poker|shared|chips)_[a-z0-9_]+)["']/g;
     let match;
     while ((match = literalPattern.exec(source))) {
       literalEvents.add(match[1]);
@@ -196,6 +197,71 @@ test("poker log serialization failures use a safe classified fallback", () => {
       severity: "DEBUG",
       category: "janitor"
     }
+  );
+});
+
+test("poker log runtime control isolates DEBUG scopes, preserves ERROR, and expires overrides", () => {
+  let nowMs = Date.parse("2026-07-28T12:00:00Z");
+  const audits = [];
+  const timers = new Set();
+  const control = createPokerLogRuntimeControl({
+    env: { WS_POKER_LOG_LEVEL: "INFO" },
+    now: () => nowMs,
+    setTimer: (fn) => {
+      const timer = { fn, unref() {} };
+      timers.add(timer);
+      return timer;
+    },
+    clearTimer: (timer) => timers.delete(timer),
+    audit: (event, payload) => audits.push({ event, payload })
+  });
+  const tableA = "11111111-1111-4111-8111-111111111111";
+  const tableB = "22222222-2222-4222-8222-222222222222";
+
+  assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableA }), false);
+  assert.equal(control.shouldEmit("ws_state_persist_failed", { tableId: tableA }), true);
+  assert.equal(control.mayBuildDebugPayload("ws_state_persist_start"), false);
+  assert.equal(control.mayBuildDebugPayload("ws_table_janitor_result"), false);
+  control.enable({ scope: "table", tableId: tableA, ttlMs: 60_000 });
+  assert.equal(control.mayBuildDebugPayload("ws_state_persist_start"), true);
+  assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableA }), true);
+  assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableB }), false);
+  control.enable({ scope: "category", category: "autoplay", ttlMs: 120_000 });
+  assert.equal(control.shouldEmit("ws_bot_autoplay_loop_start", { tableId: tableB }), true);
+  assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), false);
+  control.enable({ scope: "global", ttlMs: 180_000 });
+  assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), true);
+  control.disable({ scope: "global" });
+  assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), false);
+
+  nowMs += 61_000;
+  for (const timer of [...timers]) timer.fn();
+  assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableA }), false);
+  assert.equal(audits.some(({ event }) => event === "ws_poker_debug_override_expired"), true);
+  assert.equal(control.disable({ scope: "table", tableId: tableA }).overrides.length, 1);
+});
+
+test("poker log runtime control rejects invalid scopes, TTLs, categories, and table capacity", () => {
+  const invalidConfig = createPokerLogRuntimeControl({
+    env: { WS_POKER_LOG_LEVEL: "anything" },
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {}
+  });
+  assert.equal(invalidConfig.defaultLevel, "INFO");
+  assert.equal(invalidConfig.invalidConfiguredLevel, true);
+
+  const control = createPokerLogRuntimeControl({
+    tableOverrideLimit: 1,
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {}
+  });
+  assert.throws(() => control.enable({ scope: "global", ttlMs: 1 }), /invalid_ttl/);
+  assert.throws(() => control.enable({ scope: "category", category: "anything", ttlMs: 60_000 }), /invalid_category/);
+  assert.throws(() => control.enable({ scope: "user", ttlMs: 60_000 }), /invalid_scope/);
+  control.enable({ scope: "table", tableId: "guest_one", ttlMs: 60_000 });
+  assert.throws(
+    () => control.enable({ scope: "table", tableId: "guest_two", ttlMs: 60_000 }),
+    /table_override_capacity/
   );
 });
 
@@ -493,6 +559,78 @@ test("internal bot reaction admin endpoint requires its token and fails closed o
     });
     assert.equal(blocked.status, 403);
     assert.deepEqual(await blocked.json(), { error: "preview_only" });
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("internal poker log control requires auth and exposes bounded no-store enable/disable state", async () => {
+  const token = "internal-log-control-token";
+  const adminUserId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const { port, child } = await createServer({
+    env: {
+      POKER_WS_INTERNAL_TOKEN: token,
+      WS_POKER_LOG_LEVEL: "INFO"
+    }
+  });
+  const url = `http://127.0.0.1:${port}/internal/admin/poker-log-control`;
+  try {
+    await waitForListening(child, 5000);
+    assert.equal((await fetch(url)).status, 401);
+
+    const headers = {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json"
+    };
+    const initial = await fetch(url, { headers });
+    assert.equal(initial.status, 200);
+    assert.equal(initial.headers.get("cache-control"), "no-store");
+    assert.deepEqual((await initial.json()).overrides, []);
+
+    const enabled = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operation: "enable",
+        scope: "table",
+        category: null,
+        tableId: "guest_runtime_debug",
+        ttlMs: 60_000,
+        adminUserId
+      })
+    });
+    assert.equal(enabled.status, 200);
+    assert.equal((await enabled.json()).overrides[0].tableId, "guest_runtime_debug");
+
+    const disabled = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operation: "disable",
+        scope: "table",
+        category: null,
+        tableId: "guest_runtime_debug",
+        adminUserId
+      })
+    });
+    assert.equal(disabled.status, 200);
+    assert.deepEqual((await disabled.json()).overrides, []);
+
+    const invalid = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        operation: "enable",
+        scope: "global",
+        category: null,
+        tableId: null,
+        ttlMs: 1,
+        adminUserId
+      })
+    });
+    assert.equal(invalid.status, 400);
+    assert.deepEqual(await invalid.json(), { error: "invalid_ttl" });
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -223,13 +223,31 @@ test("poker log runtime control isolates DEBUG scopes, preserves ERROR, and expi
   assert.equal(control.mayBuildDebugPayload("ws_state_persist_start"), false);
   assert.equal(control.mayBuildDebugPayload("ws_table_janitor_result"), false);
   control.enable({ scope: "table", tableId: tableA, ttlMs: 60_000 });
-  assert.equal(control.mayBuildDebugPayload("ws_state_persist_start"), true);
+  let tableAFactoryCalls = 0;
+  let tableBFactoryCalls = 0;
+  const buildDebugPayload = (tableId, factory) => {
+    if (control.mayBuildDebugPayload("ws_state_persist_start", { tableId })) factory();
+  };
+  buildDebugPayload(tableB, () => {
+    tableBFactoryCalls += 1;
+  });
+  buildDebugPayload(tableA, () => {
+    tableAFactoryCalls += 1;
+  });
+  assert.equal(tableBFactoryCalls, 0);
+  assert.equal(tableAFactoryCalls, 1);
+  assert.equal(control.mayBuildDebugPayload("ws_state_persist_start"), false);
   assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableA }), true);
   assert.equal(control.shouldEmit("ws_state_persist_start", { tableId: tableB }), false);
   control.enable({ scope: "category", category: "autoplay", ttlMs: 120_000 });
+  assert.equal(
+    control.mayBuildDebugPayload("ws_bot_autoplay_loop_start", { tableId: tableB }),
+    true
+  );
   assert.equal(control.shouldEmit("ws_bot_autoplay_loop_start", { tableId: tableB }), true);
   assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), false);
   control.enable({ scope: "global", ttlMs: 180_000 });
+  assert.equal(control.mayBuildDebugPayload("ws_restore_start", { tableId: tableB }), true);
   assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), true);
   control.disable({ scope: "global" });
   assert.equal(control.shouldEmit("ws_restore_start", { tableId: tableB }), false);

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -283,6 +283,32 @@ test("poker log runtime control rejects invalid scopes, TTLs, categories, and ta
   );
 });
 
+test("poker log runtime control canonicalizes table override identifiers", () => {
+  const control = createPokerLogRuntimeControl({
+    env: { WS_POKER_LOG_LEVEL: "INFO" },
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {}
+  });
+  const uppercaseTableId = "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA";
+  const lowercaseTableId = uppercaseTableId.toLowerCase();
+
+  const enabled = control.enable({
+    scope: "table",
+    tableId: uppercaseTableId,
+    ttlMs: 60_000
+  });
+  assert.equal(enabled.overrides[0].tableId, lowercaseTableId);
+  assert.equal(
+    control.mayBuildDebugPayload("ws_state_persist_start", { tableId: lowercaseTableId }),
+    true
+  );
+  assert.equal(
+    control.shouldEmit("ws_state_persist_start", { tableId: lowercaseTableId }),
+    true
+  );
+  assert.equal(control.disable({ scope: "table", tableId: lowercaseTableId }).overrides.length, 0);
+});
+
 test("bot claims recovery stops when a socket appears while the executor is loading", async () => {
   let activePresence = false;
   let loadCalls = 0;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -493,13 +493,13 @@ function klogSafe(kind, data) {
   }
 }
 
-function klogVerbose(kind, createData) {
-  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
+function klogVerbose(kind, createData, { tableId = null } = {}) {
+  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind, { tableId })) return;
   klogSafe(kind, createData());
 }
 
-function klogBotAutoplayVerbose(kind, createData) {
-  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
+function klogBotAutoplayVerbose(kind, createData, { tableId = null } = {}) {
+  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind, { tableId })) return;
   klogSafe(kind, createData());
 }
 
@@ -761,7 +761,7 @@ function scheduleObservedBotTurn({ tableId, trigger, requestId = null, frameTs =
       tableId,
       trigger: trigger || null,
       scheduleKey
-    }));
+    }), { tableId });
     return true;
   } catch (error) {
     scheduledObservedBotTurnKeys.delete(tableId);
@@ -1390,8 +1390,8 @@ async function persistMutatedState({
   const privateStateForHoleCards = privateStateForHoleCardsOverride || (typeof tableManager.privatePokerStateForAudit === "function"
     ? tableManager.privatePokerStateForAudit(tableId)
     : nextState);
-  const persistStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_persist_start") ? Date.now() : 0;
-  klogVerbose("ws_state_persist_start", () => ({ tableId, expectedVersion, mutationKind }));
+  const persistStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_persist_start", { tableId }) ? Date.now() : 0;
+  klogVerbose("ws_state_persist_start", () => ({ tableId, expectedVersion, mutationKind }), { tableId });
   const persisted = await persistedStateWriter.writeMutation({
     tableId,
     expectedVersion,
@@ -1416,7 +1416,7 @@ async function persistMutatedState({
     mutationKind,
     newVersion: persisted.newVersion ?? null,
     durationMs: Math.max(0, Date.now() - persistStartedAtMs)
-  }));
+  }), { tableId });
   if (!deferRuntimeVersionUpdate && persisted.outcome !== "durable_replay") {
     tableManager.setPersistedStateVersion(tableId, persisted.newVersion);
   }
@@ -1427,13 +1427,13 @@ async function restoreTableFromPersisted(tableId) {
   if (typeof loadPersistedTableBootstrap !== "function") {
     return { ok: false, reason: "persisted_bootstrap_disabled" };
   }
-  const restoreStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_restore_start") ? Date.now() : null;
+  const restoreStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_restore_start", { tableId }) ? Date.now() : null;
   klogVerbose("ws_restore_start", () => ({
     tableId,
     stage: "load",
     ok: null,
     durationMs: 0
-  }));
+  }), { tableId });
   try {
     const restored = await loadPersistedTableBootstrap({ tableId });
     if (!restored?.ok || !restored?.table) {
@@ -1449,7 +1449,7 @@ async function restoreTableFromPersisted(tableId) {
         ok: false,
         reason,
         durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
-      }));
+      }), { tableId });
       return { ok: false, reason };
     }
     persistedStateWriter?.forgetHoleCardAcknowledgement(tableId);
@@ -1467,7 +1467,7 @@ async function restoreTableFromPersisted(tableId) {
         ok: false,
         reason,
         durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
-      }));
+      }), { tableId });
       return applied;
     }
     maybeScheduleSettledRollover(tableId);
@@ -1476,7 +1476,7 @@ async function restoreTableFromPersisted(tableId) {
       stage: "apply",
       ok: true,
       durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
-    }));
+    }), { tableId });
     return {
       ...applied,
       restoredTable: restored.table
@@ -1489,7 +1489,7 @@ async function restoreTableFromPersisted(tableId) {
       ok: false,
       reason: "restore_error",
       durationMs: Math.max(0, Date.now() - restoreStartedAtMs)
-    }));
+    }), { tableId });
     return { ok: false, reason: "restore_error" };
   }
 }
@@ -1792,7 +1792,7 @@ function scheduleSettledRolloverTimer({ tableId, generationKey, dueAt, attempt =
     delayMs,
     attempt,
     mode
-  }));
+  }), { tableId });
   const timer = setTimeout(() => {
     settledRolloverTimerByTableId.delete(tableId);
     void enqueueTableCommand({
@@ -1825,7 +1825,7 @@ function scheduleSettledRolloverRetry({ tableId, generationKey, attempt }) {
 }
 
 async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }) {
-  const rolloverStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_settled_rollover_start") ? Date.now() : null;
+  const rolloverStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_settled_rollover_start", { tableId }) ? Date.now() : null;
   const finishSettledRollover = (result) => {
     klogVerbose("ws_settled_rollover_outcome", () => ({
       tableId,
@@ -1835,14 +1835,14 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
       closed: result?.closed === true,
       reason: result?.reason || result?.code || result?.status || (result?.changed === true ? "changed" : "unchanged"),
       durationMs: Math.max(0, Date.now() - rolloverStartedAtMs)
-    }));
+    }), { tableId });
     return result;
   };
   let pokerState = tableManager.persistedPokerState(tableId);
   if (settledRolloverGenerationKey(tableId, pokerState) !== generationKey) {
     return finishSettledRollover({ ok: true, changed: false, reason: "settled_generation_changed" });
   }
-  klogVerbose("ws_settled_rollover_start", () => ({ tableId, attempt }));
+  klogVerbose("ws_settled_rollover_start", () => ({ tableId, attempt }), { tableId });
   if (!isGuestTableId(tableId) && hasSupabaseDbUrl) {
     const finalizeDeferredLeaves = await loadDeferredLeaveFinalizer();
     const finalized = await finalizeDeferredLeaves({ tableId });
@@ -3546,7 +3546,9 @@ wss.on("connection", (ws) => {
           scheduleBotStep,
           klog: klogSafe,
           klogVerbose,
-          verboseLogsEnabled: pokerLogRuntimeControl.mayBuildDebugPayload("ws_join_authoritative_start")
+          verboseLogsEnabled: pokerLogRuntimeControl.mayBuildDebugPayload("ws_join_authoritative_start", {
+            tableId: frame.__resolvedTableId
+          })
         })
       });
       maybeScheduleSettledRollover(frame.__resolvedTableId);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -51,6 +51,10 @@ import { recoverFromPersistConflict } from "./poker/runtime/persist-conflict-rec
 import { resolveSettledRevealDueAt } from "./poker/runtime/settled-reveal-timing.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
 import { serializePokerLogPayload } from "./poker/observability/poker-log-policy.mjs";
+import {
+  pokerLogRuntimeControl,
+  setPokerLogRuntimeAuditLogger
+} from "./poker/observability/poker-log-runtime-control.mjs";
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
@@ -476,6 +480,7 @@ const turnTimeoutQuarantineMs = resolvePositiveInt(process.env.WS_TIMEOUT_QUARAN
 });
 
 function klog(kind, data) {
+  if (!pokerLogRuntimeControl.shouldEmit(kind, data)) return;
   process.stdout.write(`[klog] ${kind} ${serializePokerLogPayload(kind, data)}\n`);
 }
 
@@ -488,17 +493,19 @@ function klogSafe(kind, data) {
   }
 }
 
-const verbosePokerLogs = process.env.WS_POKER_VERBOSE_LOGS === "1";
-const verboseBotAutoplayLogs = process.env.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";
-
 function klogVerbose(kind, createData) {
-  if (!verbosePokerLogs) return;
+  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
   klogSafe(kind, createData());
 }
 
 function klogBotAutoplayVerbose(kind, createData) {
-  if (!verboseBotAutoplayLogs) return;
+  if (!pokerLogRuntimeControl.mayBuildDebugPayload(kind)) return;
   klogSafe(kind, createData());
+}
+
+setPokerLogRuntimeAuditLogger(klogSafe);
+if (pokerLogRuntimeControl.invalidConfiguredLevel) {
+  klogSafe("ws_poker_log_config_invalid", { fallbackLevel: pokerLogRuntimeControl.defaultLevel });
 }
 
 const botAutoplayLogSummaryMs = resolvePositiveInt(process.env.WS_BOT_AUTOPLAY_LOG_SUMMARY_MS, 60_000, {
@@ -1383,7 +1390,7 @@ async function persistMutatedState({
   const privateStateForHoleCards = privateStateForHoleCardsOverride || (typeof tableManager.privatePokerStateForAudit === "function"
     ? tableManager.privatePokerStateForAudit(tableId)
     : nextState);
-  const persistStartedAtMs = verbosePokerLogs ? Date.now() : 0;
+  const persistStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_state_persist_start") ? Date.now() : 0;
   klogVerbose("ws_state_persist_start", () => ({ tableId, expectedVersion, mutationKind }));
   const persisted = await persistedStateWriter.writeMutation({
     tableId,
@@ -1420,7 +1427,7 @@ async function restoreTableFromPersisted(tableId) {
   if (typeof loadPersistedTableBootstrap !== "function") {
     return { ok: false, reason: "persisted_bootstrap_disabled" };
   }
-  const restoreStartedAtMs = verbosePokerLogs ? Date.now() : null;
+  const restoreStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_restore_start") ? Date.now() : null;
   klogVerbose("ws_restore_start", () => ({
     tableId,
     stage: "load",
@@ -1818,7 +1825,7 @@ function scheduleSettledRolloverRetry({ tableId, generationKey, attempt }) {
 }
 
 async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }) {
-  const rolloverStartedAtMs = verbosePokerLogs ? Date.now() : null;
+  const rolloverStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_settled_rollover_start") ? Date.now() : null;
   const finishSettledRollover = (result) => {
     klogVerbose("ws_settled_rollover_outcome", () => ({
       tableId,
@@ -2678,7 +2685,7 @@ async function sweepZombieTablesAndBroadcast() {
 async function listOpenTableIdsForJanitor({ limit = 10 } = {}) {
   if (!persistedBootstrapEnabled) return [];
   const boundedLimit = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 100) : 10;
-  const selectionStartedAtMs = verbosePokerLogs ? Date.now() : 0;
+  const selectionStartedAtMs = pokerLogRuntimeControl.mayBuildDebugPayload("ws_open_table_reconciler_batch_selected") ? Date.now() : 0;
   // UUID order is immutable and round-trips exactly, so the boundary row cannot requeue itself.
   const hasCursor = Boolean(typeof openTableJanitorCursor?.tableId === "string"
     && openTableJanitorCursor.tableId.trim());
@@ -2905,6 +2912,75 @@ async function handleInternalBotReactionConfig(req, res) {
   }
 }
 
+async function handleInternalPokerLogControl(req, res) {
+  if (req.method !== "GET" && req.method !== "POST") {
+    sendInternalJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!internalRuntimeToken) {
+    sendInternalJson(res, 503, { error: "internal_runtime_token_missing" });
+    return;
+  }
+  const authHeader = typeof req.headers?.authorization === "string" ? req.headers.authorization.trim() : "";
+  if (authHeader !== `Bearer ${internalRuntimeToken}`) {
+    sendInternalJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  try {
+    if (req.method === "GET") {
+      sendInternalJson(res, 200, pokerLogRuntimeControl.snapshot());
+      return;
+    }
+    const payload = await readJsonBody(req, { maxBytes: 2_048 });
+    const operation = typeof payload?.operation === "string" ? payload.operation.trim().toLowerCase() : "";
+    const scope = typeof payload?.scope === "string" ? payload.scope.trim().toLowerCase() : "";
+    const adminUserId = typeof payload?.adminUserId === "string" ? payload.adminUserId.trim() : "";
+    const adminIdValid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(adminUserId);
+    const scopeFieldsValid = (
+      (scope === "global" && payload?.category === null && payload?.tableId === null)
+      || (scope === "category" && typeof payload?.category === "string" && payload?.tableId === null)
+      || (scope === "table" && payload?.category === null && typeof payload?.tableId === "string")
+    );
+    const commonValid = adminIdValid && scopeFieldsValid;
+    let result;
+    if (
+      operation === "enable"
+      && commonValid
+      && hasExactKeys(payload, ["operation", "scope", "category", "tableId", "ttlMs", "adminUserId"])
+      && Object.keys(payload).length === 6
+    ) {
+      result = pokerLogRuntimeControl.enable({
+        scope,
+        category: payload.category,
+        tableId: payload.tableId,
+        ttlMs: payload.ttlMs,
+        adminUserId
+      });
+    } else if (
+      operation === "disable"
+      && commonValid
+      && hasExactKeys(payload, ["operation", "scope", "category", "tableId", "adminUserId"])
+      && Object.keys(payload).length === 5
+    ) {
+      result = pokerLogRuntimeControl.disable({
+        scope,
+        category: payload.category,
+        tableId: payload.tableId,
+        adminUserId
+      });
+    } else {
+      sendInternalJson(res, 400, { error: "invalid_request" });
+      return;
+    }
+    sendInternalJson(res, 200, result);
+  } catch (error) {
+    const code = error?.code || (error instanceof SyntaxError ? "invalid_json" : "internal_server_error");
+    const statusCode = Number(error?.status)
+      || (code === "body_too_large" || code === "invalid_json" ? 400 : 500);
+    sendInternalJson(res, statusCode, { error: code });
+  }
+}
+
 async function handleInternalBotClaimsRecovery(req, res) {
   if (req.method !== "POST") {
     sendInternalJson(res, 405, { error: "method_not_allowed" });
@@ -3102,6 +3178,11 @@ async function handleHttpRequest(req, res) {
 
   if (req.url === "/internal/admin/bot-reaction") {
     await handleInternalBotReactionConfig(req, res);
+    return;
+  }
+
+  if (req.url === "/internal/admin/poker-log-control") {
+    await handleInternalPokerLogControl(req, res);
     return;
   }
 
@@ -3465,7 +3546,7 @@ wss.on("connection", (ws) => {
           scheduleBotStep,
           klog: klogSafe,
           klogVerbose,
-          verboseLogsEnabled: verbosePokerLogs
+          verboseLogsEnabled: pokerLogRuntimeControl.mayBuildDebugPayload("ws_join_authoritative_start")
         })
       });
       maybeScheduleSettledRollover(frame.__resolvedTableId);

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -783,6 +783,7 @@ test("authoritative join adapter resolves in ws artifact layout without netlify 
       ["ws-server/poker/persistence/sql-admin.mjs", "poker/persistence/sql-admin.mjs"],
       ["ws-server/poker/persistence/poker-state-write-locked.mjs", "poker/persistence/poker-state-write-locked.mjs"],
       ["ws-server/poker/observability/poker-log-policy.mjs", "poker/observability/poker-log-policy.mjs"],
+      ["ws-server/poker/observability/poker-log-runtime-control.mjs", "poker/observability/poker-log-runtime-control.mjs"],
       ["ws-server/poker/snapshot-runtime/poker-state-utils.mjs", "poker/snapshot-runtime/poker-state-utils.mjs"],
       ["ws-server/poker/bootstrap/persisted-bootstrap-db.mjs", "poker/bootstrap/persisted-bootstrap-db.mjs"],
       ["shared/poker-domain/join.mjs", "shared/poker-domain/join.mjs"],

--- a/ws-tests/ws-ws-dependency.guard.test.mjs
+++ b/ws-tests/ws-ws-dependency.guard.test.mjs
@@ -230,13 +230,21 @@ test("ws authoritative leave adapter default loader resolves in artifact-shaped 
   try {
     const stagedAdapter = path.join(stageDir, "poker/persistence/authoritative-leave-adapter.mjs");
     const stagedBootstrap = path.join(stageDir, "poker/bootstrap/persisted-bootstrap-db.mjs");
+    const stagedLogPolicy = path.join(stageDir, "poker/observability/poker-log-policy.mjs");
+    const stagedLogRuntimeControl = path.join(stageDir, "poker/observability/poker-log-runtime-control.mjs");
     const stagedLeave = path.join(stageDir, "shared/poker-domain/leave.mjs");
 
     await fsp.mkdir(path.dirname(stagedAdapter), { recursive: true });
     await fsp.mkdir(path.dirname(stagedBootstrap), { recursive: true });
+    await fsp.mkdir(path.dirname(stagedLogPolicy), { recursive: true });
     await fsp.mkdir(path.dirname(stagedLeave), { recursive: true });
 
     await fsp.copyFile(srcAdapter, stagedAdapter);
+    await fsp.copyFile("ws-server/poker/observability/poker-log-policy.mjs", stagedLogPolicy);
+    await fsp.copyFile(
+      "ws-server/poker/observability/poker-log-runtime-control.mjs",
+      stagedLogRuntimeControl
+    );
     await fsp.writeFile(stagedBootstrap, "export async function beginSqlWs(fn) { return fn({}); }\n", "utf8");
     await fsp.writeFile(
       stagedLeave,


### PR DESCRIPTION
## Summary

- add a process-local poker log controller with default-level filtering and TTL-bound Global, Category, and Table DEBUG overrides
- apply the same filtering contract to both existing poker log sinks while preserving the current static verbose flags as compatibility inputs
- expose an authenticated internal WS endpoint for reading, enabling, updating, and disabling overrides
- audit override enable/update, disable, expiry, invalid startup configuration, and bounded table-override capacity
- keep diagnostic payload construction lazy when DEBUG is inactive

## Scope

This is PR B from the accepted plan for #775. It does not expose the endpoint through Netlify/Caddy and does not add Admin UI; that remains PR C.

The controller is process-local by design. Overrides are cleared by restart and automatically expire. `ERROR` events cannot be disabled. The default level is `INFO`, with `WS_POKER_LOG_LEVEL` allowing a startup default and the existing `WS_POKER_VERBOSE_LOGS` / `WS_BOT_AUTOPLAY_VERBOSE_LOGS` flags remaining compatible.

## Safety and breaking impact

- no gameplay, persistence schema, settlement, ledger, cleanup, or table lifecycle behavior changes
- unclassified legacy events continue to emit until their migration is complete
- classified DEBUG events are now centrally filtered unless enabled by the startup configuration, an existing verbose flag, or an active TTL override
- the internal endpoint requires the existing internal bearer token and returns `Cache-Control: no-store`

## Verification

- `npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- WS Preview workflow guard tests
- WS join runtime behavior tests
- `git diff --check`

An exact-SHA manual WS Preview Deploy and runtime verification are required before merge.

Refs #775
