### PR TITLE
feat: add Admin poker DEBUG controls

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -703,6 +703,63 @@
                 <div class="admin-note" id="adminOpsBotReactionStatus" aria-live="polite"></div>
               </section>
 
+              <section class="xp-card admin-card admin-card--wide" aria-labelledby="adminOpsPokerLogTitle">
+                <div class="admin-card__head">
+                  <div>
+                    <h2 class="xp-card__title" id="adminOpsPokerLogTitle">Poker DEBUG control</h2>
+                    <p class="admin-card__subtitle">Temporary process-local diagnostics. ERROR logging always remains enabled.</p>
+                  </div>
+                  <div class="admin-card__actions">
+                    <button class="admin-btn admin-btn--ghost" id="adminOpsPokerLogRefresh" type="button">Refresh state</button>
+                  </div>
+                </div>
+                <div id="adminOpsPokerLogSummary"></div>
+                <form class="admin-adjust" id="adminOpsPokerLogForm">
+                  <label class="admin-field">
+                    <span class="admin-field__label">Scope</span>
+                    <select class="admin-input" id="adminOpsPokerLogScope" name="scope">
+                      <option value="table">Table DEBUG</option>
+                      <option value="category">Category DEBUG</option>
+                      <option value="global">Global DEBUG</option>
+                    </select>
+                  </label>
+                  <label class="admin-field" id="adminOpsPokerLogCategoryField" hidden>
+                    <span class="admin-field__label">Category</span>
+                    <select class="admin-input" id="adminOpsPokerLogCategory" name="category"></select>
+                  </label>
+                  <div id="adminOpsPokerLogTableFields">
+                    <label class="admin-field">
+                      <span class="admin-field__label">Select an open table</span>
+                      <select class="admin-input" id="adminOpsPokerLogTable" name="tableId"></select>
+                    </label>
+                    <label class="admin-field" id="adminOpsPokerLogManualField" hidden>
+                      <span class="admin-field__label">Table ID</span>
+                      <input class="admin-input" id="adminOpsPokerLogManualTable" type="text" autocomplete="off" placeholder="Exact tableId">
+                      <span class="admin-field__hint">Manual table ID overrides the dropdown selection.</span>
+                    </label>
+                    <div class="admin-filter-actions">
+                      <button class="admin-btn admin-btn--ghost" id="adminOpsPokerLogTablesRefresh" type="button">Refresh tables</button>
+                    </div>
+                    <div class="admin-note" id="adminOpsPokerLogTablesStatus" aria-live="polite"></div>
+                  </div>
+                  <fieldset class="admin-field">
+                    <legend class="admin-field__label">TTL</legend>
+                    <div class="admin-filter-actions" id="adminOpsPokerLogTtlPresets"></div>
+                    <label class="admin-field" id="adminOpsPokerLogCustomTtlField" hidden>
+                      <span class="admin-field__label">Custom minutes</span>
+                      <input class="admin-input" id="adminOpsPokerLogCustomTtl" type="number" min="1" max="60" step="1" inputmode="numeric">
+                    </label>
+                    <span class="admin-field__hint" id="adminOpsPokerLogTtlHint"></span>
+                  </fieldset>
+                  <div class="admin-filter-actions">
+                    <button class="admin-btn admin-btn--primary" id="adminOpsPokerLogEnable" type="submit">Enable DEBUG</button>
+                  </div>
+                </form>
+                <div class="admin-note" id="adminOpsPokerLogStatus" aria-live="polite"></div>
+                <h3 class="admin-section-title">Active overrides</h3>
+                <div id="adminOpsPokerLogOverrides"></div>
+              </section>
+
               <section class="xp-card admin-card" aria-labelledby="adminOpsActionsTitle">
                 <div class="admin-card__head">
                   <div>

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -172,7 +172,7 @@ The preview VPS contract is:
 Preview deploys unpack into a temporary directory under `/tmp/arcadeplatform-ws-preview` and then sync the extracted files into `/opt/arcade-ws-preview/ws-server`.
 The `WS_PREVIEW_USER` SSH account must have passwordless sudo available to non-interactive GitHub Actions sessions. The workflow checks this with `sudo -n bash -c 'true'` before touching preview app contents because it needs elevated access to validate the systemd unit, read the preview env file, sync files into `/opt/arcade-ws-preview`, and restart `ws-server-preview.service`. Do not use `sudo -n -v` as the local smoke check here: it can still require a password when the same user has both normal passworded sudo rules and command-specific `NOPASSWD` rules.
 The workflow fails fast before mutating preview app contents when passwordless sudo, the preview base root, app dir, env file, service, Node.js, `tar`, `rsync`, `curl`, required `PORT=3001`, `WS_AUTHORITATIVE_JOIN_ENABLED=1`, non-empty `SUPABASE_DB_URL`, preview-only `POKER_WS_INTERNAL_TOKEN`, or stage Supabase project-ref match is missing. It also rejects retired `WS_BOT_REACTION_MIN_MS` and `WS_BOT_REACTION_MAX_MS` values so runtime changes have one source of truth.
-Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks. Only the preview host exposes the exact `/internal/admin/bot-reaction` reverse-proxy route; the production host must not expose it.
+Preview routing stays in `infra/vps/Caddyfile`, which must continue to define both the `ws.kcswh.pl -> 127.0.0.1:3000` and `ws-preview.kcswh.pl -> 127.0.0.1:3001` site blocks. Only the preview host exposes the exact `/internal/admin/bot-reaction` reverse-proxy route. Both hosts expose the exact `/internal/admin/poker-log-control` route for the environment-bound authenticated Netlify proxy; no wildcard `/internal/admin/*` route is allowed.
 
 ### WS Preview bot reaction control
 
@@ -186,6 +186,14 @@ Manual verification after both Netlify Deploy Preview and an explicit WS Preview
 2. Set `500 ms`, start a poker hand, and confirm subsequent bot decisions occur after about half a second.
 3. Click **Set default**, continue playing, and confirm subsequent bot decisions again vary within approximately `2000–4000 ms`.
 4. Restart or redeploy the preview WS and confirm the card returns to `Default` without database cleanup.
+
+### Poker DEBUG control
+
+Admin → Ops exposes process-local Global, Category, and Table DEBUG overrides with a mandatory server-bounded TTL. The Netlify context is bound to one WS origin: deploy previews use `https://ws-preview.kcswh.pl`, while production uses `https://ws.kcswh.pl`. Each context must define its own `POKER_WS_INTERNAL_BASE_URL` and matching `POKER_WS_INTERNAL_TOKEN`; never reuse the Preview token in Production.
+
+Table DEBUG is the normal diagnostic scope. The selector reuses the authenticated OPEN-table list and retains a manual exact-ID fallback. Global DEBUG is emergency-only and requires an additional browser confirmation on Production. Active overrides display a local countdown derived from `serverNow`; expiry remains authoritative in WS and does not depend on the Admin page.
+
+The control does not read journald, store logs in Supabase, change poker state, or suppress `ERROR`. Disable submits the exact active scope returned by WS. A restart clears all process-local overrides.
 
 Minimal preview sudoers coverage for `WS_PREVIEW_USER` must include the concrete programs used by the workflow: `systemctl`, `test`, `grep`, `bash`, `rm`, `mkdir`, `tar`, and `rsync`. On Ubuntu, verify the actual binary paths with `command -v systemctl test grep bash rm mkdir tar rsync`, then keep `/etc/sudoers.d/ws-preview-deploy` mode `0440`.
 

--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -9,6 +9,11 @@ ws.kcswh.pl {
     reverse_proxy 127.0.0.1:3000
   }
 
+  @pokerLogControlAdmin path /internal/admin/poker-log-control
+  handle @pokerLogControlAdmin {
+    reverse_proxy 127.0.0.1:3000
+  }
+
   handle {
     respond "OK" 200
   }
@@ -27,6 +32,11 @@ ws-preview.kcswh.pl {
 
   @botClaimsRecoveryAdmin path /internal/admin/bot-claims-recovery
   handle @botClaimsRecoveryAdmin {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  @pokerLogControlAdmin path /internal/admin/poker-log-control
+  handle @pokerLogControlAdmin {
     reverse_proxy 127.0.0.1:3001
   }
 

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -51,6 +51,18 @@
       botReactionError: null,
       botReactionMessage: "",
       botReactionPending: false,
+      pokerLogControl: null,
+      pokerLogControlError: null,
+      pokerLogControlMessage: "",
+      pokerLogControlPending: false,
+      pokerLogDisablePendingIndex: null,
+      pokerLogDisableErrorIndex: null,
+      pokerLogTables: [],
+      pokerLogTablesError: null,
+      pokerLogClockBaseMs: null,
+      pokerLogClockReceivedAtMs: null,
+      pokerLogExpiryRefreshDone: false,
+      pokerLogCountdownTimer: null,
       loaded: false,
     },
     pokerAudit: {
@@ -136,6 +148,25 @@
     nodes.opsBotReactionApply = doc.getElementById("adminOpsBotReactionApply");
     nodes.opsBotReactionDefault = doc.getElementById("adminOpsBotReactionDefault");
     nodes.opsBotReactionStatus = doc.getElementById("adminOpsBotReactionStatus");
+    nodes.opsPokerLogSummary = doc.getElementById("adminOpsPokerLogSummary");
+    nodes.opsPokerLogForm = doc.getElementById("adminOpsPokerLogForm");
+    nodes.opsPokerLogScope = doc.getElementById("adminOpsPokerLogScope");
+    nodes.opsPokerLogCategoryField = doc.getElementById("adminOpsPokerLogCategoryField");
+    nodes.opsPokerLogCategory = doc.getElementById("adminOpsPokerLogCategory");
+    nodes.opsPokerLogTableFields = doc.getElementById("adminOpsPokerLogTableFields");
+    nodes.opsPokerLogTable = doc.getElementById("adminOpsPokerLogTable");
+    nodes.opsPokerLogManualField = doc.getElementById("adminOpsPokerLogManualField");
+    nodes.opsPokerLogManualTable = doc.getElementById("adminOpsPokerLogManualTable");
+    nodes.opsPokerLogTablesRefresh = doc.getElementById("adminOpsPokerLogTablesRefresh");
+    nodes.opsPokerLogTablesStatus = doc.getElementById("adminOpsPokerLogTablesStatus");
+    nodes.opsPokerLogTtlPresets = doc.getElementById("adminOpsPokerLogTtlPresets");
+    nodes.opsPokerLogCustomTtlField = doc.getElementById("adminOpsPokerLogCustomTtlField");
+    nodes.opsPokerLogCustomTtl = doc.getElementById("adminOpsPokerLogCustomTtl");
+    nodes.opsPokerLogTtlHint = doc.getElementById("adminOpsPokerLogTtlHint");
+    nodes.opsPokerLogEnable = doc.getElementById("adminOpsPokerLogEnable");
+    nodes.opsPokerLogStatus = doc.getElementById("adminOpsPokerLogStatus");
+    nodes.opsPokerLogOverrides = doc.getElementById("adminOpsPokerLogOverrides");
+    nodes.opsPokerLogRefresh = doc.getElementById("adminOpsPokerLogRefresh");
     nodes.opsRefresh = doc.getElementById("adminOpsRefresh");
     nodes.opsRunReconciler = doc.getElementById("adminOpsRunReconciler");
     nodes.opsRunStaleSweep = doc.getElementById("adminOpsRunStaleSweep");
@@ -1127,6 +1158,7 @@
     var summary = state.ops.summary;
     var identity = state.ops.identity;
     renderBotReactionControl();
+    renderPokerLogControl();
     if (!summary && !identity){
       if (nodes.opsStats) nodes.opsStats.innerHTML = "";
       if (nodes.opsIdentity) nodes.opsIdentity.innerHTML = "";
@@ -1306,6 +1338,154 @@
     }
   }
 
+  function pokerLogNowMs(){
+    if (!Number.isFinite(state.ops.pokerLogClockBaseMs) || !Number.isFinite(state.ops.pokerLogClockReceivedAtMs)){
+      return Date.now();
+    }
+    return state.ops.pokerLogClockBaseMs + Math.max(0, Date.now() - state.ops.pokerLogClockReceivedAtMs);
+  }
+
+  function formatRemaining(expiresAt){
+    var remainingMs = Math.max(0, Date.parse(expiresAt) - pokerLogNowMs());
+    var seconds = Math.ceil(remainingMs / 1000);
+    var minutes = Math.floor(seconds / 60);
+    var rest = seconds % 60;
+    return minutes > 0 ? String(minutes) + "m " + String(rest) + "s remaining" : String(rest) + "s remaining";
+  }
+
+  function shortTableId(tableId){
+    var value = String(tableId || "");
+    return value.length > 8 ? value.slice(0, 8) + "…" : value;
+  }
+
+  function setPokerLogSnapshot(snapshot){
+    state.ops.pokerLogControl = snapshot || null;
+    state.ops.pokerLogClockBaseMs = snapshot ? Date.parse(snapshot.serverNow) : null;
+    state.ops.pokerLogClockReceivedAtMs = snapshot ? Date.now() : null;
+    state.ops.pokerLogExpiryRefreshDone = false;
+  }
+
+  function syncPokerLogCountdownTimer(){
+    var shouldRun = state.activeTab === "ops"
+      && state.ops.pokerLogControl
+      && Array.isArray(state.ops.pokerLogControl.overrides)
+      && state.ops.pokerLogControl.overrides.length > 0;
+    if (!shouldRun && state.ops.pokerLogCountdownTimer){
+      window.clearInterval(state.ops.pokerLogCountdownTimer);
+      state.ops.pokerLogCountdownTimer = null;
+    }
+    if (shouldRun && !state.ops.pokerLogCountdownTimer){
+      state.ops.pokerLogCountdownTimer = window.setInterval(function(){
+        var overrides = state.ops.pokerLogControl && state.ops.pokerLogControl.overrides || [];
+        var expired = overrides.some(function(item){ return Date.parse(item.expiresAt) <= pokerLogNowMs(); });
+        renderPokerLogOverrides();
+        if (expired && !state.ops.pokerLogExpiryRefreshDone){
+          state.ops.pokerLogExpiryRefreshDone = true;
+          loadPokerLogControl(true);
+        }
+      }, 1000);
+    }
+  }
+
+  function renderPokerLogOverrides(){
+    if (!nodes.opsPokerLogOverrides) return;
+    var snapshot = state.ops.pokerLogControl;
+    var overrides = snapshot && Array.isArray(snapshot.overrides) ? snapshot.overrides : [];
+    if (!overrides.length){
+      nodes.opsPokerLogOverrides.innerHTML = '<p class="admin-empty">No active DEBUG overrides.</p>';
+      syncPokerLogCountdownTimer();
+      return;
+    }
+    nodes.opsPokerLogOverrides.innerHTML = '<div class="admin-list">' + overrides.map(function(item, index){
+      var label = item.scope === "global"
+        ? "Global DEBUG"
+        : item.scope === "category"
+          ? "Category: " + item.category
+          : "Table: " + shortTableId(item.tableId);
+      return [
+        '<div class="admin-list__item">',
+        '<div class="admin-list__title"><span title="' + escapeHtml(item.tableId || item.category || "global") + '">' + escapeHtml(label) + "</span>",
+        '<button class="admin-btn admin-btn--ghost" type="button" data-poker-log-disable="' + String(index) + '"' + (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex === index ? " disabled" : "") + ">Disable</button></div>",
+        '<div class="admin-list__meta">' + escapeHtml(formatRemaining(item.expiresAt)) + (state.ops.pokerLogDisableErrorIndex === index ? " · Could not disable DEBUG." : "") + "</div>",
+        "</div>"
+      ].join("");
+    }).join("") + "</div>";
+    syncPokerLogCountdownTimer();
+  }
+
+  function renderPokerLogTables(){
+    if (!nodes.opsPokerLogTable) return;
+    var selected = nodes.opsPokerLogTable.value;
+    var items = state.ops.pokerLogTables || [];
+    var options = items.map(function(item){
+      var label = shortTableId(item.tableId) + " · " + (item.status || "OPEN") + "/" + (item.phase || "—");
+      if (item.humanCount != null && item.botCount != null){
+        label += " · " + item.humanCount + "H/" + item.botCount + "B";
+      }
+      return '<option value="' + escapeHtml(item.tableId) + '">' + escapeHtml(label) + "</option>";
+    });
+    options.push('<option value="__manual__">Enter table ID manually...</option>');
+    nodes.opsPokerLogTable.innerHTML = options.join("");
+    if (selected && items.some(function(item){ return item.tableId === selected; })) nodes.opsPokerLogTable.value = selected;
+    else if (!items.length) nodes.opsPokerLogTable.value = "__manual__";
+    var manual = nodes.opsPokerLogTable.value === "__manual__";
+    setVisible(nodes.opsPokerLogManualField, manual);
+    if (nodes.opsPokerLogTablesStatus){
+      nodes.opsPokerLogTablesStatus.textContent = state.ops.pokerLogTablesError
+        ? "Open tables unavailable. Enter a table ID manually."
+        : manual
+          ? items.length ? "Manual table ID is active." : "No open tables. Enter a table ID manually."
+          : "Selected OPEN table is active.";
+    }
+  }
+
+  function renderPokerLogControl(){
+    var snapshot = state.ops.pokerLogControl;
+    var pending = state.ops.pokerLogControlPending === true;
+    var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value || "table" : "table";
+    if (nodes.opsPokerLogSummary){
+      nodes.opsPokerLogSummary.innerHTML = snapshot
+        ? '<div class="admin-surface"><div class="admin-list__title"><span>Target environment</span>' + pill(snapshot.environment === "production" ? "Production" : "WS Preview", snapshot.environment === "production" ? "danger" : "info") + '</div><div class="admin-kv">' + renderKvRow("Default level", snapshot.defaultLevel) + "</div></div>"
+        : '<p class="admin-empty">' + escapeHtml(state.ops.pokerLogControlError ? "DEBUG control unavailable: " + state.ops.pokerLogControlError : "Loading DEBUG control…") + "</p>";
+    }
+    setVisible(nodes.opsPokerLogCategoryField, scope === "category");
+    setVisible(nodes.opsPokerLogTableFields, scope === "table");
+    if (nodes.opsPokerLogCategory && snapshot){
+      var selectedCategory = nodes.opsPokerLogCategory.value;
+      nodes.opsPokerLogCategory.innerHTML = (snapshot.categories || []).map(function(category){
+        return '<option value="' + escapeHtml(category) + '">' + escapeHtml(category) + "</option>";
+      }).join("");
+      if ((snapshot.categories || []).includes(selectedCategory)) nodes.opsPokerLogCategory.value = selectedCategory;
+    }
+    renderPokerLogTables();
+    if (nodes.opsPokerLogTtlPresets && snapshot){
+      var checked = nodes.opsPokerLogForm && nodes.opsPokerLogForm.querySelector('input[name="pokerLogTtl"]:checked');
+      var selectedTtl = checked ? checked.value : String(snapshot.ttl.defaultMs);
+      var presets = (snapshot.ttl.presetsMs || []).filter(function(value){ return value >= snapshot.ttl.minMs && value <= snapshot.ttl.maxMs; });
+      if (selectedTtl !== "custom" && !presets.some(function(value){ return String(value) === selectedTtl; })){
+        selectedTtl = presets.length ? String(presets[0]) : "custom";
+      }
+      nodes.opsPokerLogTtlPresets.innerHTML = presets.map(function(value){
+        var minutes = value / 60000;
+        return '<label><input type="radio" name="pokerLogTtl" value="' + String(value) + '"' + (selectedTtl === String(value) ? " checked" : "") + '> ' + String(minutes) + " min</label>";
+      }).join("") + '<label><input type="radio" name="pokerLogTtl" value="custom"' + (selectedTtl === "custom" ? " checked" : "") + "> Custom...</label>";
+      var customActive = selectedTtl === "custom";
+      setVisible(nodes.opsPokerLogCustomTtlField, customActive);
+      if (nodes.opsPokerLogCustomTtl){
+        nodes.opsPokerLogCustomTtl.min = String(Math.ceil(snapshot.ttl.minMs / 60000));
+        nodes.opsPokerLogCustomTtl.max = String(Math.floor(snapshot.ttl.maxMs / 60000));
+      }
+      if (nodes.opsPokerLogTtlHint){
+        nodes.opsPokerLogTtlHint.textContent = "Allowed: " + Math.ceil(snapshot.ttl.minMs / 60000) + "–" + Math.floor(snapshot.ttl.maxMs / 60000) + " minutes.";
+      }
+    }
+    if (nodes.opsPokerLogEnable) nodes.opsPokerLogEnable.disabled = pending || !snapshot;
+    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.disabled = pending;
+    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.disabled = pending;
+    if (nodes.opsPokerLogStatus) nodes.opsPokerLogStatus.textContent = pending ? "Updating DEBUG control…" : state.ops.pokerLogControlMessage || state.ops.pokerLogControlError || "";
+    renderPokerLogOverrides();
+  }
+
   function renderStat(label, value){
     return '<div class="admin-stat"><span class="admin-stat__label">' + escapeHtml(label) + '</span><span class="admin-stat__value">' + escapeHtml(value == null ? "—" : String(value)) + "</span></div>";
   }
@@ -1386,6 +1566,7 @@
       return;
     }
     state.activeTab = tab;
+    if (tab !== "ops") syncPokerLogCountdownTimer();
     renderTabs();
     if (tab === "users" && !state.users.loaded) loadUsers();
     if (tab === "tables" && !state.tables.loaded) loadTables();
@@ -1836,13 +2017,132 @@
     }
   }
 
+  async function loadPokerLogTables(){
+    state.ops.pokerLogTablesError = null;
+    try {
+      var payload = await apiFetch("/.netlify/functions/admin-tables-list?status=OPEN&sort=last_activity_desc&page=1&limit=100", { method: "GET" });
+      state.ops.pokerLogTables = Array.isArray(payload.items) ? payload.items : [];
+    } catch (err){
+      state.ops.pokerLogTables = [];
+      state.ops.pokerLogTablesError = err && err.code ? err.code : "request_failed";
+    }
+    renderPokerLogTables();
+  }
+
+  async function loadPokerLogControl(quiet){
+    if (!quiet) state.ops.pokerLogControlMessage = "";
+    try {
+      var snapshot = await apiFetch("/.netlify/functions/admin-poker-log-control", { method: "GET", cache: "no-store" });
+      setPokerLogSnapshot(snapshot);
+      state.ops.pokerLogControlError = null;
+    } catch (err){
+      state.ops.pokerLogControlError = err && err.code ? err.code : "request_failed";
+      if (!quiet) state.ops.pokerLogControl = null;
+    }
+    renderPokerLogControl();
+  }
+
+  function selectedPokerLogTtlMs(){
+    var selected = nodes.opsPokerLogForm && nodes.opsPokerLogForm.querySelector('input[name="pokerLogTtl"]:checked');
+    if (!selected) return null;
+    if (selected.value !== "custom") return Number(selected.value);
+    var minutes = Number(nodes.opsPokerLogCustomTtl && nodes.opsPokerLogCustomTtl.value);
+    return Number.isSafeInteger(minutes) ? minutes * 60000 : null;
+  }
+
+  function selectedPokerLogTableId(){
+    if (!nodes.opsPokerLogTable) return "";
+    if (nodes.opsPokerLogTable.value === "__manual__"){
+      return String(nodes.opsPokerLogManualTable && nodes.opsPokerLogManualTable.value || "").trim();
+    }
+    return String(nodes.opsPokerLogTable.value || "").trim();
+  }
+
+  async function submitPokerLogOverride(event){
+    event.preventDefault();
+    var snapshot = state.ops.pokerLogControl;
+    if (!snapshot) return;
+    var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value : "table";
+    var category = scope === "category" ? String(nodes.opsPokerLogCategory && nodes.opsPokerLogCategory.value || "") : null;
+    var tableId = scope === "table" ? selectedPokerLogTableId() : null;
+    var ttlMs = selectedPokerLogTtlMs();
+    if (!Number.isSafeInteger(ttlMs) || ttlMs < snapshot.ttl.minMs || ttlMs > snapshot.ttl.maxMs){
+      state.ops.pokerLogControlMessage = "Select a valid TTL within the advertised bounds.";
+      renderPokerLogControl();
+      return;
+    }
+    if (scope === "table" && !tableId){
+      state.ops.pokerLogControlMessage = "Select or enter an exact table ID.";
+      renderPokerLogControl();
+      return;
+    }
+    if (
+      scope === "global"
+      && snapshot.environment === "production"
+      && typeof window.confirm === "function"
+      && !window.confirm("Enable Global DEBUG on Production for " + Math.ceil(ttlMs / 60000) + " minutes?")
+    ) return;
+    state.ops.pokerLogControlPending = true;
+    state.ops.pokerLogControlMessage = "";
+    renderPokerLogControl();
+    try {
+      var result = await apiFetch("/.netlify/functions/admin-poker-log-control", {
+        method: "POST",
+        body: JSON.stringify({ operation: "enable", scope: scope, category: category, tableId: tableId, ttlMs: ttlMs })
+      });
+      setPokerLogSnapshot(result);
+      state.ops.pokerLogControlError = null;
+      state.ops.pokerLogControlMessage = "DEBUG override enabled.";
+    } catch (err){
+      state.ops.pokerLogControlError = err && err.code ? err.code : "request_failed";
+      state.ops.pokerLogControlMessage = "Could not enable DEBUG.";
+    } finally {
+      state.ops.pokerLogControlPending = false;
+      renderPokerLogControl();
+    }
+  }
+
+  async function disablePokerLogOverride(index){
+    var snapshot = state.ops.pokerLogControl;
+    var item = snapshot && snapshot.overrides && snapshot.overrides[index];
+    if (!item || state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex != null) return;
+    state.ops.pokerLogDisablePendingIndex = index;
+    state.ops.pokerLogDisableErrorIndex = null;
+    state.ops.pokerLogControlMessage = "";
+    renderPokerLogControl();
+    try {
+      var result = await apiFetch("/.netlify/functions/admin-poker-log-control", {
+        method: "POST",
+        body: JSON.stringify({
+          operation: "disable",
+          scope: item.scope,
+          category: item.category || null,
+          tableId: item.tableId || null
+        })
+      });
+      setPokerLogSnapshot(result);
+      state.ops.pokerLogControlError = null;
+      state.ops.pokerLogDisableErrorIndex = null;
+      state.ops.pokerLogControlMessage = "DEBUG override disabled.";
+    } catch (err){
+      state.ops.pokerLogControlError = err && err.code ? err.code : "request_failed";
+      state.ops.pokerLogDisableErrorIndex = index;
+      state.ops.pokerLogControlMessage = "Could not disable DEBUG.";
+    } finally {
+      state.ops.pokerLogDisablePendingIndex = null;
+      renderPokerLogControl();
+    }
+  }
+
   async function loadOps(){
     setStatus(t("loading", "Loading..."), "info");
     try {
       var results = await Promise.allSettled([
         apiFetch("/.netlify/functions/admin-stage-identity", { method: "GET" }),
         apiFetch("/.netlify/functions/admin-ops-summary", { method: "GET" }),
-        state.maintenance ? Promise.resolve(null) : apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" })
+        state.maintenance ? Promise.resolve(null) : apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" }),
+        apiFetch("/.netlify/functions/admin-poker-log-control", { method: "GET", cache: "no-store" }),
+        apiFetch("/.netlify/functions/admin-tables-list?status=OPEN&sort=last_activity_desc&page=1&limit=100", { method: "GET" })
       ]);
       if (results[0].status === "fulfilled"){
         state.ops.identity = results[0].value || null;
@@ -1871,6 +2171,20 @@
         state.ops.botReactionMessage = "";
         klog("admin_ws_preview_bot_reaction_load_failed", { code: state.ops.botReactionError });
       }
+      if (results[3].status === "fulfilled"){
+        setPokerLogSnapshot(results[3].value || null);
+        state.ops.pokerLogControlError = null;
+      } else {
+        state.ops.pokerLogControl = null;
+        state.ops.pokerLogControlError = results[3].reason && results[3].reason.code ? results[3].reason.code : "request_failed";
+      }
+      if (results[4].status === "fulfilled"){
+        state.ops.pokerLogTables = Array.isArray(results[4].value && results[4].value.items) ? results[4].value.items : [];
+        state.ops.pokerLogTablesError = null;
+      } else {
+        state.ops.pokerLogTables = [];
+        state.ops.pokerLogTablesError = results[4].reason && results[4].reason.code ? results[4].reason.code : "request_failed";
+      }
       state.ops.loaded = true;
       renderOps();
       setStatus("", "");
@@ -1889,6 +2203,20 @@
     state.ops.botReactionMessage = fallback || "Could not update WS Preview timing.";
     klog("admin_ws_preview_bot_reaction_update_failed", { code: state.ops.botReactionError });
     renderBotReactionControl();
+  }
+
+  function handlePokerLogControlChange(event){
+    var target = event && event.target;
+    if (target === nodes.opsPokerLogScope || target === nodes.opsPokerLogTable || target && target.name === "pokerLogTtl"){
+      renderPokerLogControl();
+    }
+  }
+
+  function handlePokerLogOverridesClick(event){
+    var target = closestEventTarget(event && event.target, "[data-poker-log-disable]");
+    if (!target) return;
+    var index = Number(target.getAttribute("data-poker-log-disable"));
+    if (Number.isInteger(index) && index >= 0) disablePokerLogOverride(index);
   }
 
   async function submitBotReactionOverride(event){
@@ -2190,6 +2518,11 @@
     if (nodes.pokerAuditFilters) nodes.pokerAuditFilters.addEventListener("submit", handlePokerAuditSubmit);
     if (nodes.opsBotReactionForm) nodes.opsBotReactionForm.addEventListener("submit", submitBotReactionOverride);
     if (nodes.opsBotReactionDefault) nodes.opsBotReactionDefault.addEventListener("click", clearBotReactionOverride);
+    if (nodes.opsPokerLogForm) nodes.opsPokerLogForm.addEventListener("submit", submitPokerLogOverride);
+    if (nodes.opsPokerLogForm) nodes.opsPokerLogForm.addEventListener("change", handlePokerLogControlChange);
+    if (nodes.opsPokerLogOverrides) nodes.opsPokerLogOverrides.addEventListener("click", handlePokerLogOverridesClick);
+    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.addEventListener("click", function(){ loadPokerLogControl(false); });
+    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.addEventListener("click", loadPokerLogTables);
     if (nodes.usersRefresh) nodes.usersRefresh.addEventListener("click", function(){ loadUsers(); });
     if (nodes.tablesRefresh) nodes.tablesRefresh.addEventListener("click", function(){ loadTables(); });
     if (nodes.bonusCampaignsRefresh) nodes.bonusCampaignsRefresh.addEventListener("click", function(){ loadBonusCampaigns(); });

--- a/netlify/functions/admin-poker-log-control.mjs
+++ b/netlify/functions/admin-poker-log-control.mjs
@@ -78,7 +78,16 @@ function resolveTarget(identity) {
     && identity?.databaseMatchesSupabaseProjectRef === true
     && identity?.serviceRoleStageProjectRefMatches === true
   ) return "preview";
-  if (identity?.environmentContext === "production" && identity?.databaseTarget === "production") {
+  if (
+    identity?.environmentContext === "production"
+    && identity?.databaseTarget === "production"
+    && typeof identity?.expectedProductionProjectRef === "string"
+    && identity.expectedProductionProjectRef.length > 0
+    && identity?.supabaseUrlProductionProjectRefMatches === true
+    && identity?.databaseProductionProjectRefMatches === true
+    && identity?.serviceRoleProductionProjectRefMatches === true
+    && identity?.databaseMatchesSupabaseProjectRef === true
+  ) {
     return "production";
   }
   return null;

--- a/netlify/functions/admin-poker-log-control.mjs
+++ b/netlify/functions/admin-poker-log-control.mjs
@@ -1,0 +1,255 @@
+import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.mjs";
+import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
+import { buildStageIdentity } from "./admin-stage-identity.mjs";
+
+const WS_ORIGINS = Object.freeze({
+  preview: "https://ws-preview.kcswh.pl",
+  production: "https://ws.kcswh.pl",
+});
+const CATEGORIES = Object.freeze([
+  "runtime", "transport", "session", "table_lifecycle", "gameplay", "autoplay",
+  "persistence", "recovery", "janitor", "settlement", "accounting", "ledger",
+  "http", "admin", "deployment",
+]);
+const EXPOSED_ERRORS = new Set([
+  "invalid_category", "invalid_request", "invalid_scope", "invalid_table_id",
+  "invalid_ttl", "table_override_capacity",
+]);
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+function jsonResponse(statusCode, headers, body) {
+  return {
+    statusCode,
+    headers: { ...headers, "cache-control": "no-store" },
+    body: JSON.stringify(body),
+  };
+}
+
+function controlError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function parseJsonObject(body) {
+  try {
+    const value = body ? JSON.parse(body) : {};
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error();
+    return value;
+  } catch {
+    throw controlError("invalid_json");
+  }
+}
+
+function exactKeys(value, expected) {
+  const keys = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  return keys.length === wanted.length && keys.every((key, index) => key === wanted[index]);
+}
+
+function parseBody(body) {
+  const value = parseJsonObject(body);
+  const operation = typeof value.operation === "string" ? value.operation.trim().toLowerCase() : "";
+  const scope = typeof value.scope === "string" ? value.scope.trim().toLowerCase() : "";
+  const category = value.category == null ? null : String(value.category).trim().toLowerCase();
+  const tableId = value.tableId == null ? null : String(value.tableId).trim();
+  const validIdentity = (
+    (scope === "global" && category === null && tableId === null)
+    || (scope === "category" && CATEGORIES.includes(category) && tableId === null)
+    || (scope === "table" && category === null && typeof tableId === "string" && tableId.length > 0)
+  );
+  if (!validIdentity) throw controlError("invalid_request");
+  if (operation === "enable" && exactKeys(value, ["operation", "scope", "category", "tableId", "ttlMs"])) {
+    if (!Number.isSafeInteger(value.ttlMs)) throw controlError("invalid_ttl");
+    return { operation, scope, category, tableId, ttlMs: value.ttlMs };
+  }
+  if (operation === "disable" && exactKeys(value, ["operation", "scope", "category", "tableId"])) {
+    return { operation, scope, category, tableId };
+  }
+  throw controlError("invalid_request");
+}
+
+function resolveTarget(identity) {
+  if (
+    identity?.environmentContext === "deploy-preview"
+    && identity?.databaseTarget === "stage"
+    && identity?.stageProjectRefMatches === true
+    && identity?.databaseMatchesSupabaseProjectRef === true
+    && identity?.serviceRoleStageProjectRefMatches === true
+  ) return "preview";
+  if (identity?.environmentContext === "production" && identity?.databaseTarget === "production") {
+    return "production";
+  }
+  return null;
+}
+
+function resolveBaseUrl(env, target) {
+  const raw = typeof env?.POKER_WS_INTERNAL_BASE_URL === "string"
+    ? env.POKER_WS_INTERNAL_BASE_URL.trim()
+    : "";
+  if (!raw || !WS_ORIGINS[target]) return null;
+  try {
+    const url = new URL(raw);
+    if (
+      url.origin !== WS_ORIGINS[target]
+      || (url.pathname !== "/" && url.pathname !== "")
+      || url.username || url.password || url.search || url.hash
+    ) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveTimeoutMs(env) {
+  const parsed = Number(env?.POKER_WS_INTERNAL_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed >= 250 && parsed <= 10_000
+    ? Math.trunc(parsed)
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function validOverride(value) {
+  if (!value || !["global", "category", "table"].includes(value.scope)) return false;
+  if (typeof value.expiresAt !== "string" || !Number.isFinite(Date.parse(value.expiresAt))) return false;
+  if (value.scope === "category") return CATEGORIES.includes(value.category) && value.tableId == null;
+  if (value.scope === "table") return typeof value.tableId === "string" && value.tableId.length > 0 && value.category == null;
+  return value.category == null && value.tableId == null;
+}
+
+function normalizeSnapshot(value, target) {
+  if (!value || typeof value !== "object" || !["DEBUG", "INFO", "WARN", "ERROR"].includes(value.defaultLevel)) {
+    throw controlError("ws_log_control_invalid_response", 502);
+  }
+  const serverNowMs = Date.parse(value.serverNow);
+  const ttl = value.ttl;
+  const validTtl = ttl
+    && Number.isSafeInteger(ttl.minMs)
+    && Number.isSafeInteger(ttl.defaultMs)
+    && Number.isSafeInteger(ttl.maxMs)
+    && ttl.minMs > 0
+    && ttl.minMs <= ttl.defaultMs
+    && ttl.defaultMs <= ttl.maxMs
+    && Array.isArray(ttl.presetsMs)
+    && ttl.presetsMs.every((item) => Number.isSafeInteger(item) && item >= ttl.minMs && item <= ttl.maxMs);
+  if (!Number.isFinite(serverNowMs) || !validTtl || !Array.isArray(value.overrides) || !value.overrides.every(validOverride)) {
+    throw controlError("ws_log_control_invalid_response", 502);
+  }
+  return {
+    environment: target,
+    defaultLevel: value.defaultLevel,
+    serverNow: value.serverNow,
+    ttl: {
+      minMs: ttl.minMs,
+      defaultMs: ttl.defaultMs,
+      maxMs: ttl.maxMs,
+      presetsMs: ttl.presetsMs,
+    },
+    categories: [...CATEGORIES],
+    overrides: value.overrides.map((item) => ({
+      scope: item.scope,
+      ...(item.category ? { category: item.category } : {}),
+      ...(item.tableId ? { tableId: item.tableId } : {}),
+      expiresAt: item.expiresAt,
+    })),
+  };
+}
+
+async function proxyControl({ method, payload, adminUserId, target, env, fetchImpl }) {
+  const baseUrl = resolveBaseUrl(env, target);
+  const token = typeof env?.POKER_WS_INTERNAL_TOKEN === "string" ? env.POKER_WS_INTERNAL_TOKEN.trim() : "";
+  if (!baseUrl || !token || typeof fetchImpl !== "function") {
+    throw controlError("ws_log_control_unavailable", 503);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), resolveTimeoutMs(env));
+  timer?.unref?.();
+  try {
+    const options = {
+      method,
+      cache: "no-store",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      signal: controller.signal,
+    };
+    if (method === "POST") options.body = JSON.stringify({ ...payload, adminUserId });
+    const response = await fetchImpl(`${baseUrl}/internal/admin/poker-log-control`, options);
+    let body = {};
+    try {
+      body = await response.json();
+    } catch {}
+    if (!response.ok) {
+      const upstream = typeof body?.error === "string" ? body.error : "";
+      const exposed = EXPOSED_ERRORS.has(upstream);
+      throw controlError(exposed ? upstream : "ws_log_control_unavailable", exposed ? response.status : 502);
+    }
+    return normalizeSnapshot(body, target);
+  } catch (error) {
+    if (error?.name === "AbortError") throw controlError("ws_log_control_timeout", 504);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createAdminPokerLogControlHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const requireAdmin = deps.requireAdminUser || requireAdminUser;
+  const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
+  const fetchImpl = deps.fetchImpl || globalThis.fetch;
+  return async function handler(event) {
+    if (env.CHIPS_ENABLED !== "1") return jsonResponse(404, baseHeaders(), { error: "not_found" });
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) return jsonResponse(403, baseHeaders(), { error: "forbidden_origin" });
+    if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: { ...cors, "cache-control": "no-store" }, body: "" };
+    if (event.httpMethod !== "GET" && event.httpMethod !== "POST") {
+      return jsonResponse(405, cors, { error: "method_not_allowed" });
+    }
+    try {
+      const admin = await requireAdmin(event, env);
+      const target = resolveTarget(buildIdentity());
+      if (!target) return jsonResponse(403, cors, { error: "environment_not_allowed" });
+      const payload = event.httpMethod === "POST" ? parseBody(event.body) : null;
+      const result = await proxyControl({
+        method: event.httpMethod,
+        payload,
+        adminUserId: admin.userId,
+        target,
+        env,
+        fetchImpl,
+      });
+      klog("admin_poker_log_control_outcome", {
+        adminUserId: admin.userId,
+        environment: target,
+        operation: payload?.operation || "read",
+        scope: payload?.scope || null,
+        ok: true,
+      });
+      return jsonResponse(200, cors, result);
+    } catch (error) {
+      if (error?.status === 401 || (error?.status === 403 && error?.code === "admin_required")) {
+        const response = adminAuthErrorResponse(error, cors);
+        return { ...response, headers: { ...response.headers, "cache-control": "no-store" } };
+      }
+      const status = Number(error?.status) || 500;
+      const code = error?.code || "server_error";
+      klog("admin_poker_log_control_failed", { status, code });
+      return jsonResponse(status, cors, { error: code });
+    }
+  };
+}
+
+const handler = createAdminPokerLogControlHandler();
+
+export {
+  CATEGORIES,
+  createAdminPokerLogControlHandler,
+  handler,
+  normalizeSnapshot,
+  parseBody,
+  proxyControl,
+  resolveTarget,
+};

--- a/netlify/functions/admin-stage-identity.mjs
+++ b/netlify/functions/admin-stage-identity.mjs
@@ -78,6 +78,10 @@ function resolveExpectedStageProjectRef(env = process.env) {
   ) || null;
 }
 
+function resolveExpectedProductionProjectRef(env = process.env) {
+  return normalizeString(env.EXPECTED_SUPABASE_PROD_PROJECT_REF) || null;
+}
+
 function resolveDatabaseTarget({ environmentContext, projectRef, expectedStageProjectRef } = {}) {
   if (expectedStageProjectRef && projectRef && projectRef === expectedStageProjectRef) return "stage";
   if (environmentContext === "production") return "production";
@@ -90,6 +94,7 @@ function buildStageIdentity(env = process.env, options = {}) {
   const databaseProjectRef = parseProjectRefFromDbUrl(env.SUPABASE_DB_URL);
   const supabaseProjectRef = supabaseUrlProjectRef || databaseProjectRef || resolveConfiguredProjectRef(env);
   const expectedStageProjectRef = resolveExpectedStageProjectRef(env);
+  const expectedProductionProjectRef = resolveExpectedProductionProjectRef(env);
   const serviceRoleProjectRef = parseProjectRefFromSupabaseJwt(env.SUPABASE_SERVICE_ROLE_KEY);
   const stageProjectRefMatches = !!expectedStageProjectRef && !!supabaseProjectRef && expectedStageProjectRef === supabaseProjectRef;
   const databaseTarget = resolveDatabaseTarget({
@@ -105,12 +110,22 @@ function buildStageIdentity(env = process.env, options = {}) {
     databaseProjectRef: databaseProjectRef || null,
     databaseMatchesSupabaseProjectRef: !!supabaseUrlProjectRef && !!databaseProjectRef && supabaseUrlProjectRef === databaseProjectRef,
     expectedStageProjectRef,
+    expectedProductionProjectRef,
     databaseTarget,
     chipsEnabled: env.CHIPS_ENABLED === "1",
     stageProjectRefConfigured: !!expectedStageProjectRef,
     stageProjectRefMatches,
     serviceRoleProjectRef: serviceRoleProjectRef || null,
     serviceRoleStageProjectRefMatches: !!expectedStageProjectRef && !!serviceRoleProjectRef && expectedStageProjectRef === serviceRoleProjectRef,
+    supabaseUrlProductionProjectRefMatches: !!expectedProductionProjectRef
+      && !!supabaseUrlProjectRef
+      && expectedProductionProjectRef === supabaseUrlProjectRef,
+    databaseProductionProjectRefMatches: !!expectedProductionProjectRef
+      && !!databaseProjectRef
+      && expectedProductionProjectRef === databaseProjectRef,
+    serviceRoleProductionProjectRefMatches: !!expectedProductionProjectRef
+      && !!serviceRoleProjectRef
+      && expectedProductionProjectRef === serviceRoleProjectRef,
     config: {
       hasSupabaseUrl: !!normalizeString(env.SUPABASE_URL || env.SUPABASE_URL_V2),
       hasSupabaseDbUrl: !!normalizeString(env.SUPABASE_DB_URL),

--- a/tests/admin-endpoints.behavior.test.mjs
+++ b/tests/admin-endpoints.behavior.test.mjs
@@ -5,6 +5,7 @@ const { createAdminMeHandler } = await import("../netlify/functions/admin-me.mjs
 const { createAdminUserBalanceHandler } = await import("../netlify/functions/admin-user-balance.mjs");
 const { createAdminUserLedgerHandler } = await import("../netlify/functions/admin-user-ledger.mjs");
 const { createAdminWsPreviewBotReactionHandler, parseBody: parseBotReactionBody } = await import("../netlify/functions/admin-ws-preview-bot-reaction.mjs");
+const { createAdminPokerLogControlHandler, parseBody: parsePokerLogControlBody } = await import("../netlify/functions/admin-poker-log-control.mjs");
 
 function event(method, queryStringParameters = {}, body = null) {
   return {
@@ -21,6 +22,21 @@ function previewStageIdentity() {
     databaseTarget: "stage",
     stageProjectRefMatches: true,
     databaseMatchesSupabaseProjectRef: true,
+    serviceRoleStageProjectRefMatches: true,
+  };
+}
+
+function pokerLogSnapshot() {
+  return {
+    defaultLevel: "INFO",
+    serverNow: "2026-07-28T13:00:00.000Z",
+    ttl: {
+      minMs: 60000,
+      defaultMs: 900000,
+      maxMs: 3600000,
+      presetsMs: [900000, 1800000, 3600000],
+    },
+    overrides: [],
   };
 }
 
@@ -188,6 +204,118 @@ test("admin WS Preview bot reaction endpoint stays unavailable during CH mainten
     assert.deepEqual(JSON.parse(response.body), { error: "not_found" });
   }
   assert.equal(authCalls, 0);
+  assert.equal(fetchCalls, 0);
+});
+
+test("admin poker log control binds Preview and Production contexts to exact WS origins", async () => {
+  const seen = [];
+  const baseDeps = {
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    fetchImpl: async (url, options) => {
+      seen.push({ url, options });
+      return { ok: true, status: 200, json: async () => pokerLogSnapshot() };
+    },
+  };
+  const previewHandler = createAdminPokerLogControlHandler({
+    ...baseDeps,
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token",
+    },
+    buildStageIdentity: previewStageIdentity,
+  });
+  const previewResponse = await previewHandler(event("GET"));
+  assert.equal(previewResponse.statusCode, 200);
+  assert.equal(JSON.parse(previewResponse.body).environment, "preview");
+  assert.equal(seen[0].url, "https://ws-preview.kcswh.pl/internal/admin/poker-log-control");
+
+  const productionHandler = createAdminPokerLogControlHandler({
+    ...baseDeps,
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "production-token",
+    },
+    buildStageIdentity: () => ({ environmentContext: "production", databaseTarget: "production" }),
+  });
+  const productionResponse = await productionHandler(event("GET"));
+  assert.equal(productionResponse.statusCode, 200);
+  assert.equal(JSON.parse(productionResponse.body).environment, "production");
+  assert.equal(seen[1].url, "https://ws.kcswh.pl/internal/admin/poker-log-control");
+  assert.equal(productionResponse.headers["cache-control"], "no-store");
+});
+
+test("admin poker log control forwards exact allowlisted scope with trusted admin identity", async () => {
+  let forwarded = null;
+  const handler = createAdminPokerLogControlHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token",
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: previewStageIdentity,
+    fetchImpl: async (_url, options) => {
+      forwarded = JSON.parse(options.body);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ...pokerLogSnapshot(),
+          overrides: [{
+            scope: "table",
+            tableId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            expiresAt: "2026-07-28T13:15:00.000Z",
+          }],
+        }),
+      };
+    },
+  });
+  const payload = {
+    operation: "enable",
+    scope: "table",
+    category: null,
+    tableId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    ttlMs: 900000,
+  };
+  const response = await handler(event("POST", {}, JSON.stringify(payload)));
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(forwarded, {
+    ...payload,
+    adminUserId: "00000000-0000-4000-8000-000000000010",
+  });
+});
+
+test("admin poker log control rejects unknown fields, cross-environment origins, and invalid categories", async () => {
+  assert.throws(
+    () => parsePokerLogControlBody(JSON.stringify({
+      operation: "enable", scope: "global", category: null, tableId: null, ttlMs: 900000, wildcard: "*",
+    })),
+    { code: "invalid_request" },
+  );
+  assert.throws(
+    () => parsePokerLogControlBody(JSON.stringify({
+      operation: "enable", scope: "category", category: "anything", tableId: null, ttlMs: 900000,
+    })),
+    { code: "invalid_request" },
+  );
+  let fetchCalls = 0;
+  const handler = createAdminPokerLogControlHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "wrong-context-token",
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: previewStageIdentity,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error("unexpected_fetch");
+    },
+  });
+  const response = await handler(event("GET"));
+  assert.equal(response.statusCode, 503);
   assert.equal(fetchCalls, 0);
 });
 

--- a/tests/admin-endpoints.behavior.test.mjs
+++ b/tests/admin-endpoints.behavior.test.mjs
@@ -26,6 +26,18 @@ function previewStageIdentity() {
   };
 }
 
+function productionStageIdentity() {
+  return {
+    environmentContext: "production",
+    databaseTarget: "production",
+    expectedProductionProjectRef: "production-project-ref",
+    supabaseUrlProductionProjectRefMatches: true,
+    databaseProductionProjectRefMatches: true,
+    serviceRoleProductionProjectRefMatches: true,
+    databaseMatchesSupabaseProjectRef: true,
+  };
+}
+
 function pokerLogSnapshot() {
   return {
     defaultLevel: "INFO",
@@ -237,13 +249,57 @@ test("admin poker log control binds Preview and Production contexts to exact WS 
       POKER_WS_INTERNAL_BASE_URL: "https://ws.kcswh.pl",
       POKER_WS_INTERNAL_TOKEN: "production-token",
     },
-    buildStageIdentity: () => ({ environmentContext: "production", databaseTarget: "production" }),
+    buildStageIdentity: productionStageIdentity,
   });
   const productionResponse = await productionHandler(event("GET"));
   assert.equal(productionResponse.statusCode, 200);
   assert.equal(JSON.parse(productionResponse.body).environment, "production");
   assert.equal(seen[1].url, "https://ws.kcswh.pl/internal/admin/poker-log-control");
   assert.equal(productionResponse.headers["cache-control"], "no-store");
+});
+
+test("admin poker log control fails closed for unverified Production project identity", async () => {
+  const invalidIdentities = [
+    {
+      ...productionStageIdentity(),
+      expectedProductionProjectRef: null,
+    },
+    {
+      ...productionStageIdentity(),
+      supabaseUrlProductionProjectRefMatches: false,
+      databaseProductionProjectRefMatches: false,
+      serviceRoleProductionProjectRefMatches: false,
+    },
+    {
+      ...productionStageIdentity(),
+      databaseMatchesSupabaseProjectRef: false,
+      databaseProductionProjectRefMatches: false,
+    },
+    {
+      ...productionStageIdentity(),
+      serviceRoleProductionProjectRefMatches: false,
+    },
+  ];
+  let fetchCalls = 0;
+  for (const identity of invalidIdentities) {
+    const handler = createAdminPokerLogControlHandler({
+      env: {
+        CHIPS_ENABLED: "1",
+        POKER_WS_INTERNAL_BASE_URL: "https://ws.kcswh.pl",
+        POKER_WS_INTERNAL_TOKEN: "production-token",
+      },
+      requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+      buildStageIdentity: () => identity,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        throw new Error("unexpected_fetch");
+      },
+    });
+    const response = await handler(event("GET"));
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), { error: "environment_not_allowed" });
+  }
+  assert.equal(fetchCalls, 0);
 });
 
 test("admin poker log control forwards exact allowlisted scope with trusted admin identity", async () => {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -27,6 +27,18 @@ test("admin table recovery requires explicit analysis before the confirmed repai
   );
 });
 
+test("admin poker DEBUG control keeps bounded scopes, TTL, manual fallback, and Production confirmation", () => {
+  assert.match(source, /operation: "enable"/);
+  assert.match(source, /operation: "disable"/);
+  assert.match(source, /scope === "global"/);
+  assert.match(source, /snapshot\.environment === "production"/);
+  assert.match(source, /Enable Global DEBUG on Production/);
+  assert.match(source, /__manual__/);
+  assert.match(source, /admin-tables-list\?status=OPEN/);
+  assert.match(source, /pokerLogExpiryRefreshDone/);
+  assert.doesNotMatch(source, /journalctl/);
+});
+
 function createClassList(node) {
   function read() {
     return String(node.className || "").split(/\s+/).filter(Boolean);
@@ -299,6 +311,24 @@ function createAdminDom() {
     "adminOpsBotReactionApply",
     "adminOpsBotReactionDefault",
     "adminOpsBotReactionStatus",
+    "adminOpsPokerLogSummary",
+    "adminOpsPokerLogScope",
+    "adminOpsPokerLogCategoryField",
+    "adminOpsPokerLogCategory",
+    "adminOpsPokerLogTableFields",
+    "adminOpsPokerLogTable",
+    "adminOpsPokerLogManualField",
+    "adminOpsPokerLogManualTable",
+    "adminOpsPokerLogTablesRefresh",
+    "adminOpsPokerLogTablesStatus",
+    "adminOpsPokerLogTtlPresets",
+    "adminOpsPokerLogCustomTtlField",
+    "adminOpsPokerLogCustomTtl",
+    "adminOpsPokerLogTtlHint",
+    "adminOpsPokerLogEnable",
+    "adminOpsPokerLogStatus",
+    "adminOpsPokerLogOverrides",
+    "adminOpsPokerLogRefresh",
     "adminOpsRefresh",
     "adminOpsRunReconciler",
     "adminOpsRunStaleSweep",
@@ -338,6 +368,7 @@ function createAdminDom() {
   addField(pokerAuditFilters, { name: "handId", value: "" });
   addField(pokerAuditFilters, { name: "limit", value: "20" });
   createForm(document, "adminOpsBotReactionForm");
+  createForm(document, "adminOpsPokerLogForm");
 
   const tabs = ["users", "tables", "ledger", "bonusCampaigns", "pokerAudit", "ops"].map((tab, index) => {
     const button = registerNode(document, createElement("button", `adminTabButton${tab[0].toUpperCase()}${tab.slice(1)}`));
@@ -478,6 +509,21 @@ function buildContext(options = {}) {
         defaults: { minMs: 2000, maxMs: 4000 },
         active: { minMs: 2000, maxMs: 4000 },
         override: null,
+      }) };
+    }
+    if (text.includes("/.netlify/functions/admin-poker-log-control")) {
+      return { ok: true, json: async () => ({
+        environment: "preview",
+        defaultLevel: "INFO",
+        serverNow: "2026-07-28T13:00:00.000Z",
+        ttl: {
+          minMs: 60000,
+          defaultMs: 900000,
+          maxMs: 3600000,
+          presetsMs: [900000, 1800000, 3600000],
+        },
+        categories: ["autoplay", "persistence", "janitor"],
+        overrides: [],
       }) };
     }
     if (text.includes("/.netlify/functions/admin-stage-identity")) {
@@ -720,12 +766,18 @@ test("admin page tabs switch panels on click and keep ARIA state in sync", async
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-stage-identity"), true);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-ops-summary"), true);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-ws-preview-bot-reaction"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-poker-log-control"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-tables-list?status=OPEN&sort=last_activity_desc&page=1&limit=100"), true);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Database target/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /stageabc/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Service role stage match/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /stage/);
   assert.match(document.getElementById("adminOpsBotReactionSummary").innerHTML, /Default/);
   assert.match(document.getElementById("adminOpsBotReactionSummary").innerHTML, /2000–4000 ms/);
+  assert.match(document.getElementById("adminOpsPokerLogSummary").innerHTML, /WS Preview/);
+  assert.match(document.getElementById("adminOpsPokerLogSummary").innerHTML, /INFO/);
+  assert.match(document.getElementById("adminOpsPokerLogTtlPresets").innerHTML, /15 min/);
+  assert.match(document.getElementById("adminOpsPokerLogOverrides").innerHTML, /No active DEBUG overrides/);
   assert.match(document.getElementById("adminOpsPokerEscrow").innerHTML, /1 problem/);
   assert.match(document.getElementById("adminOpsPokerEscrow").innerHTML, /ORPHANED/);
   assert.match(document.getElementById("adminOpsPokerEscrow").innerHTML, /Latest escrow update/);

--- a/tests/admin-page.contract.test.mjs
+++ b/tests/admin-page.contract.test.mjs
@@ -40,6 +40,20 @@ test("admin ops exposes the WS Preview bot reaction control", () => {
   assert.match(adminHtml, />WS Preview</);
 });
 
+test("admin ops exposes bounded poker DEBUG controls without a log viewer", () => {
+  assert.match(adminHtml, /id="adminOpsPokerLogScope"/);
+  assert.match(adminHtml, />Table DEBUG</);
+  assert.match(adminHtml, />Category DEBUG</);
+  assert.match(adminHtml, />Global DEBUG</);
+  assert.match(adminHtml, /id="adminOpsPokerLogTable"/);
+  assert.match(adminHtml, /id="adminOpsPokerLogManualTable"/);
+  assert.match(adminHtml, /id="adminOpsPokerLogTablesRefresh"/);
+  assert.match(adminHtml, /id="adminOpsPokerLogTtlPresets"/);
+  assert.match(adminHtml, /id="adminOpsPokerLogOverrides"/);
+  assert.match(adminHtml, /Active overrides/);
+  assert.doesNotMatch(adminHtml, /journalctl/);
+});
+
 test("admin bonus campaign form exposes campaign type suggestions", () => {
   assert.match(adminHtml, /name="campaignType"[^>]+list="adminBonusCampaignTypeOptions"/);
   assert.match(adminHtml, /<datalist id="adminBonusCampaignTypeOptions">/);

--- a/tests/admin-stage-identity.behavior.test.mjs
+++ b/tests/admin-stage-identity.behavior.test.mjs
@@ -8,6 +8,7 @@ const {
   parseProjectRefFromSupabaseUrl,
   parseProjectRefFromSupabaseJwt,
 } = await import("../netlify/functions/admin-stage-identity.mjs");
+const { resolveTarget: resolvePokerLogControlTarget } = await import("../netlify/functions/admin-poker-log-control.mjs");
 
 function makeUnsignedSupabaseJwt(projectRef) {
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
@@ -63,6 +64,36 @@ test("admin-stage-identity marks production context as production when stage ref
 
   assert.equal(identity.databaseTarget, "production");
   assert.equal(identity.stageProjectRefMatches, false);
+});
+
+test("poker log control positively verifies every Production Supabase identity source", () => {
+  const productionEnv = {
+    CONTEXT: "production",
+    SUPABASE_URL: "https://prodabc.supabase.co",
+    SUPABASE_DB_URL: "postgresql://postgres.prodabc:secret@aws-0-eu.pooler.supabase.com:6543/postgres",
+    SUPABASE_SERVICE_ROLE_KEY: makeUnsignedSupabaseJwt("prodabc"),
+    EXPECTED_SUPABASE_PROD_PROJECT_REF: "prodabc",
+  };
+
+  assert.equal(resolvePokerLogControlTarget(buildStageIdentity(productionEnv)), "production");
+  assert.equal(resolvePokerLogControlTarget(buildStageIdentity({
+    ...productionEnv,
+    SUPABASE_URL: "https://stageabc.supabase.co",
+    SUPABASE_DB_URL: "postgresql://postgres.stageabc:secret@aws-0-eu.pooler.supabase.com:6543/postgres",
+    SUPABASE_SERVICE_ROLE_KEY: makeUnsignedSupabaseJwt("stageabc"),
+  })), null);
+  assert.equal(resolvePokerLogControlTarget(buildStageIdentity({
+    ...productionEnv,
+    SUPABASE_DB_URL: "postgresql://postgres.otherabc:secret@aws-0-eu.pooler.supabase.com:6543/postgres",
+  })), null);
+  assert.equal(resolvePokerLogControlTarget(buildStageIdentity({
+    ...productionEnv,
+    SUPABASE_SERVICE_ROLE_KEY: makeUnsignedSupabaseJwt("otherabc"),
+  })), null);
+  assert.equal(resolvePokerLogControlTarget(buildStageIdentity({
+    ...productionEnv,
+    EXPECTED_SUPABASE_PROD_PROJECT_REF: "",
+  })), null);
 });
 
 test("admin-stage-identity uses the build-generated production target when Netlify omits runtime context", () => {

--- a/ws-tests/infra-vps-caddy.guard.test.mjs
+++ b/ws-tests/infra-vps-caddy.guard.test.mjs
@@ -28,17 +28,20 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
 
   assert.match(prod, /@healthz path \/healthz/);
   assert.match(prod, /@ws path \/ws\*/);
+  assert.match(prod, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(prod, /reverse_proxy 127\.0\.0\.1:3000/);
   assert.match(prod, /respond "OK" 200/);
 
   assert.match(preview, /@healthz path \/healthz/);
   assert.match(preview, /@botReactionAdmin path \/internal\/admin\/bot-reaction/);
   assert.match(preview, /@botClaimsRecoveryAdmin path \/internal\/admin\/bot-claims-recovery/);
+  assert.match(preview, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(preview, /@ws path \/ws\*/);
   assert.match(preview, /reverse_proxy 127\.0\.0\.1:3001/);
   assert.match(preview, /respond "OK" 200/);
   assert.doesNotMatch(prod, /internal\/admin\/bot-reaction/);
   assert.doesNotMatch(prod, /internal\/admin\/bot-claims-recovery/);
+  assert.doesNotMatch(text, /path \/internal\/admin\/\*/);
 });
 
 test("WS PR harness runs the unified infra VPS Caddy guard", () => {


### PR DESCRIPTION
## Summary

- add an authenticated, environment-bound Netlify proxy for the existing poker runtime DEBUG override controller;
- expose only the exact `/internal/admin/poker-log-control` route through Caddy on WS Production and WS Preview;
- add an Admin Ops control for Global, Category, and Table DEBUG with mandatory TTL and explicit Disable actions;
- use the existing open-table admin endpoint for the table selector, with a manual table ID fallback;
- show active overrides with remaining-time countdowns and per-override Disable controls.

## Security and operational constraints

- browser access still requires the existing allowlisted admin authorization;
- Netlify-to-WS access uses the existing internal bearer pattern and context-specific endpoint/token configuration;
- Preview and Production origins are validated exactly and cannot be selected by browser input;
- Caddy exposes only the exact control path, not a wildcard internal route;
- Global DEBUG always has a bounded TTL and requires an additional confirmation in Production;
- no journal access, arbitrary filters, shell arguments, log viewer, user-level overrides, wildcards, or regex scopes were added;
- critical logs cannot be disabled, and the default runtime logging behavior remains unchanged.

## UI behavior

- scope choices: Global DEBUG, Category DEBUG, Table DEBUG, and Disable;
- TTL shortcuts: 15, 30, and 60 minutes, plus a bounded Custom option;
- open-table dropdown with safe summary labels, explicit refresh, and manual fallback;
- active overrides display a local countdown and remain visible when a disable request fails;
- no aggressive polling is introduced.

## Validation

- `npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- focused Admin, Netlify, Caddy, workflow, and WS PR guard suites
- `git diff --check`

All checks passed.

## Runtime and data impact

- no poker gameplay, state-transition, persistence, settlement, ledger, cleanup, or accounting behavior changed;
- no database migration or new logging framework was added;
- this PR adds an exact authenticated infrastructure route and Admin control surface for the process-local controller delivered in PR B.

## Rollout notes

- apply the updated Caddy configuration using the existing VPS infrastructure deployment path;
- configure distinct `POKER_WS_INTERNAL_BASE_URL` and `POKER_WS_INTERNAL_TOKEN` values for Preview and Production Netlify contexts;
- never reuse the Preview internal token in Production;
- verify the target environment shown by the Admin UI before enabling an override;
- smoke with a short Table DEBUG override first, confirm expiry/disable, then separately verify the guarded Production Global DEBUG confirmation.

Refs #775
