### PR TITLE
fix: stop continuous bot replacement retry loop

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -87,6 +87,7 @@ run("node", ["tests/poker-v2-live.behavior.test.mjs"], "poker-v2-live-behavior")
 run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test.mjs"], "ws-inactive-cleanup-adapter-behavior");
 run("node", ["ws-server/poker/persistence/deferred-leave-finalization-adapter.behavior.test.mjs"], "ws-deferred-leave-finalization-adapter-behavior");
 run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");
+run("node", ["ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs"], "ws-continuous-bot-table-repository-behavior");
 run("node", ["ws-server/poker/idempotency/action-command.behavior.test.mjs"], "ws-action-command-idempotency-behavior");
 run("node", ["ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs"], "ws-authoritative-rebuy-adapter-behavior");
 run("node", ["ws-server/poker/handlers/rebuy.behavior.test.mjs"], "ws-rebuy-handler-behavior");

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -264,7 +264,7 @@ test("adapter rejects an unrecoverable all-in hand with invalid or duplicate pri
   assert.equal(result.reason, "live_hand_runtime_unrecoverable");
 });
 
-test("adapter restores replacement bot identity from persisted state when seat rows still reference prior bot id", () => {
+test("adapter restores current replacement bot identity from persisted seat rows", () => {
   const result = adaptPersistedBootstrap({
     tableId: "table_replacement_bot_restore",
     tableRow: { id: "table_replacement_bot_restore", max_players: 6, status: "OPEN" },
@@ -299,27 +299,31 @@ test("adapter restores replacement bot identity from persisted state when seat r
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.table.coreState.members, [
-    { userId: "bot_auto_2_38", seat: 2 },
+    { userId: "bot_old_2", seat: 2 },
     { userId: "bot_keep_3", seat: 3 }
   ]);
   assert.deepEqual(result.table.coreState.seats, {
-    bot_auto_2_38: 2,
+    bot_old_2: 2,
     bot_keep_3: 3
   });
   assert.deepEqual(result.table.coreState.publicStacks, {
-    bot_auto_2_38: 100,
+    bot_old_2: 1,
     bot_keep_3: 87
   });
-  assert.equal(result.table.coreState.seatDetailsByUserId.bot_auto_2_38?.isBot, true);
-  assert.equal(result.table.coreState.seatDetailsByUserId.bot_auto_2_38?.botProfile, "TRIVIAL");
-  assert.equal(result.table.coreState.pokerState.turnUserId, "bot_auto_2_38");
+  assert.deepEqual(result.table.coreState.pokerState.stacks, {
+    bot_old_2: 1,
+    bot_keep_3: 87
+  });
+  assert.equal(result.table.coreState.seatDetailsByUserId.bot_old_2?.isBot, true);
+  assert.equal(result.table.coreState.seatDetailsByUserId.bot_old_2?.botProfile, "TRIVIAL");
+  assert.equal(result.table.coreState.pokerState.turnUserId, "bot_old_2");
   assert.deepEqual(result.table.coreState.pokerState.seats, [
     { userId: "user_a", seatNo: 1, status: "ACTIVE" },
-    { userId: "bot_auto_2_38", seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
+    { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
     { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" }
   ]);
-  assert.equal(result.table.presenceByUserId.has("bot_auto_2_38"), true);
-  assert.equal(result.table.presenceByUserId.has("bot_old_2"), false);
+  assert.equal(result.table.presenceByUserId.has("bot_old_2"), true);
+  assert.equal(result.table.presenceByUserId.has("bot_auto_2_38"), false);
 });
 
 test("adapter keeps authoritative human stack while retaining bot seat projection", () => {

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { adaptPersistedBootstrap } from "./persisted-bootstrap-adapter.mjs";
 import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitives.mjs";
 import { applyAction } from "../shared/poker-action-reducer.mjs";
+import { createTableManager } from "../table/table-manager.mjs";
 
 test("adapter maps persisted rows into deterministic ws table/core state", () => {
   const result = adaptPersistedBootstrap({
@@ -329,7 +330,13 @@ test("adapter preserves persisted live-hand identity when seat rows still refere
 test("adapter restores settled replacement identity from the current persisted seat row", () => {
   const result = adaptPersistedBootstrap({
     tableId: "table_replacement_bot_restore_settled",
-    tableRow: { id: "table_replacement_bot_restore_settled", max_players: 6, status: "OPEN" },
+    tableRow: {
+      id: "table_replacement_bot_restore_settled",
+      max_players: 6,
+      status: "OPEN",
+      lifecycle_kind: "CONTINUOUS_BOT",
+      managed_profile_key: "CONTINUOUS_BOT_DEFAULT"
+    },
     seatRows: [
       { user_id: "bot_current_2", seat_no: 2, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 100 },
       { user_id: "bot_keep_3", seat_no: 3, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 87 }
@@ -340,11 +347,22 @@ test("adapter restores settled replacement identity from the current persisted s
         tableId: "table_replacement_bot_restore_settled",
         handId: "hand_replacement_bot_restore_settled",
         phase: "SETTLED",
+        dealerUserId: "bot_old_2",
+        lastAggressorUserId: "bot_old_2",
+        winnerUserId: "bot_old_2",
         seats: [
           { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true },
           { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true }
         ],
-        stacks: { bot_old_2: 1, bot_keep_3: 87 }
+        handSeats: [
+          { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true },
+          { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { bot_old_2: 1, bot_keep_3: 87 },
+        contributionsByUserId: { bot_old_2: 12, bot_keep_3: 12 },
+        foldedByUserId: { bot_old_2: false, bot_keep_3: true },
+        holeCardsByUserId: { bot_old_2: ["AS", "KD"], bot_keep_3: ["2C", "2D"] },
+        privateCardsByUserId: { bot_old_2: ["AS", "KD"] }
       }
     }
   });
@@ -364,8 +382,71 @@ test("adapter restores settled replacement identity from the current persisted s
   });
   assert.equal(result.table.coreState.pokerState.seats[0].userId, "bot_current_2");
   assert.equal(result.table.coreState.pokerState.stacks.bot_old_2, undefined);
+  assert.deepEqual(result.table.coreState.pokerState.handSeats, [
+    { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true },
+    { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true }
+  ]);
+  assert.deepEqual(result.table.coreState.pokerState.contributionsByUserId, {
+    bot_old_2: 12,
+    bot_keep_3: 12
+  });
+  assert.deepEqual(result.table.coreState.pokerState.holeCardsByUserId, {
+    bot_old_2: ["AS", "KD"],
+    bot_keep_3: ["2C", "2D"]
+  });
+  assert.equal(result.table.coreState.pokerState.dealerUserId, "bot_old_2");
+  assert.equal(result.table.coreState.pokerState.lastAggressorUserId, "bot_old_2");
+  assert.equal(result.table.coreState.pokerState.winnerUserId, "bot_old_2");
   assert.equal(result.table.presenceByUserId.has("bot_current_2"), true);
   assert.equal(result.table.presenceByUserId.has("bot_old_2"), false);
+
+  const tableManager = createTableManager({
+    maxSeats: 6,
+    tableBootstrapLoader: async () => ({ ok: false })
+  });
+  assert.equal(tableManager.restoreTableFromPersisted(result.table.tableId, result.table).ok, true);
+  const prepared = tableManager.prepareSettledHandRollover({
+    tableId: result.table.tableId,
+    nowMs: 1_000,
+    allowManagedBotsOnly: true,
+    managedBotProfile: { minBotCount: 2, targetBotCount: 3, maxBotCount: 3 }
+  });
+  assert.equal(prepared.ok, true);
+  assert.equal(prepared.changed, true);
+  assert.deepEqual(prepared.nextCoreState.pokerState.handSeats.map((seat) => seat.userId).sort(), [
+    "bot_current_2",
+    "bot_keep_3"
+  ]);
+  assert.equal(prepared.nextCoreState.pokerState.stacks.bot_old_2, undefined);
+});
+
+test("adapter fails closed instead of remapping a settled human identity", () => {
+  const result = adaptPersistedBootstrap({
+    tableId: "table_settled_human_identity_conflict",
+    tableRow: { id: "table_settled_human_identity_conflict", max_players: 6, status: "OPEN" },
+    seatRows: [
+      { user_id: "human_current", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+      { user_id: "bot_keep", seat_no: 2, status: "ACTIVE", is_bot: true, stack: 100 }
+    ],
+    stateRow: {
+      version: 24,
+      state: {
+        tableId: "table_settled_human_identity_conflict",
+        phase: "SETTLED",
+        seats: [
+          { userId: "human_old", seatNo: 1, status: "ACTIVE" },
+          { userId: "bot_keep", seatNo: 2, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { human_old: 100, bot_keep: 100 },
+        winnerUserId: "human_old",
+        holeCardsByUserId: { human_old: ["AS", "KD"] }
+      }
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "invalid_persisted_state");
+  assert.equal(result.message, "persisted_seat_identity_conflict");
 });
 
 test("adapter keeps authoritative human stack while retaining bot seat projection", () => {

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -264,7 +264,7 @@ test("adapter rejects an unrecoverable all-in hand with invalid or duplicate pri
   assert.equal(result.reason, "live_hand_runtime_unrecoverable");
 });
 
-test("adapter restores current replacement bot identity from persisted seat rows", () => {
+test("adapter preserves persisted live-hand identity when seat rows still reference a prior bot", () => {
   const result = adaptPersistedBootstrap({
     tableId: "table_replacement_bot_restore",
     tableRow: { id: "table_replacement_bot_restore", max_players: 6, status: "OPEN" },
@@ -299,31 +299,73 @@ test("adapter restores current replacement bot identity from persisted seat rows
 
   assert.equal(result.ok, true);
   assert.deepEqual(result.table.coreState.members, [
-    { userId: "bot_old_2", seat: 2 },
+    { userId: "bot_auto_2_38", seat: 2 },
     { userId: "bot_keep_3", seat: 3 }
   ]);
   assert.deepEqual(result.table.coreState.seats, {
-    bot_old_2: 2,
+    bot_auto_2_38: 2,
     bot_keep_3: 3
   });
   assert.deepEqual(result.table.coreState.publicStacks, {
-    bot_old_2: 1,
+    bot_auto_2_38: 100,
     bot_keep_3: 87
   });
   assert.deepEqual(result.table.coreState.pokerState.stacks, {
-    bot_old_2: 1,
+    bot_auto_2_38: 100,
     bot_keep_3: 87
   });
-  assert.equal(result.table.coreState.seatDetailsByUserId.bot_old_2?.isBot, true);
-  assert.equal(result.table.coreState.seatDetailsByUserId.bot_old_2?.botProfile, "TRIVIAL");
-  assert.equal(result.table.coreState.pokerState.turnUserId, "bot_old_2");
+  assert.equal(result.table.coreState.seatDetailsByUserId.bot_auto_2_38?.isBot, true);
+  assert.equal(result.table.coreState.seatDetailsByUserId.bot_auto_2_38?.botProfile, "TRIVIAL");
+  assert.equal(result.table.coreState.pokerState.turnUserId, "bot_auto_2_38");
   assert.deepEqual(result.table.coreState.pokerState.seats, [
     { userId: "user_a", seatNo: 1, status: "ACTIVE" },
-    { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
+    { userId: "bot_auto_2_38", seatNo: 2, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" },
     { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true, botProfile: "TRIVIAL" }
   ]);
-  assert.equal(result.table.presenceByUserId.has("bot_old_2"), true);
-  assert.equal(result.table.presenceByUserId.has("bot_auto_2_38"), false);
+  assert.equal(result.table.presenceByUserId.has("bot_auto_2_38"), true);
+  assert.equal(result.table.presenceByUserId.has("bot_old_2"), false);
+});
+
+test("adapter restores settled replacement identity from the current persisted seat row", () => {
+  const result = adaptPersistedBootstrap({
+    tableId: "table_replacement_bot_restore_settled",
+    tableRow: { id: "table_replacement_bot_restore_settled", max_players: 6, status: "OPEN" },
+    seatRows: [
+      { user_id: "bot_current_2", seat_no: 2, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 100 },
+      { user_id: "bot_keep_3", seat_no: 3, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 87 }
+    ],
+    stateRow: {
+      version: 23,
+      state: {
+        tableId: "table_replacement_bot_restore_settled",
+        handId: "hand_replacement_bot_restore_settled",
+        phase: "SETTLED",
+        seats: [
+          { userId: "bot_old_2", seatNo: 2, status: "ACTIVE", isBot: true },
+          { userId: "bot_keep_3", seatNo: 3, status: "ACTIVE", isBot: true }
+        ],
+        stacks: { bot_old_2: 1, bot_keep_3: 87 }
+      }
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.table.coreState.members, [
+    { userId: "bot_current_2", seat: 2 },
+    { userId: "bot_keep_3", seat: 3 }
+  ]);
+  assert.deepEqual(result.table.coreState.seats, {
+    bot_current_2: 2,
+    bot_keep_3: 3
+  });
+  assert.deepEqual(result.table.coreState.pokerState.stacks, {
+    bot_current_2: 100,
+    bot_keep_3: 87
+  });
+  assert.equal(result.table.coreState.pokerState.seats[0].userId, "bot_current_2");
+  assert.equal(result.table.coreState.pokerState.stacks.bot_old_2, undefined);
+  assert.equal(result.table.presenceByUserId.has("bot_current_2"), true);
+  assert.equal(result.table.presenceByUserId.has("bot_old_2"), false);
 });
 
 test("adapter keeps authoritative human stack while retaining bot seat projection", () => {

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -261,6 +261,110 @@ function normalizeSeatRows(seatRows, maxSeats) {
   return activeSeats;
 }
 
+function remapUserId(value, aliases) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized && aliases?.[normalized] ? aliases[normalized] : value;
+}
+
+function remapUserKeyedObject(value, aliases, { preferSeatStacks = false, seatRowsByUserId = null } = {}) {
+  if (!asPlainObject(value) || !aliases || Object.keys(aliases).length === 0) {
+    return value;
+  }
+  const remapped = {};
+  for (const [userId, entry] of Object.entries(value)) {
+    if (!aliases[userId]) {
+      remapped[userId] = entry;
+    }
+  }
+  for (const [userId, entry] of Object.entries(value)) {
+    const currentUserId = aliases[userId];
+    if (!currentUserId) {
+      continue;
+    }
+    if (preferSeatStacks) {
+      const seatRow = seatRowsByUserId?.get(currentUserId);
+      const seatStack = Number(seatRow?.stack);
+      if (Number.isSafeInteger(seatStack) && seatStack >= 0) {
+        remapped[currentUserId] = seatStack;
+        continue;
+      }
+    }
+    if (!Object.prototype.hasOwnProperty.call(remapped, currentUserId)) {
+      remapped[currentUserId] = entry;
+    }
+  }
+  return remapped;
+}
+
+function remapUserIdArray(value, aliases) {
+  if (!Array.isArray(value) || !aliases || Object.keys(aliases).length === 0) {
+    return value;
+  }
+  return value.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
+    const userId = typeof entry.userId === "string" ? entry.userId.trim() : "";
+    return userId && aliases[userId] ? { ...entry, userId: aliases[userId] } : entry;
+  });
+}
+
+function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
+  if (!asPlainObject(pokerState)) return pokerState;
+  const seatRows = Array.isArray(normalizedSeatRows) ? normalizedSeatRows : [];
+  const seatRowsBySeatNo = new Map(seatRows.map((seat) => [seat.seat, seat]));
+  const seatRowsByUserId = new Map(seatRows.map((seat) => [seat.userId, seat]));
+  const aliases = {};
+  for (const stateSeat of Array.isArray(pokerState.seats) ? pokerState.seats : []) {
+    const stateUserId = typeof stateSeat?.userId === "string" ? stateSeat.userId.trim() : "";
+    const seatNo = normalizeSeatNo(stateSeat?.seatNo ?? stateSeat?.seat_no ?? stateSeat?.seat);
+    const currentSeat = seatRowsBySeatNo.get(seatNo);
+    if (stateUserId && currentSeat?.userId && currentSeat.userId !== stateUserId) {
+      aliases[stateUserId] = currentSeat.userId;
+    }
+  }
+
+  const reconciled = { ...pokerState };
+  const userKeyedFields = [
+    "contributionsByUserId",
+    "betThisRoundByUserId",
+    "actedThisRoundByUserId",
+    "toCallByUserId",
+    "foldedByUserId",
+    "allInByUserId",
+    "sitOutByUserId",
+    "waitingForNextHandByUserId",
+    "holeCardsByUserId",
+    "privateCardsByUserId"
+  ];
+  for (const field of userKeyedFields) {
+    if (asPlainObject(pokerState[field])) {
+      reconciled[field] = remapUserKeyedObject(pokerState[field], aliases);
+    }
+  }
+  if (asPlainObject(pokerState.stacks)) {
+    reconciled.stacks = remapUserKeyedObject(pokerState.stacks, aliases, {
+      preferSeatStacks: true,
+      seatRowsByUserId
+    });
+  }
+  if (Array.isArray(pokerState.handSeats)) {
+    reconciled.handSeats = remapUserIdArray(pokerState.handSeats, aliases);
+  }
+  for (const field of ["turnUserId", "dealerUserId", "lastAggressorUserId", "winnerUserId"]) {
+    if (typeof pokerState[field] === "string" && aliases[pokerState[field]]) {
+      reconciled[field] = remapUserId(pokerState[field], aliases);
+    }
+  }
+
+  for (const seat of seatRows) {
+    if (seat.isBot !== true || !Number.isSafeInteger(Number(seat.stack)) || Number(seat.stack) < 0) continue;
+    const currentUserId = seat.userId;
+    if (!Object.prototype.hasOwnProperty.call(reconciled.stacks || {}, currentUserId)) {
+      reconciled.stacks = { ...(reconciled.stacks || {}), [currentUserId]: Number(seat.stack) };
+    }
+  }
+  return reconciled;
+}
+
 function mergeSeatMetadata(seat, metadata) {
   const mergedSeat = { ...seat };
   if (metadata?.isBot === true) mergedSeat.isBot = true;
@@ -288,6 +392,7 @@ function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows) {
   const metadataBySeatNo = new Map(seatRows.map((seat) => [seat.seat, seat]));
   const leftTableByUserId = asPlainObject(pokerState?.leftTableByUserId) || {};
   const replacementSeatNos = new Set();
+  const representedSeatNos = new Set();
   const mergedStateSeats = Array.isArray(stateSeats)
     ? stateSeats
         .map((seat) => {
@@ -303,10 +408,19 @@ function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows) {
             return null;
           }
           if (replacementBotMetadata) replacementSeatNos.add(seatNo);
-          return mergeSeatMetadata({ ...seat, seatNo }, directMetadata || replacementBotMetadata);
+          const currentMetadata = directMetadata || replacementBotMetadata;
+          const currentUserId = currentMetadata?.userId || userId;
+          representedSeatNos.add(seatNo);
+          return mergeSeatMetadata({ ...seat, userId: currentUserId, seatNo }, currentMetadata);
         })
         .filter(Boolean)
     : [];
+
+  for (const seat of seatRows) {
+    if (representedSeatNos.has(seat.seat)) continue;
+    representedSeatNos.add(seat.seat);
+    mergedStateSeats.push(toSeatSnapshot(seat));
+  }
 
   return {
     stateSeats: mergedStateSeats.length > 0 ? mergedStateSeats : seatRows.map(toSeatSnapshot),
@@ -383,15 +497,16 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
     return { ok: false, code: "invalid_table_state", message: "invalid_table_state" };
   }
 
-  const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(pokerState, seats);
+  const reconciledPokerState = reconcilePersistedStateIdentity(pokerState, seats);
+  const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(reconciledPokerState, seats);
   const runtimeSeats = buildRuntimeSeats({ seatRows: seats, stateSeats, replacementSeatNos, leftTableByUserId });
   const members = runtimeSeats.map((seat) => ({ userId: seat.userId, seat: seat.seat }));
-  const publicStackResult = normalizePublicStacks(runtimeSeats, pokerState);
+  const publicStackResult = normalizePublicStacks(runtimeSeats, reconciledPokerState);
   if (!publicStackResult.ok) {
     return { ok: false, code: "invalid_persisted_state", message: "human_stack_ambiguous" };
   }
   const publicStacks = publicStackResult.stacks;
-  const normalizedPokerState = { ...pokerState, seats: stateSeats };
+  const normalizedPokerState = { ...reconciledPokerState, seats: stateSeats };
   const derivedRuntimeHandState = deriveDeterministicRuntimeHandState(normalizedPokerState);
   if (
     LIVE_HAND_PHASES.has(normalizedPokerState.phase)

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -261,11 +261,6 @@ function normalizeSeatRows(seatRows, maxSeats) {
   return activeSeats;
 }
 
-function remapUserId(value, aliases) {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  return normalized && aliases?.[normalized] ? aliases[normalized] : value;
-}
-
 function remapUserKeyedObject(value, aliases, { preferSeatStacks = false, seatRowsByUserId = null } = {}) {
   if (!asPlainObject(value) || !aliases || Object.keys(aliases).length === 0) {
     return value;
@@ -296,19 +291,8 @@ function remapUserKeyedObject(value, aliases, { preferSeatStacks = false, seatRo
   return remapped;
 }
 
-function remapUserIdArray(value, aliases) {
-  if (!Array.isArray(value) || !aliases || Object.keys(aliases).length === 0) {
-    return value;
-  }
-  return value.map((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
-    const userId = typeof entry.userId === "string" ? entry.userId.trim() : "";
-    return userId && aliases[userId] ? { ...entry, userId: aliases[userId] } : entry;
-  });
-}
-
 function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
-  if (!asPlainObject(pokerState)) return pokerState;
+  if (!asPlainObject(pokerState)) return { ok: true, state: pokerState, aliases: {} };
   // A seat-row identity is authoritative for a completed hand, when the
   // replacement flow has already settled and the next runtime can be
   // reconstructed without moving live-hand history between users. During a
@@ -316,7 +300,7 @@ function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
   // turn, cards, or contributions to a different user would corrupt the
   // in-progress hand.
   if (pokerState.phase !== "SETTLED") {
-    return pokerState;
+    return { ok: true, state: pokerState, aliases: {} };
   }
   const seatRows = Array.isArray(normalizedSeatRows) ? normalizedSeatRows : [];
   const seatRowsBySeatNo = new Map(seatRows.map((seat) => [seat.seat, seat]));
@@ -327,41 +311,23 @@ function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
     const seatNo = normalizeSeatNo(stateSeat?.seatNo ?? stateSeat?.seat_no ?? stateSeat?.seat);
     const currentSeat = seatRowsBySeatNo.get(seatNo);
     if (stateUserId && currentSeat?.userId && currentSeat.userId !== stateUserId) {
+      if (stateSeat?.isBot !== true || currentSeat.isBot !== true) {
+        return { ok: false, reason: "persisted_seat_identity_conflict" };
+      }
       aliases[stateUserId] = currentSeat.userId;
     }
   }
 
-  const reconciled = { ...pokerState };
-  const userKeyedFields = [
-    "contributionsByUserId",
-    "betThisRoundByUserId",
-    "actedThisRoundByUserId",
-    "toCallByUserId",
-    "foldedByUserId",
-    "allInByUserId",
-    "sitOutByUserId",
-    "waitingForNextHandByUserId",
-    "holeCardsByUserId",
-    "privateCardsByUserId"
-  ];
-  for (const field of userKeyedFields) {
-    if (asPlainObject(pokerState[field])) {
-      reconciled[field] = remapUserKeyedObject(pokerState[field], aliases);
-    }
+  if (Object.keys(aliases).length === 0) {
+    return { ok: true, state: pokerState, aliases };
   }
+
+  const reconciled = { ...pokerState };
   if (asPlainObject(pokerState.stacks)) {
     reconciled.stacks = remapUserKeyedObject(pokerState.stacks, aliases, {
       preferSeatStacks: true,
       seatRowsByUserId
     });
-  }
-  if (Array.isArray(pokerState.handSeats)) {
-    reconciled.handSeats = remapUserIdArray(pokerState.handSeats, aliases);
-  }
-  for (const field of ["turnUserId", "dealerUserId", "lastAggressorUserId", "winnerUserId"]) {
-    if (typeof pokerState[field] === "string" && aliases[pokerState[field]]) {
-      reconciled[field] = remapUserId(pokerState[field], aliases);
-    }
   }
 
   for (const seat of seatRows) {
@@ -371,7 +337,7 @@ function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
       reconciled.stacks = { ...(reconciled.stacks || {}), [currentUserId]: Number(seat.stack) };
     }
   }
-  return reconciled;
+  return { ok: true, state: reconciled, aliases };
 }
 
 function mergeSeatMetadata(seat, metadata) {
@@ -394,7 +360,7 @@ function toSeatSnapshot(seat) {
   return snapshot;
 }
 
-function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows, { reconcileIdentity = false } = {}) {
+function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows, { reconciledIdentityUserIds = new Set() } = {}) {
   const stateSeats = Array.isArray(pokerState?.seats) ? pokerState.seats : [];
   const seatRows = Array.isArray(normalizedSeatRows) ? normalizedSeatRows : [];
   const metadataByUserId = new Map(seatRows.map((seat) => [seat.userId, seat]));
@@ -418,7 +384,9 @@ function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows, { reconcile
           }
           if (replacementBotMetadata) replacementSeatNos.add(seatNo);
           const currentMetadata = directMetadata || replacementBotMetadata;
-          const currentUserId = reconcileIdentity ? (currentMetadata?.userId || userId) : userId;
+          const currentUserId = reconciledIdentityUserIds.has(userId)
+            ? (currentMetadata?.userId || userId)
+            : userId;
           representedSeatNos.add(seatNo);
           return mergeSeatMetadata({ ...seat, userId: currentUserId, seatNo }, currentMetadata);
         })
@@ -506,11 +474,19 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
     return { ok: false, code: "invalid_table_state", message: "invalid_table_state" };
   }
 
-  const reconciledPokerState = reconcilePersistedStateIdentity(pokerState, seats);
+  const identityReconciliation = reconcilePersistedStateIdentity(pokerState, seats);
+  if (!identityReconciliation?.ok) {
+    return {
+      ok: false,
+      code: "invalid_persisted_state",
+      message: identityReconciliation.reason || "persisted_seat_identity_conflict"
+    };
+  }
+  const reconciledPokerState = identityReconciliation.state;
   const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(
     reconciledPokerState,
     seats,
-    { reconcileIdentity: pokerState.phase === "SETTLED" }
+    { reconciledIdentityUserIds: new Set(Object.keys(identityReconciliation.aliases || {})) }
   );
   const runtimeSeats = buildRuntimeSeats({ seatRows: seats, stateSeats, replacementSeatNos, leftTableByUserId });
   const members = runtimeSeats.map((seat) => ({ userId: seat.userId, seat: seat.seat }));

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -309,6 +309,15 @@ function remapUserIdArray(value, aliases) {
 
 function reconcilePersistedStateIdentity(pokerState, normalizedSeatRows) {
   if (!asPlainObject(pokerState)) return pokerState;
+  // A seat-row identity is authoritative for a completed hand, when the
+  // replacement flow has already settled and the next runtime can be
+  // reconstructed without moving live-hand history between users. During a
+  // live hand the persisted state remains authoritative; silently remapping
+  // turn, cards, or contributions to a different user would corrupt the
+  // in-progress hand.
+  if (pokerState.phase !== "SETTLED") {
+    return pokerState;
+  }
   const seatRows = Array.isArray(normalizedSeatRows) ? normalizedSeatRows : [];
   const seatRowsBySeatNo = new Map(seatRows.map((seat) => [seat.seat, seat]));
   const seatRowsByUserId = new Map(seatRows.map((seat) => [seat.userId, seat]));
@@ -385,7 +394,7 @@ function toSeatSnapshot(seat) {
   return snapshot;
 }
 
-function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows) {
+function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows, { reconcileIdentity = false } = {}) {
   const stateSeats = Array.isArray(pokerState?.seats) ? pokerState.seats : [];
   const seatRows = Array.isArray(normalizedSeatRows) ? normalizedSeatRows : [];
   const metadataByUserId = new Map(seatRows.map((seat) => [seat.userId, seat]));
@@ -409,7 +418,7 @@ function mergeStateSeatsWithSeatRows(pokerState, normalizedSeatRows) {
           }
           if (replacementBotMetadata) replacementSeatNos.add(seatNo);
           const currentMetadata = directMetadata || replacementBotMetadata;
-          const currentUserId = currentMetadata?.userId || userId;
+          const currentUserId = reconcileIdentity ? (currentMetadata?.userId || userId) : userId;
           representedSeatNos.add(seatNo);
           return mergeSeatMetadata({ ...seat, userId: currentUserId, seatNo }, currentMetadata);
         })
@@ -498,7 +507,11 @@ export function adaptPersistedBootstrap({ tableId, tableRow, seatRows, stateRow 
   }
 
   const reconciledPokerState = reconcilePersistedStateIdentity(pokerState, seats);
-  const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(reconciledPokerState, seats);
+  const { stateSeats, replacementSeatNos, leftTableByUserId } = mergeStateSeatsWithSeatRows(
+    reconciledPokerState,
+    seats,
+    { reconcileIdentity: pokerState.phase === "SETTLED" }
+  );
   const runtimeSeats = buildRuntimeSeats({ seatRows: seats, stateSeats, replacementSeatNos, leftTableByUserId });
   const members = runtimeSeats.map((seat) => ({ userId: seat.userId, seat: seat.seat }));
   const publicStackResult = normalizePublicStacks(runtimeSeats, reconciledPokerState);

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -283,7 +283,8 @@ register("ERROR", "table_lifecycle", [
   "ws_leave_authoritative_failed",
   "ws_leave_authoritative_unavailable",
   "ws_rebuy_authoritative_failed",
-  "ws_rebuy_authoritative_unavailable"
+  "ws_rebuy_authoritative_unavailable",
+  "ws_continuous_bot_table_retirement_persist_failed"
 ]);
 
 register("ERROR", "transport", [

--- a/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createContinuousBotTableRepository } from "./continuous-bot-table-repository.mjs";
+
+test("requestRetirement persists a due rotation for the exact managed table", async () => {
+  const tableId = "00000000-0000-4000-8000-000000000807";
+  const queries = [];
+  const repository = createContinuousBotTableRepository({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    beginSql: async (run) => run({
+      unsafe: async (sql, params) => {
+        queries.push({ sql, params });
+        if (sql.includes("select id, rotation_due_at")) {
+          return [{ id: tableId, rotation_due_at: null }];
+        }
+        if (sql.includes("update public.poker_tables")) {
+          return [{ id: tableId, rotation_due_at: "2026-07-29T15:00:00.000Z" }];
+        }
+        return [];
+      }
+    })
+  });
+
+  const result = await repository.requestRetirement(tableId);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.changed, true);
+  assert.equal(queries.some(({ sql }) => sql.includes("pg_advisory_xact_lock")), true);
+  assert.equal(queries.some(({ sql }) => sql.includes("lifecycle_kind = 'CONTINUOUS_BOT'")), true);
+  assert.equal(queries.some(({ sql }) => sql.includes("rotation_due_at = least")), true);
+});

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -201,8 +201,53 @@ export function createContinuousBotTableRepository({
     }
   }
 
+  async function requestRetirement(tableId) {
+    const normalizedTableId = typeof tableId === "string" ? tableId.trim() : "";
+    if (!normalizedTableId) {
+      return { ok: false, reason: "invalid_table_id" };
+    }
+    try {
+      return await beginSql(async (tx) => {
+        await tx.unsafe("select pg_advisory_xact_lock(hashtext($1));", ["poker:continuous-bot-supervisor:v1"]);
+        const tableRows = await tx.unsafe(
+          `select id, rotation_due_at
+             from public.poker_tables
+            where id = $1
+              and status = 'OPEN'
+              and lifecycle_kind = 'CONTINUOUS_BOT'
+              and managed_profile_key = $2
+            for update;`,
+          [normalizedTableId, CONTINUOUS_BOT_PROFILE_KEY]
+        );
+        if (!Array.isArray(tableRows) || tableRows.length !== 1) {
+          return { ok: false, reason: "managed_table_not_found" };
+        }
+        const updatedRows = await tx.unsafe(
+          `update public.poker_tables
+              set rotation_due_at = least(coalesce(rotation_due_at, now()), now()), updated_at = now()
+            where id = $1
+            returning id, rotation_due_at;`,
+          [normalizedTableId]
+        );
+        return {
+          ok: updatedRows?.length === 1,
+          changed: updatedRows?.length === 1 && !tableRows[0]?.rotation_due_at,
+          rotationDueAt: updatedRows?.[0]?.rotation_due_at ?? tableRows[0]?.rotation_due_at ?? null,
+          reason: updatedRows?.length === 1 ? null : "retirement_request_failed"
+        };
+      }, { env });
+    } catch (error) {
+      klog("ws_continuous_bot_table_retirement_persist_failed", {
+        tableId: normalizedTableId,
+        reason: error?.code || error?.message || "unknown"
+      });
+      return { ok: false, reason: error?.code || error?.message || "retirement_request_failed" };
+    }
+  }
+
   return {
     reconcile,
+    requestRetirement,
     currentProfile: () => lastKnownProfile
   };
 }

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -1185,7 +1185,7 @@ test("replacement seat identity conflict fails closed before ledger funding", as
   });
 
   assert.equal(result.ok, false);
-  assert.equal(result.reason, "db_error");
+  assert.equal(result.reason, "replacement_seat_projection_conflict");
   assert.equal(harness.durable.version, 7);
   assert.deepEqual(harness.durable.state, previousState);
   assert.equal(harness.durable.seats.get(2)?.user_id, "00000000-0000-4000-8000-0000000000ff");

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -1023,10 +1023,11 @@ export function createPersistedStateWriter({ env = process.env, beginSql = begin
         ...(meta && typeof meta === "object" ? meta : {})
       });
       const stateConflict = error?.code === "durable_action_state_conflict";
+      const replacementSeatProjectionConflict = error?.code === "replacement_seat_projection_conflict";
       return {
         ok: false,
         ...(durableActionPlan.supplied ? { outcome: "failure" } : {}),
-        reason: stateConflict ? "conflict" : "db_error",
+        reason: replacementSeatProjectionConflict ? "replacement_seat_projection_conflict" : (stateConflict ? "conflict" : "db_error"),
         message: error?.message || "unknown"
       };
     }

--- a/ws-server/poker/runtime/continuous-bot-retirement.mjs
+++ b/ws-server/poker/runtime/continuous-bot-retirement.mjs
@@ -1,0 +1,61 @@
+export function isManagedReplacementSeatProjectionConflict({
+  managedContinuousTable,
+  replacementFundingCount,
+  persisted
+} = {}) {
+  return managedContinuousTable === true
+    && Number(replacementFundingCount) > 0
+    && persisted?.reason === "replacement_seat_projection_conflict";
+}
+
+export async function retireManagedTableAfterReplacementConflict({
+  tableId,
+  generationKey,
+  attempt,
+  requestRetirement,
+  markRetirementRequested = () => {},
+  restoreTableFromPersisted,
+  markTableRotationDue = () => {},
+  scheduleSettledRolloverRetry,
+  broadcastStateSnapshots,
+  hasActiveHumanMember,
+  hasConnectedHumanPresence,
+  applyInactiveCleanupAndBroadcast
+} = {}) {
+  const persisted = await requestRetirement(tableId);
+  if (!persisted?.ok) {
+    return persisted || { ok: false, reason: "retirement_request_unavailable" };
+  }
+
+  markRetirementRequested(tableId);
+  const restored = await restoreTableFromPersisted(tableId);
+  if (!restored?.ok) {
+    markTableRotationDue(tableId, Date.now());
+    scheduleSettledRolloverRetry(tableId, generationKey, attempt + 1);
+    return {
+      ok: true,
+      changed: false,
+      deferred: true,
+      reason: "managed_retirement_restore_pending",
+      retryable: true
+    };
+  }
+  broadcastStateSnapshots(tableId);
+
+  if (hasActiveHumanMember(tableId) || hasConnectedHumanPresence(tableId)) {
+    scheduleSettledRolloverRetry(tableId, generationKey, attempt + 1);
+    return {
+      ok: true,
+      changed: false,
+      deferred: true,
+      reason: "managed_retirement_human_present",
+      retryable: true
+    };
+  }
+
+  return applyInactiveCleanupAndBroadcast({
+    tableId,
+    requestId: `continuous-bot-table-close:${tableId}`,
+    logPrefix: "ws_continuous_bot_table_retirement"
+  });
+}

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -2243,6 +2243,27 @@ export function createTableManager({
     return normalizeTableMeta(table.tableMeta, table?.coreState?.maxSeats || maxSeats);
   }
 
+  function markTableRotationDue(tableId, dueAtMs = Date.now()) {
+    const table = tables.get(tableId);
+    if (!table || table.tableMeta?.lifecycleKind !== "CONTINUOUS_BOT") {
+      return { ok: false, changed: false, reason: "managed_table_not_found" };
+    }
+    const normalizedDueAtMs = normalizeTimestampMs(dueAtMs);
+    if (!Number.isFinite(normalizedDueAtMs)) {
+      return { ok: false, changed: false, reason: "invalid_rotation_due_at" };
+    }
+    const previousDueAtMs = normalizeTimestampMs(table.tableMeta?.rotationDueAtMs);
+    table.tableMeta = normalizeTableMeta({
+      ...table.tableMeta,
+      rotationDueAtMs: previousDueAtMs == null ? normalizedDueAtMs : Math.min(previousDueAtMs, normalizedDueAtMs)
+    }, table?.coreState?.maxSeats || maxSeats);
+    return {
+      ok: true,
+      changed: previousDueAtMs == null || normalizedDueAtMs < previousDueAtMs,
+      rotationDueAtMs: table.tableMeta.rotationDueAtMs
+    };
+  }
+
   function resolveImplicitLeaveTableId({ ws, userId }) {
     const conn = connStateBySocket.get(ws);
     if (conn?.joinedTableId) {
@@ -2287,6 +2308,7 @@ export function createTableManager({
     orderedConnectionsForTable,
     listTableIds,
     tableMeta,
+    markTableRotationDue,
     materializeLobbyTable,
     materializeGuestTable,
     connectionTableAssociation,

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -35,6 +35,10 @@ import {
   tableMatchesContinuousBotProfile
 } from "./poker/persistence/continuous-bot-table-repository.mjs";
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
+import {
+  isManagedReplacementSeatProjectionConflict,
+  retireManagedTableAfterReplacementConflict
+} from "./poker/runtime/continuous-bot-retirement.mjs";
 import { createTableManager } from "./poker/table/table-manager.mjs";
 
 const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
@@ -134,6 +138,192 @@ test("continuous bot supervisor coalesces overlapping sweeps and activates each 
   assert.equal(calls, 2);
   assert.deepEqual(activated, ["table-a"]);
   supervisor.stop();
+});
+
+test("replacement projection conflict eligibility is limited to managed replacement funding", () => {
+  assert.equal(isManagedReplacementSeatProjectionConflict({
+    managedContinuousTable: true,
+    replacementFundingCount: 1,
+    persisted: { ok: false, reason: "replacement_seat_projection_conflict" }
+  }), true);
+  assert.equal(isManagedReplacementSeatProjectionConflict({
+    managedContinuousTable: false,
+    replacementFundingCount: 1,
+    persisted: { ok: false, reason: "replacement_seat_projection_conflict" }
+  }), false);
+  assert.equal(isManagedReplacementSeatProjectionConflict({
+    managedContinuousTable: true,
+    replacementFundingCount: 0,
+    persisted: { ok: false, reason: "replacement_seat_projection_conflict" }
+  }), false);
+  assert.equal(isManagedReplacementSeatProjectionConflict({
+    managedContinuousTable: true,
+    replacementFundingCount: 1,
+    persisted: { ok: false, reason: "conflict" }
+  }), false);
+});
+
+test("replacement projection conflict closes a managed table once when no human remains", async () => {
+  const calls = { request: 0, restore: 0, close: 0, retry: 0 };
+  const result = await retireManagedTableAfterReplacementConflict({
+    tableId: "managed-close",
+    generationKey: "managed-close:7:hand",
+    attempt: 0,
+    requestRetirement: async () => {
+      calls.request += 1;
+      if (calls.request > 1) return { ok: false, reason: "managed_table_not_found" };
+      return { ok: true, changed: true };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    scheduleSettledRolloverRetry: () => { calls.retry += 1; },
+    broadcastStateSnapshots: () => {},
+    hasActiveHumanMember: () => false,
+    hasConnectedHumanPresence: () => false,
+    applyInactiveCleanupAndBroadcast: async (args) => {
+      calls.close += 1;
+      assert.deepEqual(args, {
+        tableId: "managed-close",
+        requestId: "continuous-bot-table-close:managed-close",
+        logPrefix: "ws_continuous_bot_table_retirement"
+      });
+      return { ok: true, changed: true, closed: true };
+    }
+  });
+  assert.deepEqual(result, { ok: true, changed: true, closed: true });
+  assert.deepEqual(calls, { request: 1, restore: 1, close: 1, retry: 0 });
+  const replay = await retireManagedTableAfterReplacementConflict({
+    tableId: "managed-close",
+    generationKey: "managed-close:7:hand",
+    attempt: 1,
+    requestRetirement: async () => {
+      calls.request += 1;
+      return { ok: false, reason: "managed_table_not_found" };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    scheduleSettledRolloverRetry: () => { calls.retry += 1; },
+    broadcastStateSnapshots: () => {},
+    hasActiveHumanMember: () => false,
+    hasConnectedHumanPresence: () => false,
+    applyInactiveCleanupAndBroadcast: async () => {
+      calls.close += 1;
+      return { ok: true, changed: true, closed: true };
+    }
+  });
+  assert.deepEqual(replay, { ok: false, reason: "managed_table_not_found" });
+  assert.deepEqual(calls, { request: 2, restore: 1, close: 1, retry: 0 });
+});
+
+test("replacement projection conflict defers retirement while a human is present", async () => {
+  const calls = { request: 0, restore: 0, close: 0, retry: [] };
+  let humanPresent = true;
+  const dependencies = {
+    tableId: "managed-deferred",
+    generationKey: "managed-deferred:8:hand",
+    attempt: 2,
+    requestRetirement: async () => {
+      calls.request += 1;
+      return { ok: true, changed: calls.request === 1 };
+    },
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    scheduleSettledRolloverRetry: (...args) => { calls.retry.push(args); },
+    broadcastStateSnapshots: () => {},
+    hasActiveHumanMember: () => humanPresent,
+    hasConnectedHumanPresence: () => false,
+    applyInactiveCleanupAndBroadcast: async () => {
+      calls.close += 1;
+      return { ok: true, changed: true, closed: true };
+    }
+  };
+  const result = await retireManagedTableAfterReplacementConflict(dependencies);
+  assert.deepEqual(result, {
+    ok: true,
+    changed: false,
+    deferred: true,
+    reason: "managed_retirement_human_present",
+    retryable: true
+  });
+  assert.deepEqual(calls, {
+    request: 1,
+    restore: 1,
+    close: 0,
+    retry: [["managed-deferred", "managed-deferred:8:hand", 3]]
+  });
+
+  humanPresent = false;
+  const closed = await retireManagedTableAfterReplacementConflict({
+    ...dependencies,
+    attempt: 3
+  });
+  assert.deepEqual(closed, { ok: true, changed: true, closed: true });
+  assert.equal(calls.request, 2);
+  assert.equal(calls.restore, 2);
+  assert.equal(calls.close, 1);
+});
+
+test("replacement projection conflict keeps the existing retry when retirement persistence fails", async () => {
+  const calls = { restore: 0, due: 0, retry: 0, close: 0 };
+  const result = await retireManagedTableAfterReplacementConflict({
+    tableId: "managed-retirement-write-failure",
+    generationKey: "managed-retirement-write-failure:9:hand",
+    attempt: 1,
+    requestRetirement: async () => ({ ok: false, reason: "retirement_request_failed" }),
+    restoreTableFromPersisted: async () => {
+      calls.restore += 1;
+      return { ok: true };
+    },
+    markTableRotationDue: () => { calls.due += 1; },
+    scheduleSettledRolloverRetry: () => { calls.retry += 1; },
+    broadcastStateSnapshots: () => {},
+    hasActiveHumanMember: () => false,
+    hasConnectedHumanPresence: () => false,
+    applyInactiveCleanupAndBroadcast: async () => {
+      calls.close += 1;
+      return { ok: true, changed: true, closed: true };
+    }
+  });
+  assert.deepEqual(result, { ok: false, reason: "retirement_request_failed" });
+  assert.deepEqual(calls, { restore: 0, due: 0, retry: 0, close: 0 });
+});
+
+test("replacement projection conflict resumes durable retirement after restore failure", async () => {
+  const calls = { request: 0, due: [], retry: [] };
+  const result = await retireManagedTableAfterReplacementConflict({
+    tableId: "managed-restore-retry",
+    generationKey: "managed-restore-retry:10:hand",
+    attempt: 3,
+    requestRetirement: async () => {
+      calls.request += 1;
+      return { ok: true, changed: false };
+    },
+    restoreTableFromPersisted: async () => ({ ok: false, reason: "restore_failed" }),
+    markTableRotationDue: (...args) => { calls.due.push(args); },
+    scheduleSettledRolloverRetry: (...args) => { calls.retry.push(args); },
+    broadcastStateSnapshots: () => {},
+    hasActiveHumanMember: () => false,
+    hasConnectedHumanPresence: () => false,
+    applyInactiveCleanupAndBroadcast: async () => ({ ok: true, changed: true, closed: true })
+  });
+  assert.deepEqual(result, {
+    ok: true,
+    changed: false,
+    deferred: true,
+    reason: "managed_retirement_restore_pending",
+    retryable: true
+  });
+  assert.equal(calls.request, 1);
+  assert.equal(calls.due.length, 1);
+  assert.equal(calls.due[0][0], "managed-restore-retry");
+  assert.equal(Number.isFinite(calls.due[0][1]), true);
+  assert.deepEqual(calls.retry, [["managed-restore-retry", "managed-restore-retry:10:hand", 4]]);
 });
 
 async function listProductionModuleFiles(rootPath) {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -59,6 +59,10 @@ import {
 import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 import { createContinuousBotTableRepository } from "./poker/persistence/continuous-bot-table-repository.mjs";
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
+import {
+  isManagedReplacementSeatProjectionConflict,
+  retireManagedTableAfterReplacementConflict as retireManagedTableAfterReplacementConflictFlow
+} from "./poker/runtime/continuous-bot-retirement.mjs";
 
 const PORT = Number(process.env.PORT || 3000);
 const PROTECTED_MESSAGE_TYPES = new Set([
@@ -1951,9 +1955,11 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     deferRuntimeVersionUpdate: true
   });
   if (!persisted?.ok || persisted.alreadyApplied) {
-    const replacementSeatConflict = managedContinuousTable
-      && prepared.replacementFundings.length > 0
-      && persisted?.reason === "replacement_seat_projection_conflict";
+    const replacementSeatConflict = isManagedReplacementSeatProjectionConflict({
+      managedContinuousTable,
+      replacementFundingCount: prepared.replacementFundings.length,
+      persisted
+    });
     if (replacementSeatConflict) {
       const retirement = await retireManagedTableAfterReplacementConflict({
         tableId,
@@ -4273,41 +4279,25 @@ async function materializeCreatedContinuousBotTable({ tableId, created = false }
 }
 
 async function retireManagedTableAfterReplacementConflict({ tableId, generationKey, attempt }) {
-  const persisted = await continuousBotTableRepository?.requestRetirement?.(tableId);
-  if (!persisted?.ok) {
-    return persisted || { ok: false, reason: "retirement_request_unavailable" };
-  }
-
-  continuousBotRetirementRequested.add(tableId);
-  const restored = await restoreTableFromPersisted(tableId);
-  if (!restored?.ok) {
-    tableManager.markTableRotationDue?.(tableId, Date.now());
-    scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
-    return {
-      ok: true,
-      changed: false,
-      deferred: true,
-      reason: "managed_retirement_restore_pending",
-      retryable: true
-    };
-  }
-  broadcastStateSnapshots(tableId);
-
-  if (tableManager.hasActiveHumanMember(tableId) || tableManager.hasConnectedHumanPresence(tableId)) {
-    scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
-    return {
-      ok: true,
-      changed: false,
-      deferred: true,
-      reason: "managed_retirement_human_present",
-      retryable: true
-    };
-  }
-
-  return applyInactiveCleanupAndBroadcast({
+  return retireManagedTableAfterReplacementConflictFlow({
     tableId,
-    requestId: `continuous-bot-table-close:${tableId}`,
-    logPrefix: "ws_continuous_bot_table_retirement"
+    generationKey,
+    attempt,
+    requestRetirement: (requestedTableId) => continuousBotTableRepository?.requestRetirement?.(requestedTableId),
+    markRetirementRequested: (requestedTableId) => continuousBotRetirementRequested.add(requestedTableId),
+    restoreTableFromPersisted,
+    markTableRotationDue: (requestedTableId, dueAtMs) => tableManager.markTableRotationDue?.(requestedTableId, dueAtMs),
+    scheduleSettledRolloverRetry: (requestedTableId, requestedGenerationKey, requestedAttempt) => {
+      scheduleSettledRolloverRetry({
+        tableId: requestedTableId,
+        generationKey: requestedGenerationKey,
+        attempt: requestedAttempt
+      });
+    },
+    broadcastStateSnapshots,
+    hasActiveHumanMember: (requestedTableId) => tableManager.hasActiveHumanMember(requestedTableId),
+    hasConnectedHumanPresence: (requestedTableId) => tableManager.hasConnectedHumanPresence(requestedTableId),
+    applyInactiveCleanupAndBroadcast
   });
 }
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1951,6 +1951,19 @@ async function runSettledRolloverCommand({ tableId, generationKey, attempt = 0 }
     deferRuntimeVersionUpdate: true
   });
   if (!persisted?.ok || persisted.alreadyApplied) {
+    const replacementSeatConflict = managedContinuousTable
+      && prepared.replacementFundings.length > 0
+      && persisted?.reason === "replacement_seat_projection_conflict";
+    if (replacementSeatConflict) {
+      const retirement = await retireManagedTableAfterReplacementConflict({
+        tableId,
+        generationKey,
+        attempt
+      });
+      if (retirement?.ok === true) {
+        return finishSettledRollover(retirement);
+      }
+    }
     if (!persisted?.alreadyApplied) {
       klogSafe("ws_settled_rollover_persist_failed", {
         tableId,
@@ -4259,8 +4272,51 @@ async function materializeCreatedContinuousBotTable({ tableId, created = false }
   });
 }
 
+async function retireManagedTableAfterReplacementConflict({ tableId, generationKey, attempt }) {
+  const persisted = await continuousBotTableRepository?.requestRetirement?.(tableId);
+  if (!persisted?.ok) {
+    return persisted || { ok: false, reason: "retirement_request_unavailable" };
+  }
+
+  continuousBotRetirementRequested.add(tableId);
+  const restored = await restoreTableFromPersisted(tableId);
+  if (!restored?.ok) {
+    tableManager.markTableRotationDue?.(tableId, Date.now());
+    scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
+    return {
+      ok: true,
+      changed: false,
+      deferred: true,
+      reason: "managed_retirement_restore_pending",
+      retryable: true
+    };
+  }
+  broadcastStateSnapshots(tableId);
+
+  if (tableManager.hasActiveHumanMember(tableId) || tableManager.hasConnectedHumanPresence(tableId)) {
+    scheduleSettledRolloverRetry({ tableId, generationKey, attempt: attempt + 1 });
+    return {
+      ok: true,
+      changed: false,
+      deferred: true,
+      reason: "managed_retirement_human_present",
+      retryable: true
+    };
+  }
+
+  return applyInactiveCleanupAndBroadcast({
+    tableId,
+    requestId: `continuous-bot-table-close:${tableId}`,
+    logPrefix: "ws_continuous_bot_table_retirement"
+  });
+}
+
 async function requestContinuousBotTableRetirement({ tableId }) {
   if (continuousBotRetirementRequested.has(tableId)) return { ok: true, changed: false };
+  const persisted = await continuousBotTableRepository?.requestRetirement?.(tableId);
+  if (!persisted?.ok) {
+    return persisted || { ok: false, reason: "retirement_request_unavailable" };
+  }
   continuousBotRetirementRequested.add(tableId);
   return enqueueTableCommand({
     tableId,


### PR DESCRIPTION
## Summary

Refs #807.

The persisted restore path could keep the stale bot identity from `poker_state.seats` even when `poker_seats.user_id` had already advanced after a replacement funding attempt. The next settled rollover then prepared funding for the stale identity and the writer repeatedly failed its exact seat projection update.

## Changes

- Reconcile active seat identity from `poker_seats.user_id` during persisted restore.
- Reconcile identity-keyed state used by rollover, including stacks, hand seats and bot metadata; for a replaced bot, use the current seat projection stack and remove the stale identity.
- Preserve the existing rollover retry/recompute path; it derives the next replacement from the reconstructed runtime state.
- Preserve the specific `replacement_seat_projection_conflict` reason from the persisted writer.
- Add a small transaction-locked repository operation that persists `rotation_due_at` for the exact managed table.
- On a managed replacement projection conflict, persist retirement before suppressing that generation's replacement retry, refresh runtime metadata, and use the existing retirement/terminal-close flow. If a human is present, retirement remains deferred; other persistence failures keep their existing retry behavior.
- Add focused restore, writer, repository and test-runner coverage.

## Verification

- `npm test` — pass
- `npm run syntax` — pass
- `git diff --check` — pass
- Targeted adapter, repository and persisted-writer behavior tests — pass

## Runtime verification

This PR changes `ws-server/**`. A manual WS Preview Deploy for the exact PR SHA is required before runtime verification. The smoke should cover restore after replacement, exactly-once funding, conflict retirement with and without human presence, and restart without resuming the broken generation.

## Risk / breaking impact

Only managed `CONTINUOUS_BOT` tables with a specific replacement seat projection conflict change behavior: they are durably marked for existing graceful retirement instead of retrying the same replacement funding forever. Normal tables and other persistence failures retain current behavior. No migration, ledger policy change, settlement algorithm change, or production configuration change is included.