### PR TITLE
feat: add continuous bot table foundation

### DIFF
--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -117,6 +117,42 @@ The host is a single shared preview runtime, so automatic deployment from every 
 Changes to bot replacement funding touch the authoritative WS runtime and therefore require a manual WS preview deploy before stage acceptance. Verify a replacement with old stack `0` or `1`, then confirm the next hand starts and the table escrow increased by exactly the funded delta. A Netlify deploy preview alone is not sufficient for this server-side path.
 
 Terminal bot cash-out also requires a manual WS preview deploy. Test it only with a newly created preview table: allow at least one bot replacement, close the table through the terminal inactive-cleanup path, and verify that every positive final bot stack moves from table ESCROW to the exact SYSTEM account proven by its seed/replacement ledger lineage. A successful close must leave the escrow balance at `0`; repeating cleanup must not create another transfer. Missing or mixed provenance, a mismatch between authoritative claims and escrow, or any non-zero post-cash-out escrow must return `terminal_accounting_invariant_failed` and leave table accounting and lifecycle state unchanged.
+
+## Continuous bot tables (foundation)
+
+Continuous bot tables are controlled by the single database profile
+`public.poker_managed_table_profiles.profile_key = 'CONTINUOUS_BOT_DEFAULT'`.
+The migration seeds it disabled with `desired_table_count = 0`; deployment alone
+does not create a table. There are no continuous-table ENV settings.
+
+The V1 foundation supports at most two six-seat tables. Profile constraints and
+runtime validation bound desired count, bot counts, stakes and timing values.
+The supervisor polls the profile, serializes create/retire decisions with a
+database advisory transaction lock and retains the last valid profile across a
+transient read failure. Only a successfully read disabled/zero profile requests
+graceful retirement.
+
+Initial managed bots and settled-boundary top-ups use the established internal
+`SYSTEM -> ESCROW` funding shape with `created_by = NULL`. The actual SYSTEM
+account and immutable ledger entries are the funding authority. Do not create a
+technical USER actor and do not pass bot identities through human join, leave or
+rebuy contracts.
+
+Preview rollout:
+
+1. Apply `20260729100000_poker_managed_table_profiles.sql` to stage.
+2. Deploy the exact PR SHA with manual `WS Preview Deploy`.
+3. Verify release metadata, `ws_artifact_start`, local/public `/healthz` and no supervisor failure.
+4. Confirm the seeded profile is disabled and no managed table was created.
+5. In one reviewed database update set `enabled = true`, `desired_table_count = 1` and `updated_at = now()`.
+6. Verify exactly one `CONTINUOUS_BOT` table, three initial bots, one escrow account, three seed funding transactions and one playable persisted hand.
+7. Join as a real player through normal quick-seat/direct join; verify actions, settlement, reconnect, rebuy and leave.
+8. Verify settled rollover, bot replacement/top-up idempotency and absence of accounting/persistence failures.
+9. Set the valid profile to `enabled = false`, `desired_table_count = 0`; verify the table waits for `SETTLED`, never removes a human, then closes once through terminal accounting with escrow `0`.
+
+Do not change stakes or `max_seats` on an active production profile without
+expecting graceful retirement. Existing tables keep their persisted stakes and
+capacity; replacements use the new construction values.
 Repo-side Caddy ownership is unified: `infra/vps/Caddyfile` is the single source of truth for both production and preview WS routing, so any Caddy change for either host must be made in that file.
 
 ### Dispatch a preview deploy for a selected ref

--- a/netlify/functions/_shared/poker-table-init.mjs
+++ b/netlify/functions/_shared/poker-table-init.mjs
@@ -1,11 +1,21 @@
-export const createPokerTableWithState = async (tx, { userId, maxPlayers, stakesJson }) => {
+export const createPokerTableWithState = async (tx, {
+  userId,
+  maxPlayers,
+  stakesJson,
+  lifecycleKind = "STANDARD",
+  managedProfileKey = null,
+  rotationDueAt = null
+}) => {
   const tableRows = await tx.unsafe(
     `
-insert into public.poker_tables (stakes, max_players, status, created_by, updated_at, last_activity_at)
-values ($1::jsonb, $2, 'OPEN', $3, now(), now())
+insert into public.poker_tables (
+  stakes, max_players, status, created_by, updated_at, last_activity_at,
+  lifecycle_kind, managed_profile_key, rotation_due_at
+)
+values ($1::jsonb, $2, 'OPEN', $3, now(), now(), $4, $5, $6)
 returning id;
     `,
-    [stakesJson, maxPlayers, userId]
+    [stakesJson, maxPlayers, userId, lifecycleKind, managedProfileKey, rotationDueAt]
   );
   const tableId = tableRows?.[0]?.id || null;
   if (!tableId) {

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -84,6 +84,11 @@ from public.poker_tables t
 where t.status = 'OPEN'
   and t.max_players = $1
   and t.stakes = $2::jsonb
+  and not (
+    t.lifecycle_kind = 'CONTINUOUS_BOT'
+    and t.rotation_due_at is not null
+    and t.rotation_due_at <= now()
+  )
   and (select count(*)::int from public.poker_seats s where s.table_id = t.id and s.status = 'ACTIVE') < t.max_players
   and not exists (
     select 1
@@ -102,6 +107,7 @@ where t.status = 'OPEN'
         and coalesce(hs.is_bot, false) = false
         and coalesce(hs.last_seen_at, to_timestamp(0)) >= $4::timestamptz
     )
+    or t.lifecycle_kind = 'CONTINUOUS_BOT'
     or coalesce((
       select ps.state ->> 'phase'
       from public.poker_state ps

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -87,6 +87,9 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat--folded .poker-seat-cards,.poker-seat--folded .poker-seat-name,.poker-seat--folded .poker-seat-action-badge,.poker-seat--folded .poker-seat-best-hand{opacity:0.46;}
 
 .poker-seat--folded .poker-seat-status{color:#f9c1c1; border-color:rgba(236,132,132,0.52); background:rgba(73,17,17,0.66);}
+.poker-seat--waiting-next-hand{opacity:1;}
+.poker-seat--waiting-next-hand .poker-seat-avatar{filter:none; border-color:#f4c95d; box-shadow:0 0 0 3px rgba(244,201,93,0.22),0 0 18px rgba(244,201,93,0.32);}
+.poker-seat--waiting-next-hand .poker-seat-status{color:#fff1b8; border-color:rgba(244,201,93,0.72); background:rgba(85,61,12,0.88);}
 
 .poker-seat--hero{width:124px;}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -163,6 +163,12 @@
   var autoJoinErrorActive = false;
   var reconnectSeatNo = null;
   var lastKnownCurrentSeatNo = null;
+  var joinOperation = {
+    phase: 'idle',
+    requestId: null,
+    payload: null,
+    source: null
+  };
   var bootReady = false;
   var queuedPreaction = null;
   var queuedPreactionInFlight = false;
@@ -1470,6 +1476,78 @@
     return null;
   }
 
+  function isJoinOperationPending(){
+    return joinOperation.phase === 'reserving' || joinOperation.phase === 'checking';
+  }
+
+  function pendingJoinStorageKey(){
+    if (!state.currentUserId || !state.tableId) return null;
+    return 'poker:pendingJoin:' + String(state.currentUserId) + ':' + String(state.tableId);
+  }
+
+  function persistPendingJoin(){
+    var key = pendingJoinStorageKey();
+    if (!key || !joinOperation.requestId || !joinOperation.payload) return;
+    try {
+      if (window.sessionStorage) {
+        window.sessionStorage.setItem(key, JSON.stringify({
+          requestId: joinOperation.requestId,
+          tableId: state.tableId,
+          payload: joinOperation.payload,
+          phase: 'unresolved'
+        }));
+      }
+    } catch (_err){}
+  }
+
+  function clearPendingJoin(){
+    var key = pendingJoinStorageKey();
+    if (!key) return;
+    try { if (window.sessionStorage) window.sessionStorage.removeItem(key); } catch (_err){}
+  }
+
+  function loadPendingJoin(){
+    var key = pendingJoinStorageKey();
+    if (!key) return null;
+    try {
+      var raw = window.sessionStorage ? window.sessionStorage.getItem(key) : null;
+      var parsed = raw ? JSON.parse(raw) : null;
+      if (!parsed || parsed.tableId !== state.tableId || typeof parsed.requestId !== 'string' || !parsed.requestId || !isObject(parsed.payload)) return null;
+      return {
+        requestId: parsed.requestId,
+        payload: parsed.payload
+      };
+    } catch (_err){
+      return null;
+    }
+  }
+
+  function setJoinOperationPhase(phase){
+    joinOperation.phase = phase;
+    if (phase === 'reserving') state.statusText = 'Reserving seat…';
+    else if (phase === 'checking') state.statusText = 'Checking seat reservation…';
+    else if (phase === 'waiting_next_hand') state.statusText = 'Seat reserved · Joining next hand';
+    else if (phase === 'active') state.statusText = LIVE_STATUS_COPY.live;
+    renderInfoPanel();
+    renderControls();
+  }
+
+  function buildJoinRequestId(){
+    return 'join_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function reconcileJoinOperationFromSnapshot(){
+    var seat = deriveCurrentSeat();
+    if (!seat) return false;
+    var waiting = currentPlayerStatus() === 'WAITING_NEXT_HAND';
+    joinOperation.phase = waiting ? 'waiting_next_hand' : 'active';
+    state.statusText = waiting ? 'Seat reserved · Joining next hand' : LIVE_STATUS_COPY.live;
+    joinOperation.requestId = null;
+    joinOperation.payload = null;
+    clearPendingJoin();
+    return true;
+  }
+
   function hasRenderableCurrentSeat(){
     var currentUserId = state.currentUserId;
     if (!currentUserId) return false;
@@ -2312,6 +2390,7 @@
       var hero = isCurrentUserSeat(seat);
       var lastAction = getSeatLastBettingRoundAction(seat);
       var folded = !!(seat && /FOLD/i.test(seat.status || ''));
+      var waitingNextHand = !!(seat && String(seat.status || '').toUpperCase() === 'WAITING_NEXT_HAND');
       var rotatedIndex = rotateSeatIndex(i, state.maxSeats);
       var anchor = getSeatAnchor(rotatedIndex, state.maxSeats);
       if (hero && state.maxSeats >= 4) anchor = { x: 34, y: 91 };
@@ -2324,6 +2403,7 @@
         + (seat && hasWonContestedPot(seat) ? ' poker-seat--pot-winner' : '')
         + (seat && hasReturnedChips(seat) ? ' poker-seat--returned' : '')
         + (hero ? ' poker-seat--hero' : '')
+        + (waitingNextHand ? ' poker-seat--waiting-next-hand' : '')
         + (!seat ? ' poker-seat--empty' : '');
       article.style.left = anchor.x + '%';
       article.style.top = anchor.y + '%';
@@ -2340,7 +2420,7 @@
 
       var cards = document.createElement('div');
       cards.className = 'poker-seat-cards';
-      if (!hero && seat && seat.userId){
+      if (!hero && seat && seat.userId && !waitingNextHand){
         var revealCards = getSeatRevealCards(seat);
         if (revealCards){
           revealCards.forEach(function(card){
@@ -2360,6 +2440,7 @@
       var statusPosition = getSeatStatusBadgePosition(rotatedIndex, hero);
       status.className = 'poker-seat-status';
       status.textContent = seat ? String(seat.status || 'ACTIVE').replace(/_/g, ' ') : 'OPEN';
+      if (waitingNextHand) status.textContent = 'NEXT HAND';
       status.style.left = statusPosition.left;
       status.style.top = statusPosition.top;
 
@@ -2423,6 +2504,11 @@
   function renderHeroCards(){
     if (!els.heroCards) return;
     els.heroCards.innerHTML = '';
+    if (currentPlayerStatus() === 'WAITING_NEXT_HAND'){
+      els.heroCards.hidden = true;
+      return;
+    }
+    els.heroCards.hidden = false;
     if (isCurrentUserFolded()) els.heroCards.className = 'poker-hero-cards poker-hero-cards--folded';
     else els.heroCards.className = 'poker-hero-cards';
     var cards = Array.isArray(state.heroCards) ? state.heroCards : [];
@@ -2786,10 +2872,11 @@
     var preactionAmountBounds = resolveAmountBounds(preactionAmountAction, stackAmount);
     var displayPrimary = primary || preactionPrimary || 'CHECK';
     var displayAmountAction = amountAction || preactionAmountAction || 'BET';
-    var showActionButtons = signedIn && seated;
+    var showActionButtons = signedIn && seated && currentPlayerStatus() !== 'WAITING_NEXT_HAND';
     var showLiveActionButtons = showActionButtons && !preactionMode;
     var actionControlsLocked = !liveReady || !usersTurn || controlsLocked || playerSittingOut;
-    var joinDisabled = !signedIn || seated || !state.tableId || !liveReady;
+    var joinPending = isJoinOperationPending();
+    var joinDisabled = !signedIn || seated || !state.tableId || !liveReady || joinPending;
     if (!seated || !activeHand || isCurrentUserFolded() || playerSittingOut) clearQueuedPreaction();
     if (preactionMode) {
       syncQueuedPreactionWithPreactionState({
@@ -2809,10 +2896,15 @@
     if (els.joinBtn) els.joinBtn.hidden = false;
     if (els.joinBtn) els.joinBtn.disabled = joinDisabled;
     if (els.joinBtn) {
-      if (seated) els.joinBtn.textContent = 'Joined';
+      if (joinOperation.phase === 'reserving') els.joinBtn.textContent = 'Reserving seat…';
+      else if (joinOperation.phase === 'checking') els.joinBtn.textContent = 'Checking reservation…';
+      else if (seated && currentPlayerStatus() === 'WAITING_NEXT_HAND') els.joinBtn.textContent = 'Joining next hand';
+      else if (seated) els.joinBtn.textContent = 'Joined';
       else if (!signedIn) els.joinBtn.textContent = 'Join';
       else if (!liveReady) els.joinBtn.textContent = 'Connecting…';
       else els.joinBtn.textContent = 'Join';
+      if (joinPending) els.joinBtn.setAttribute('aria-busy', 'true');
+      else els.joinBtn.removeAttribute('aria-busy');
     }
     if (els.joinSeat) els.joinSeat.disabled = !signedIn || seated || !liveReady;
     if (els.joinBuyIn) els.joinBuyIn.disabled = !signedIn || seated || !liveReady;
@@ -3015,12 +3107,63 @@
     return payload;
   }
 
-  function sendCommand(methodName, payload){
+  function sendCommand(methodName, payload, requestId){
     if (!wsClient || typeof wsClient[methodName] !== 'function' || !isWsReady()){
       setError('Live table connection is still starting');
       return Promise.reject(new Error('ws_unavailable'));
     }
-    return wsClient[methodName](payload || {});
+    return wsClient[methodName](payload || {}, requestId || null);
+  }
+
+  function beginJoinOperation(payload, options){
+    var opts = options || {};
+    if (isJoinOperationPending() && opts.resume !== true) return joinOperation.promise || Promise.resolve({ ok: true, pending: true });
+    var requestId = typeof opts.requestId === 'string' && opts.requestId ? opts.requestId : buildJoinRequestId();
+    joinOperation = {
+      phase: opts.resume === true ? 'checking' : 'reserving',
+      requestId: requestId,
+      payload: payload,
+      source: opts.source || 'manual',
+      promise: null
+    };
+    persistPendingJoin();
+    setError('');
+    setJoinOperationPhase(joinOperation.phase);
+    var promise = sendCommand('sendJoin', payload, requestId).then(function(result){
+      if (joinOperation.requestId !== requestId) return result;
+      clearPendingJoin();
+      joinOperation.requestId = null;
+      joinOperation.payload = null;
+      setJoinOperationPhase(result && result.joinStatus === 'WAITING_NEXT_HAND' ? 'waiting_next_hand' : 'active');
+      return result;
+    }).catch(function(error){
+      if (joinOperation.requestId !== requestId) return;
+      clearPendingJoin();
+      joinOperation.requestId = null;
+      joinOperation.payload = null;
+      joinOperation.phase = 'rejected';
+      renderControls();
+      throw error;
+    });
+    joinOperation.promise = promise;
+    return promise;
+  }
+
+  function resumePendingJoinOperation(){
+    if (deriveCurrentSeat()){
+      reconcileJoinOperationFromSnapshot();
+      return false;
+    }
+    var pendingJoin = loadPendingJoin();
+    if (!pendingJoin) return false;
+    void beginJoinOperation(pendingJoin.payload, {
+      requestId: pendingJoin.requestId,
+      source: 'resume_pending',
+      resume: true
+    }).catch(function(error){
+      setError(joinErrorMessage(error));
+    });
+    return true;
   }
 
   function queueLeaveAndNavigateImmediately(){
@@ -3142,9 +3285,11 @@
     if (suggestedSeatNoParam && els.joinSeat) els.joinSeat.value = String(suggestedSeatNoParam);
     autoJoinErrorActive = false;
     setError('');
-    sendCommand('sendJoin', buildJoinPayloadWithOptions({ autoSeat: true })).then(function(result){
+    beginJoinOperation(buildJoinPayloadWithOptions({ autoSeat: true }), { source: 'auto' }).then(function(result){
       resetAutoJoinRetryState();
-      state.statusText = result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted';
+      state.statusText = result && result.joinStatus === 'WAITING_NEXT_HAND'
+        ? 'Seat reserved · Joining next hand'
+        : (result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted');
       renderInfoPanel();
     }).catch(function(err){
       autoJoinAttempted = false;
@@ -3180,13 +3325,15 @@
       preferredSeatNo: preferredSeatNo
     };
     if (isGuestMode) reconnectPayload.guestJoinIntent = 'resume';
-    sendCommand('sendJoin', reconnectPayload).then(function(result){
+    beginJoinOperation(reconnectPayload, { source: 'reconnect' }).then(function(result){
       var resolvedSeatNo = result && Number.isInteger(Number(result.seatNo))
         ? Number(result.seatNo)
         : preferredSeatNo;
       reconnectSeatNo = null;
       lastKnownCurrentSeatNo = resolvedSeatNo;
-      state.statusText = 'Reconnected to seat ' + resolvedSeatNo;
+      state.statusText = result && result.joinStatus === 'WAITING_NEXT_HAND'
+        ? 'Seat reserved · Joining next hand'
+        : ('Reconnected to seat ' + resolvedSeatNo);
       renderInfoPanel();
     }).catch(function(err){
       autoJoinAttempted = false;
@@ -3317,9 +3464,10 @@
       handleAction('FOLD');
     });
     if (els.joinBtn) els.joinBtn.addEventListener('click', function(){
-      setError('');
-      sendCommand('sendJoin', buildJoinPayloadWithOptions({ autoSeat: true })).then(function(result){
-        state.statusText = result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted';
+      beginJoinOperation(buildJoinPayloadWithOptions({ autoSeat: true }), { source: 'manual' }).then(function(result){
+        state.statusText = result && result.joinStatus === 'WAITING_NEXT_HAND'
+          ? 'Seat reserved · Joining next hand'
+          : (result && result.seatNo != null ? ('Joined seat ' + result.seatNo) : 'Join accepted');
         renderInfoPanel();
       }).catch(function(err){
         setError(joinErrorMessage(err));
@@ -3535,7 +3683,11 @@
             leaveAndReturnToLobby();
             return;
           }
-          if (!rejoinSeatAfterReconnect()) autoJoinSeat();
+          if (!resumePendingJoinOperation() && !rejoinSeatAfterReconnect()) autoJoinSeat();
+        } else if (status === 'join_pending'){
+          if (joinOperation.requestId && info && info.requestId === joinOperation.requestId) {
+            setJoinOperationPhase('checking');
+          }
         } else if (status === 'reconnecting'){
           cancelSettlementAnimations();
           suppressSettlementAnimationUntilAuthoritativeSnapshot = true;
@@ -3585,6 +3737,7 @@
         }
         var previousVisual = captureVisualSnapshot();
         mergeSnapshot(payload, frame);
+        reconcileJoinOperationFromSnapshot();
         maybeExecuteQueuedPreaction();
         render();
         var nextVisual = captureVisualSnapshot();

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -124,12 +124,49 @@
       return rid;
     }
 
-    function rejectAllPending(code){
+    function markJoinPending(entry, reason){
+      if (!entry || entry.type !== 'join') return;
+      if (entry.timer) clearTimeout(entry.timer);
+      entry.timer = null;
+      entry.softPending = true;
+      emitStatus('join_pending', {
+        requestId: entry.requestId,
+        reason: reason || 'pending'
+      });
+    }
+
+    function armCommandTimer(entry){
+      if (!entry) return;
+      if (entry.timer) clearTimeout(entry.timer);
+      entry.timer = setTimeout(function(){
+        if (!pending.has(entry.requestId)) return;
+        if (entry.type === 'join'){
+          markJoinPending(entry, 'soft_timeout');
+          requestGameplaySnapshot();
+          return;
+        }
+        pending.delete(entry.requestId);
+        entry.reject(createError('timeout'));
+      }, COMMAND_TIMEOUT_MS);
+    }
+
+    function rejectAllPending(code, options){
+      var preserveJoins = !!(options && options.preserveJoins);
       pending.forEach(function(entry){
-        clearTimeout(entry.timer);
+        if (preserveJoins && entry.type === 'join'){
+          markJoinPending(entry, code || 'ws_closed');
+          return;
+        }
+        if (entry.timer) clearTimeout(entry.timer);
         entry.reject(createError(code || 'ws_closed'));
       });
-      pending.clear();
+      if (!preserveJoins) {
+        pending.clear();
+        return;
+      }
+      pending.forEach(function(entry, requestId){
+        if (entry.type !== 'join') pending.delete(requestId);
+      });
     }
 
     function sendCommand(type, payload, requestId){
@@ -137,11 +174,29 @@
       var rid = send(type, payload, requestId || null);
       if (!rid) return Promise.reject(createError('ws_unavailable'));
       return new Promise(function(resolve, reject){
-        var timer = setTimeout(function(){
-          pending.delete(rid);
-          reject(createError('timeout'));
-        }, COMMAND_TIMEOUT_MS);
-        pending.set(rid, { resolve: resolve, reject: reject, timer: timer, type: type });
+        var entry = {
+          resolve: resolve,
+          reject: reject,
+          timer: null,
+          type: type,
+          requestId: rid,
+          payload: payload || {},
+          softPending: false
+        };
+        pending.set(rid, entry);
+        armCommandTimer(entry);
+      });
+    }
+
+    function retryPendingJoins(){
+      if (!authOk || !ws || ws.readyState !== 1) return;
+      pending.forEach(function(entry){
+        if (entry.type !== 'join' || !entry.softPending) return;
+        var retriedRequestId = send('join', entry.payload || {}, entry.requestId);
+        if (!retriedRequestId) return;
+        entry.softPending = false;
+        armCommandTimer(entry);
+        emitStatus('join_retry', { requestId: entry.requestId });
       });
     }
 
@@ -283,7 +338,7 @@
         mintAndAuth().catch(function(err){ var code = safeErrorCode(err); log('poker_ws_auth_error', { tableId: tableId, code: code }); emitStatus('failed', { stage: 'auth', code: code }); emitProtocolError(code, 'auth_failed'); destroy(); });
         return;
       }
-      if (frame.type === 'authOk') { authOk = true; reconnectAttempt = 0; emitStatus('auth_ok', { roomId: frame.payload && frame.payload.roomId ? frame.payload.roomId : null }); requestLiveState(); return; }
+      if (frame.type === 'authOk') { authOk = true; reconnectAttempt = 0; emitStatus('auth_ok', { roomId: frame.payload && frame.payload.roomId ? frame.payload.roomId : null }); requestLiveState(); retryPendingJoins(); return; }
       if (frame.type === 'lobby_snapshot') {
         var initialLobby = !initialLobbySnapshotDelivered;
         initialLobbySnapshotDelivered = true;
@@ -313,8 +368,14 @@
         var rid = frame.requestId || (frame.payload && frame.payload.requestId) || null;
         var commandErrorHandled = false;
         if (rid && pending.has(rid)) {
-          var entry = pending.get(rid); pending.delete(rid); clearTimeout(entry.timer); entry.reject(createError(frame.payload && frame.payload.code ? frame.payload.code : 'ws_error'));
-          commandErrorHandled = true;
+          var entry = pending.get(rid);
+          if (entry.type === 'join') {
+            markJoinPending(entry, frame.payload && frame.payload.code ? frame.payload.code : 'ws_error');
+            commandErrorHandled = true;
+          } else {
+            pending.delete(rid); clearTimeout(entry.timer); entry.reject(createError(frame.payload && frame.payload.code ? frame.payload.code : 'ws_error'));
+            commandErrorHandled = true;
+          }
         }
         var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error';
         if (commandErrorHandled) {
@@ -357,7 +418,7 @@
         authOk = false;
         connecting = false;
         clearHeartbeat();
-        rejectAllPending('ws_closed');
+        rejectAllPending('ws_closed', { preserveJoins: true });
         log('poker_ws_close', { tableId: tableId, readyState: safeReadyState(ws), code: code, reason: sanitizeText(evt && evt.reason), wasClean: !!(evt && evt.wasClean) });
         emitStatus('closed', { code: code });
         ws = null;
@@ -384,7 +445,7 @@
       authOk = false;
       clearHeartbeat();
       clearReconnect();
-      rejectAllPending('ws_closed');
+      rejectAllPending('ws_closed', { preserveJoins: true });
       if (ws && ws.readyState <= 1){ try { ws.close(1000, 'client_shutdown'); } catch (_err){} }
       ws = null;
     }

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -315,6 +315,11 @@
       var rid = payload.requestId || frame.requestId || null;
       if (!rid || !pending.has(rid)) return;
       var entry = pending.get(rid);
+      if (entry.type === 'join' && payload.status === 'pending') {
+        markJoinPending(entry, payload.reason || 'server_recovery_pending');
+        requestGameplaySnapshot();
+        return;
+      }
       pending.delete(rid);
       clearTimeout(entry.timer);
       if (payload.status === 'accepted') {

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -206,7 +206,22 @@ async function loadSeatRows(tx, tableId) {
   return Array.isArray(rows) ? rows : [];
 }
 
-async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, humanUserId, postTransaction, targetBotCount = null, klog = () => {}, random = Math.random }) {
+async function seedBotsForJoin({
+  tx,
+  tableId,
+  maxPlayers,
+  tableStakes,
+  cfg,
+  humanUserId,
+  postTransaction,
+  targetBotCount = null,
+  allowBotsOnly = false,
+  requireExactTarget = false,
+  fundingReason = "BOT_SEED_BUY_IN",
+  idempotencyPrefix = "bot-seed-buyin",
+  klog = () => {},
+  random = Math.random
+}) {
   if (!cfg?.enabled || typeof postTransaction !== "function") return [];
   const stakesParsed = parseStakes(tableStakes);
   if (!stakesParsed.ok) {
@@ -217,7 +232,10 @@ async function seedBotsForJoin({ tx, tableId, maxPlayers, tableStakes, cfg, huma
   const seatRows = await loadSeatRows(tx, tableId);
   const activeSeats = seatRows.filter((row) => String(row?.status || "ACTIVE").toUpperCase() === "ACTIVE");
   const humanCount = activeSeats.filter((row) => !row?.is_bot).length;
-  if (!shouldSeedBotsOnJoin({ humanCount })) return [];
+  if (!allowBotsOnly && !shouldSeedBotsOnJoin({ humanCount })) return [];
+  if (allowBotsOnly && humanCount !== 0) {
+    throw new Error("managed_bot_seed_human_present");
+  }
 
   const targetBots = Number.isInteger(targetBotCount)
     ? targetBotCount
@@ -253,7 +271,7 @@ returning seat_no;
       await postTransaction({
         userId: null,
         txType: "TABLE_BUY_IN",
-        idempotencyKey: `bot-seed-buyin:${tableId}:${seatNo}`,
+        idempotencyKey: `${idempotencyPrefix}:${tableId}:${seatNo}`,
         metadata: {
           actor: "BOT",
           botUserId,
@@ -261,13 +279,13 @@ returning seat_no;
           tableId,
           seatNo,
           botProfile: botProfile,
-          reason: "BOT_SEED_BUY_IN"
+          reason: fundingReason
         },
         entries: [
           { accountType: "SYSTEM", systemKey: cfg.bankrollSystemKey, amount: -buyInChips },
           { accountType: "ESCROW", systemKey: escrowSystemKey, amount: buyInChips }
         ],
-        createdBy: humanUserId,
+        createdBy: allowBotsOnly ? null : humanUserId,
         tx
       });
       seededBots.push({
@@ -289,6 +307,11 @@ returning seat_no;
     }
   }
 
+  if (requireExactTarget && existingBotCount + seededBots.length !== targetBots) {
+    const error = new Error("managed_bot_table_seed_incomplete");
+    error.code = "managed_bot_table_seed_incomplete";
+    throw error;
+  }
   return seededBots;
 }
 

--- a/shared/poker-domain/deferred-leave-finalization.behavior.test.mjs
+++ b/shared/poker-domain/deferred-leave-finalization.behavior.test.mjs
@@ -6,7 +6,7 @@ const tableId = "11111111-1111-4111-8111-111111111111";
 const leaverId = "22222222-2222-4222-8222-222222222222";
 const activeId = "33333333-3333-4333-8333-333333333333";
 
-function createFixture({ withActiveHuman, initialVersion = 7 }) {
+function createFixture({ withActiveHuman, initialVersion = 7, managedContinuous = false }) {
   let version = initialVersion;
   let state = {
     tableId,
@@ -30,7 +30,14 @@ function createFixture({ withActiveHuman, initialVersion = 7 }) {
   const tx = {
     unsafe: async (query, params) => {
       const sql = String(query).toLowerCase();
-      if (sql.includes("select id, status from public.poker_tables")) return [{ id: tableId, status: "OPEN" }];
+      if (sql.includes("select id, status, lifecycle_kind, managed_profile_key from public.poker_tables")) {
+        return [{
+          id: tableId,
+          status: "OPEN",
+          lifecycle_kind: managedContinuous ? "CONTINUOUS_BOT" : null,
+          managed_profile_key: managedContinuous ? "CONTINUOUS_BOT_DEFAULT" : null
+        }];
+      }
       if (sql.includes("select version, state from public.poker_state") && sql.includes("for update")) return [{ version, state }];
       if (sql.includes("select user_id, seat_no, status, is_bot, stack from public.poker_seats")) return seats;
       if (sql.includes("update public.poker_state set version = version + 1")) {
@@ -96,6 +103,32 @@ test("delegates the last deferred human to existing terminal close", async () =>
   assert.equal(result.closed, true);
   assert.equal(terminalCalls, 1);
   assert.equal(fixture.cashouts.length, 0);
+});
+
+test("managed continuous table finalizes the last deferred human without terminal close", async () => {
+  const fixture = createFixture({ withActiveHuman: false, managedContinuous: true });
+  let terminalCalls = 0;
+
+  const result = await finalizeDeferredLeavesAfterSettlement({
+    beginSql: fixture.beginSql,
+    tableId,
+    postTransactionFn: fixture.postTransactionFn,
+    executeTerminalClose: async () => {
+      terminalCalls += 1;
+      return { ok: true, changed: true, closed: true, status: "should_not_happen" };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(result.closed, false);
+  assert.equal(result.status, "deferred_leaves_finalized");
+  assert.equal(terminalCalls, 0);
+  assert.equal(fixture.cashouts.length, 1);
+  assert.equal(fixture.cashouts[0].entries[0].amount, -25);
+  assert.deepEqual(fixture.getSeats(), []);
+  assert.deepEqual(fixture.getState().seats, []);
+  assert.equal(Object.hasOwn(fixture.getState().stacks, leaverId), false);
 });
 
 test("uses different idempotency keys for separate deferred leaves on the same table", async () => {

--- a/shared/poker-domain/inactive-cleanup.behavior.test.mjs
+++ b/shared/poker-domain/inactive-cleanup.behavior.test.mjs
@@ -11,6 +11,8 @@ function createCleanupHarness({
   seatRows,
   state,
   tableStatus = "OPEN",
+  lifecycleKind = null,
+  managedProfileKey = null,
   createdAt = "2026-03-01T00:00:00.000Z",
   lastActivityAt = null,
   updatedAt = null,
@@ -42,6 +44,13 @@ function createCleanupHarness({
       }
       if (sql.includes("select version, state from public.poker_state")) {
         return [{ version: tableState.stateRow.version, state: { ...tableState.stateRow.state } }];
+      }
+      if (sql.includes("delete from public.poker_seats where table_id = $1 and user_id = $2")) {
+        const [, userId] = params;
+        for (let i = seatState.length - 1; i >= 0; i -= 1) {
+          if (seatState[i].user_id === userId) seatState.splice(i, 1);
+        }
+        return [];
       }
       if (sql.includes("where table_id = $1 and user_id = $2 limit 1 for update")) {
         const [, userId] = params;
@@ -92,7 +101,9 @@ function createCleanupHarness({
           status: tableState.tableStatus,
           created_at: tableState.createdAt,
           last_activity_at: tableState.lastActivityAt,
-          updated_at: tableState.updatedAt
+          updated_at: tableState.updatedAt,
+          lifecycle_kind: lifecycleKind,
+          managed_profile_key: managedProfileKey
         }];
       }
       if (sql.includes("update public.poker_tables set status = 'CLOSED'")) {
@@ -355,6 +366,47 @@ test("inactive cleanup closes stale live hand for disconnected human after activ
   assert.equal(harness.tableState.stateRow.state.phase, "HAND_DONE");
   assert.equal(harness.tableState.stateRow.state.turnUserId, null);
   assert.deepEqual(harness.tableState.stateRow.state.stacks, {});
+});
+
+test("inactive cleanup defers the last human on a managed continuous live hand instead of closing the table", async () => {
+  const harness = createCleanupHarness({
+    seatRows: [
+      { user_id: "human_1", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 250 },
+      { user_id: "bot_1", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 170 },
+      { user_id: "bot_2", seat_no: 3, status: "ACTIVE", is_bot: true, stack: 165 }
+    ],
+    state: {
+      phase: "PREFLOP",
+      handId: "h-managed-stale-disconnect",
+      turnUserId: "human_1",
+      turnDeadlineAt: null,
+      seats: [
+        { userId: "human_1", seatNo: 1, status: "ACTIVE" },
+        { userId: "bot_1", seatNo: 2, status: "ACTIVE", isBot: true },
+        { userId: "bot_2", seatNo: 3, status: "ACTIVE", isBot: true }
+      ],
+      stacks: { human_1: 250, bot_1: 170, bot_2: 165 },
+      leftTableByUserId: {}
+    },
+    lifecycleKind: "CONTINUOUS_BOT",
+    managedProfileKey: "CONTINUOUS_BOT_DEFAULT",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastActivityAt: "2026-03-01T00:00:10.000Z",
+    nowMs: Date.parse("2026-03-01T00:02:00.000Z")
+  });
+
+  const result = await harness.run();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(result.closed, false);
+  assert.equal(result.status, "managed_continuous_human_deferred");
+  assert.equal(harness.cashouts.length, 0);
+  assert.equal(harness.tableState.tableStatus, "OPEN");
+  assert.equal(harness.seatState.find((row) => row.user_id === "human_1")?.status, "ACTIVE");
+  assert.equal(harness.tableState.stateRow.state.leftTableByUserId.human_1, true);
+  assert.equal(harness.tableState.stateRow.state.phase, "PREFLOP");
+  assert.deepEqual(harness.tableState.stateRow.state.stacks, { human_1: 250, bot_1: 170, bot_2: 165 });
 });
 
 test("inactive cleanup refunds stale live-hand contributions including zero-stack all-in participant", async () => {

--- a/shared/poker-domain/inactive-cleanup.mjs
+++ b/shared/poker-domain/inactive-cleanup.mjs
@@ -26,11 +26,24 @@ const ACTION_HAND_PHASES = new Set(["PREFLOP", "FLOP", "TURN", "RIVER"]);
 const LIVE_HAND_PHASES = new Set([...ACTION_HAND_PHASES, "SHOWDOWN"]);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const LEDGER_IDEMPOTENCY_CONSTRAINT = "chips_transactions_idempotency_key_unique";
+const MANAGED_CONTINUOUS_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
 
 function normalizePositiveInt(n) {
   const value = Number(n);
   if (!Number.isInteger(value) || value <= 0 || Math.abs(value) > Number.MAX_SAFE_INTEGER) return null;
   return value;
+}
+
+function normalizeTableStatus(value) {
+  if (typeof value !== "string") return "OPEN";
+  const normalized = value.trim().toUpperCase();
+  return normalized || "OPEN";
+}
+
+function isManagedContinuousTable(tableRow) {
+  const lifecycleKind = typeof tableRow?.lifecycle_kind === "string" ? tableRow.lifecycle_kind.trim().toUpperCase() : "";
+  const managedProfileKey = typeof tableRow?.managed_profile_key === "string" ? tableRow.managed_profile_key.trim().toUpperCase() : "";
+  return lifecycleKind === "CONTINUOUS_BOT" && managedProfileKey === MANAGED_CONTINUOUS_PROFILE_KEY;
 }
 
 function normalizeSeatNo(value) {
@@ -112,6 +125,22 @@ function activeSeatUserIdSet(seats) {
   return ids;
 }
 
+function parseSeats(state) {
+  return Array.isArray(state?.seats) ? state.seats : [];
+}
+
+function parseStacks(state) {
+  return state?.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
+    ? { ...state.stacks }
+    : {};
+}
+
+function parseWaitingForNextHand(state) {
+  return state?.waitingForNextHandByUserId && typeof state.waitingForNextHandByUserId === "object" && !Array.isArray(state.waitingForNextHandByUserId)
+    ? { ...state.waitingForNextHandByUserId }
+    : {};
+}
+
 function hasReplacementBotSeatMatch({ state, seats, userId }) {
   if (typeof userId !== "string" || !userId) return false;
   const stateSeats = Array.isArray(state?.seats) ? state.seats : [];
@@ -187,7 +216,7 @@ export async function executeInactiveCleanup({
       if (seat.is_bot === true) return { ok: true, changed: false, status: "bot_skipped", retryable: false };
     }
 
-    const stateRows = await tx.unsafe("select state from public.poker_state where table_id = $1 limit 1 for update;", [tableId]);
+    const stateRows = await tx.unsafe("select version, state from public.poker_state where table_id = $1 limit 1 for update;", [tableId]);
     const stateRow = stateRows?.[0] || null;
     const state = normalizeState(stateRow?.state);
     const nowMs = Date.now();
@@ -199,9 +228,11 @@ export async function executeInactiveCleanup({
     }
 
     const tableRows = await tx.unsafe(
-      "select status, created_at, last_activity_at, updated_at from public.poker_tables where id = $1 limit 1 for update;",
+      "select status, created_at, last_activity_at, updated_at, lifecycle_kind, managed_profile_key from public.poker_tables where id = $1 limit 1 for update;",
       [tableId]
     );
+    const tableRow = tableRows?.[0] || null;
+    const managedContinuousTable = isManagedContinuousTable(tableRow);
     const tableCreatedAtMs = parseTimestampMs(tableRows?.[0]?.created_at);
     const tableLastActivityAtMs =
       parseTimestampMs(tableRows?.[0]?.last_activity_at)
@@ -259,6 +290,77 @@ export async function executeInactiveCleanup({
       && row?.status === "ACTIVE"
       && !(seatWasActive && row?.user_id === normalizedUserId)
     ));
+    if (!anotherActiveHumanRemains && normalizedUserId && seatWasActive && managedContinuousTable && normalizeTableStatus(tableRow?.status) === "OPEN") {
+      const phase = typeof state?.phase === "string" ? state.phase : "";
+      if (hasLiveHandSignal(state)) {
+        const nextLeftTableByUserId = state?.leftTableByUserId && typeof state.leftTableByUserId === "object" && !Array.isArray(state.leftTableByUserId)
+          ? { ...state.leftTableByUserId }
+          : {};
+        if (nextLeftTableByUserId[normalizedUserId] === true) {
+          return { ok: true, changed: false, status: "managed_continuous_human_deferred", closed: false, retryable: false };
+        }
+        nextLeftTableByUserId[normalizedUserId] = true;
+        const nextWaitingForNextHandByUserId = parseWaitingForNextHand(state);
+        delete nextWaitingForNextHandByUserId[normalizedUserId];
+        const nextState = {
+          ...state,
+          leftTableByUserId: nextLeftTableByUserId,
+          waitingForNextHandByUserId: nextWaitingForNextHandByUserId
+        };
+        if (stateRow) {
+          await tx.unsafe("update public.poker_state set state = $2 where table_id = $1;", [tableId, JSON.stringify(nextState)]);
+        }
+        return {
+          ok: true,
+          changed: true,
+          closed: false,
+          status: "managed_continuous_human_deferred",
+          retryable: false
+        };
+      }
+
+      let targetCashout;
+      try {
+        targetCashout = requireAuthoritativeHumanStack({ state, userId: normalizedUserId });
+      } catch (error) {
+        klog("poker_inactive_cleanup_stack_ambiguous", { tableId, reason: error?.code || "stack_ambiguous", source: "ambiguous" });
+        throw error;
+      }
+      await postCashout({
+        postTransaction,
+        tx,
+        tableId,
+        userId: normalizedUserId,
+        amount: targetCashout.amount,
+        idempotencyKey: `poker:deferred-leave:v1:${tableId}:${Number(stateRow?.version || 0)}:${normalizedUserId}`,
+        createdBy: normalizedUserId,
+        reason: "ws_disconnect_inactive_cleanup"
+      });
+      const nextStacks = parseStacks(state);
+      delete nextStacks[normalizedUserId];
+      const nextLeftTableByUserId = state?.leftTableByUserId && typeof state.leftTableByUserId === "object" && !Array.isArray(state.leftTableByUserId)
+        ? { ...state.leftTableByUserId }
+        : {};
+      nextLeftTableByUserId[normalizedUserId] = true;
+      const nextState = {
+        ...state,
+        seats: parseSeats(state).filter((seatEntry) => seatEntry?.userId !== normalizedUserId),
+        stacks: nextStacks,
+        leftTableByUserId: nextLeftTableByUserId,
+      };
+      if (stateRow) {
+        await tx.unsafe("update public.poker_state set state = $2 where table_id = $1;", [tableId, JSON.stringify(nextState)]);
+      }
+      await tx.unsafe("delete from public.poker_seats where table_id = $1 and user_id = $2;", [tableId, normalizedUserId]);
+      await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
+      return {
+        ok: true,
+        changed: true,
+        closed: false,
+        status: "managed_continuous_human_removed",
+        retryable: false
+      };
+    }
     if (anotherActiveHumanRemains) {
       if (!normalizedUserId) {
         return { ok: true, changed: false, status: "active_human_present", closed: false, retryable: false };

--- a/shared/poker-domain/join.behavior.test.mjs
+++ b/shared/poker-domain/join.behavior.test.mjs
@@ -147,6 +147,11 @@ test("fresh funded join preserves existing authoritative stacks when seat projec
       tableId: "t-live",
       phase: "FLOP",
       handId: "hand_live_join",
+      handSeats: [
+        { userId: "human_1", seatNo: 1 },
+        { userId: "bot_1", seatNo: 2, isBot: true },
+        { userId: "bot_2", seatNo: 3, isBot: true }
+      ],
       seats: [
         { userId: "human_1", seatNo: 1, status: "ACTIVE" },
         { userId: "bot_1", seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
@@ -217,6 +222,9 @@ test("fresh funded join preserves existing authoritative stacks when seat projec
   assert.equal(result.snapshot.stacks.human_2, 100);
   assert.equal(result.snapshot.stacks.bot_1, 120);
   assert.equal(result.snapshot.stacks.bot_2, 84);
+  assert.equal(result.joinStatus, "WAITING_NEXT_HAND");
+  assert.equal(stateRow.state.waitingForNextHandByUserId.human_2, true);
+  assert.deepEqual(stateRow.state.handSeats.map((seat) => seat.userId), ["human_1", "bot_1", "bot_2"]);
   assert.equal(stateRow.state.stacks.bot_1, 120);
   assert.equal(stateRow.state.stacks.bot_2, 84);
   assert.deepEqual(stateRow.state.community, ["AS", "KS", "QS"]);
@@ -1096,7 +1104,7 @@ test("first human authoritative join validates the same randomized bot target th
   }
 }));
 
-test("authoritative join replay does not duplicate bots and only fills missing bot seat", async () => withBotEnv(async () => {
+test("same-request authoritative join replay becomes rejoin without duplicate seat, stack, or buy-in", async () => withBotEnv(async () => {
   const state = {
     table: { id: "t-bots-replay", status: "OPEN", max_players: 6, stakes: '{"sb":1,"bb":2}' },
     seatRows: [
@@ -1168,7 +1176,7 @@ test("authoritative join replay does not duplicate bots and only fills missing b
     }
   }));
 
-  const first = await runJoin("join-replay-1");
+  const first = await runJoin("join-replay-same-request");
   assert.equal(first.seededBots.length, 1);
   assert.equal(first.snapshot.seats.filter((seat) => seat.isBot).length, 2);
   assert.equal(first.snapshot.stateVersion, 5);
@@ -1177,10 +1185,14 @@ test("authoritative join replay does not duplicate bots and only fills missing b
   assert.equal(first.snapshot.stacks[first.seededBots[0].userId], first.seededBots[0].stack);
   assert.equal(state.stateRow.state.stacks[first.seededBots[0].userId], first.seededBots[0].stack);
 
-  const second = await runJoin("join-replay-2");
+  const second = await runJoin("join-replay-same-request");
   assert.equal(second.rejoin, true);
+  assert.equal(second.seatNo, first.seatNo);
+  assert.equal(second.joinStatus, "ACTIVE");
   assert.equal(second.snapshot.seats.filter((seat) => seat.isBot).length, 2);
   assert.equal(second.snapshot.stacks.existing_bot, 200);
+  assert.equal(state.seatRows.filter((seat) => seat.user_id === "human_replay").length, 1);
+  assert.equal(state.stateRow.state.stacks.human_replay, 120);
   assert.equal(state.seatRows.filter((seat) => seat.is_bot).length, 2);
   assert.equal(state.ledgerCalls.filter((payload) => payload.txType === "TABLE_BUY_IN").length, 2);
 }));

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -409,6 +409,33 @@ function applyAuthoritativeSeatRowsToState(state, { tableId, seatEntries = [], f
   };
 }
 
+const LIVE_JOIN_PHASES = new Set(["POSTING_BLINDS", "PREFLOP", "FLOP", "TURN", "RIVER", "SHOWDOWN"]);
+
+function joinStatusForState(state, userId) {
+  return state?.waitingForNextHandByUserId?.[userId] === true ? "WAITING_NEXT_HAND" : "ACTIVE";
+}
+
+function markFreshJoinWaitingForNextHand(state, userId) {
+  const phase = typeof state?.phase === "string" ? state.phase.trim().toUpperCase() : "";
+  const handSeats = Array.isArray(state?.handSeats) ? state.handSeats : [];
+  const alreadyInHand = handSeats.some((seat) => seat?.userId === userId);
+  if (!LIVE_JOIN_PHASES.has(phase) || alreadyInHand) {
+    return { state, joinStatus: joinStatusForState(state, userId) };
+  }
+  return {
+    state: {
+      ...state,
+      waitingForNextHandByUserId: {
+        ...(state?.waitingForNextHandByUserId && typeof state.waitingForNextHandByUserId === "object" && !Array.isArray(state.waitingForNextHandByUserId)
+          ? state.waitingForNextHandByUserId
+          : {}),
+        [userId]: true
+      }
+    },
+    joinStatus: "WAITING_NEXT_HAND"
+  };
+}
+
 function buildProjectedSnapshot({ state, seatRows, maxPlayers, stateVersion }) {
   const { runtimeSeats } = projectEffectiveRuntimeSeats({ state, seatRows, maxPlayers });
   const stateStacks = state?.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks)
@@ -503,7 +530,7 @@ function assertAuthoritativeJoinStateComplete({
   }
 }
 
-async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackEntries, loadStateForUpdate, updateStateLocked, validateStateForStorage, targetBotCount }) {
+async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackEntries, loadStateForUpdate, updateStateLocked, validateStateForStorage, targetBotCount, markFreshJoinWaiting = false }) {
   const stateRow = normalizeLockedStateResult(await loadStateForUpdate(tx, tableId));
   const seatRows = await loadSeatRows(tx, tableId);
   const merged = applyAuthoritativeSeatRowsToState(stateRow.state, {
@@ -511,7 +538,10 @@ async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackE
     seatEntries: activeSeatRows(seatRows).map(asSeatSnapshot).filter(Boolean),
     fundedStackEntries
   });
-  const nextState = merged.state;
+  const waitingProjection = markFreshJoinWaiting
+    ? markFreshJoinWaitingForNextHand(merged.state, userId)
+    : { state: merged.state, joinStatus: "ACTIVE" };
+  const nextState = waitingProjection.state;
   const nextStateForStorage = sanitizeStateForStorage(nextState);
   if (!isStorageStateValid(validateStateForStorage, nextStateForStorage)) {
     throw makeError("state_invalid", "storage_state_validation_failed");
@@ -529,7 +559,7 @@ async function syncStateSeatAndStack({ tx, tableId, userId, seatNo, fundedStackE
     fundedStacks: merged.fundedStacks,
     displacedUserIds: merged.displacedUserIds
   });
-  return { version, state: nextStateForStorage, seatRows };
+  return { version, state: nextStateForStorage, seatRows, joinStatus: waitingProjection.joinStatus };
 }
 
 async function readPersistedSeatStack({ tx, tableId, userId }) {
@@ -662,6 +692,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
             rejoin: true,
             requestId: requestId || null,
             me: { seated: true },
+            joinStatus: joinStatusForState(stateRow.state, userId),
             snapshot: buildProjectedSnapshot({
               state: stateRow.state,
               seatRows,
@@ -698,6 +729,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
           rejoin: true,
           requestId: requestId || null,
           me: { seated: true },
+          joinStatus: joinStatusForState(nextStateForStorage, userId),
           snapshot: buildProjectedSnapshot({
             state: nextStateForStorage,
             seatRows,
@@ -846,7 +878,8 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       loadStateForUpdate,
       updateStateLocked,
       validateStateForStorage,
-      targetBotCount
+      targetBotCount,
+      markFreshJoinWaiting: true
       });
       await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
       return {
@@ -858,6 +891,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         rejoin: false,
         requestId: requestId || null,
         me: { seated: true },
+        joinStatus: updatedStateRow.joinStatus,
         seededBots,
         snapshot: buildProjectedSnapshot({
           state: updatedStateRow.state,

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -13,6 +13,7 @@ import { executeTerminalPokerCloseInTx } from "./terminal-close.mjs";
 const REQUEST_PENDING_STALE_SEC = 30;
 const BOT_AUTOPLAY_MAX_ACTIONS = 8;
 const BOT_AUTOPLAY_BOTS_ONLY_HARD_CAP = 30;
+const MANAGED_CONTINUOUS_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
 
 
 const isPlainObjectValue = (value) => value && typeof value === "object" && !Array.isArray(value);
@@ -53,6 +54,12 @@ const normalizeTableStatus = (value) => {
   if (typeof value !== "string") return "OPEN";
   const normalized = value.trim().toUpperCase();
   return normalized || "OPEN";
+};
+
+const isManagedContinuousTable = (table) => {
+  const lifecycleKind = typeof table?.lifecycle_kind === "string" ? table.lifecycle_kind.trim().toUpperCase() : "";
+  const managedProfileKey = typeof table?.managed_profile_key === "string" ? table.managed_profile_key.trim().toUpperCase() : "";
+  return lifecycleKind === "CONTINUOUS_BOT" && managedProfileKey === MANAGED_CONTINUOUS_PROFILE_KEY;
 };
 
 const normalizeCardCodeForValidation = (cardCode) => {
@@ -1019,7 +1026,7 @@ export async function finalizeDeferredLeavesAfterSettlement({
   }
   return beginSql(async (tx) => {
     const tableRows = await tx.unsafe(
-      "select id, status from public.poker_tables where id = $1 limit 1 for update;",
+      "select id, status, lifecycle_kind, managed_profile_key from public.poker_tables where id = $1 limit 1 for update;",
       [tableId]
     );
     const table = tableRows?.[0] || null;
@@ -1052,7 +1059,7 @@ export async function finalizeDeferredLeavesAfterSettlement({
       return { ok: true, changed: false, closed: false, status: "no_deferred_leaves", retryable: false };
     }
     const remainingActiveHumans = activeHumans.filter((seat) => leftMap[seat.user_id] !== true);
-    if (remainingActiveHumans.length === 0) {
+    if (remainingActiveHumans.length === 0 && !isManagedContinuousTable(table)) {
       return executeTerminalClose({
         tx,
         tableId,

--- a/supabase/migrations/20260729100000_poker_managed_table_profiles.sql
+++ b/supabase/migrations/20260729100000_poker_managed_table_profiles.sql
@@ -1,0 +1,67 @@
+create table public.poker_managed_table_profiles (
+  profile_key text primary key,
+  enabled boolean not null default false,
+  desired_table_count integer not null default 0,
+  min_bot_count integer not null,
+  target_bot_count integer not null,
+  max_bot_count integer not null,
+  rotation_interval_seconds integer not null,
+  postpone_interval_seconds integer not null,
+  small_blind integer not null,
+  big_blind integer not null,
+  max_seats integer not null,
+  updated_at timestamptz not null default now(),
+  updated_by uuid,
+  constraint poker_managed_table_profiles_key_chk check (profile_key ~ '^[A-Z0-9_]{1,64}$'),
+  constraint poker_managed_table_profiles_desired_count_chk check (desired_table_count between 0 and 2),
+  constraint poker_managed_table_profiles_seats_chk check (max_seats between 2 and 6),
+  constraint poker_managed_table_profiles_stakes_chk check (small_blind > 0 and big_blind > small_blind and big_blind <= 1000000),
+  constraint poker_managed_table_profiles_bots_chk check (
+    min_bot_count between 0 and 5
+    and min_bot_count <= target_bot_count
+    and target_bot_count <= max_bot_count
+    and max_bot_count < max_seats
+  ),
+  constraint poker_managed_table_profiles_rotation_chk check (rotation_interval_seconds between 60 and 86400),
+  constraint poker_managed_table_profiles_postpone_chk check (postpone_interval_seconds between 30 and 3600)
+);
+
+insert into public.poker_managed_table_profiles (
+  profile_key,
+  enabled,
+  desired_table_count,
+  min_bot_count,
+  target_bot_count,
+  max_bot_count,
+  rotation_interval_seconds,
+  postpone_interval_seconds,
+  small_blind,
+  big_blind,
+  max_seats
+) values (
+  'CONTINUOUS_BOT_DEFAULT',
+  false,
+  0,
+  2,
+  3,
+  3,
+  900,
+  300,
+  1,
+  2,
+  6
+);
+
+alter table public.poker_tables
+  add column lifecycle_kind text not null default 'STANDARD',
+  add column managed_profile_key text references public.poker_managed_table_profiles(profile_key) on delete restrict,
+  add column rotation_due_at timestamptz,
+  add constraint poker_tables_lifecycle_kind_chk check (lifecycle_kind in ('STANDARD', 'CONTINUOUS_BOT')),
+  add constraint poker_tables_managed_profile_chk check (
+    (lifecycle_kind = 'STANDARD' and managed_profile_key is null)
+    or (lifecycle_kind = 'CONTINUOUS_BOT' and managed_profile_key is not null)
+  );
+
+create index poker_tables_open_continuous_bot_idx
+  on public.poker_tables (managed_profile_key, rotation_due_at, id)
+  where status = 'OPEN' and lifecycle_kind = 'CONTINUOUS_BOT';

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -144,6 +144,7 @@ function createHarness(options = {}){
   const documentEvents = {};
   const logs = [];
   const joinPayloads = [];
+  const joinRequestIds = [];
   const actPayloads = [];
   const startPayloads = [];
   const leavePayloads = [];
@@ -165,9 +166,10 @@ function createHarness(options = {}){
     },
     destroy(){ this._ready = false; },
     isReady(){ return this._ready; },
-    sendJoin(payload){
+    sendJoin(payload, requestId){
       joinPayloads.push(payload);
-      if (typeof options.sendJoin === 'function') return options.sendJoin(payload, { attempt: joinPayloads.length });
+      joinRequestIds.push(requestId || null);
+      if (typeof options.sendJoin === 'function') return options.sendJoin(payload, { attempt: joinPayloads.length, requestId: requestId || null });
       return Promise.resolve({ ok: true, seatNo: payload.seatNo || payload.preferredSeatNo || 1 });
     },
     sendAct(payload){ actPayloads.push(payload); return Promise.resolve({ ok: true }); },
@@ -311,6 +313,7 @@ async function flush(){
     logs,
     windowLocation: sandbox.window.location,
     joinPayloads,
+    joinRequestIds,
     actPayloads,
     startPayloads,
     leavePayloads,
@@ -437,6 +440,69 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   assert.equal(harness.leavePayloads.length, 1);
   assert.equal(JSON.stringify(harness.leavePayloads[0]), JSON.stringify({ tableId: 'table-1' }));
   assert.equal(harness.windowLocation.href, '/poker/');
+});
+
+test('poker v2 shows one reserved next-hand join without cards, actions, or folded styling', async () => {
+  const unresolvedJoin = new Promise(() => {});
+  const harness = createHarness({
+    sendJoin: () => unresolvedJoin
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  await waitFor(() => harness.elements.pokerV2JoinBtn.disabled === false);
+
+  harness.elements.pokerV2JoinBtn.click();
+  harness.elements.pokerV2JoinBtn.click();
+  await harness.flush();
+
+  assert.equal(harness.joinPayloads.length, 1);
+  assert.equal(harness.elements.pokerV2JoinBtn.disabled, true);
+  assert.equal(harness.elements.pokerV2JoinBtn.textContent, 'Reserving seat…');
+  assert.equal(harness.elements.pokerV2JoinBtn.attributes['aria-busy'], 'true');
+  assert.ok(harness.getSessionStorage('poker:pendingJoin:user-1:table-1'));
+
+  ws.onStatus('join_pending', { requestId: harness.joinRequestIds[0], reason: 'soft_timeout' });
+  assert.equal(harness.elements.pokerV2JoinBtn.textContent, 'Checking reservation…');
+  assert.equal(harness.elements.pokerV2ErrorText.hidden, true);
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 8,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [{ userId: 'user-1', seat: 4, status: 'WAITING_NEXT_HAND' }]
+      },
+      public: {
+        hand: { handId: 'hand-live', status: 'TURN', dealerSeatNo: 2 },
+        turn: { userId: 'bot-1' },
+        board: [],
+        pot: { total: 15, sidePots: [] },
+        legalActions: { seat: null, actions: [] }
+      },
+      private: {
+        playerState: { status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false },
+        holeCards: []
+      },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  const heroSeat = harness.elements.pokerSeatLayer.children.find((node) => /poker-seat--hero/.test(node.className));
+  assert.ok(heroSeat);
+  assert.match(heroSeat.className, /poker-seat--waiting-next-hand/);
+  assert.doesNotMatch(heroSeat.className, /poker-seat--folded/);
+  assert.equal(findSeatChild(heroSeat, 'poker-seat-status').textContent, 'NEXT HAND');
+  assert.equal(findSeatChild(heroSeat, 'poker-seat-cards'), undefined);
+  assert.equal(harness.elements.pokerHeroCards.hidden, true);
+  assert.equal(harness.elements.pokerV2FoldBtn.hidden, true);
+  assert.equal(harness.elements.pokerV2JoinBtn.textContent, 'Joining next hand');
+  assert.equal(harness.getSessionStorage('poker:pendingJoin:user-1:table-1'), null);
 });
 
 test('poker v2 guest mode shows restrictions panel, hides XP badge, and still auto-joins', async () => {

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -184,7 +184,7 @@ test('poker ws client gameplay commands including rebuy resolve and reject by co
   await assert.rejects(actPromise, (err) => err && err.code === 'hand_not_live');
 });
 
-test('poker ws client keeps the socket ready after a command-scoped error frame', async () => {
+test('poker ws client keeps an ambiguous join pending after a command-scoped attach error', async () => {
   const h = loadClientHarness();
   h.client.start();
   const ws = h.FakeWebSocket.instances[0];
@@ -204,11 +204,60 @@ test('poker ws client keeps the socket ready after a command-scoped error frame'
     }
   });
 
-  await assert.rejects(joinPromise, (err) => err && err.code === 'TABLE_BOOTSTRAP_FAILED');
-  assert.equal(h.client.isReady(), true);
   assert.equal(h.statuses.some((entry) => entry.status === 'command_error' && entry.data.code === 'TABLE_BOOTSTRAP_FAILED'), true);
+  assert.equal(h.statuses.some((entry) => entry.status === 'join_pending' && entry.data.requestId === 'join_bootstrap_retry'), true);
+  ws.message({
+    type: 'commandResult',
+    requestId: 'join_bootstrap_retry',
+    payload: {
+      requestId: 'join_bootstrap_retry',
+      status: 'accepted',
+      seatNo: 3,
+      joinStatus: 'WAITING_NEXT_HAND'
+    }
+  });
+  const result = await joinPromise;
+  assert.equal(result.seatNo, 3);
+  assert.equal(result.joinStatus, 'WAITING_NEXT_HAND');
+  assert.equal(h.client.isReady(), true);
   assert.equal(h.statuses.some((entry) => entry.status === 'error'), false);
   assert.equal(h.protocolErrors.length, 0);
+});
+
+test('poker ws client treats the join timeout as soft and accepts a late result', async () => {
+  let commandTimeout = null;
+  const h = loadClientHarness({
+    setTimeout(fn, delay){
+      if (delay === 12_000) commandTimeout = fn;
+      return 1;
+    },
+    clearTimeout(){}
+  });
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await Promise.resolve();
+  await Promise.resolve();
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const joinPromise = h.client.sendJoin({ tableId: 'table_test_1', autoSeat: true }, 'join_soft_timeout');
+  assert.equal(typeof commandTimeout, 'function');
+  commandTimeout();
+  assert.equal(h.statuses.some((entry) => entry.status === 'join_pending' && entry.data.requestId === 'join_soft_timeout'), true);
+  assert.equal(h.sentFrames.some((frame) => frame.type === 'table_state_sub' && frame.payload.view === 'snapshot'), true);
+
+  ws.message({
+    type: 'commandResult',
+    requestId: 'join_soft_timeout',
+    payload: {
+      requestId: 'join_soft_timeout',
+      status: 'accepted',
+      seatNo: 4,
+      joinStatus: 'WAITING_NEXT_HAND'
+    }
+  });
+  assert.equal((await joinPromise).seatNo, 4);
 });
 
 test('poker ws client can queue leave without waiting for commandResult', async () => {

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -224,6 +224,47 @@ test('poker ws client keeps an ambiguous join pending after a command-scoped att
   assert.equal(h.protocolErrors.length, 0);
 });
 
+test('poker ws client keeps a server recovery-pending join under the same request id', async () => {
+  const h = loadClientHarness();
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const joinPromise = h.client.sendJoin({ tableId: 'table_test_1' }, 'join_recovery_1');
+  ws.message({
+    type: 'commandResult',
+    requestId: 'join_recovery_1',
+    payload: {
+      requestId: 'join_recovery_1',
+      status: 'pending',
+      reason: 'runtime_attach_failed'
+    }
+  });
+
+  assert.equal(h.statuses.some((entry) => entry.status === 'join_pending'
+    && entry.data.requestId === 'join_recovery_1'
+    && entry.data.reason === 'runtime_attach_failed'), true);
+
+  ws.message({
+    type: 'commandResult',
+    requestId: 'join_recovery_1',
+    payload: {
+      requestId: 'join_recovery_1',
+      status: 'accepted',
+      seatNo: 2,
+      joinStatus: 'WAITING_NEXT_HAND'
+    }
+  });
+
+  const result = await joinPromise;
+  assert.equal(result.requestId, 'join_recovery_1');
+  assert.equal(result.seatNo, 2);
+  assert.equal(result.joinStatus, 'WAITING_NEXT_HAND');
+});
+
 test('poker ws client treats the join timeout as soft and accepts a late result', async () => {
   let commandTimeout = null;
   const h = loadClientHarness({

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -378,3 +378,49 @@ test("adapter fails closed when an active human has no authoritative state stack
   assert.equal(result.code, "invalid_persisted_state");
   assert.equal(result.message, "human_stack_ambiguous");
 });
+
+test("adapter carries only the trusted managed lifecycle binding into runtime metadata", () => {
+  const managed = adaptPersistedBootstrap({
+    tableId: "table_managed_meta",
+    tableRow: {
+      id: "table_managed_meta",
+      max_players: 6,
+      status: "OPEN",
+      stakes: { sb: 1, bb: 2 },
+      lifecycle_kind: "CONTINUOUS_BOT",
+      managed_profile_key: "CONTINUOUS_BOT_DEFAULT",
+      rotation_due_at: "2026-07-29T12:00:00.000Z"
+    },
+    seatRows: [
+      { user_id: "bot_a", seat_no: 1, status: "ACTIVE", is_bot: true, bot_profile: "NORMAL", stack: 100 },
+      { user_id: "bot_b", seat_no: 2, status: "ACTIVE", is_bot: true, bot_profile: "NORMAL", stack: 100 }
+    ],
+    stateRow: {
+      version: 0,
+      state: { tableId: "table_managed_meta", phase: "INIT", seats: [
+        { userId: "bot_a", seatNo: 1, isBot: true },
+        { userId: "bot_b", seatNo: 2, isBot: true }
+      ], stacks: { bot_a: 100, bot_b: 100 } }
+    }
+  });
+  assert.equal(managed.ok, true);
+  assert.equal(managed.table.tableMeta.lifecycleKind, "CONTINUOUS_BOT");
+  assert.equal(managed.table.tableMeta.managedProfileKey, "CONTINUOUS_BOT_DEFAULT");
+  assert.equal(managed.table.tableMeta.rotationDueAtMs, Date.parse("2026-07-29T12:00:00.000Z"));
+
+  const untrusted = adaptPersistedBootstrap({
+    tableId: "table_untrusted_meta",
+    tableRow: {
+      id: "table_untrusted_meta",
+      max_players: 6,
+      status: "OPEN",
+      lifecycle_kind: "CONTINUOUS_BOT",
+      managed_profile_key: "OTHER"
+    },
+    seatRows: [],
+    stateRow: { version: 0, state: { tableId: "table_untrusted_meta", phase: "INIT", seats: [], stacks: {} } }
+  });
+  assert.equal(untrusted.ok, true);
+  assert.equal(untrusted.table.tableMeta.lifecycleKind, "STANDARD");
+  assert.equal(untrusted.table.tableMeta.managedProfileKey, null);
+});

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -166,11 +166,25 @@ function normalizeTableMeta(tableRow, maxSeats) {
   const stakesParsed = parseStakes(tableRow?.stakes);
   const createdAtMs = normalizeTimestampMs(tableRow?.created_at ?? tableRow?.createdAt);
   const lastActivityAtMs = normalizeTimestampMs(tableRow?.last_activity_at ?? tableRow?.lastActivityAt) ?? createdAtMs;
+  const lifecycleKind = typeof tableRow?.lifecycle_kind === "string"
+    ? tableRow.lifecycle_kind.trim().toUpperCase()
+    : "STANDARD";
+  const managedProfileKey = typeof tableRow?.managed_profile_key === "string"
+    ? tableRow.managed_profile_key.trim().toUpperCase()
+    : null;
+  const trustedLifecycleKind = lifecycleKind === "CONTINUOUS_BOT" && managedProfileKey === "CONTINUOUS_BOT_DEFAULT"
+    ? lifecycleKind
+    : "STANDARD";
   return {
     maxPlayers,
     stakes: stakesParsed.ok ? stakesParsed.value : null,
     createdAtMs,
-    lastActivityAtMs
+    lastActivityAtMs,
+    lifecycleKind: trustedLifecycleKind,
+    managedProfileKey: trustedLifecycleKind === "CONTINUOUS_BOT" ? managedProfileKey : null,
+    rotationDueAtMs: trustedLifecycleKind === "CONTINUOUS_BOT"
+      ? normalizeTimestampMs(tableRow?.rotation_due_at ?? tableRow?.rotationDueAt)
+      : null
   };
 }
 

--- a/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
@@ -81,7 +81,10 @@ async function beginSqlFileStore(fn, { env = process.env } = {}) {
           stakes: row.stakes ?? '{"sb":1,"bb":2}',
           created_at: row.created_at ?? null,
           updated_at: row.updated_at ?? null,
-          last_activity_at: row.last_activity_at ?? null
+          last_activity_at: row.last_activity_at ?? null,
+          lifecycle_kind: row.lifecycle_kind ?? "STANDARD",
+          managed_profile_key: row.managed_profile_key ?? null,
+          rotation_due_at: row.rotation_due_at ?? null
         }];
       }
 

--- a/ws-server/poker/bootstrap/persisted-bootstrap-repository.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-repository.mjs
@@ -31,7 +31,7 @@ export function createPersistedBootstrapRepository({ env = process.env } = {}) {
     const beginSql = await loadBeginSql();
     return beginSql(async (tx) => {
       const tableRows = await tx.unsafe(
-        "select id, status, max_players, stakes, created_at, updated_at, last_activity_at from public.poker_tables where id = $1 limit 1;",
+        "select id, status, max_players, stakes, created_at, updated_at, last_activity_at, lifecycle_kind, managed_profile_key, rotation_due_at from public.poker_tables where id = $1 limit 1;",
         [tableId]
       );
       const tableRow = tableRows?.[0] || null;

--- a/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
@@ -42,6 +42,30 @@ test("engine bootstrap creates deterministic preflop hand with expected invarian
   assert.equal(typeof pokerState.roomId, "string");
 });
 
+for (const stakes of [{ sb: 1, bb: 2 }, { sb: 5, bb: 10 }]) {
+  test(`engine bootstrap posts configured ${stakes.sb}/${stakes.bb} blinds`, () => {
+    const result = bootstrapCoreStateHand({
+      tableId: `table_engine_${stakes.sb}_${stakes.bb}`,
+      coreState: {
+        ...coreStateBase(),
+        publicStacks: { user_a: 100, user_b: 100, user_c: 100 }
+      },
+      stakes,
+      nowMs: 1_000
+    });
+
+    const state = result.coreState.pokerState;
+    assert.equal(state.betThisRoundByUserId.user_b, stakes.sb);
+    assert.equal(state.betThisRoundByUserId.user_c, stakes.bb);
+    assert.equal(state.contributionsByUserId.user_b, stakes.sb);
+    assert.equal(state.contributionsByUserId.user_c, stakes.bb);
+    assert.equal(state.potTotal, stakes.sb + stakes.bb);
+    assert.equal(state.currentBet, stakes.bb);
+    assert.equal(state.lastRaiseSize, stakes.bb);
+    assert.equal(state.toCallByUserId.user_a, stakes.bb);
+  });
+}
+
 test("bootstrap maps dealer/SB/BB/UTG deterministically for 2-player and 3-player tables", () => {
   const twoPlayerCore = {
     roomId: "table_engine_2p",

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -184,6 +184,43 @@ test("fold settlement carryover preserves stack-eligible members and determinist
   assert.equal(next.turnUserId, "user_b");
 });
 
+for (const stakes of [{ sb: 1, bb: 2 }, { sb: 5, bb: 10 }]) {
+  test(`settled rollover posts configured ${stakes.sb}/${stakes.bb} blinds`, () => {
+    const coreState = {
+      roomId: `table_rollover_${stakes.sb}_${stakes.bb}`,
+      version: 9,
+      seats: { user_a: 1, user_b: 2, user_c: 3 },
+      members: [
+        { userId: "user_a", seat: 1 },
+        { userId: "user_b", seat: 2 },
+        { userId: "user_c", seat: 3 }
+      ],
+      pokerState: null
+    };
+    const next = buildNextHandStateFromSettled({
+      tableId: coreState.roomId,
+      coreState,
+      settledState: {
+        handId: "settled_configured_stakes",
+        phase: "SETTLED",
+        dealerSeatNo: 3,
+        stacks: { user_a: 100, user_b: 100, user_c: 100 }
+      },
+      nextVersion: 10,
+      stakes
+    });
+
+    assert.equal(next.betThisRoundByUserId.user_b, stakes.sb);
+    assert.equal(next.betThisRoundByUserId.user_c, stakes.bb);
+    assert.equal(next.contributionsByUserId.user_b, stakes.sb);
+    assert.equal(next.contributionsByUserId.user_c, stakes.bb);
+    assert.equal(next.potTotal, stakes.sb + stakes.bb);
+    assert.equal(next.currentBet, stakes.bb);
+    assert.equal(next.lastRaiseSize, stakes.bb);
+    assert.equal(next.toCallByUserId.user_a, stakes.bb);
+  });
+}
+
 test("human with one chip remains eligible and posts a partial blind", () => {
   const coreState = {
     roomId: "table_one_chip",

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -184,6 +184,37 @@ test("fold settlement carryover preserves stack-eligible members and determinist
   assert.equal(next.turnUserId, "user_b");
 });
 
+test("settled rollover admits a funded waiting player and clears only their next-hand marker", () => {
+  const coreState = {
+    roomId: "table_waiting_join",
+    version: 20,
+    seats: { user_a: 1, user_b: 2, user_joining: 3 },
+    members: [
+      { userId: "user_a", seat: 1 },
+      { userId: "user_b", seat: 2 },
+      { userId: "user_joining", seat: 3 }
+    ],
+    pokerState: null
+  };
+  const next = buildNextHandStateFromSettled({
+    tableId: coreState.roomId,
+    coreState,
+    settledState: {
+      handId: "settled_before_join",
+      phase: "SETTLED",
+      dealerSeatNo: 2,
+      stacks: { user_a: 90, user_b: 110, user_joining: 100 },
+      waitingForNextHandByUserId: { user_joining: true, unrelated_user: true }
+    },
+    nextVersion: 21
+  });
+
+  assert.equal(next.handSeats.some((seat) => seat.userId === "user_joining"), true);
+  assert.equal(next.stacks.user_joining, 100);
+  assert.equal(next.waitingForNextHandByUserId.user_joining, undefined);
+  assert.equal(next.waitingForNextHandByUserId.unrelated_user, true);
+});
+
 for (const stakes of [{ sb: 1, bb: 2 }, { sb: 5, bb: 10 }]) {
   test(`settled rollover posts configured ${stakes.sb}/${stakes.bb} blinds`, () => {
     const coreState = {

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -6,7 +6,8 @@ import {
   buildBootstrappedPokerState,
   buildNextHandStateFromSettled,
   calculateReplacementFundingDelta,
-  replaceBrokeBotsForNextHand
+  replaceBrokeBotsForNextHand,
+  topUpManagedBotsForNextHand
 } from "./poker-engine.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitives.mjs";
 
@@ -24,6 +25,79 @@ test("replacement funding delta rejects invalid accounting inputs", () => {
   }
   assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: 0 }).ok, false);
   assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: Number.NaN }).ok, false);
+});
+
+test("managed settled top-up fills vacant bot seats deterministically without changing humans", () => {
+  const coreState = {
+    roomId: "table_managed_top_up",
+    version: 7,
+    maxSeats: 6,
+    members: [
+      { userId: "human_a", seat: 1 },
+      { userId: "bot_a", seat: 2 }
+    ],
+    seats: { human_a: 1, bot_a: 2 },
+    publicStacks: { human_a: 250, bot_a: 80 },
+    seatDetailsByUserId: {
+      human_a: { isBot: false },
+      bot_a: { isBot: true, botProfile: "NORMAL" }
+    }
+  };
+  const settledState = {
+    handId: "hand_managed_top_up",
+    phase: "SETTLED",
+    stacks: { human_a: 250, bot_a: 80 }
+  };
+
+  const result = topUpManagedBotsForNextHand({
+    coreState,
+    settledState,
+    nextVersion: 8,
+    minBotCount: 2,
+    targetBotCount: 3,
+    maxBotCount: 3
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.topUpFundings.length, 2);
+  assert.deepEqual(result.topUpFundings.map((entry) => entry.seatNo), [3, 4]);
+  assert.equal(result.settledState.stacks.human_a, 250);
+  assert.equal(result.coreState.publicStacks.human_a, 250);
+  assert.equal(result.coreState.members.length, 4);
+  assert.equal(result.topUpFundings.every((entry) => entry.fundingDelta === 100), true);
+});
+
+test("managed settled top-up never displaces humans when capacity cannot reach target", () => {
+  const members = [
+    { userId: "human_a", seat: 1 },
+    { userId: "human_b", seat: 2 },
+    { userId: "human_c", seat: 3 },
+    { userId: "human_d", seat: 4 },
+    { userId: "bot_a", seat: 5 }
+  ];
+  const details = Object.fromEntries(members.map((member) => [member.userId, { isBot: member.userId.startsWith("bot_") }]));
+  const stacks = Object.fromEntries(members.map((member) => [member.userId, 100]));
+  const result = topUpManagedBotsForNextHand({
+    coreState: {
+      roomId: "table_managed_capacity",
+      version: 2,
+      maxSeats: 6,
+      members,
+      seats: Object.fromEntries(members.map((member) => [member.userId, member.seat])),
+      publicStacks: stacks,
+      seatDetailsByUserId: details
+    },
+    settledState: { handId: "hand_capacity", phase: "SETTLED", stacks },
+    nextVersion: 3,
+    minBotCount: 2,
+    targetBotCount: 3,
+    maxBotCount: 3
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.topUpFundings.length, 1);
+  assert.equal(result.topUpFundings[0].seatNo, 6);
+  assert.deepEqual(result.coreState.members.filter((member) => member.userId.startsWith("human_")), members.slice(0, 4));
 });
 
 function initialCore() {

--- a/ws-server/poker/engine/engine-timeout.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-timeout.behavior.test.mjs
@@ -153,3 +153,37 @@ test("timeout on a turn with legal CHECK applies CHECK and advances turn", () =>
   assert.equal(timeout.coreState.pokerState.phase, "FLOP");
   assert.equal(timeout.coreState.pokerState.turnUserId, "user_a");
 });
+
+test("timeout can fold a deferred-leave human even when runtime membership already excludes them", () => {
+  const boot = bootstrapCoreStateHand({ tableId: "table_engine_timeout", coreState: initialCore(), nowMs: 10_000 });
+  const actorUserId = boot.coreState.pokerState.turnUserId;
+  const actorSeat = boot.coreState.seats[actorUserId];
+  const deadline = boot.coreState.pokerState.turnDeadlineAt;
+
+  const deferredCore = {
+    ...boot.coreState,
+    seats: { user_b: 2 },
+    members: [{ userId: "user_b", seat: 2 }],
+    pokerState: {
+      ...boot.coreState.pokerState,
+      leftTableByUserId: { [actorUserId]: true }
+    }
+  };
+
+  const timeout = applyCoreStateTurnTimeout({
+    tableId: "table_engine_timeout",
+    coreState: deferredCore,
+    nowMs: deadline + 1
+  });
+
+  assert.equal(timeout.changed, true);
+  assert.equal(timeout.actorUserId, actorUserId);
+  assert.equal(timeout.action, "FOLD");
+  assert.equal(timeout.coreState.pokerState.foldedByUserId[actorUserId], true);
+  assert.equal(timeout.coreState.pokerState.leftTableByUserId[actorUserId], true);
+  assert.equal(timeout.coreState.seats[actorUserId], undefined);
+  assert.equal(timeout.coreState.members.some((member) => member.userId === actorUserId), false);
+  assert.equal(timeout.coreState.pokerState.phase, "SETTLED");
+  assert.equal(timeout.coreState.pokerState.turnUserId, null);
+  assert.equal(actorSeat, 1);
+});

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -100,7 +100,24 @@ export function orderedEligibleSeatMembers(coreState, stacksByUserId = null) {
   }));
 }
 
-export function buildBootstrappedPokerState({ tableId, coreState, dealerSeatNo = null, startingStacks = null, handVersion = null }) {
+function normalizeHandStakes(stakes) {
+  const smallBlind = Number(stakes?.sb);
+  const bigBlind = Number(stakes?.bb);
+  if (Number.isInteger(smallBlind) && smallBlind > 0
+    && Number.isInteger(bigBlind) && bigBlind > smallBlind) {
+    return { smallBlind, bigBlind };
+  }
+  return { smallBlind: 1, bigBlind: 2 };
+}
+
+export function buildBootstrappedPokerState({
+  tableId,
+  coreState,
+  dealerSeatNo = null,
+  startingStacks = null,
+  handVersion = null,
+  stakes = null
+}) {
   const members = orderedEligibleSeatMembers(coreState, startingStacks);
   if (members.length < MIN_PLAYERS_TO_BOOTSTRAP) {
     return null;
@@ -144,8 +161,9 @@ export function buildBootstrappedPokerState({ tableId, coreState, dealerSeatNo =
     return posted;
   };
 
-  const sbPosted = postBlind(sbUserId, 1);
-  const bbPosted = postBlind(bbUserId, 2);
+  const { smallBlind, bigBlind } = normalizeHandStakes(stakes);
+  const sbPosted = postBlind(sbUserId, smallBlind);
+  const bbPosted = postBlind(bbUserId, bigBlind);
   const currentBet = Math.max(sbPosted, bbPosted);
   for (const userId of userIds) {
     toCallByUserId[userId] = Math.max(0, currentBet - Number(betThisRoundByUserId[userId] ?? 0));
@@ -167,7 +185,7 @@ export function buildBootstrappedPokerState({ tableId, coreState, dealerSeatNo =
     potTotal: sbPosted + bbPosted,
     sidePots: [],
     currentBet,
-    lastRaiseSize: bbPosted,
+    lastRaiseSize: bigBlind,
     stacks,
     toCallByUserId,
     betThisRoundByUserId,
@@ -204,7 +222,7 @@ export function resolveNextDealerSeatNo({ members, settledState, coreState = nul
   return eligibleMembers[nextIndex]?.seat ?? eligibleMembers[0].seat;
 }
 
-export function buildNextHandStateFromSettled({ tableId, coreState, settledState, nextVersion }) {
+export function buildNextHandStateFromSettled({ tableId, coreState, settledState, nextVersion, stakes = null }) {
   const members = orderedEligibleSeatMembers(coreState, settledState?.stacks);
   const nextDealerSeatNo = resolveNextDealerSeatNo({ members, settledState, coreState });
   const nextHandState = buildBootstrappedPokerState({
@@ -212,7 +230,8 @@ export function buildNextHandStateFromSettled({ tableId, coreState, settledState
     coreState,
     dealerSeatNo: nextDealerSeatNo,
     startingStacks: settledState?.stacks,
-    handVersion: nextVersion
+    handVersion: nextVersion,
+    stakes
   });
   if (!nextHandState) return null;
   const durableStacks = { ...nextHandState.stacks };
@@ -460,7 +479,7 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
   };
 }
 
-export function bootstrapCoreStateHand({ tableId, coreState, nowMs = Date.now() }) {
+export function bootstrapCoreStateHand({ tableId, coreState, nowMs = Date.now(), stakes = null }) {
   const currentPokerState = coreState?.pokerState;
   if (currentPokerState?.phase === "SETTLED") {
     return {
@@ -488,7 +507,8 @@ export function bootstrapCoreStateHand({ tableId, coreState, nowMs = Date.now() 
   const bootstrappedState = buildBootstrappedPokerState({
     tableId,
     coreState,
-    startingStacks: coreState?.publicStacks
+    startingStacks: coreState?.publicStacks,
+    stakes
   });
   if (!bootstrappedState) {
     return { ok: true, changed: false, bootstrap: "not_eligible", stateVersion: coreState.version, coreState };

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -244,6 +244,96 @@ function nextBotReplacementUserId({ tableId, seatNo, version, existingUserIds })
   return candidate;
 }
 
+export function topUpManagedBotsForNextHand({
+  coreState,
+  settledState,
+  nextVersion,
+  minBotCount,
+  targetBotCount,
+  maxBotCount
+} = {}) {
+  if (!coreState || typeof coreState !== "object" || !settledState || typeof settledState !== "object") {
+    return { ok: false, reason: "invalid_managed_top_up_state", coreState, settledState, topUpFundings: [] };
+  }
+  if (Number(coreState.version) + 1 !== nextVersion) {
+    return { ok: false, reason: "invalid_managed_top_up_version", coreState, settledState, topUpFundings: [] };
+  }
+  const minimum = Number(minBotCount);
+  const target = Number(targetBotCount);
+  const maximum = Number(maxBotCount);
+  if (!Number.isInteger(minimum) || !Number.isInteger(target) || !Number.isInteger(maximum)
+    || minimum < 0 || minimum > target || target > maximum) {
+    return { ok: false, reason: "invalid_managed_top_up_config", coreState, settledState, topUpFundings: [] };
+  }
+  const members = orderedSeatMembers(coreState);
+  const details = coreState.seatDetailsByUserId && typeof coreState.seatDetailsByUserId === "object"
+    ? coreState.seatDetailsByUserId
+    : {};
+  const botCount = members.filter((member) => details?.[member.userId]?.isBot === true).length;
+  if (botCount >= minimum) {
+    return { ok: true, coreState, settledState, topUpFundings: [] };
+  }
+  const maxSeats = Number(coreState.maxSeats);
+  if (!Number.isInteger(maxSeats) || maxSeats < 2) {
+    return { ok: false, reason: "invalid_managed_top_up_capacity", coreState, settledState, topUpFundings: [] };
+  }
+  const toAdd = Math.min(Math.max(0, target - botCount), Math.max(0, maximum - botCount), Math.max(0, maxSeats - members.length));
+  if (toAdd <= 0) {
+    return { ok: true, coreState, settledState, topUpFundings: [] };
+  }
+  const occupied = new Set(members.map((member) => member.seat));
+  const existingUserIds = new Set(members.map((member) => member.userId));
+  const nextMembers = members.slice();
+  const nextSeats = { ...(coreState.seats || {}) };
+  const nextDetails = { ...details };
+  const nextStacks = { ...(settledState.stacks || {}) };
+  const nextPublicStacks = { ...(coreState.publicStacks || {}) };
+  const topUpFundings = [];
+  for (let seatNo = 1; seatNo <= maxSeats && topUpFundings.length < toAdd; seatNo += 1) {
+    if (occupied.has(seatNo)) continue;
+    const botUserId = nextBotReplacementUserId({
+      tableId: `managed_top_up:${coreState.roomId || ""}`,
+      seatNo,
+      version: nextVersion,
+      existingUserIds
+    });
+    nextMembers.push({ userId: botUserId, seat: seatNo });
+    nextSeats[botUserId] = seatNo;
+    nextDetails[botUserId] = {
+      seatNo,
+      isBot: true,
+      botProfile: "NORMAL",
+      status: "ACTIVE",
+      leaveAfterHand: false
+    };
+    nextStacks[botUserId] = BOT_REPLACEMENT_STACK;
+    nextPublicStacks[botUserId] = BOT_REPLACEMENT_STACK;
+    topUpFundings.push({
+      seatNo,
+      botUserId,
+      botProfile: "NORMAL",
+      targetStack: BOT_REPLACEMENT_STACK,
+      fundingDelta: BOT_REPLACEMENT_STACK,
+      settledHandId: settledState.handId,
+      fromStateVersion: Number(coreState.version),
+      toStateVersion: nextVersion
+    });
+    occupied.add(seatNo);
+  }
+  return {
+    ok: true,
+    coreState: {
+      ...coreState,
+      members: nextMembers.sort((left, right) => left.seat - right.seat),
+      seats: nextSeats,
+      seatDetailsByUserId: nextDetails,
+      publicStacks: nextPublicStacks
+    },
+    settledState: { ...settledState, stacks: nextStacks },
+    topUpFundings
+  };
+}
+
 export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersion }) {
   if (!coreState || typeof coreState !== "object" || Array.isArray(coreState)) {
     return { ok: false, reason: "invalid_core_state", coreState, settledState, replacementFundings: [] };

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -654,11 +654,49 @@ export function applyCoreStateTurnTimeout({ tableId, coreState, nowMs = Date.now
     return { ok: true, changed: false, reason: decision.reason, stateVersion: coreState.version, coreState };
   }
 
+  const actorUserId = decision.actorUserId;
+  const leftTableByUserId = liveState.leftTableByUserId && typeof liveState.leftTableByUserId === "object" && !Array.isArray(liveState.leftTableByUserId)
+    ? liveState.leftTableByUserId
+    : null;
+  const actorDeferredLeave = leftTableByUserId?.[actorUserId] === true;
+  const actorSeatNo = actorDeferredLeave
+    ? (() => {
+        const stateSeats = Array.isArray(liveState.handSeats) && liveState.handSeats.length > 0
+          ? liveState.handSeats
+          : Array.isArray(liveState.seats)
+            ? liveState.seats
+            : [];
+        const match = stateSeats.find((seat) => seat?.userId === actorUserId);
+        return Number.isInteger(Number(match?.seatNo))
+          ? Number(match.seatNo)
+          : Number.isInteger(Number(match?.seat))
+            ? Number(match.seat)
+            : null;
+      })()
+    : null;
+  const timeoutCoreState = actorDeferredLeave
+    ? {
+        ...coreState,
+        seats: Number.isInteger(actorSeatNo)
+          ? { ...(coreState?.seats && typeof coreState.seats === "object" && !Array.isArray(coreState.seats) ? coreState.seats : {}), [actorUserId]: actorSeatNo }
+          : coreState?.seats,
+        members: Number.isInteger(actorSeatNo) && Array.isArray(coreState?.members) && !coreState.members.some((member) => member?.userId === actorUserId)
+          ? [...coreState.members, { userId: actorUserId, seat: actorSeatNo }]
+          : coreState?.members,
+        pokerState: {
+          ...liveState,
+          leftTableByUserId: {
+            ...leftTableByUserId,
+            [actorUserId]: false
+          }
+        }
+      }
+    : coreState;
   const applied = applyCoreStateAction({
     tableId,
-    coreState,
+    coreState: timeoutCoreState,
     handId: liveState.handId,
-    userId: decision.actorUserId,
+    userId: actorUserId,
     action: decision.action.type,
     amount: null,
     nowIso: new Date(nowMs).toISOString(),
@@ -671,19 +709,31 @@ export function applyCoreStateTurnTimeout({ tableId, coreState, nowMs = Date.now
       changed: false,
       reason: applied.reason || "timeout_rejected",
       stateVersion: coreState.version,
-      actorUserId: decision.actorUserId,
+      actorUserId,
       action: decision.action.type,
       coreState
     };
   }
 
+  const nextCoreState = actorDeferredLeave
+    ? {
+        ...applied.coreState,
+        seats: coreState?.seats,
+        members: coreState?.members,
+        pokerState: {
+          ...applied.coreState.pokerState,
+          leftTableByUserId: { ...leftTableByUserId }
+        }
+      }
+    : applied.coreState;
+
   return {
     ok: true,
     changed: true,
     reason: null,
-    actorUserId: decision.actorUserId,
+    actorUserId,
     action: decision.action.type,
     stateVersion: applied.stateVersion,
-    coreState: applied.coreState
+    coreState: nextCoreState
   };
 }

--- a/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.behavior.test.mjs
@@ -1,12 +1,79 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  createBotAutoplayCascadeScheduler,
   createBotAutoplayObservability,
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
   shouldClearBotTimeoutSafetySuppression,
   shouldSuppressBotTimeoutSafetyRetry
 } from "./bot-autoplay.mjs";
+import { createTableCommandQueue } from "../runtime/table-command-queue.mjs";
+
+test("bot autoplay cascade coalesces triggers and lets a human join run before its next step", async () => {
+  const queue = createTableCommandQueue();
+  const order = [];
+  let releaseFirstStep;
+  let resolveFirstStepStarted;
+  const firstStepGate = new Promise((resolve) => { releaseFirstStep = resolve; });
+  const firstStepStarted = new Promise((resolve) => { resolveFirstStepStarted = resolve; });
+  let stepCount = 0;
+
+  const scheduler = createBotAutoplayCascadeScheduler({
+    runStep: ({ tableId }) => queue.enqueue({
+      tableId,
+      run: async () => {
+        stepCount += 1;
+        order.push(`bot:${stepCount}:start`);
+        if (stepCount === 1) {
+          resolveFirstStepStarted();
+          await firstStepGate;
+        }
+        order.push(`bot:${stepCount}:end`);
+        return { ok: true, shouldContinue: stepCount === 1 };
+      }
+    })
+  });
+
+  const firstCascade = scheduler.schedule({ tableId: "managed-table", trigger: "created" });
+  await firstStepStarted;
+  const overlappingCascade = scheduler.schedule({ tableId: "managed-table", trigger: "observed_turn" });
+  assert.equal(overlappingCascade, firstCascade);
+
+  const humanJoin = queue.enqueue({
+    tableId: "managed-table",
+    run: async () => {
+      order.push("human:join");
+      return { ok: true };
+    }
+  });
+  releaseFirstStep();
+
+  await Promise.all([firstCascade, humanJoin]);
+  assert.equal(stepCount, 2);
+  assert.deepEqual(order, [
+    "bot:1:start",
+    "bot:1:end",
+    "human:join",
+    "bot:2:start",
+    "bot:2:end"
+  ]);
+});
+
+test("bot autoplay cascade clears after stopping so a later trigger starts a fresh step", async () => {
+  let stepCount = 0;
+  const scheduler = createBotAutoplayCascadeScheduler({
+    runStep: async () => {
+      stepCount += 1;
+      return { ok: true, shouldContinue: false };
+    }
+  });
+
+  await scheduler.schedule({ tableId: "managed-table", trigger: "first" });
+  await scheduler.schedule({ tableId: "managed-table", trigger: "second" });
+
+  assert.equal(stepCount, 2);
+});
 
 test("bot autoplay observability preserves first and terminal events while aggregating repeated failures", () => {
   const logs = [];

--- a/ws-server/poker/handlers/bot-autoplay.mjs
+++ b/ws-server/poker/handlers/bot-autoplay.mjs
@@ -126,6 +126,48 @@ export function shouldClearBotTimeoutSafetySuppression(result) {
   return result?.ok === true && result?.changed === true;
 }
 
+export function createBotAutoplayCascadeScheduler({
+  runStep,
+  defer = (callback) => setImmediate(callback)
+} = {}) {
+  if (typeof runStep !== "function") {
+    throw new Error("bot_autoplay_cascade_scheduler_requires_run_step");
+  }
+  if (typeof defer !== "function") {
+    throw new Error("bot_autoplay_cascade_scheduler_requires_defer");
+  }
+
+  const activeCascadeByTableId = new Map();
+
+  const schedule = ({ tableId, ...stepContext }) => {
+    const normalizedTableId = typeof tableId === "string" ? tableId.trim() : "";
+    if (!normalizedTableId) {
+      throw new Error("bot_autoplay_cascade_scheduler_requires_table_id");
+    }
+
+    const activeCascade = activeCascadeByTableId.get(normalizedTableId);
+    if (activeCascade) return activeCascade;
+
+    const runCascade = async () => {
+      const result = await runStep({ tableId: normalizedTableId, ...stepContext });
+      if (result?.ok !== true || result?.shouldContinue !== true) return result;
+      await new Promise((resolve) => defer(resolve));
+      return runCascade();
+    };
+
+    const cascade = runCascade().finally(() => {
+      if (activeCascadeByTableId.get(normalizedTableId) === cascade) {
+        activeCascadeByTableId.delete(normalizedTableId);
+      }
+    });
+    activeCascadeByTableId.set(normalizedTableId, cascade);
+    void cascade.catch(() => {});
+    return cascade;
+  };
+
+  return { schedule };
+}
+
 export async function handleBotStepCommand({
   tableId,
   trigger,

--- a/ws-server/poker/handlers/join.behavior.test.mjs
+++ b/ws-server/poker/handlers/join.behavior.test.mjs
@@ -160,7 +160,7 @@ test('handleJoinCommand authoritative rehydrate failure does not emit accepted s
   assert.equal(calls.table, 0);
 });
 
-test('handleJoinCommand rejects restored human-only authoritative state instead of broadcasting success', async () => {
+test('handleJoinCommand keeps a persisted authoritative join pending when restored state validation fails', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 200 });
   ctx.authoritativeJoinEnabled = true;
   ctx.persistedBootstrapEnabled = true;
@@ -191,7 +191,7 @@ test('handleJoinCommand rejects restored human-only authoritative state instead 
   await handleJoinCommand(ctx);
 
   assert.equal(calls.command.length, 1);
-  assert.equal(calls.command[0].status, 'rejected');
+  assert.equal(calls.command[0].status, 'pending');
   assert.equal(calls.command[0].reason, 'authoritative_state_invalid');
   assert.equal(calls.joinArgs, null);
   assert.equal(calls.actorTableState, 0);
@@ -251,7 +251,52 @@ test('handleJoinCommand accepts restored authoritative state before live members
   assert.equal(calls.snapshots, 0);
 });
 
-test('handleJoinCommand rejects restored authoritative state when restore version diverges from join snapshot version', async () => {
+test('handleJoinCommand keeps the same request pending when runtime attach fails after authoritative join', async () => {
+  const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 200 });
+  ctx.authoritativeJoinEnabled = true;
+  ctx.persistedBootstrapEnabled = true;
+  ctx.loadAuthoritativeJoinExecutor = async () => async (args) => {
+    calls.authoritativeArgs = args;
+    return {
+      ok: true,
+      seatNo: 1,
+      stack: 200,
+      snapshot: {
+        stateVersion: 2,
+        seats: [{ userId: 'u1', seatNo: 1, status: 'ACTIVE' }],
+        stacks: { u1: 200 }
+      }
+    };
+  };
+  ctx.restoreTableFromPersisted = async () => ({
+    ok: true,
+    restoredTable: {
+      coreState: {
+        version: 2,
+        seats: { u1: 1 },
+        publicStacks: { u1: 200 }
+      }
+    }
+  });
+  ctx.tableManager.join = (args) => {
+    calls.joinArgs = args;
+    return { ok: false, code: 'runtime_attach_failed' };
+  };
+
+  await handleJoinCommand(ctx);
+
+  assert.equal(calls.command.length, 1);
+  assert.deepEqual(calls.command[0], {
+    requestId: 'r1',
+    tableId: 't1',
+    status: 'pending',
+    reason: 'runtime_attach_failed'
+  });
+  assert.equal(calls.authoritativeArgs.requestId, 'r1');
+  assert.equal(calls.actorTableState, 0);
+});
+
+test('handleJoinCommand keeps a persisted authoritative join pending when restore version diverges', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 1, buyIn: 200 });
   ctx.authoritativeJoinEnabled = true;
   ctx.persistedBootstrapEnabled = true;
@@ -279,7 +324,7 @@ test('handleJoinCommand rejects restored authoritative state when restore versio
   await handleJoinCommand(ctx);
 
   assert.equal(calls.command.length, 1);
-  assert.equal(calls.command[0].status, 'rejected');
+  assert.equal(calls.command[0].status, 'pending');
   assert.equal(calls.command[0].reason, 'authoritative_state_invalid');
   assert.equal(calls.joinArgs, null);
   assert.equal(calls.actorTableState, 0);
@@ -316,7 +361,7 @@ test('handleJoinCommand rejects seatNo 0 and preferredSeatNo 0 deterministically
   }
 });
 
-test('handleJoinCommand emits one rejected result when bootstrap persist fails', async () => {
+test('handleJoinCommand emits one rejected result when non-authoritative bootstrap persist fails', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 2, buyIn: 100 });
   ctx.tableManager.bootstrapHand = () => ({ ok: true, changed: true });
   ctx.persistMutatedState = async () => ({ ok: false, reason: 'persist_failed' });
@@ -330,7 +375,7 @@ test('handleJoinCommand emits one rejected result when bootstrap persist fails',
   assert.equal(calls.snapshots, 1);
 });
 
-test('handleJoinCommand emits resync only when bootstrap restore fails after persist conflict', async () => {
+test('handleJoinCommand emits resync when non-authoritative bootstrap conflict recovery fails', async () => {
   const { ctx, calls } = baseCtx({ seatNo: 2, buyIn: 100 });
   ctx.tableManager.bootstrapHand = () => ({ ok: true, changed: true });
   ctx.persistMutatedState = async () => ({ ok: false, reason: 'persist_failed' });

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -85,6 +85,15 @@ function restoredAuthoritativeValidationReason(validation) {
   return "restore_validation_failed";
 }
 
+function sendRecoverableJoinResult({ sendCommandResult, ws, connState, requestId, tableId, reason }) {
+  sendCommandResult(ws, connState, {
+    requestId: requestId ?? null,
+    tableId,
+    status: "pending",
+    reason: reason || "join_runtime_recovery_required"
+  });
+}
+
 import { recoverFromPersistConflict } from "../runtime/persist-conflict-recovery.mjs";
 
 export async function handleJoinCommand({ frame, ws, connState, sessionStore, tableManager, ensureTableLoadedErrorMapper, restoreTableFromPersisted, persistMutatedState, broadcastResyncRequired, broadcastStateSnapshots, broadcastTableState, sendError, sendCommandResult, sendTableState, authoritativeJoinEnabled, observeOnlyJoinEnabled, persistedBootstrapEnabled, loadAuthoritativeJoinExecutor, scheduleBotStep = () => {}, klog = () => {}, klogVerbose = () => {}, verboseLogsEnabled = false }) {
@@ -208,10 +217,12 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
         humanStackValid: restoreValidation.humanStackValid,
         seededBotProjectionValid: restoreValidation.seededBotProjectionValid
       });
-      sendCommandResult(ws, connState, {
-        requestId: frame.requestId ?? null,
+      sendRecoverableJoinResult({
+        sendCommandResult,
+        ws,
+        connState,
+        requestId: frame.requestId,
         tableId,
-        status: "rejected",
         reason: "authoritative_state_invalid"
       });
       return;
@@ -239,12 +250,23 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
       requestId: frame.requestId ?? null,
       code: joined?.code || "join_failed"
     });
-    sendCommandResult(ws, connState, {
-      requestId: frame.requestId ?? null,
-      tableId,
-      status: "rejected",
-      reason: joined.code || "join_failed"
-    });
+    if (authoritativeJoinResult) {
+      sendRecoverableJoinResult({
+        sendCommandResult,
+        ws,
+        connState,
+        requestId: frame.requestId,
+        tableId,
+        reason: joined.code || "join_failed"
+      });
+    } else {
+      sendCommandResult(ws, connState, {
+        requestId: frame.requestId ?? null,
+        tableId,
+        status: "rejected",
+        reason: joined.code || "join_failed"
+      });
+    }
     return;
   }
 
@@ -267,12 +289,23 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
         broadcastStateSnapshots,
         broadcastResyncRequired
       });
-      sendCommandResult(ws, connState, {
-        requestId: frame.requestId ?? null,
-        tableId,
-        status: "rejected",
-        reason: persisted?.reason || "persist_failed"
-      });
+      if (authoritativeJoinResult) {
+        sendRecoverableJoinResult({
+          sendCommandResult,
+          ws,
+          connState,
+          requestId: frame.requestId,
+          tableId,
+          reason: persisted?.reason || "persist_failed"
+        });
+      } else {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: persisted?.reason || "persist_failed"
+        });
+      }
       return;
     }
   }

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -281,7 +281,10 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     requestId: frame.requestId ?? null,
     tableId,
     status: "accepted",
-    reason: joined.changed ? null : "already_joined"
+    reason: joined.changed ? null : "already_joined",
+    seatNo: authoritativeJoinResult?.seatNo ?? joined?.seatNo ?? null,
+    joinStatus: authoritativeJoinResult?.joinStatus
+      || (authoritativeJoinResult?.rejoin === true ? "ACTIVE" : null)
   });
 
   const tableSnapshot = tableManager.tableSnapshot(tableId, connState.session.userId);

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -121,6 +121,9 @@ register("INFO", "table_lifecycle", [
   "poker_leave_advanced",
   "poker_leave_retained_live_hand",
   "poker_rebuy_committed",
+  "ws_continuous_bot_table_created",
+  "ws_continuous_bot_table_restored",
+  "ws_continuous_bot_table_retirement_requested",
   "ws_guest_table_evicted"
 ]);
 
@@ -236,6 +239,7 @@ register("ERROR", "recovery", [
 ]);
 
 register("ERROR", "runtime", [
+  "ws_continuous_bot_table_supervisor_failed",
   "ws_error",
   "ws_message_processing_error",
   "ws_table_command_failed",
@@ -297,6 +301,7 @@ register("ERROR", "gameplay", [
 
 const cleanupPrefixCategories = Object.freeze({
   ws_bot_claims_recovery: "recovery",
+  ws_continuous_bot_table_retirement: "table_lifecycle",
   ws_disconnect_cleanup: "janitor",
   ws_settled_rollover_close: "janitor",
   ws_settled_rollover_deferred_leave: "janitor",

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -1,0 +1,209 @@
+import { createPokerTableWithState } from "../../../netlify/functions/_shared/poker-table-init.mjs";
+import {
+  applySeatsAndStacksToState,
+  getBotConfig,
+  seedBotsForJoin
+} from "../../../shared/poker-domain/bots.mjs";
+import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
+import { postTransaction } from "./chips-ledger.mjs";
+
+export const CONTINUOUS_BOT_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
+const MAX_DESIRED_TABLES = 2;
+const MAX_SEATS = 6;
+const MAX_INTERVAL_SECONDS = 86_400;
+
+function intInRange(value, min, max) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= min && parsed <= max ? parsed : null;
+}
+
+export function normalizeContinuousBotProfile(row) {
+  const profileKey = typeof row?.profile_key === "string" ? row.profile_key.trim().toUpperCase() : "";
+  const desiredTableCount = intInRange(row?.desired_table_count, 0, MAX_DESIRED_TABLES);
+  const maxSeats = intInRange(row?.max_seats, 2, MAX_SEATS);
+  const minBotCount = intInRange(row?.min_bot_count, 0, MAX_SEATS - 1);
+  const targetBotCount = intInRange(row?.target_bot_count, 0, MAX_SEATS - 1);
+  const maxBotCount = intInRange(row?.max_bot_count, 0, MAX_SEATS - 1);
+  const rotationIntervalSeconds = intInRange(row?.rotation_interval_seconds, 60, MAX_INTERVAL_SECONDS);
+  const postponeIntervalSeconds = intInRange(row?.postpone_interval_seconds, 30, 3_600);
+  const smallBlind = intInRange(row?.small_blind, 1, 999_999);
+  const bigBlind = intInRange(row?.big_blind, 2, 1_000_000);
+  if (
+    profileKey !== CONTINUOUS_BOT_PROFILE_KEY
+    || desiredTableCount == null
+    || maxSeats == null
+    || minBotCount == null
+    || targetBotCount == null
+    || maxBotCount == null
+    || rotationIntervalSeconds == null
+    || postponeIntervalSeconds == null
+    || smallBlind == null
+    || bigBlind == null
+    || bigBlind <= smallBlind
+    || minBotCount > targetBotCount
+    || targetBotCount > maxBotCount
+    || maxBotCount >= maxSeats
+  ) {
+    return null;
+  }
+  return {
+    profileKey,
+    enabled: row?.enabled === true,
+    desiredTableCount,
+    minBotCount,
+    targetBotCount,
+    maxBotCount,
+    rotationIntervalSeconds,
+    postponeIntervalSeconds,
+    smallBlind,
+    bigBlind,
+    maxSeats,
+    updatedAt: row?.updated_at ?? null
+  };
+}
+
+function canonicalStakes(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const sb = Number(value.sb);
+  const bb = Number(value.bb);
+  return Number.isInteger(sb) && Number.isInteger(bb) ? { sb, bb } : null;
+}
+
+function tableMatchesCreationProfile(table, profile) {
+  const stakes = canonicalStakes(table?.stakes);
+  return table?.managed_profile_key === profile.profileKey
+    && Number(table?.max_players) === profile.maxSeats
+    && stakes?.sb === profile.smallBlind
+    && stakes?.bb === profile.bigBlind;
+}
+
+async function createManagedTable(tx, { profile, botConfig, klog }) {
+  const stakes = { sb: profile.smallBlind, bb: profile.bigBlind };
+  const created = await createPokerTableWithState(tx, {
+    userId: null,
+    maxPlayers: profile.maxSeats,
+    stakesJson: JSON.stringify(stakes),
+    lifecycleKind: "CONTINUOUS_BOT",
+    managedProfileKey: profile.profileKey,
+    rotationDueAt: null
+  });
+  const seededBots = await seedBotsForJoin({
+    tx,
+    tableId: created.tableId,
+    maxPlayers: profile.maxSeats,
+    tableStakes: stakes,
+    cfg: botConfig,
+    humanUserId: null,
+    postTransaction,
+    targetBotCount: profile.targetBotCount,
+    allowBotsOnly: true,
+    requireExactTarget: true,
+    fundingReason: "BOT_SEED_BUY_IN",
+    idempotencyPrefix: "managed-bot-seed-buyin",
+    klog
+  });
+  const stateRows = await tx.unsafe(
+    "select state from public.poker_state where table_id = $1 and version = 0 for update;",
+    [created.tableId]
+  );
+  const initialState = stateRows?.[0]?.state;
+  const projectedState = applySeatsAndStacksToState(initialState, {
+    tableId: created.tableId,
+    seatEntries: seededBots,
+    stackEntries: seededBots.map((bot) => [bot.userId, bot.stack])
+  });
+  const updatedRows = await tx.unsafe(
+    "update public.poker_state set state = $2::jsonb, updated_at = now() where table_id = $1 and version = 0 returning table_id;",
+    [created.tableId, JSON.stringify(projectedState)]
+  );
+  if (updatedRows?.length !== 1) throw new Error("managed_bot_state_projection_failed");
+  return created.tableId;
+}
+
+export function createContinuousBotTableRepository({
+  env = process.env,
+  beginSql = beginSqlWs,
+  klog = () => {}
+} = {}) {
+  let lastKnownProfile = null;
+
+  async function reconcile() {
+    const botConfig = getBotConfig(env);
+    try {
+      const result = await beginSql(async (tx) => {
+        await tx.unsafe("select pg_advisory_xact_lock(hashtext($1));", ["poker:continuous-bot-supervisor:v1"]);
+        const profileRows = await tx.unsafe(
+          `select profile_key, enabled, desired_table_count, min_bot_count, target_bot_count, max_bot_count,
+                  rotation_interval_seconds, postpone_interval_seconds, small_blind, big_blind, max_seats, updated_at
+             from public.poker_managed_table_profiles where profile_key = $1 limit 1;`,
+          [CONTINUOUS_BOT_PROFILE_KEY]
+        );
+        const profile = normalizeContinuousBotProfile(profileRows?.[0]);
+        if (!profile) throw Object.assign(new Error("managed_profile_invalid"), { code: "managed_profile_invalid" });
+        const tableRows = await tx.unsafe(
+          `select id, status, max_players, stakes, managed_profile_key, rotation_due_at
+             from public.poker_tables
+            where status = 'OPEN' and lifecycle_kind = 'CONTINUOUS_BOT'
+            order by created_at asc, id asc
+            for update;`
+        );
+        const openTables = Array.isArray(tableRows) ? tableRows : [];
+        const desiredCount = profile.enabled ? profile.desiredTableCount : 0;
+        const retirementTableIds = [];
+        for (const table of openTables) {
+          if (!tableMatchesCreationProfile(table, profile)) {
+            retirementTableIds.push(table.id);
+          }
+        }
+        const nonRetiring = openTables.filter((table) => !retirementTableIds.includes(table.id));
+        if (nonRetiring.length > desiredCount) {
+          retirementTableIds.push(...nonRetiring.slice(desiredCount).map((table) => table.id));
+        }
+        if (desiredCount === 0) {
+          retirementTableIds.splice(0, retirementTableIds.length, ...openTables.map((table) => table.id));
+        }
+        const uniqueRetirements = [...new Set(retirementTableIds)];
+        if (uniqueRetirements.length > 0) {
+          await tx.unsafe(
+            "update public.poker_tables set rotation_due_at = least(coalesce(rotation_due_at, now()), now()), updated_at = now() where id = any($1::uuid[]);",
+            [uniqueRetirements]
+          );
+        }
+        const createdTableIds = [];
+        const retainedCount = openTables.length;
+        for (let index = retainedCount; index < desiredCount; index += 1) {
+          if (!botConfig.enabled) throw Object.assign(new Error("bots_disabled"), { code: "bots_disabled" });
+          createdTableIds.push(await createManagedTable(tx, { profile, botConfig, klog }));
+        }
+        return {
+          profile,
+          createdTableIds,
+          activeTableIds: [
+            ...openTables.filter((table) => !uniqueRetirements.includes(table.id)).map((table) => table.id),
+            ...createdTableIds
+          ],
+          retirementTableIds: uniqueRetirements
+        };
+      }, { env });
+      lastKnownProfile = result.profile;
+      return { ok: true, ...result };
+    } catch (error) {
+      klog("ws_continuous_bot_table_supervisor_failed", {
+        reason: error?.code || error?.message || "unknown"
+      });
+      return {
+        ok: false,
+        reason: error?.code || error?.message || "profile_read_failed",
+        profile: lastKnownProfile,
+        createdTableIds: [],
+        activeTableIds: [],
+        retirementTableIds: []
+      };
+    }
+  }
+
+  return {
+    reconcile,
+    currentProfile: () => lastKnownProfile
+  };
+}

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -3,7 +3,7 @@ import {
   applySeatsAndStacksToState,
   getBotConfig,
   seedBotsForJoin
-} from "../../../shared/poker-domain/bots.mjs";
+} from "../../shared/poker-domain/bots.mjs";
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -2,6 +2,7 @@ import { createPokerTableWithState } from "../../../netlify/functions/_shared/po
 import {
   applySeatsAndStacksToState,
   getBotConfig,
+  parseStakes,
   seedBotsForJoin
 } from "../../shared/poker-domain/bots.mjs";
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
@@ -63,13 +64,11 @@ export function normalizeContinuousBotProfile(row) {
 }
 
 function canonicalStakes(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const sb = Number(value.sb);
-  const bb = Number(value.bb);
-  return Number.isInteger(sb) && Number.isInteger(bb) ? { sb, bb } : null;
+  const parsed = parseStakes(value);
+  return parsed?.ok ? parsed.value : null;
 }
 
-function tableMatchesCreationProfile(table, profile) {
+export function tableMatchesContinuousBotProfile(table, profile) {
   const stakes = canonicalStakes(table?.stakes);
   return table?.managed_profile_key === profile.profileKey
     && Number(table?.max_players) === profile.maxSeats
@@ -151,7 +150,7 @@ export function createContinuousBotTableRepository({
         const desiredCount = profile.enabled ? profile.desiredTableCount : 0;
         const retirementTableIds = [];
         for (const table of openTables) {
-          if (!tableMatchesCreationProfile(table, profile)) {
+          if (!tableMatchesContinuousBotProfile(table, profile)) {
             retirementTableIds.push(table.id);
           }
         }

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -902,6 +902,14 @@ test("persisted state writer never projects human stack when state CAS conflicts
 });
 
 function createReplacementFundingDbHarness({ tableId, version = 7, state, treasuryBalance = 1_000, escrowBalance = 50 } = {}) {
+  const replacementSeat = {
+    table_id: tableId,
+    user_id: "00000000-0000-4000-8000-0000000000b2",
+    seat_no: 2,
+    status: "ACTIVE",
+    is_bot: true,
+    stack: 1
+  };
   const sourceAccount = { id: "10000000-0000-4000-8000-000000000001", system_key: "TREASURY", account_type: "SYSTEM", status: "active", balance: treasuryBalance };
   const escrowAccount = { id: "10000000-0000-4000-8000-000000000002", system_key: `POKER_TABLE:${tableId}`, account_type: "ESCROW", status: "active", balance: escrowBalance };
   const durable = {
@@ -909,6 +917,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
     state: structuredClone(state),
     accounts: new Map([[sourceAccount.system_key, sourceAccount], [escrowAccount.system_key, escrowAccount]]),
     transactions: new Map(),
+    seats: new Map([[replacementSeat.seat_no, replacementSeat]]),
     ledgerInsertCount: 0,
     transactionInsertSql: null,
     failFunding: false
@@ -920,6 +929,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
       state: structuredClone(durable.state),
       accounts: new Map([...durable.accounts].map(([key, account]) => [key, { ...account }])),
       transactions: new Map([...durable.transactions].map(([key, transaction]) => [key, { ...transaction }])),
+      seats: new Map([...durable.seats].map(([key, seat]) => [key, { ...seat }])),
       ledgerInsertCount: durable.ledgerInsertCount
     };
     const tx = {
@@ -939,6 +949,26 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
         }
         if (text.includes("insert into public.poker_seats")) {
           return [{ seat_no: Number(params[2]) }];
+        }
+        if (text.includes("update public.poker_seats") && text.includes("set user_id = $4")) {
+          const [requestedTableId, seatNo, oldBotUserId, replacementBotUserId, targetStack] = params;
+          const seat = working.seats.get(Number(seatNo));
+          if (!seat
+            || seat.table_id !== requestedTableId
+            || seat.user_id !== oldBotUserId
+            || seat.status !== "ACTIVE"
+            || seat.is_bot !== true) {
+            return [];
+          }
+          const replacement = {
+            ...seat,
+            user_id: replacementBotUserId,
+            stack: Number(targetStack),
+            status: "ACTIVE",
+            is_bot: true
+          };
+          working.seats.set(Number(seatNo), replacement);
+          return [{ seat_no: replacement.seat_no, user_id: replacement.user_id, stack: replacement.stack }];
         }
         if (text.includes("insert into public.chips_transactions")) {
           durable.transactionInsertSql = text;
@@ -971,6 +1001,7 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
     durable.state = working.state;
     durable.accounts = working.accounts;
     durable.transactions = working.transactions;
+    durable.seats = working.seats;
     durable.ledgerInsertCount = working.ledgerInsertCount;
     return result;
   };
@@ -1019,6 +1050,8 @@ test("replacement funding without a configured human actor atomically increases 
   assert.equal(first.replacementFundingCommitted, true);
   assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + funding[0].fundingDelta);
   assert.equal(harness.durable.ledgerInsertCount, 1);
+  assert.equal(harness.durable.seats.get(2)?.user_id, funding[0].replacementBotUserId);
+  assert.equal(harness.durable.seats.get(2)?.stack, funding[0].targetStack);
   assert.equal([...harness.durable.transactions.values()][0]?.created_by, null);
   assert.match(harness.durable.transactionInsertSql, /values\s*\(\$1, \$2, \(\$3::text\)::jsonb,/);
 
@@ -1124,6 +1157,38 @@ test("replacement funding failure rolls back persisted state and escrow", async 
   assert.equal(result.reason, "db_error");
   assert.equal(harness.durable.version, 7);
   assert.deepEqual(harness.durable.state, previousState);
+  assert.equal(harness.durable.seats.get(2)?.user_id, "00000000-0000-4000-8000-0000000000b2");
+  assert.equal(harness.durable.seats.get(2)?.stack, 1);
+  assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore);
+  assert.equal(harness.durable.ledgerInsertCount, 0);
+});
+
+test("replacement seat identity conflict fails closed before ledger funding", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000707";
+  const previousState = { tableId, handId: "hand_replacement_conflict", phase: "SETTLED", stacks: {} };
+  const nextState = { tableId, handId: "hand_after_replacement_conflict", phase: "PREFLOP", stacks: {} };
+  const harness = createReplacementFundingDbHarness({ tableId, state: previousState });
+  harness.durable.seats.get(2).user_id = "00000000-0000-4000-8000-0000000000ff";
+  const escrowBefore = harness.balance(`POKER_TABLE:${tableId}`);
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: harness.beginSql,
+    klog: () => {}
+  });
+
+  const result = await writer.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState,
+    replacementFundings: replacementFundingFixture({ tableId }),
+    botFundingSystemKey: "TREASURY"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "db_error");
+  assert.equal(harness.durable.version, 7);
+  assert.deepEqual(harness.durable.state, previousState);
+  assert.equal(harness.durable.seats.get(2)?.user_id, "00000000-0000-4000-8000-0000000000ff");
   assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore);
   assert.equal(harness.durable.ledgerInsertCount, 0);
 });

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -937,6 +937,9 @@ function createReplacementFundingDbHarness({ tableId, version = 7, state, treasu
         if (text.includes("from public.chips_accounts") && text.includes("system_key = any")) {
           return params[0].map((key) => working.accounts.get(key)).filter(Boolean).map((account) => ({ ...account }));
         }
+        if (text.includes("insert into public.poker_seats")) {
+          return [{ seat_no: Number(params[2]) }];
+        }
         if (text.includes("insert into public.chips_transactions")) {
           durable.transactionInsertSql = text;
           if (durable.failFunding) throw new Error("simulated_funding_failure");
@@ -1059,6 +1062,42 @@ test("replacement funding without a configured human actor atomically increases 
   assert.equal(conflict.ok, false);
   assert.equal(conflict.reason, "conflict");
   assert.equal(harness.durable.ledgerInsertCount, 1);
+});
+
+test("managed bot top-up atomically persists state, seat and SYSTEM funding without a human actor", async () => {
+  const tableId = "00000000-0000-4000-8000-0000000007a5";
+  const previousState = { tableId, handId: "hand_managed_settled", phase: "SETTLED", stacks: {} };
+  const nextState = { tableId, handId: "hand_managed_next", phase: "PREFLOP", stacks: {} };
+  const harness = createReplacementFundingDbHarness({ tableId, state: previousState, escrowBalance: 200 });
+  const writer = createPersistedStateWriter({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: harness.beginSql,
+    klog: () => {}
+  });
+  const escrowBefore = harness.balance(`POKER_TABLE:${tableId}`);
+  const result = await writer.writeMutation({
+    tableId,
+    expectedVersion: 7,
+    nextState,
+    managedBotTopUps: [{
+      seatNo: 3,
+      botUserId: "00000000-0000-5000-8000-0000000000d3",
+      botProfile: "NORMAL",
+      targetStack: 100,
+      fundingDelta: 100,
+      settledHandId: "hand_managed_settled",
+      fromStateVersion: 7,
+      toStateVersion: 8
+    }],
+    botFundingSystemKey: "TREASURY"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.managedBotTopUpCommitted, true);
+  assert.equal(result.fundedManagedBotTopUps.length, 1);
+  assert.equal(result.fundedManagedBotTopUps[0].seatNo, 3);
+  assert.equal(harness.balance(`POKER_TABLE:${tableId}`), escrowBefore + 100);
+  assert.equal([...harness.durable.transactions.values()][0]?.created_by, null);
 });
 
 test("replacement funding failure rolls back persisted state and escrow", async () => {

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -9,6 +9,7 @@ const SETTLEMENT_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
 const MAX_REPLACEMENT_FUNDINGS = 10;
+const MAX_MANAGED_BOT_TOP_UPS = 6;
 const MAX_HUMAN_STACK_UPDATES = 10;
 const DURABLE_ACTION_KIND = "ACT";
 const PAYLOAD_HASH_PATTERN = /^[a-f0-9]{64}$/;
@@ -500,6 +501,48 @@ function normalizeReplacementFundings({ replacementFundings, tableId, expectedVe
   return { ok: true, supplied: true, fundings };
 }
 
+function normalizeManagedBotTopUps({ managedBotTopUps, tableId, expectedVersion }) {
+  if (managedBotTopUps === undefined) return { ok: true, supplied: false, fundings: [] };
+  if (!Array.isArray(managedBotTopUps) || managedBotTopUps.length > MAX_MANAGED_BOT_TOP_UPS) {
+    return { ok: false, reason: "invalid_managed_bot_top_ups" };
+  }
+  const seenSeats = new Set();
+  const fundings = [];
+  for (const value of managedBotTopUps) {
+    const seatNo = Number(value?.seatNo);
+    const botUserId = typeof value?.botUserId === "string" ? value.botUserId.trim() : "";
+    const botProfile = typeof value?.botProfile === "string" ? value.botProfile.trim().toUpperCase() : "";
+    const targetStack = Number(value?.targetStack);
+    const fundingDelta = Number(value?.fundingDelta);
+    const settledHandId = typeof value?.settledHandId === "string" ? value.settledHandId.trim() : "";
+    const fromStateVersion = Number(value?.fromStateVersion);
+    const toStateVersion = Number(value?.toStateVersion);
+    if (!Number.isInteger(seatNo) || seatNo < 1 || seatNo > MAX_MANAGED_BOT_TOP_UPS || seenSeats.has(seatNo)
+      || !botUserId || !botProfile
+      || !Number.isInteger(targetStack) || targetStack <= 0
+      || fundingDelta !== targetStack
+      || !settledHandId
+      || fromStateVersion !== expectedVersion
+      || toStateVersion !== expectedVersion + 1) {
+      return { ok: false, reason: "invalid_managed_bot_top_ups" };
+    }
+    seenSeats.add(seatNo);
+    fundings.push({
+      seatNo,
+      botUserId,
+      botProfile,
+      targetStack,
+      fundingDelta,
+      settledHandId,
+      fromStateVersion,
+      toStateVersion,
+      idempotencyKey: `poker:managed-bot-top-up:v1:${tableId}:${toStateVersion}:${seatNo}`
+    });
+  }
+  fundings.sort((left, right) => left.seatNo - right.seatNo);
+  return { ok: true, supplied: true, fundings };
+}
+
 function normalizeHumanStackUpdates({ humanStackUpdates, expectedVersion }) {
   if (humanStackUpdates === undefined) return { ok: true, supplied: false, updates: [] };
   if (!Array.isArray(humanStackUpdates) || humanStackUpdates.length > MAX_HUMAN_STACK_UPDATES) {
@@ -613,6 +656,72 @@ async function writeReplacementFundings({ tx, tableId, fundings, botFundingSyste
   return fundedReplacements;
 }
 
+async function writeManagedBotTopUps({ tx, tableId, fundings, botFundingSystemKey }) {
+  if (fundings.length === 0) return [];
+  const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
+  if (!sourceSystemKey) throw Object.assign(new Error("managed_bot_top_up_config_invalid"), { code: "managed_bot_top_up_config_invalid" });
+  const escrowSystemKey = `POKER_TABLE:${tableId}`;
+  const funded = [];
+  for (const funding of fundings) {
+    const inserted = await tx.unsafe(
+      `insert into public.poker_seats
+         (table_id, user_id, seat_no, status, is_bot, bot_profile, leave_after_hand, stack, last_seen_at, joined_at)
+       values ($1, $2, $3, 'ACTIVE', true, $4, false, $5, now(), now())
+       on conflict (table_id, seat_no) do update
+         set user_id = excluded.user_id,
+             status = 'ACTIVE',
+             is_bot = true,
+             bot_profile = excluded.bot_profile,
+             leave_after_hand = false,
+             stack = excluded.stack,
+             last_seen_at = now(),
+             joined_at = now()
+       where poker_seats.is_bot = true and poker_seats.status <> 'ACTIVE'
+       returning seat_no;`,
+      [tableId, funding.botUserId, funding.seatNo, funding.botProfile, funding.targetStack]
+    );
+    if (Number(inserted?.[0]?.seat_no) !== funding.seatNo) {
+      throw Object.assign(new Error("managed_bot_top_up_seat_conflict"), { code: "managed_bot_top_up_seat_conflict" });
+    }
+    const result = await postTransaction({
+      userId: null,
+      txType: "TABLE_BUY_IN",
+      idempotencyKey: funding.idempotencyKey,
+      reference: `MANAGED_BOT_TOP_UP:${tableId}:${funding.toStateVersion}:${funding.seatNo}`,
+      description: "Poker managed bot top-up funding",
+      metadata: {
+        actor: "BOT",
+        reason: "BOT_SEED_BUY_IN",
+        lifecycleReason: "MANAGED_BOT_TOP_UP",
+        tableId,
+        seatNo: funding.seatNo,
+        botUserId: funding.botUserId,
+        botProfile: funding.botProfile,
+        settledHandId: funding.settledHandId,
+        fromStateVersion: funding.fromStateVersion,
+        toStateVersion: funding.toStateVersion,
+        sourceSystemKey
+      },
+      entries: [
+        { accountType: "SYSTEM", systemKey: sourceSystemKey, amount: -funding.fundingDelta, metadata: { reason: "BOT_SEED_BUY_IN", tableId, seatNo: funding.seatNo } },
+        { accountType: "ESCROW", systemKey: escrowSystemKey, amount: funding.fundingDelta, metadata: { reason: "BOT_SEED_BUY_IN", tableId, seatNo: funding.seatNo } }
+      ],
+      createdBy: null,
+      tx
+    });
+    const transactionId = typeof result?.transaction?.id === "string" ? result.transaction.id : "";
+    if (!transactionId) throw Object.assign(new Error("managed_bot_top_up_receipt_invalid"), { code: "managed_bot_top_up_receipt_invalid" });
+    funded.push({
+      seatNo: funding.seatNo,
+      botUserId: funding.botUserId,
+      fundingDelta: funding.fundingDelta,
+      idempotencyKey: funding.idempotencyKey,
+      transactionId
+    });
+  }
+  return funded;
+}
+
 export function createPersistedStateWriter({ env = process.env, beginSql = beginSqlWs, klog = () => {} } = {}) {
   const holeCardAcknowledgementByTableId = new Map();
 
@@ -623,6 +732,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     privateStateForHoleCards = null,
     acceptedActionAudit = null,
     replacementFundingPlan,
+    managedBotTopUpPlan,
     humanStackUpdatePlan,
     botFundingSystemKey = null,
     durableActionPlan
@@ -652,6 +762,12 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
           tx,
           tableId,
           fundings: replacementFundingPlan.fundings,
+          botFundingSystemKey
+        });
+        const fundedManagedBotTopUps = await writeManagedBotTopUps({
+          tx,
+          tableId,
+          fundings: managedBotTopUpPlan.fundings,
           botFundingSystemKey
         });
         await tx.unsafe("update public.poker_tables set last_activity_at = now() where id = $1;", [tableId]);
@@ -709,6 +825,12 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
             expectedVersion,
             replacementFundingCommitted: true,
             fundedReplacements
+          } : {}),
+          ...(managedBotTopUpPlan.supplied ? {
+            tableId,
+            expectedVersion,
+            managedBotTopUpCommitted: true,
+            fundedManagedBotTopUps
           } : {}),
           ...(humanStackUpdatePlan.supplied ? {
             tableId,
@@ -795,6 +917,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     meta = null,
     acceptedActionAudit = null,
     replacementFundings = undefined,
+    managedBotTopUps = undefined,
     humanStackUpdates = undefined,
     botFundingSystemKey = null,
     durableActionRequest = null
@@ -818,11 +941,13 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
     if (!replacementFundingPlan.ok) {
       return { ok: false, reason: replacementFundingPlan.reason };
     }
+    const managedBotTopUpPlan = normalizeManagedBotTopUps({ managedBotTopUps, tableId, expectedVersion });
+    if (!managedBotTopUpPlan.ok) return { ok: false, reason: managedBotTopUpPlan.reason };
     const humanStackUpdatePlan = normalizeHumanStackUpdates({ humanStackUpdates, expectedVersion });
     if (!humanStackUpdatePlan.ok) return { ok: false, reason: humanStackUpdatePlan.reason };
     const durableActionPlan = normalizeDurableActionRequest(durableActionRequest, { expectedVersion });
     if (!durableActionPlan.ok) return { ok: false, outcome: "invalid", reason: durableActionPlan.reason };
-    if (replacementFundingPlan.fundings.length > 0) {
+    if (replacementFundingPlan.fundings.length > 0 || managedBotTopUpPlan.fundings.length > 0) {
       const sourceSystemKey = typeof botFundingSystemKey === "string" ? botFundingSystemKey.trim() : "";
       if (!sourceSystemKey) {
         return { ok: false, reason: "replacement_funding_config_invalid" };
@@ -838,7 +963,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         if (durableActionPlan.supplied) {
           return { ok: false, outcome: "failure", reason: "durable_action_store_unavailable" };
         }
-        if (replacementFundingPlan.fundings.length > 0) {
+        if (replacementFundingPlan.fundings.length > 0 || managedBotTopUpPlan.fundings.length > 0) {
           return { ok: false, reason: "ledger_unavailable" };
         }
         return writePersistedTableToFile({
@@ -859,6 +984,7 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         privateStateForHoleCards: holeCardPrivateState,
         acceptedActionAudit,
         replacementFundingPlan,
+        managedBotTopUpPlan,
         humanStackUpdatePlan,
         botFundingSystemKey,
         durableActionPlan

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -600,6 +600,31 @@ async function writeReplacementFundings({ tx, tableId, fundings, botFundingSyste
   const escrowSystemKey = `POKER_TABLE:${tableId}`;
   const fundedReplacements = [];
   for (const funding of fundings) {
+    const replacedSeats = await tx.unsafe(
+      `update public.poker_seats
+          set user_id = $4,
+              stack = $5,
+              status = 'ACTIVE',
+              is_bot = true,
+              leave_after_hand = false,
+              last_seen_at = now(),
+              joined_at = now()
+        where table_id = $1
+          and seat_no = $2
+          and user_id = $3
+          and status = 'ACTIVE'
+          and is_bot = true
+        returning seat_no, user_id, stack;`,
+      [tableId, funding.seatNo, funding.oldBotUserId, funding.replacementBotUserId, funding.targetStack]
+    );
+    if (replacedSeats?.length !== 1
+      || Number(replacedSeats[0]?.seat_no) !== funding.seatNo
+      || String(replacedSeats[0]?.user_id || "") !== funding.replacementBotUserId
+      || Number(replacedSeats[0]?.stack) !== funding.targetStack) {
+      const error = new Error("replacement_seat_projection_conflict");
+      error.code = "replacement_seat_projection_conflict";
+      throw error;
+    }
     const result = await postTransaction({
       userId: null,
       txType: "TABLE_BUY_IN",

--- a/ws-server/poker/runtime/continuous-bot-table-supervisor.mjs
+++ b/ws-server/poker/runtime/continuous-bot-table-supervisor.mjs
@@ -1,0 +1,58 @@
+const DEFAULT_SWEEP_MS = 10_000;
+
+export function createContinuousBotTableSupervisor({
+  repository,
+  onCreatedTable = async () => {},
+  onRetirementRequested = async () => {},
+  klog = () => {},
+  sweepMs = DEFAULT_SWEEP_MS
+} = {}) {
+  let timer = null;
+  let running = false;
+  let stopped = false;
+  const activatedTableIds = new Set();
+
+  async function sweep() {
+    if (running || stopped) return { ok: true, skipped: true };
+    running = true;
+    try {
+      const result = await repository.reconcile();
+      if (!result?.ok) return result;
+      const created = new Set(result.createdTableIds || []);
+      const active = new Set(result.activeTableIds || []);
+      for (const tableId of active) {
+        if (activatedTableIds.has(tableId)) continue;
+        const activated = await onCreatedTable({ tableId, profile: result.profile, created: created.has(tableId) });
+        if (activated?.ok === true) activatedTableIds.add(tableId);
+      }
+      for (const tableId of result.retirementTableIds || []) {
+        await onRetirementRequested({ tableId, profile: result.profile });
+        activatedTableIds.delete(tableId);
+      }
+      for (const tableId of [...activatedTableIds]) {
+        if (!active.has(tableId)) activatedTableIds.delete(tableId);
+      }
+      return result;
+    } catch (error) {
+      klog("ws_continuous_bot_table_supervisor_failed", { reason: error?.message || "unknown" });
+      return { ok: false, reason: error?.message || "unknown" };
+    } finally {
+      running = false;
+    }
+  }
+
+  function start() {
+    if (timer || stopped) return;
+    void sweep();
+    timer = setInterval(() => void sweep(), sweepMs);
+    if (typeof timer?.unref === "function") timer.unref();
+  }
+
+  function stop() {
+    stopped = true;
+    if (timer) clearInterval(timer);
+    timer = null;
+  }
+
+  return { start, stop, sweep };
+}

--- a/ws-server/poker/runtime/table-janitor.behavior.test.mjs
+++ b/ws-server/poker/runtime/table-janitor.behavior.test.mjs
@@ -425,3 +425,39 @@ test("terminal janitor suppression rejects changed, retryable, and unrelated res
     result: terminalFailure
   }), null);
 });
+
+test("managed continuous inert table remains supervisor-owned until retirement is due", () => {
+  const base = {
+    tableId: "managed-table",
+    persistedSeats: [
+      { user_id: "bot-a", seat_no: 1, status: "ACTIVE", is_bot: true, stack: 100 }
+    ],
+    persistedState: { phase: "SETTLED", stacks: { "bot-a": 100 } },
+    runtime: { loaded: true, tableStatus: "OPEN", connectedUserIds: [] },
+    nowMs: NOW_MS
+  };
+  const healthy = evaluateTableHealth({
+    ...base,
+    persistedTable: {
+      status: "OPEN",
+      lifecycle_kind: "CONTINUOUS_BOT",
+      managed_profile_key: "CONTINUOUS_BOT_DEFAULT",
+      rotation_due_at: new Date(NOW_MS + 60_000).toISOString(),
+      created_at: new Date(NOW_MS - 600_000).toISOString()
+    }
+  });
+  assert.equal(healthy.action, "noop");
+  assert.equal(healthy.reasonCode, "managed_continuous_table_supervisor_owned");
+
+  const due = evaluateTableHealth({
+    ...base,
+    persistedTable: {
+      status: "OPEN",
+      lifecycle_kind: "CONTINUOUS_BOT",
+      managed_profile_key: "CONTINUOUS_BOT_DEFAULT",
+      rotation_due_at: new Date(NOW_MS - 1).toISOString(),
+      created_at: new Date(NOW_MS - 600_000).toISOString()
+    }
+  });
+  assert.equal(due.action, "zombie_cleanup");
+});

--- a/ws-server/poker/runtime/table-janitor.mjs
+++ b/ws-server/poker/runtime/table-janitor.mjs
@@ -396,6 +396,23 @@ export function evaluateTableHealth({
     });
   }
 
+  const managedContinuousTable = normalizeStatus(persistedTable?.lifecycle_kind, "") === "CONTINUOUS_BOT"
+    && normalizeRequiredString(persistedTable?.managed_profile_key).toUpperCase() === "CONTINUOUS_BOT_DEFAULT";
+  const rotationDueAtMs = parseTimestampMs(persistedTable?.rotation_due_at);
+  if (managedContinuousTable && (rotationDueAtMs == null || rotationDueAtMs > nowMs)) {
+    return buildClassification({
+      tableId,
+      healthy: true,
+      classification: "healthy",
+      action: "noop",
+      reasonCode: "managed_continuous_table_supervisor_owned",
+      concerns,
+      details: {
+        phase: typeof state?.phase === "string" ? state.phase : null
+      }
+    });
+  }
+
   if (activeHumanSeats.length === 0) {
     const normalizedCloseGraceMs = normalizePositiveInt(tableCloseGraceMs, DEFAULT_TABLE_CLOSE_GRACE_MS);
     const tableCreatedAtMs = resolveTableCreatedAtMs(persistedTable);

--- a/ws-server/poker/shared/poker-turn-timeout.mjs
+++ b/ws-server/poker/shared/poker-turn-timeout.mjs
@@ -24,7 +24,19 @@ function isLiveHand(state) {
 }
 
 function defaultTimeoutActionFor(state, userId) {
-  const legalInfo = computeSharedLegalActions({ statePublic: state, userId });
+  const leftTableByUserId = state?.leftTableByUserId && typeof state.leftTableByUserId === "object" && !Array.isArray(state.leftTableByUserId)
+    ? state.leftTableByUserId
+    : null;
+  const statePublic = leftTableByUserId?.[userId] === true
+    ? {
+        ...state,
+        leftTableByUserId: {
+          ...leftTableByUserId,
+          [userId]: false
+        }
+      }
+    : state;
+  const legalInfo = computeSharedLegalActions({ statePublic, userId });
   const actions = Array.isArray(legalInfo.actions) ? legalInfo.actions : [];
   if (actions.includes("CHECK")) {
     return { type: "CHECK", userId };

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -56,6 +56,49 @@ test("resolveNextDealerSeatNo skips ineligible seats based on settled continuati
   assert.equal(nextDealer, 3);
 });
 
+test("bots-only bootstrap requires both trusted managed metadata and explicit internal intent", () => {
+  const tableId = "table_managed_bootstrap_gate";
+  const manager = createTableManager({ maxSeats: 6 });
+  const restored = manager.restoreTableFromPersisted(tableId, {
+    tableMeta: {
+      maxPlayers: 6,
+      stakes: { sb: 1, bb: 2 },
+      lifecycleKind: "CONTINUOUS_BOT",
+      managedProfileKey: "CONTINUOUS_BOT_DEFAULT"
+    },
+    coreState: {
+      version: 0,
+      roomId: tableId,
+      maxSeats: 6,
+      members: [
+        { userId: "bot_a", seat: 1 },
+        { userId: "bot_b", seat: 2 }
+      ],
+      seats: { bot_a: 1, bot_b: 2 },
+      publicStacks: { bot_a: 100, bot_b: 100 },
+      seatDetailsByUserId: {
+        bot_a: { isBot: true, botProfile: "NORMAL" },
+        bot_b: { isBot: true, botProfile: "NORMAL" }
+      },
+      pokerState: {
+        tableId,
+        phase: "INIT",
+        seats: [
+          { userId: "bot_a", seatNo: 1, isBot: true },
+          { userId: "bot_b", seatNo: 2, isBot: true }
+        ],
+        stacks: { bot_a: 100, bot_b: 100 }
+      }
+    }
+  });
+  assert.equal(restored.ok, true);
+  assert.equal(manager.bootstrapHand(tableId, { nowMs: 1_000 }).changed, false);
+  const started = manager.bootstrapHand(tableId, { nowMs: 1_000, allowManagedBotsOnly: true });
+  assert.equal(started.ok, true);
+  assert.equal(started.changed, true);
+  assert.equal(manager.persistedPokerState(tableId).phase, "PREFLOP");
+});
+
 test("applyAction returns accepted action audit context without private cards", () => {
   const tableManager = createTableManager({ maxSeats: 4 });
   const tableId = "table_action_audit_context";

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -252,6 +252,105 @@ test("rolloverSettledHand delays next-hand bootstrap until explicitly invoked", 
   assert.equal(nextState.turnDeadlineAt > nextState.turnStartedAt, true);
 });
 
+test("managed continuous table rolls the same table into the next bots-only hand after the last human was finalized", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const tableId = "table_managed_continuous_same_table";
+  const restored = tableManager.restoreTableFromPersisted(tableId, {
+    tableMeta: {
+      maxPlayers: 6,
+      stakes: { sb: 1, bb: 2 },
+      lifecycleKind: "CONTINUOUS_BOT",
+      managedProfileKey: "CONTINUOUS_BOT_DEFAULT"
+    },
+    coreState: {
+      version: 14,
+      roomId: tableId,
+      maxSeats: 6,
+      members: [
+        { userId: "bot_a", seat: 2 },
+        { userId: "bot_b", seat: 3 },
+        { userId: "bot_c", seat: 4 }
+      ],
+      seats: { bot_a: 2, bot_b: 3, bot_c: 4 },
+      publicStacks: { bot_a: 110, bot_b: 95, bot_c: 105 },
+      seatDetailsByUserId: {
+        bot_a: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false },
+        bot_b: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false },
+        bot_c: { isBot: true, botProfile: "NORMAL", leaveAfterHand: false }
+      },
+      pokerState: {
+        tableId,
+        roomId: tableId,
+        handId: "hand_managed_after_human_cleanup",
+        phase: "SETTLED",
+        dealerSeatNo: 2,
+        seats: [
+          { userId: "bot_a", seatNo: 2, status: "ACTIVE", isBot: true },
+          { userId: "bot_b", seatNo: 3, status: "ACTIVE", isBot: true },
+          { userId: "bot_c", seatNo: 4, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { bot_a: 110, bot_b: 95, bot_c: 105 },
+        leftTableByUserId: { human_1: true },
+        showdown: {
+          handId: "hand_managed_after_human_cleanup",
+          winners: ["bot_a"],
+          potsAwarded: [{ amount: 12, winners: ["bot_a"], eligibleUserIds: ["bot_a", "bot_b", "bot_c"] }],
+          potAwardedTotal: 12,
+          reason: "computed"
+        },
+        handSettlement: {
+          handId: "hand_managed_after_human_cleanup",
+          settledAt: "2026-07-29T14:00:00.000Z",
+          payouts: { bot_a: 12 }
+        },
+        holeCardsByUserId: {
+          bot_a: ["AS", "KD"],
+          bot_b: ["2C", "2D"],
+          bot_c: ["3H", "3S"]
+        }
+      }
+    }
+  });
+
+  assert.equal(restored.ok, true);
+
+  const prepared = tableManager.prepareSettledHandRollover({
+    tableId,
+    nowMs: 8_000,
+    allowManagedBotsOnly: true,
+    managedBotProfile: {
+      minBotCount: 2,
+      targetBotCount: 3,
+      maxBotCount: 3
+    }
+  });
+
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.changed, true);
+  const committed = tableManager.commitSettledHandRollover({
+    tableId,
+    expectedVersion: prepared.expectedVersion,
+    nextCoreState: prepared.nextCoreState,
+    replacementFundings: prepared.replacementFundings,
+    managedBotTopUps: prepared.managedBotTopUps,
+    managedBotProfile: { minBotCount: 2, targetBotCount: 3, maxBotCount: 3 },
+    humanStackUpdates: prepared.humanStackUpdates,
+    persistenceReceipt: { ok: true, tableId, expectedVersion: prepared.expectedVersion, newVersion: prepared.stateVersion },
+    economyMode: "none",
+    nowMs: 8_000
+  });
+
+  assert.equal(committed.ok, true);
+  assert.equal(committed.changed, true);
+  assert.equal(committed.handId !== "hand_managed_after_human_cleanup", true);
+  const nextState = tableManager.persistedPokerState(tableId);
+  assert.equal(nextState.phase, "PREFLOP");
+  assert.equal(nextState.roomId, tableId);
+  assert.deepEqual(nextState.handSeats.map((seat) => seat.userId).sort(), ["bot_a", "bot_b", "bot_c"]);
+  assert.equal(nextState.handSeats.length, 3);
+  assert.equal(Object.hasOwn(nextState.stacks, "human_1"), false);
+});
+
 test("persistent bot replacement commits runtime only with matching funding receipt", () => {
   const tableManager = createTableManager({ maxSeats: 6, tableBootstrapLoader: async () => ({ ok: false }) });
   const tableId = "00000000-0000-4000-8000-000000000705";

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -816,7 +816,12 @@ export function createTableManager({
     const handEligibleCoreState = existingLiveState || settlementPending
       ? table.coreState
       : buildHandEligibleCoreState({ table, nowMs: resolvedNowMs });
-    const result = bootstrapCoreStateHand({ tableId, coreState: handEligibleCoreState, nowMs: resolvedNowMs });
+    const result = bootstrapCoreStateHand({
+      tableId,
+      coreState: handEligibleCoreState,
+      nowMs: resolvedNowMs,
+      stakes: table.tableMeta?.stakes
+    });
     table.coreState = result.changed && !existingLiveState
       ? {
           ...table.coreState,
@@ -1178,7 +1183,8 @@ export function createTableManager({
         ? toppedUp.coreState
         : buildHandEligibleCoreState({ table, coreState: toppedUp.coreState, nowMs }),
       settledState: toppedUp.settledState,
-      nextVersion
+      nextVersion,
+      stakes: table.tableMeta?.stakes
     });
 
     if (!nextHandState) {

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -12,7 +12,8 @@ import {
   isContinuationEligibleByStack,
   orderedEligibleSeatMembers,
   replaceBrokeBotsForNextHand,
-  resolveNextDealerSeatNo
+  resolveNextDealerSeatNo,
+  topUpManagedBotsForNextHand
 } from "../engine/poker-engine.mjs";
 import { deriveDeterministicRuntimeHandState } from "../shared/runtime-hand-state.mjs";
 import { stampTurnDeadline } from "../shared/poker-turn-timeout.mjs";
@@ -191,13 +192,31 @@ function normalizeTableMeta(value, fallbackMaxPlayers, { defaultCreatedAtMs = nu
     ?? createdAtMs
     ?? defaultLastActivityAtMs
     ?? defaultCreatedAtMs;
+  const lifecycleKindRaw = typeof value?.lifecycleKind === "string"
+    ? value.lifecycleKind.trim().toUpperCase()
+    : typeof value?.lifecycle_kind === "string"
+      ? value.lifecycle_kind.trim().toUpperCase()
+      : "STANDARD";
+  const managedProfileKeyRaw = typeof value?.managedProfileKey === "string"
+    ? value.managedProfileKey.trim().toUpperCase()
+    : typeof value?.managed_profile_key === "string"
+      ? value.managed_profile_key.trim().toUpperCase()
+      : null;
+  const lifecycleKind = lifecycleKindRaw === "CONTINUOUS_BOT" && managedProfileKeyRaw === "CONTINUOUS_BOT_DEFAULT"
+    ? "CONTINUOUS_BOT"
+    : "STANDARD";
   return {
     maxPlayers,
     stakes: stakes && Number.isInteger(stakes.sb) && Number.isInteger(stakes.bb)
       ? stakes
       : null,
     createdAtMs,
-    lastActivityAtMs
+    lastActivityAtMs,
+    lifecycleKind,
+    managedProfileKey: lifecycleKind === "CONTINUOUS_BOT" ? managedProfileKeyRaw : null,
+    rotationDueAtMs: lifecycleKind === "CONTINUOUS_BOT"
+      ? normalizeTimestampMs(value?.rotationDueAtMs ?? value?.rotation_due_at ?? value?.rotationDueAt)
+      : null
   };
 }
 
@@ -773,7 +792,7 @@ export function createTableManager({
     };
   }
 
-  function bootstrapHand(tableId, { nowMs } = {}) {
+  function bootstrapHand(tableId, { nowMs, allowManagedBotsOnly = false } = {}) {
     const table = tables.get(tableId);
     if (!table) {
       return { ok: false, code: "table_missing", bootstrap: "table_missing" };
@@ -782,7 +801,10 @@ export function createTableManager({
     const resolvedNowMs = resolveNowMs({ nowMs });
     const existingLiveState = asLiveHandState(table.coreState?.pokerState);
     const settlementPending = table.coreState?.pokerState?.phase === "SETTLED";
-    if (!existingLiveState && !settlementPending && !hasHandEligibleHumanMember({ table, nowMs: resolvedNowMs })) {
+    const managedBotsOnlyAllowed = allowManagedBotsOnly === true
+      && table.tableMeta?.lifecycleKind === "CONTINUOUS_BOT"
+      && table.tableMeta?.managedProfileKey === "CONTINUOUS_BOT_DEFAULT";
+    if (!existingLiveState && !settlementPending && !managedBotsOnlyAllowed && !hasHandEligibleHumanMember({ table, nowMs: resolvedNowMs })) {
       return {
         ok: true,
         changed: false,
@@ -1028,6 +1050,39 @@ export function createTableManager({
     });
   }
 
+  function normalizedManagedTopUpShape(value) {
+    if (!Array.isArray(value)) return [];
+    return value.map((entry) => ({
+      seatNo: entry?.seatNo,
+      botUserId: entry?.botUserId,
+      botProfile: entry?.botProfile,
+      targetStack: entry?.targetStack,
+      fundingDelta: entry?.fundingDelta,
+      settledHandId: entry?.settledHandId,
+      fromStateVersion: entry?.fromStateVersion,
+      toStateVersion: entry?.toStateVersion
+    }));
+  }
+
+  function managedTopUpReceiptMatches({ tableId, expectedVersion, stateVersion, topUps, persistenceReceipt }) {
+    if (topUps.length === 0) return true;
+    if (!persistenceReceipt || persistenceReceipt.ok !== true
+      || persistenceReceipt.tableId !== tableId
+      || persistenceReceipt.expectedVersion !== expectedVersion
+      || persistenceReceipt.newVersion !== stateVersion
+      || persistenceReceipt.managedBotTopUpCommitted !== true) return false;
+    const funded = Array.isArray(persistenceReceipt.fundedManagedBotTopUps)
+      ? persistenceReceipt.fundedManagedBotTopUps
+      : [];
+    return funded.length === topUps.length && topUps.every((entry, index) => {
+      const receipt = funded[index];
+      return receipt?.seatNo === entry.seatNo
+        && receipt?.botUserId === entry.botUserId
+        && receipt?.fundingDelta === entry.fundingDelta
+        && receipt?.idempotencyKey === `poker:managed-bot-top-up:v1:${tableId}:${stateVersion}:${entry.seatNo}`;
+    });
+  }
+
   function normalizedHumanStackUpdates({ coreState, settledState, fromStateVersion, toStateVersion }) {
     const members = Array.isArray(coreState?.members) ? coreState.members : [];
     const humanMembers = members.filter((member) => !isCoreStateBotUser(coreState, member?.userId));
@@ -1060,7 +1115,12 @@ export function createTableManager({
       || (economyMode === "none" && typeof tableId === "string" && tableId.startsWith("guest_table_"));
   }
 
-  function prepareSettledHandRollover({ tableId, nowMs = Date.now() } = {}) {
+  function prepareSettledHandRollover({
+    tableId,
+    nowMs = Date.now(),
+    allowManagedBotsOnly = false,
+    managedBotProfile = null
+  } = {}) {
     const table = tables.get(tableId);
     if (!table) {
       return { ok: false, changed: false, reason: "table_not_found", stateVersion: 0 };
@@ -1088,7 +1148,23 @@ export function createTableManager({
         stateVersion: table.coreState.version
       };
     }
-    if (!hasHandEligibleHumanMember({ table, coreState: recycled.coreState, nowMs })) {
+    const managedBotsOnlyAllowed = allowManagedBotsOnly === true
+      && table.tableMeta?.lifecycleKind === "CONTINUOUS_BOT"
+      && table.tableMeta?.managedProfileKey === "CONTINUOUS_BOT_DEFAULT";
+    const toppedUp = managedBotsOnlyAllowed
+      ? topUpManagedBotsForNextHand({
+          coreState: recycled.coreState,
+          settledState: recycled.settledState,
+          nextVersion,
+          minBotCount: managedBotProfile?.minBotCount,
+          targetBotCount: managedBotProfile?.targetBotCount,
+          maxBotCount: managedBotProfile?.maxBotCount
+        })
+      : { ok: true, coreState: recycled.coreState, settledState: recycled.settledState, topUpFundings: [] };
+    if (!toppedUp?.ok) {
+      return { ok: false, changed: false, reason: toppedUp?.reason || "managed_bot_top_up_invalid", stateVersion: table.coreState.version };
+    }
+    if (!managedBotsOnlyAllowed && !hasHandEligibleHumanMember({ table, coreState: toppedUp.coreState, nowMs })) {
       return {
         ok: true,
         changed: false,
@@ -1098,8 +1174,10 @@ export function createTableManager({
     }
     const nextHandState = buildNextHandStateFromSettled({
       tableId,
-      coreState: buildHandEligibleCoreState({ table, coreState: recycled.coreState, nowMs }),
-      settledState: recycled.settledState,
+      coreState: managedBotsOnlyAllowed
+        ? toppedUp.coreState
+        : buildHandEligibleCoreState({ table, coreState: toppedUp.coreState, nowMs }),
+      settledState: toppedUp.settledState,
       nextVersion
     });
 
@@ -1113,8 +1191,8 @@ export function createTableManager({
     }
 
     const humanStackUpdates = normalizedHumanStackUpdates({
-      coreState: recycled.coreState,
-      settledState: recycled.settledState,
+      coreState: toppedUp.coreState,
+      settledState: toppedUp.settledState,
       fromStateVersion: Number(table.coreState.version),
       toStateVersion: nextVersion
     });
@@ -1124,7 +1202,7 @@ export function createTableManager({
     const projectedPublicStacks = { ...(recycled.coreState.publicStacks || {}) };
     for (const update of humanStackUpdates) projectedPublicStacks[update.userId] = update.stack;
     const nextCoreState = {
-      ...recycled.coreState,
+      ...toppedUp.coreState,
       version: nextVersion,
       publicStacks: projectedPublicStacks,
       pokerState: stampTurnDeadline(nextHandState, resolveNowMs({ nowMs }))
@@ -1139,6 +1217,7 @@ export function createTableManager({
       nextCoreState,
       handId: nextCoreState?.pokerState?.handId ?? null,
       replacementFundings: normalizedReplacementFundingShape(recycled.replacementFundings),
+      managedBotTopUps: normalizedManagedTopUpShape(toppedUp.topUpFundings),
       humanStackUpdates
     };
   }
@@ -1148,6 +1227,8 @@ export function createTableManager({
     expectedVersion,
     nextCoreState,
     replacementFundings = [],
+    managedBotTopUps = [],
+    managedBotProfile = null,
     humanStackUpdates = [],
     persistenceReceipt = null,
     economyMode = null,
@@ -1174,6 +1255,23 @@ export function createTableManager({
     if (!recalculated?.ok || !replacementFundingPlansEqual(recalculated.replacementFundings, replacementFundings)) {
       return { ok: false, changed: false, reason: "replacement_funding_mismatch", stateVersion: currentVersion };
     }
+    const managed = table.tableMeta?.lifecycleKind === "CONTINUOUS_BOT"
+      && table.tableMeta?.managedProfileKey === "CONTINUOUS_BOT_DEFAULT";
+    const recalculatedTopUp = managed
+      ? topUpManagedBotsForNextHand({
+          coreState: recalculated.coreState,
+          settledState: recalculated.settledState,
+          nextVersion,
+          minBotCount: managedBotProfile?.minBotCount,
+          targetBotCount: managedBotProfile?.targetBotCount,
+          maxBotCount: managedBotProfile?.maxBotCount
+        })
+      : { ok: true, coreState: recalculated.coreState, settledState: recalculated.settledState, topUpFundings: [] };
+    const normalizedTopUps = normalizedManagedTopUpShape(managedBotTopUps);
+    if (!recalculatedTopUp?.ok
+      || JSON.stringify(normalizedManagedTopUpShape(recalculatedTopUp.topUpFundings)) !== JSON.stringify(normalizedTopUps)) {
+      return { ok: false, changed: false, reason: "managed_bot_top_up_mismatch", stateVersion: currentVersion };
+    }
 
     const normalizedFundings = normalizedReplacementFundingShape(replacementFundings);
     const economyFree = isEconomyFreeRollover({ tableId, economyMode });
@@ -1185,6 +1283,15 @@ export function createTableManager({
       persistenceReceipt
     })) {
       return { ok: false, changed: false, reason: "replacement_funding_unconfirmed", stateVersion: currentVersion };
+    }
+    if (!economyFree && !managedTopUpReceiptMatches({
+      tableId,
+      expectedVersion,
+      stateVersion: nextVersion,
+      topUps: normalizedTopUps,
+      persistenceReceipt
+    })) {
+      return { ok: false, changed: false, reason: "managed_bot_top_up_unconfirmed", stateVersion: currentVersion };
     }
     const expectedHumanUpdates = normalizedHumanStackUpdates({
       coreState: recalculated.coreState,
@@ -1213,7 +1320,8 @@ export function createTableManager({
       reason: null,
       stateVersion: nextVersion,
       handId: nextCoreState?.pokerState?.handId ?? null,
-      replacementFundings: normalizedFundings
+      replacementFundings: normalizedFundings,
+      managedBotTopUps: normalizedTopUps
     };
   }
 

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -30,12 +30,81 @@ import {
 import { createPokerLogRuntimeControl } from "./poker/observability/poker-log-runtime-control.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
+import { normalizeContinuousBotProfile } from "./poker/persistence/continuous-bot-table-repository.mjs";
+import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 
 const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   "./poker/runtime/accepted-bot-autoplay-adapter.fixed-random.fixture.mjs",
   import.meta.url
 ).href;
+
+test("continuous bot profile validation accepts only the bounded V1 singleton", () => {
+  const valid = normalizeContinuousBotProfile({
+    profile_key: "CONTINUOUS_BOT_DEFAULT",
+    enabled: true,
+    desired_table_count: 1,
+    min_bot_count: 2,
+    target_bot_count: 3,
+    max_bot_count: 3,
+    rotation_interval_seconds: 900,
+    postpone_interval_seconds: 300,
+    small_blind: 1,
+    big_blind: 2,
+    max_seats: 6
+  });
+  assert.equal(valid?.desiredTableCount, 1);
+  assert.equal(valid?.targetBotCount, 3);
+  assert.equal(normalizeContinuousBotProfile({ ...valid, profile_key: "OTHER" }), null);
+  assert.equal(normalizeContinuousBotProfile({
+    profile_key: "CONTINUOUS_BOT_DEFAULT",
+    enabled: true,
+    desired_table_count: 3,
+    min_bot_count: 2,
+    target_bot_count: 3,
+    max_bot_count: 3,
+    rotation_interval_seconds: 900,
+    postpone_interval_seconds: 300,
+    small_blind: 1,
+    big_blind: 2,
+    max_seats: 6
+  }), null);
+});
+
+test("continuous bot supervisor coalesces overlapping sweeps and activates each table once", async () => {
+  let release;
+  let calls = 0;
+  const activated = [];
+  const repository = {
+    reconcile: async () => {
+      calls += 1;
+      if (calls === 1) await new Promise((resolve) => { release = resolve; });
+      return {
+        ok: true,
+        profile: { profileKey: "CONTINUOUS_BOT_DEFAULT" },
+        createdTableIds: calls === 1 ? ["table-a"] : [],
+        activeTableIds: ["table-a"],
+        retirementTableIds: []
+      };
+    }
+  };
+  const supervisor = createContinuousBotTableSupervisor({
+    repository,
+    onCreatedTable: async ({ tableId }) => {
+      activated.push(tableId);
+      return { ok: true };
+    }
+  });
+  const first = supervisor.sweep();
+  const overlapping = await supervisor.sweep();
+  assert.equal(overlapping.skipped, true);
+  release();
+  await first;
+  await supervisor.sweep();
+  assert.equal(calls, 2);
+  assert.deepEqual(activated, ["table-a"]);
+  supervisor.stop();
+});
 
 async function listProductionModuleFiles(rootPath) {
   const stat = await fs.stat(rootPath);

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -30,7 +30,10 @@ import {
 import { createPokerLogRuntimeControl } from "./poker/observability/poker-log-runtime-control.mjs";
 import { buildBootstrappedPokerState } from "./poker/engine/poker-engine.mjs";
 import { loadBotClaimsRecoveryExecutorIfInactive } from "./poker/persistence/bot-claims-recovery-adapter.mjs";
-import { normalizeContinuousBotProfile } from "./poker/persistence/continuous-bot-table-repository.mjs";
+import {
+  normalizeContinuousBotProfile,
+  tableMatchesContinuousBotProfile
+} from "./poker/persistence/continuous-bot-table-repository.mjs";
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 
@@ -69,6 +72,33 @@ test("continuous bot profile validation accepts only the bounded V1 singleton", 
     big_blind: 2,
     max_seats: 6
   }), null);
+});
+
+test("continuous bot profile comparison accepts Postgres stringified jsonb stakes", () => {
+  const profile = normalizeContinuousBotProfile({
+    profile_key: "CONTINUOUS_BOT_DEFAULT",
+    enabled: true,
+    desired_table_count: 1,
+    min_bot_count: 2,
+    target_bot_count: 3,
+    max_bot_count: 3,
+    rotation_interval_seconds: 900,
+    postpone_interval_seconds: 300,
+    small_blind: 5,
+    big_blind: 10,
+    max_seats: 6
+  });
+
+  assert.equal(tableMatchesContinuousBotProfile({
+    managed_profile_key: "CONTINUOUS_BOT_DEFAULT",
+    max_players: 6,
+    stakes: "{\"sb\":5,\"bb\":10}"
+  }, profile), true);
+  assert.equal(tableMatchesContinuousBotProfile({
+    managed_profile_key: "CONTINUOUS_BOT_DEFAULT",
+    max_players: 6,
+    stakes: "{\"sb\":1,\"bb\":2}"
+  }, profile), false);
 });
 
 test("continuous bot supervisor coalesces overlapping sweeps and activates each table once", async () => {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1633,13 +1633,16 @@ async function executeUserInactiveCleanupPrimitive({
     commandName,
     dedupeKey,
     run: async () => {
+      const tableMeta = tableManager.tableMeta(tableId);
+      const managedContinuousTable = tableMeta?.lifecycleKind === "CONTINUOUS_BOT"
+        && tableMeta?.managedProfileKey === "CONTINUOUS_BOT_DEFAULT";
       if (!skipSocketCheck) {
         const activeSockets = sessionStore.connectionsForUser(userId) || [];
         if (activeSockets.some((socket) => tableSocketMatches(socket, tableId))) {
           return { ok: true, changed: false, status: "socket_present" };
         }
       }
-      if (await isSettledRevealPending(tableId)) {
+      if (!managedContinuousTable && await isSettledRevealPending(tableId)) {
         maybeScheduleSettledRollover(tableId);
         klogSafe(`${logPrefix}_settled_reveal_deferred`, {
           tableId,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -56,6 +56,8 @@ import {
   setPokerLogRuntimeAuditLogger
 } from "./poker/observability/poker-log-runtime-control.mjs";
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
+import { createContinuousBotTableRepository } from "./poker/persistence/continuous-bot-table-repository.mjs";
+import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -296,6 +298,9 @@ const durableActionStore = hasSupabaseDbUrl && persistedStateWriter?.readDurable
   ? persistedStateWriter
   : null;
 const botFundingSystemKey = getBotConfig(process.env).bankrollSystemKey;
+const continuousBotTableRepository = hasSupabaseDbUrl
+  ? createContinuousBotTableRepository({ env: process.env, klog: klogSafe })
+  : null;
 const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
 const lobbySubscribers = new Set();
@@ -303,6 +308,7 @@ const activeLobbyTablesById = new Map();
 const pendingTableJanitorEvaluationByTableId = new Map();
 const suppressedNonRetryableTerminalJanitorFailuresByTableId = new Map();
 const suppressedTerminalJanitorCountsByReason = new Map();
+const continuousBotRetirementRequested = new Set();
 const AUTOMATIC_TABLE_JANITOR_TRIGGERS = new Set([
   "stale_active_seat_sweep",
   "zombie_table_sweep",
@@ -1357,6 +1363,7 @@ async function persistMutatedState({
   nextStateOverride = null,
   privateStateForHoleCardsOverride = null,
   replacementFundings = undefined,
+  managedBotTopUps = undefined,
   humanStackUpdates = undefined,
   replacementFundingSystemKey = null,
   durableActionRequest = null,
@@ -1366,7 +1373,8 @@ async function persistMutatedState({
     return { ok: true, skipped: true, guest: true };
   }
   if (!persistedStateWriter) {
-    if (Array.isArray(replacementFundings) && replacementFundings.length > 0) {
+    if ((Array.isArray(replacementFundings) && replacementFundings.length > 0)
+      || (Array.isArray(managedBotTopUps) && managedBotTopUps.length > 0)) {
       return { ok: false, reason: "persistence_required" };
     }
     if (process.env.WS_PERSISTED_BOOTSTRAP_FIXTURES_JSON && Array.isArray(humanStackUpdates)) {
@@ -1402,6 +1410,7 @@ async function persistMutatedState({
     meta: { mutationKind },
     acceptedActionAudit,
     replacementFundings,
+    managedBotTopUps,
     humanStackUpdates,
     botFundingSystemKey: replacementFundingSystemKey,
     durableActionRequest
@@ -1539,6 +1548,7 @@ function releaseTableRuntimeResources(tableId) {
   suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(tableId);
   guestDisconnectCleanupRuntime?.forgetTable(tableId);
   streamLog.forgetTable(tableId);
+  continuousBotRetirementRequested.delete(tableId);
 }
 
 function shouldEvictClosedRuntimeTable(tableId, result) {
@@ -1874,7 +1884,13 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
       }
     }
   }
-  if (!tableManager.hasActiveHumanMember(tableId)) {
+  const tableMeta = tableManager.tableMeta(tableId);
+  const managedContinuousTable = tableMeta?.lifecycleKind === "CONTINUOUS_BOT"
+    && tableMeta?.managedProfileKey === "CONTINUOUS_BOT_DEFAULT";
+  const managedRetirementDue = managedContinuousTable
+    && Number.isFinite(tableMeta?.rotationDueAtMs)
+    && tableMeta.rotationDueAtMs <= Date.now();
+  if (!managedContinuousTable && !tableManager.hasActiveHumanMember(tableId)) {
     if (tableManager.hasConnectedHumanPresence(tableId)) {
       klogSafe("ws_settled_rollover_close_skipped_human_presence", { tableId, phase: pokerState?.phase || null });
       return finishSettledRollover({ ok: true, changed: false, deferred: true, reason: "human_presence_present" });
@@ -1885,6 +1901,17 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
       logPrefix: "ws_settled_rollover_close"
     });
     return finishSettledRollover(cleanupResult);
+  }
+  if (managedRetirementDue) {
+    if (tableManager.hasActiveHumanMember(tableId) || tableManager.hasConnectedHumanPresence(tableId)) {
+      scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
+      return finishSettledRollover({ ok: true, changed: false, deferred: true, reason: "managed_retirement_human_present" });
+    }
+    return finishSettledRollover(await applyInactiveCleanupAndBroadcast({
+      tableId,
+      requestId: `continuous-bot-table-close:${tableId}`,
+      logPrefix: "ws_continuous_bot_table_retirement"
+    }));
   }
 
   if (isGuestTableId(tableId)) {
@@ -1901,7 +1928,17 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     return finishSettledRollover(guestRollover);
   }
 
-  const prepared = tableManager.prepareSettledHandRollover({ tableId, nowMs: Date.now() });
+  const managedBotProfile = managedContinuousTable ? continuousBotTableRepository?.currentProfile() : null;
+  if (managedContinuousTable && !managedBotProfile) {
+    scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
+    return finishSettledRollover({ ok: false, changed: false, reason: "managed_profile_unavailable" });
+  }
+  const prepared = tableManager.prepareSettledHandRollover({
+    tableId,
+    nowMs: Date.now(),
+    allowManagedBotsOnly: managedContinuousTable,
+    managedBotProfile
+  });
   if (!prepared?.ok || !prepared.changed) {
     return finishSettledRollover(prepared);
   }
@@ -1914,6 +1951,7 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     nextStateOverride: candidatePokerState,
     privateStateForHoleCardsOverride: candidatePokerState,
     replacementFundings: prepared.replacementFundings,
+    managedBotTopUps: prepared.managedBotTopUps,
     humanStackUpdates: prepared.humanStackUpdates,
     replacementFundingSystemKey: botFundingSystemKey,
     deferRuntimeVersionUpdate: true
@@ -1957,6 +1995,8 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     expectedVersion: prepared.expectedVersion,
     nextCoreState: prepared.nextCoreState,
     replacementFundings: prepared.replacementFundings,
+    managedBotTopUps: prepared.managedBotTopUps,
+    managedBotProfile,
     humanStackUpdates: prepared.humanStackUpdates,
     persistenceReceipt: persisted,
     nowMs: Date.now()
@@ -2407,7 +2447,7 @@ async function loadPersistedTableHealthSnapshot(tableId) {
     const beginSqlWs = await loadBeginSqlWs();
     return beginSqlWs(async (tx) => {
       const tableRows = await tx.unsafe(
-        "select id, status, created_at, updated_at, last_activity_at from public.poker_tables where id = $1 limit 1;",
+        "select id, status, created_at, updated_at, last_activity_at, lifecycle_kind, managed_profile_key, rotation_due_at from public.poker_tables where id = $1 limit 1;",
         [tableId]
       );
       const seatRows = await tx.unsafe(
@@ -4184,6 +4224,79 @@ function sweepTransportWatchdog() {
   }
 }
 
+async function materializeCreatedContinuousBotTable({ tableId, created = false }) {
+  return enqueueTableCommand({
+    tableId,
+    commandName: "continuous_bot_table_materialize",
+    dedupeKey: "continuous_bot_table_materialize",
+    run: async () => {
+      const restored = await restoreTableFromPersisted(tableId);
+      if (!restored?.ok) return restored;
+      const expectedVersion = tableManager.persistedStateVersion(tableId);
+      const bootstrapped = tableManager.bootstrapHand(tableId, {
+        nowMs: Date.now(),
+        allowManagedBotsOnly: true
+      });
+      if (!bootstrapped?.ok) return bootstrapped;
+      let stateVersion = bootstrapped.stateVersion;
+      if (bootstrapped.changed) {
+        const persisted = await persistMutatedState({
+          tableId,
+          expectedVersion,
+          mutationKind: "continuous_bot_table_bootstrap"
+        });
+        if (!persisted?.ok) {
+          await restoreTableFromPersisted(tableId);
+          return persisted;
+        }
+        stateVersion = persisted.newVersion;
+      }
+      syncLobbyTable(tableId);
+      maybeBroadcastLobbySnapshot({ force: true });
+      broadcastStateSnapshots(tableId);
+      scheduleBotStep({ tableId, trigger: "continuous_bot_table_created", requestId: null, frameTs: null });
+      if (created) {
+        klogSafe("ws_continuous_bot_table_created", { tableId, stateVersion });
+      } else {
+        klogSafe("ws_continuous_bot_table_restored", { tableId, stateVersion });
+      }
+      return { ok: true, changed: bootstrapped.changed === true, stateVersion };
+    }
+  });
+}
+
+async function requestContinuousBotTableRetirement({ tableId }) {
+  if (continuousBotRetirementRequested.has(tableId)) return { ok: true, changed: false };
+  continuousBotRetirementRequested.add(tableId);
+  return enqueueTableCommand({
+    tableId,
+    commandName: "continuous_bot_table_retirement",
+    dedupeKey: "continuous_bot_table_retirement",
+    run: async () => {
+      const restored = await restoreTableFromPersisted(tableId);
+      if (!restored?.ok) {
+        continuousBotRetirementRequested.delete(tableId);
+        return restored;
+      }
+      klogSafe("ws_continuous_bot_table_retirement_requested", {
+        tableId,
+        phase: tableManager.persistedPokerState(tableId)?.phase || null
+      });
+      maybeScheduleSettledRollover(tableId);
+      return { ok: true, changed: false };
+    }
+  });
+}
+
+const continuousBotTableSupervisor = continuousBotTableRepository
+  ? createContinuousBotTableSupervisor({
+      repository: continuousBotTableRepository,
+      onCreatedTable: materializeCreatedContinuousBotTable,
+      onRetirementRequested: requestContinuousBotTableRetirement,
+      klog: klogSafe
+    })
+  : null;
+
 const transportWatchdogTimer = setInterval(() => {
   sweepTransportWatchdog();
 }, transportWatchdogSweepMs);
@@ -4237,6 +4350,7 @@ async function startServer() {
     deployRef: release.deployRef || null,
     environment: release.environment || "unknown"
   });
+  continuousBotTableSupervisor?.start();
   server.listen(PORT, "0.0.0.0", () => {
     klogSafe("ws_listening", { message: `WS listening on ${PORT}`, port: PORT });
   });

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -38,6 +38,7 @@ import { handleActCommand } from "./poker/handlers/act.mjs";
 import { handleStartHandCommand } from "./poker/handlers/start-hand.mjs";
 import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import {
+  createBotAutoplayCascadeScheduler,
   createBotAutoplayObservability,
   handleBotStepCommand,
   matchesBotTimeoutSafetySuppression,
@@ -709,8 +710,8 @@ function pruneBotTimeoutSafetySuppressions() {
   }
 }
 
-function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
-  const enqueueStep = () => enqueueTableCommand({
+const botAutoplayCascadeScheduler = createBotAutoplayCascadeScheduler({
+  runStep: ({ tableId, trigger, requestId, frameTs }) => enqueueTableCommand({
     tableId,
     commandName: "bot_step",
     run: async () => {
@@ -735,22 +736,11 @@ function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
       clearBotTimeoutSafetySuppressionAfterSuccess(tableId, result);
       return result;
     }
-  });
+  })
+});
 
-  const runCascade = () => {
-    const queued = enqueueStep();
-    void queued
-      .then((result) => {
-        if (result?.ok === true && result?.shouldContinue === true) {
-          setImmediate(() => {
-            void runCascade();
-          });
-        }
-      })
-      .catch(() => {});
-    return queued;
-  };
-  return runCascade();
+function scheduleBotStep({ tableId, trigger, requestId, frameTs }) {
+  return botAutoplayCascadeScheduler.schedule({ tableId, trigger, requestId, frameTs });
 }
 
 function scheduleObservedBotTurn({ tableId, trigger, requestId = null, frameTs = null }) {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1282,7 +1282,7 @@ function sendResumeAck(ws, connState, { requestId = null, tableId }) {
   sendFrame(ws, frame);
 }
 
-function sendCommandResult(ws, connState, { requestId = null, tableId = null, status, reason = null }) {
+function sendCommandResult(ws, connState, { requestId = null, tableId = null, status, reason = null, ...result }) {
   const frame = {
     version: "1.0",
     type: "commandResult",
@@ -1291,7 +1291,8 @@ function sendCommandResult(ws, connState, { requestId = null, tableId = null, st
     payload: {
       requestId,
       status,
-      reason
+      reason,
+      ...result
     }
   };
 

--- a/ws-server/shared/poker-domain/bots.mjs
+++ b/ws-server/shared/poker-domain/bots.mjs
@@ -1,1 +1,2 @@
 export { getBotConfig, makeBotUserId, parseStakes } from "../../../shared/poker-domain/bots.mjs";
+export { applySeatsAndStacksToState, seedBotsForJoin } from "../../../shared/poker-domain/bots.mjs";


### PR DESCRIPTION
## Summary

- adds the disabled-by-default database profile and persisted lifecycle metadata for managed continuous bot tables
- creates and restores the desired table count through a serialized supervisor and one atomic table/state/escrow/bot-funding transaction
- allows trusted managed bots-only bootstrap/rollover, settled-boundary bot top-up, quick-seat joins for real players, and graceful retirement when disabled or reconfigured
- preserves existing gameplay, janitor, ledger, settlement, and terminal accounting paths for standard tables

## Safety and rollout

- Refs #784; this is foundation PR A, not the periodic 15-minute rotation PR
- the seeded profile is `enabled=false` and `desired_table_count=0`
- apply the migration before deploying the WS artifact
- enable only on WS Preview first by updating the singleton profile row
- `enabled=false` or `desired_table_count=0` requests graceful retirement at the next safe SETTLED boundary; humans are never forced out
- creation-time changes to stakes or max seats gracefully retire old managed tables before replacements are created

## Validation

- `npm test`
- 253 focused WS/domain behavior tests
- `npm run syntax`
- `npm run check:csp-inline`
- `npm run ci:guards`
- `git diff --check`

## Breaking impact

No behavior change for normal tables while the managed profile remains disabled. Enabling the profile creates funded bot tables and persistent ledger traffic through existing SYSTEM -> ESCROW contracts. The migration must precede this WS build because it adds the profile and lifecycle columns consumed by runtime queries.