### PR TITLE
poker: add bounded action-history retention with human-participant detection

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -384,3 +384,7 @@ Server-side session validation prevents session hijacking and token forgery atta
 - Session exists and is valid in Redis
 
 See `netlify.toml` for the complete environment variable reference.
+
+## Poker
+
+See `docs/poker-deployment.md` for poker-specific operational documentation, including the action-history retention cleanup configuration.

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -259,3 +259,181 @@ These secrets are intentionally separate from the production WS deploy credentia
 
 ## Post-deploy migration note
 Legacy HTTP sweep is retired for gameplay authority and no scheduler invokes it. Any stale active gameplay cleanup must run from WS-owned runtime/ops flows, not from `/.netlify/functions/poker-sweep`.
+
+## Poker action-history retention cleanup
+
+**Purpose and ownership.** The retention cleanup is owned by the authoritative WS server process (`ws-server/server.mjs`). It bounds the growth of `public.poker_actions` by deleting rows from completed hands older than configurable retention windows. The cleanup is a continuous background sweep inside the WS runtime; it is not an HTTP endpoint, Supabase scheduled job, cron job, or table janitor operation.
+
+Implementation: `ws-server/poker/persistence/action-history-cleanup.mjs`, scheduler wiring in `ws-server/server.mjs`.
+
+### Data classification — `has_human_participant`
+
+The one-way boolean column `public.poker_tables.has_human_participant` classifies tables for retention purposes:
+
+| Value | Meaning | Retention |
+|-------|---------|-----------|
+| `false` | No human participation detected | Uses **bot** retention windows |
+| `true` | Human has played at this table | Uses **human** retention windows |
+
+Once set to `true` the flag never returns to `false`. Existing tables are backfilled by the migration `20260730160000_poker_tables_has_human_participant.sql` from three sources: current human seats (`poker_seats.is_bot IS NOT TRUE`), historical human gameplay requests (`poker_requests.kind IN ('JOIN','LEAVE','ACT','REBUY')`), and creator gameplay evidence (`poker_actions.user_id = poker_tables.created_by` with a non-ADMIN action).
+
+This classification affects retention only. It does not make the database authoritative for active gameplay, does not replace `poker_seats` or `poker_state`, and is not consulted by bot claims recovery, terminal accounting, or any gameplay decision.
+
+### Two-phase deletion semantics
+
+Cleanup runs in two sequential phases inside a single database transaction:
+
+**Phase 1 — ordinary actions.** Deletes all action rows except `HAND_SETTLED` for completed hands whose `HAND_SETTLED` audit row is older than the applicable action-retention cutoff. Only hands that still have ordinary action rows are selected (correlated `EXISTS`). A table's retention classification is read while holding a row lock (`FOR UPDATE OF t SKIP LOCKED`) and locked tables are bounded by `lockLimit = batchSize * 2`.
+
+**Phase 2 — settlement markers.** Deletes old `HAND_SETTLED` rows only when no ordinary actions remain for the same hand (correlated `NOT EXISTS`). This guarantees Phase 1 processes a hand before Phase 2 removes its marker, even if a sweep backlog builds up.
+
+Phase 1 always runs before Phase 2 in the same transaction. Both phases use the same three-level CTE structure: `locked_tables` (bounded `FOR UPDATE SKIP LOCKED`) → `candidates` (UNION ALL with per-classification cutoffs) → `DELETE … RETURNING id`.
+
+`batchSize` limits the number of candidate hands (Phase 1) or settlement rows (Phase 2) selected per sweep, not the number of ordinary action rows deleted. A single Phase 1 candidate hand may contain dozens of ordinary action rows, so `phase1Deleted` in the log may be much larger than `batchSize`.
+
+### Environment variables
+
+| Variable | Unit | Default | Range | Disabled | Meaning |
+|----------|------|---------|-------|----------|---------|
+| `WS_POKER_BOT_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete ordinary actions for bot-only tables after this many ms since the hand's `HAND_SETTLED` marker |
+| `WS_POKER_BOT_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for bot-only tables after this many ms, and only when ordinary actions are already gone |
+| `WS_POKER_HUMAN_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-action but for tables where a human ever played |
+| `WS_POKER_HUMAN_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-settled but for human-participated tables |
+| `WS_POKER_ACTION_HISTORY_SWEEP_MS` | ms | `300000` (5 min) | `30_000`–`3_600_000` | N/A | Interval between cleanup sweep invocations |
+| `WS_POKER_ACTION_HISTORY_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate hands/settlements per phase per sweep. `lockLimit` is derived as `batchSize * 2` |
+
+Validation rules (fail-fast at WS startup):
+
+- Every retention value must be a finite, non-negative integer.
+- `action = 0` with `settled > 0` is **invalid** — throws at startup.
+- When both `> 0`, `settled` must be `>= action`.
+- `batchSize` must be an integer from 1 through 100.
+- Bot and human retention pairs are validated independently.
+- All defaults are `0`, so cleanup is disabled until explicitly configured.
+
+A sweep-in-progress guard prevents concurrent sweeps when a sweep takes longer than the sweep interval.
+
+### Current WS Preview policy
+
+The following policy is intentionally enabled on Preview in `/opt/arcade-ws-preview/.env.preview`:
+
+```
+WS_POKER_BOT_ACTION_RETENTION_MS=86400000
+WS_POKER_BOT_SETTLED_RETENTION_MS=604800000
+WS_POKER_HUMAN_ACTION_RETENTION_MS=604800000
+WS_POKER_HUMAN_SETTLED_RETENTION_MS=2592000000
+WS_POKER_ACTION_HISTORY_SWEEP_MS=300000
+WS_POKER_ACTION_HISTORY_BATCH_SIZE=50
+```
+
+Human-readable equivalents:
+- Bot ordinary actions: **24 hours**
+- Bot settlements: **7 days**
+- Human-table ordinary actions: **7 days**
+- Human-table settlements: **30 days**
+- Sweep interval: **5 minutes**
+- Batch size: **50** (lock limit: **100**)
+
+This Preview policy is distinct from code defaults. Production defaults remain `0` (disabled) until separately configured. The `/opt/arcade-ws-preview/.env.preview` file is **not touched** by the `ws-preview-deploy.yml` workflow — rsync syncs only `ws-server/`, `shared/`, and `netlify/functions/_shared/` directories, so Preview env configuration persists across deploys.
+
+### Required migrations and deployment order
+
+Two migrations are introduced by this feature:
+
+| Migration | Purpose |
+|-----------|---------|
+| `20260730160000_poker_tables_has_human_participant.sql` | Add `has_human_participant` column + 3-source backfill |
+| `20260730160001_poker_actions_hand_settled_cleanup_idx.sql` | Partial index `(table_id, created_at) WHERE action_type = 'HAND_SETTLED'` |
+
+Deployment order:
+1. Apply both migrations to the target database.
+2. Deploy the matching WS revision.
+3. Configure non-zero retention values for the environment.
+4. Restart the WS service and verify health.
+
+Editing an already-applied migration is not allowed. Use a new timestamped migration file for corrections.
+
+### Observability and verification
+
+**klog events:**
+
+| Event | Severity | Fields |
+|-------|----------|--------|
+| `ws_action_history_cleanup_complete` | INFO | `phase1Deleted`, `phase2Deleted`, `batchSize`, `lockLimit` |
+| `ws_action_history_cleanup_failed` | ERROR | `reason` (error code or message) |
+
+The `complete` event is emitted only when at least one row was deleted. The `failed` event is emitted on any unexpected error.
+
+**Preview verification commands:**
+
+```bash
+# Health check
+curl -s http://127.0.0.1:3001/healthz
+
+# Cleanup logs since the service activation timestamp
+sudo journalctl -u ws-server-preview.service --no-pager | grep "ws_action_history_cleanup_"
+
+# Inspect running environment values
+sudo cat /opt/arcade-ws-preview/.env.preview | grep WS_POKER_ACTION_HISTORY
+```
+
+**SQL verification queries:**
+
+```sql
+-- Count expired bot ordinary actions (actions past bot-action retention
+-- belonging to a completed, settled hand)
+SELECT COUNT(*)
+FROM public.poker_actions pa
+JOIN public.poker_tables t ON t.id = pa.table_id
+WHERE t.has_human_participant = false
+  AND pa.action_type != 'HAND_SETTLED'
+  AND EXISTS (
+    SELECT 1 FROM public.poker_actions hs
+    WHERE hs.table_id = pa.table_id
+      AND hs.hand_id = pa.hand_id
+      AND hs.action_type = 'HAND_SETTLED'
+      AND hs.created_at < now() - interval '24 hours'
+  );
+
+-- Group expired bot settlement markers by table
+SELECT pa.table_id, COUNT(*) AS expired_settlements
+FROM public.poker_actions pa
+JOIN public.poker_tables t ON t.id = pa.table_id
+WHERE t.has_human_participant = false
+  AND pa.action_type = 'HAND_SETTLED'
+  AND pa.created_at < now() - interval '7 days'
+  AND NOT EXISTS (
+    SELECT 1 FROM public.poker_actions oa
+    WHERE oa.table_id = pa.table_id
+      AND oa.hand_id = pa.hand_id
+      AND oa.action_type != 'HAND_SETTLED'
+  )
+GROUP BY pa.table_id
+ORDER BY expired_settlements DESC;
+
+-- Verify has_human_participant for a specific table
+SELECT id, status, lifecycle_kind, has_human_participant, created_at
+FROM public.poker_tables
+WHERE id = '<TABLE_ID>';
+```
+
+A shared stage database may contain a historical backlog. A recently active continuous bot table may still show expired rows while the sweep processes older tables first. Successful repeated bounded-deletion logs plus decreasing global eligible counts demonstrate progress; a single active table not reaching zero immediately does not indicate a failure.
+
+### Safety, disabling, and rollback
+
+**This process permanently deletes historical `poker_actions` rows.**
+
+- Set all four retention values to `0` to disable deletion entirely.
+- Restart the WS service after changing configuration — the values are read once at process start.
+- Disabling cleanup stops future deletion but **cannot restore already deleted rows**.
+- Do not accidentally apply a short human retention — human and bot retention are independently configurable.
+- The `has_human_participant` flag is one-way and not reversible. If a table is incorrectly classified, only the retention values (not the flag) can be adjusted.
+
+### Preview smoke evidence (2026-07-30)
+
+- Deployed SHA: `a9eacc3f6ac37d9dab473e6f12febf417b4f06d1`
+- Local health (`http://127.0.0.1:3001/healthz`) returned `200`; public health passed.
+- Both phases deleted rows against real PostgreSQL on the stage database.
+- Bounded `phase1Deleted` and `phase2Deleted` values were observed in `ws_action_history_cleanup_complete` logs.
+- No `ws_action_history_cleanup_failed` events were observed.
+- Preview was then configured for continuous retention with the policy documented above.

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -287,7 +287,7 @@ Cleanup runs in two sequential phases inside a single database transaction:
 
 **Phase 2 — settlement markers.** Deletes old `HAND_SETTLED` rows only when no ordinary actions remain for the same hand (correlated `NOT EXISTS`). This guarantees Phase 1 processes a hand before Phase 2 removes its marker, even if a sweep backlog builds up.
 
-Phase 1 always runs before Phase 2 in the same transaction. Both phases use the same three-level CTE structure: `locked_tables` (bounded `FOR UPDATE SKIP LOCKED`) → `candidates` (UNION ALL with per-classification cutoffs) → `DELETE … RETURNING id`.
+Phase 1 always runs before Phase 2 in the same transaction. Both phases use bounded `locked_tables` and candidate CTEs followed by `DELETE … RETURNING id`. Bot and human cutoffs are selected through classification predicates (`has_human_participant`) inside each CTE.
 
 `batchSize` limits the number of candidate hands (Phase 1) or settlement rows (Phase 2) selected per sweep, not the number of ordinary action rows deleted. A single Phase 1 candidate hand may contain dozens of ordinary action rows, so `phase1Deleted` in the log may be much larger than `batchSize`.
 
@@ -374,7 +374,7 @@ curl -s http://127.0.0.1:3001/healthz
 sudo journalctl -u ws-server-preview.service --no-pager | grep "ws_action_history_cleanup_"
 
 # Inspect running environment values
-sudo cat /opt/arcade-ws-preview/.env.preview | grep WS_POKER_ACTION_HISTORY
+sudo grep -E '^WS_POKER_(BOT|HUMAN)_(ACTION|SETTLED)_RETENTION_MS=|^WS_POKER_ACTION_HISTORY_(SWEEP_MS|BATCH_SIZE)=' /opt/arcade-ws-preview/.env.preview
 ```
 
 **SQL verification queries:**

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -653,11 +653,23 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       if (!resolvedBuyIn) throw makeError("invalid_buy_in");
 
       const tableRows = await tx.unsafe(
-        "select id, status, max_players, stakes from public.poker_tables where id = $1 limit 1;",
+        "select id, status, max_players, stakes from public.poker_tables where id = $1 limit 1 for update;",
         [tableId]
       );
       const table = tableRows?.[0] || null;
       if (!table) throw makeError("table_not_found");
+
+      // Lock the table row before any mutation.  Mark human participation
+      // one-way (false -> true) so that action history retention uses the
+      // correct (long) window for tables with human gameplay.  The flag
+      // rolls back if the join transaction fails.
+      await tx.unsafe(
+        `update public.poker_tables
+            set has_human_participant = true
+          where id = $1 and has_human_participant = false`,
+        [tableId]
+      );
+
       const maxPlayers = Number(table.max_players);
       if (!Number.isInteger(maxPlayers) || maxPlayers < 1) throw makeError("table_not_open");
 

--- a/supabase/migrations/20260730160000_poker_tables_has_human_participant.sql
+++ b/supabase/migrations/20260730160000_poker_tables_has_human_participant.sql
@@ -1,0 +1,43 @@
+-- Add has_human_participant marker to poker_tables.
+-- One-way flag: false -> true, never reverted.
+-- Used by action history retention to distinguish bot-only tables
+-- (short retention) from tables with human gameplay (long retention).
+
+alter table public.poker_tables
+  add column if not exists has_human_participant boolean not null default false;
+
+-- Backfill 1: current human seats
+update public.poker_tables t
+   set has_human_participant = true
+ where t.has_human_participant = false
+   and exists (
+     select 1 from public.poker_seats s
+      where s.table_id = t.id
+        and s.is_bot is not true
+   );
+
+-- Backfill 2: historical human gameplay requests.
+-- poker_requests with kind IN ('JOIN','LEAVE','ACT','REBUY')
+-- are only created by human players; bots bypass the request pipeline.
+update public.poker_tables t
+   set has_human_participant = true
+ where t.has_human_participant = false
+   and exists (
+     select 1 from public.poker_requests r
+      where r.table_id = t.id
+        and r.kind in ('JOIN', 'LEAVE', 'ACT', 'REBUY')
+      limit 1
+   );
+
+-- Backfill 3: table creator who also played (has non-ADMIN actions).
+update public.poker_tables t
+   set has_human_participant = true
+ where t.has_human_participant = false
+   and t.created_by is not null
+   and exists (
+     select 1 from public.poker_actions a
+      where a.table_id = t.id
+        and a.user_id = t.created_by
+        and a.action_type not like 'ADMIN_%'
+      limit 1
+   );

--- a/supabase/migrations/20260730160001_poker_actions_hand_settled_cleanup_idx.sql
+++ b/supabase/migrations/20260730160001_poker_actions_hand_settled_cleanup_idx.sql
@@ -1,0 +1,8 @@
+-- Partial index for action history cleanup queries.
+-- Covers (table_id, created_at) for HAND_SETTLED rows only,
+-- supporting the locked_tables EXISTS subquery that finds
+-- tables with old settlements.
+
+create index if not exists poker_actions_hand_settled_table_created_idx
+  on public.poker_actions (table_id, created_at)
+  where action_type = 'HAND_SETTLED';

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -86,7 +86,8 @@ register("DEBUG", "table_lifecycle", [
 
 register("INFO", "accounting", [
   "poker_leave_cashout",
-  "poker_terminal_accounting_closed"
+  "poker_terminal_accounting_closed",
+  "ws_action_history_cleanup_complete"
 ]);
 
 register("INFO", "admin", [
@@ -263,7 +264,8 @@ register("ERROR", "http", [
 
 register("ERROR", "admin", [
   "ws_poker_log_config_invalid",
-  "ws_preview_bot_reaction_failed"
+  "ws_preview_bot_reaction_failed",
+  "ws_action_history_cleanup_failed"
 ]);
 
 register("ERROR", "session", [

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -187,7 +187,8 @@ register("WARN", "table_lifecycle", [
 ]);
 
 register("ERROR", "accounting", [
-  "poker_terminal_accounting_invariant_failed"
+  "poker_terminal_accounting_invariant_failed",
+  "ws_action_history_cleanup_failed"
 ]);
 
 register("ERROR", "autoplay", [
@@ -264,8 +265,7 @@ register("ERROR", "http", [
 
 register("ERROR", "admin", [
   "ws_poker_log_config_invalid",
-  "ws_preview_bot_reaction_failed",
-  "ws_action_history_cleanup_failed"
+  "ws_preview_bot_reaction_failed"
 ]);
 
 register("ERROR", "session", [

--- a/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
@@ -1,0 +1,334 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createActionHistoryCleanup } from "./action-history-cleanup.mjs";
+
+function mockTx(handlers) {
+  return {
+    unsafe: async (sql, params) => {
+      for (const [pattern, handler] of handlers) {
+        if (sql.includes(pattern)) {
+          return handler(sql, params);
+        }
+      }
+      return [];
+    }
+  };
+}
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Phase 1
+// ---------------------------------------------------------------------------
+
+test("phase 1 deletes ordinary actions for bot-only table past cutoff", async () => {
+  let phase1DeletedCount = 0;
+  const tx = mockTx([
+    // Phase 1 uses "candidate_hands" CTE name + "action_type != 'HAND_SETTLED'" in DELETE
+    ["candidate_hands", (sql) => {
+      if (sql.includes("action_type != 'HAND_SETTLED'")) {
+        phase1DeletedCount = 3;
+        return [{ id: 1 }, { id: 2 }, { id: 3 }];
+      }
+      return [];
+    }],
+    ["id in (select id from candidates)", () => []],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, true);
+  assert.equal(result.phase1Deleted, 3);
+  assert.equal(result.phase2Deleted, 0);
+});
+
+test("phase 1 deletes nothing when all retentions are 0", async () => {
+  const tx = mockTx([
+    ["candidate_hands", () => []],
+    ["id in (select id from candidates)", () => []],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: "0",
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.skipped, true);
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2
+// ---------------------------------------------------------------------------
+
+test("phase 2 deletes HAND_SETTLED when ordinary actions already gone", async () => {
+  let phase1Called = false;
+  let phase2DeletedCount = 0;
+  const tx = mockTx([
+    // Phase 1 returns nothing
+    ["candidate_hands", () => { phase1Called = true; return []; }],
+    // Phase 2 uses "id in (select id from candidates)" pattern
+    ["id in (select id from candidates)", () => {
+      phase2DeletedCount = 2;
+      return [{ id: 100 }, { id: 101 }];
+    }],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: String(7 * DAY),
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, true);
+  assert.equal(phase1Called, true);  // Phase 1 always runs first
+  assert.equal(result.phase2Deleted, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+test("bot action=0 + settled>0 throws", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: "0",
+        WS_POKER_BOT_SETTLED_RETENTION_MS: String(HOUR),
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /is unsafe|must be >=/);
+});
+
+test("0/0 is valid (cleanup disabled)", () => {
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: "0",
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async () => {}
+  });
+  assert.equal(typeof cleanup.sweep, "function");
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+test("idempotent: second sweep deletes nothing", async () => {
+  const tx = mockTx([
+    ["candidate_hands", () => []],
+    ["id in (select id from candidates)", () => []],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.phase1Deleted, 0);
+  assert.equal(result.phase2Deleted, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Batch config
+// ---------------------------------------------------------------------------
+
+test("batch size and lockLimit passed to SQL", async () => {
+  let capturedParams = null;
+  const tx = mockTx([
+    ["candidate_hands", (sql, params) => {
+      capturedParams = params;
+      return [];
+    }],
+    ["id in (select id from candidates)", () => []],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "7",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  await cleanup.sweep();
+  assert.equal(capturedParams[2], 7);
+  assert.equal(capturedParams[3], 14);
+});
+
+// ---------------------------------------------------------------------------
+// Fail-fast validation of individual values
+// ---------------------------------------------------------------------------
+
+test("rejects NaN retention", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: "8640000x",
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /must be a finite non-negative integer/);
+});
+
+test("rejects negative retention", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: "-100",
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /must be a finite non-negative integer/);
+});
+
+test("rejects non-integer retention", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: "12.5",
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /must be a finite non-negative integer/);
+});
+
+test("rejects batchSize 0", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "0",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /BATCH_SIZE.*must be an integer 1-100/);
+});
+
+test("rejects batchSize >100", () => {
+  assert.throws(() => {
+    createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "101",
+        SUPABASE_DB_URL: "postgres://test/db"
+      },
+      beginSql: async () => {}
+    });
+  }, /BATCH_SIZE.*must be an integer 1-100/);
+});
+
+// ---------------------------------------------------------------------------
+// Sweep-in-progress guard
+// ---------------------------------------------------------------------------
+
+test("skips sweep when previous sweep is still in progress", async () => {
+  let calls = 0;
+  let resolveTx;
+  const txPromise = new Promise((resolve) => { resolveTx = resolve; });
+
+  const tx = mockTx([
+    ["candidate_hands", async () => {
+      calls++;
+      await txPromise; // hold the transaction open
+      return [];
+    }],
+    ["id in (select id from candidates)", () => []],
+  ]);
+
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn(tx)
+  });
+
+  // Start first sweep (will hang on txPromise)
+  const first = cleanup.sweep();
+
+  // Attempt second sweep while first is in progress
+  const second = await cleanup.sweep();
+
+  assert.equal(second.skipped, true);
+  assert.equal(second.reason, "sweep_in_progress");
+
+  // Release first sweep
+  resolveTx();
+  const firstResult = await first;
+  assert.equal(firstResult.ok, true);
+});

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -1,0 +1,283 @@
+// Action-history retention cleanup.
+//
+// Two-phase sweep that runs on a timer (see server.mjs).
+// Phase 1 deletes ordinary actions (everything except HAND_SETTLED)
+// for completed hands older than the applicable retention cutoff.
+// Phase 2 deletes HAND_SETTLED audit rows for hands whose ordinary
+// actions have already been cleaned up.
+//
+// Retention is per-table: bot-only tables (has_human_participant = false)
+// use a short window; tables with human gameplay use a long window.
+// A retention value of 0 disables the corresponding category.
+
+import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
+
+function resolveCutoff(retentionMs) {
+  if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
+  return new Date(Date.now() - retentionMs).toISOString();
+}
+
+// Phase 1 — delete ordinary actions for completed hands.
+//
+// Only hands that have a HAND_SETTLED audit row older than the cutoff AND
+// still have ordinary action rows are eligible.
+async function sweepPhase1({ tx, botActionCutoff, humanActionCutoff, batchSize, lockLimit, klog }) {
+  const result = await tx.unsafe(
+    `with locked_tables as (
+  select t.id, t.has_human_participant
+    from public.poker_tables t
+   where exists (
+           select 1
+             from public.poker_actions pa
+            where pa.table_id = t.id
+              and pa.action_type = 'HAND_SETTLED'
+              and (
+                    (t.has_human_participant = false
+                     and $1::timestamptz is not null
+                     and pa.created_at < $1::timestamptz)
+                 or (t.has_human_participant = true
+                     and $2::timestamptz is not null
+                     and pa.created_at < $2::timestamptz)
+                  )
+              and exists (
+                    select 1
+                      from public.poker_actions oa
+                     where oa.table_id = pa.table_id
+                       and oa.hand_id = pa.hand_id
+                       and oa.action_type != 'HAND_SETTLED'
+                  )
+         )
+   order by (
+     select min(pa2.created_at) from public.poker_actions pa2
+      where pa2.table_id = t.id
+        and pa2.action_type = 'HAND_SETTLED'
+   )
+   limit $4
+   for update skip locked
+),
+candidate_hands as (
+  select pa.table_id, pa.hand_id, pa.created_at
+    from public.poker_actions pa
+    join locked_tables t on t.id = pa.table_id
+   where pa.action_type = 'HAND_SETTLED'
+     and (
+           (t.has_human_participant = false
+            and $1::timestamptz is not null
+            and pa.created_at < $1::timestamptz)
+        or (t.has_human_participant = true
+            and $2::timestamptz is not null
+            and pa.created_at < $2::timestamptz)
+         )
+     and exists (
+           select 1
+             from public.poker_actions oa
+            where oa.table_id = pa.table_id
+              and oa.hand_id = pa.hand_id
+              and oa.action_type != 'HAND_SETTLED'
+         )
+   order by created_at
+   limit $3
+)
+delete from public.poker_actions
+ where action_type != 'HAND_SETTLED'
+   and (table_id, hand_id) in (
+     select table_id, hand_id from candidate_hands
+   )
+returning id;`,
+    [botActionCutoff, humanActionCutoff, batchSize, lockLimit]
+  );
+  return Array.isArray(result) ? result.length : 0;
+}
+
+// Phase 2 — delete HAND_SETTLED rows for hands whose ordinary actions
+// have already been cleaned up (no remaining ordinary-action rows).
+async function sweepPhase2({ tx, botSettledCutoff, humanSettledCutoff, batchSize, lockLimit, klog }) {
+  const result = await tx.unsafe(
+    `with locked_tables as (
+  select t.id, t.has_human_participant
+    from public.poker_tables t
+   where exists (
+           select 1
+             from public.poker_actions pa
+            where pa.table_id = t.id
+              and pa.action_type = 'HAND_SETTLED'
+              and (
+                    (t.has_human_participant = false
+                     and $1::timestamptz is not null
+                     and pa.created_at < $1::timestamptz)
+                 or (t.has_human_participant = true
+                     and $2::timestamptz is not null
+                     and pa.created_at < $2::timestamptz)
+                  )
+              and not exists (
+                    select 1
+                      from public.poker_actions oa
+                     where oa.table_id = pa.table_id
+                       and oa.hand_id = pa.hand_id
+                       and oa.action_type != 'HAND_SETTLED'
+                  )
+         )
+   order by (
+     select min(pa2.created_at) from public.poker_actions pa2
+      where pa2.table_id = t.id
+        and pa2.action_type = 'HAND_SETTLED'
+   )
+   limit $4
+   for update skip locked
+),
+candidates as (
+  select pa.id, pa.created_at
+    from public.poker_actions pa
+    join locked_tables t on t.id = pa.table_id
+   where pa.action_type = 'HAND_SETTLED'
+     and (
+           (t.has_human_participant = false
+            and $1::timestamptz is not null
+            and pa.created_at < $1::timestamptz)
+        or (t.has_human_participant = true
+            and $2::timestamptz is not null
+            and pa.created_at < $2::timestamptz)
+         )
+     and not exists (
+           select 1
+             from public.poker_actions oa
+            where oa.table_id = pa.table_id
+              and oa.hand_id = pa.hand_id
+              and oa.action_type != 'HAND_SETTLED'
+         )
+   order by created_at
+   limit $3
+)
+delete from public.poker_actions
+ where id in (select id from candidates)
+returning id;`,
+    [botSettledCutoff, humanSettledCutoff, batchSize, lockLimit]
+  );
+  return Array.isArray(result) ? result.length : 0;
+}
+
+export function createActionHistoryCleanup({
+  env = process.env,
+  beginSql = beginSqlWs,
+  klog = () => {}
+} = {}) {
+  // --- Fail-fast config validation ---------------------------------------
+
+  function resolveRetentionMs(rawValue, label) {
+    if (rawValue === undefined) return 0;
+    const num = Number(rawValue);
+    if (!Number.isFinite(num) || num < 0 || !Number.isInteger(num)) {
+      throw new Error(
+        `WS_POKER_${label}_RETENTION_MS must be a finite non-negative integer, got: ${JSON.stringify(rawValue)}`
+      );
+    }
+    return num;
+  }
+
+  const botActionMs = resolveRetentionMs(env.WS_POKER_BOT_ACTION_RETENTION_MS, "BOT_ACTION");
+  const botSettledMs = resolveRetentionMs(env.WS_POKER_BOT_SETTLED_RETENTION_MS, "BOT_SETTLED");
+  const humanActionMs = resolveRetentionMs(env.WS_POKER_HUMAN_ACTION_RETENTION_MS, "HUMAN_ACTION");
+  const humanSettledMs = resolveRetentionMs(env.WS_POKER_HUMAN_SETTLED_RETENTION_MS, "HUMAN_SETTLED");
+
+  function validateRetentionPair(actionMs, settledMs, label) {
+    if (actionMs === 0 && settledMs > 0) {
+      throw new Error(
+        `WS_POKER_${label}_ACTION_RETENTION_MS=0 with WS_POKER_${label}_SETTLED_RETENTION_MS>0 ` +
+        "is unsafe: HAND_SETTLED markers would be deleted while ordinary actions remain."
+      );
+    }
+    if (actionMs > 0 && settledMs > 0 && settledMs < actionMs) {
+      throw new Error(
+        `WS_POKER_${label}_SETTLED_RETENTION_MS must be >= ` +
+        `WS_POKER_${label}_ACTION_RETENTION_MS when both are >0.`
+      );
+    }
+  }
+  validateRetentionPair(botActionMs, botSettledMs, "BOT");
+  validateRetentionPair(humanActionMs, humanSettledMs, "HUMAN");
+
+  function resolveBatchSize(rawValue) {
+    if (rawValue === undefined) return 20;
+    const num = Number(rawValue);
+    if (!Number.isFinite(num) || num < 1 || num > 100 || !Number.isInteger(num)) {
+      throw new Error(
+        `WS_POKER_ACTION_HISTORY_BATCH_SIZE must be an integer 1-100, got: ${JSON.stringify(rawValue)}`
+      );
+    }
+    return num;
+  }
+
+  const batchSize = resolveBatchSize(env.WS_POKER_ACTION_HISTORY_BATCH_SIZE);
+  const lockLimit = batchSize * 2;
+
+  function buildCutoffs() {
+
+    return {
+      botActionCutoff: resolveCutoff(botActionMs),
+      botSettledCutoff: resolveCutoff(botSettledMs),
+      humanActionCutoff: resolveCutoff(humanActionMs),
+      humanSettledCutoff: resolveCutoff(humanSettledMs),
+      botActionEnabled: botActionMs > 0,
+      humanActionEnabled: humanActionMs > 0,
+      botSettledEnabled: botSettledMs > 0,
+      humanSettledEnabled: humanSettledMs > 0
+    };
+  }
+
+  let sweepInProgress = false;
+
+  async function sweep() {
+    if (sweepInProgress) return { ok: true, phase1Deleted: 0, phase2Deleted: 0, skipped: true, reason: "sweep_in_progress" };
+    sweepInProgress = true;
+    try {
+      const cutoffs = buildCutoffs();
+      const anyEnabled = cutoffs.botActionEnabled || cutoffs.humanActionEnabled
+        || cutoffs.botSettledEnabled || cutoffs.humanSettledEnabled;
+      if (!anyEnabled) return { ok: true, phase1Deleted: 0, phase2Deleted: 0, skipped: true };
+
+      try {
+        return await beginSql(async (tx) => {
+        // Phase 1 — ordinary actions (must run before Phase 2)
+        const phase1Deleted = await sweepPhase1({
+          tx,
+          botActionCutoff: cutoffs.botActionCutoff,
+          humanActionCutoff: cutoffs.humanActionCutoff,
+          batchSize,
+          lockLimit,
+          klog
+        });
+
+        // Phase 2 — HAND_SETTLED rows whose ordinary actions are already gone
+        const phase2Deleted = await sweepPhase2({
+          tx,
+          botSettledCutoff: cutoffs.botSettledCutoff,
+          humanSettledCutoff: cutoffs.humanSettledCutoff,
+          batchSize,
+          lockLimit,
+          klog
+        });
+
+        if (phase1Deleted > 0 || phase2Deleted > 0) {
+          klog("ws_action_history_cleanup_complete", {
+            phase1Deleted,
+            phase2Deleted,
+            batchSize,
+            lockLimit
+          });
+        }
+
+        return { ok: true, phase1Deleted, phase2Deleted };
+      }, { env });
+    } catch (error) {
+      klog("ws_action_history_cleanup_failed", {
+        reason: error?.code || error?.message || "unknown"
+      });
+      return { ok: false, phase1Deleted: 0, phase2Deleted: 0, reason: error?.message };
+    }
+    } finally {
+      sweepInProgress = false;
+    }
+  }
+
+  return { sweep };
+}

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -60,6 +60,7 @@ import { getBotConfig, parseStakes } from "./shared/poker-domain/bots.mjs";
 import { createContinuousBotTableRepository } from "./poker/persistence/continuous-bot-table-repository.mjs";
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 import { handleContinuousBotRotationAtSettled } from "./poker/runtime/continuous-bot-table-rotation.mjs";
+import { createActionHistoryCleanup } from "./poker/persistence/action-history-cleanup.mjs";
 import {
   isManagedReplacementSeatProjectionConflict,
   retireManagedTableAfterReplacementConflict as retireManagedTableAfterReplacementConflictFlow
@@ -4404,6 +4405,26 @@ const lobbyVisibilitySweepTimer = setInterval(() => {
   maybeBroadcastLobbySnapshot();
 }, lobbyVisibilitySweepMs);
 lobbyVisibilitySweepTimer.unref();
+
+// --- Action history retention cleanup ---------------------------------
+// Validation (action=0 + settled>0, settled<action) is inside the module.
+
+const actionHistoryCleanupSweepMs = resolvePositiveInt(
+  process.env.WS_POKER_ACTION_HISTORY_SWEEP_MS, 300_000, { min: 30_000, max: 3_600_000 }
+);
+
+const actionHistoryCleanup = hasSupabaseDbUrl
+  ? createActionHistoryCleanup({ env: process.env, klog: klogSafe })
+  : null;
+
+if (actionHistoryCleanup) {
+  const actionHistoryCleanupTimer = setInterval(() => {
+    void actionHistoryCleanup.sweep();
+  }, actionHistoryCleanupSweepMs);
+  actionHistoryCleanupTimer.unref();
+}
+
+// -----------------------------------------------------------------------
 
 async function startServer() {
   const release = loadReleaseMetadata();


### PR DESCRIPTION
"## Summary\n\nCloses #811.\n\nAdd bounded retention for `poker_actions`. Continuous bot tables generate ~25-30k action rows/day; this caps growth via a configurable two-phase cleanup sweep.\n\n## Design\n\n### `has_human_participant` flag on `poker_tables`\n- One-way `false \u2192 true`, never reverted.\n- Set during human join (with `FOR UPDATE` on the table row before seat insert \u2014 rolls back on failure).\n- Backfill at migration time from `poker_seats`, `poker_requests` (human-only), and creator action evidence.\n\n### Two retention windows per table\n| Table type | Phase 1 (ordinary actions) | Phase 2 (`HAND_SETTLED`) |\n|---|---|---|\n| Bot-only | `WS_POKER_BOT_ACTION_RETENTION_MS` | `WS_POKER_BOT_SETTLED_RETENTION_MS` |\n| Human ever played | `WS_POKER_HUMAN_ACTION_RETENTION_MS` | `WS_POKER_HUMAN_SETTLED_RETENTION_MS` |\n\nAll default to `0` (disabled). Fail-fast validation rejects `action=0 + settled>0`, NaN, negative, and non-integer values.\n\n### Cleanup sweep\n- Three-level CTE: `locked_tables` (bounded `FOR UPDATE SKIP LOCKED`) \u2192 `candidates` \u2192 `DELETE`.\n- Phase 1 runs before Phase 2 in the same transaction.\n- Phase 2 only deletes `HAND_SETTLED` when ordinary actions are already gone (`NOT EXISTS`).\n- Phase 1 only selects tables that still have ordinary actions (`EXISTS`, correlated per-hand).\n- `LIMIT batchSize * 2` on locked tables \u2014 bounds lock scope.\n- `sweepInProgress` guard prevents overlapping sweeps.\n\n### Concurrency\n- Cleanup uses `FOR UPDATE SKIP LOCKED`: skips tables locked by a concurrent join.\n- Join locks the table row first (`SELECT ... FOR UPDATE`) then sets the flag before seat insert.\n- No race window between read and flag update.\n\n## Files\n\n| File | Change |\n|---|---|\n| `migrations/...has_human_participant.sql` | New column + 3-source backfill |\n| `migrations/...hand_settled_cleanup_idx.sql` | Partial index `(table_id, created_at) WHERE HAND_SETTLED` |\n| `shared/poker-domain/join.mjs` | `FOR UPDATE` + one-way flag before seat insert |\n| `action-history-cleanup.mjs` | Cleanup module |\n| `action-history-cleanup.behavior.test.mjs` | 13 behavior tests |\n| `server.mjs` | Sweep timer, cleanup instance |\n| `poker-log-policy.mjs` | 2 new events |\n\n## Rollout\n\n- **Preview**: `BOT_ACTION=900000 BOT_SETTLED=3600000` (smoke test)\n- **Staging**: 24h/7d after Preview verified\n- **Production**: values TBD, defaults to 0 (disabled) until configured\n\n## Deployment order\n\n1. Apply migrations (column + index)\n2. Deploy code\n\n## Manual Verification\n\n### 1. Migration verification (before merge)\n\nRun a dry-run against the target Supabase instance:\n\n```\nnpx supabase db push --dry-run\n```\n\nConfirm only these two migrations would be applied:\n- `20260730160000_poker_tables_has_human_participant.sql`\n- `20260730160001_poker_actions_hand_settled_cleanup_idx.sql`\n\n### 2. Runtime cleanup smoke test (post-deploy)\n\nDeploy to Preview with non-zero retention, then validate the cleanup SQL against real PostgreSQL.\n\n**2a. Configure Preview with short retention:**\n\n```\nWS_POKER_BOT_ACTION_RETENTION_MS=180000\nWS_POKER_BOT_SETTLED_RETENTION_MS=300000\nWS_POKER_ACTION_HISTORY_SWEEP_MS=30000\n```\n\nSet these env vars on Preview and restart `ws-server-preview.service`.\n\n**2b. Wait for a continuous bot table to play hands.** The sweep runs every 30s.\n\n**2c. Verify Phase 1 \u2014 ordinary actions removed after action retention (~3min):**\n\n```\nsudo journalctl -u ws-server-preview.service --since \"5 min ago\" --no-pager \\\n  | grep \"ws_action_history_cleanup_complete\"\n```\n\nExpected: `phase1Deleted > 0`, `phase2Deleted = 0`.\n\n**2d. Verify HAND_SETTLED remains after Phase 1:**\n\nQuery Supabase SQL editor:\n```sql\nSELECT COUNT(*) FILTER (WHERE action_type = 'HAND_SETTLED') AS settled_count\nFROM public.poker_actions\nWHERE table_id = '<TEST_TABLE_ID>';\n```\n\nExpected: `settled_count > 0` \u2014 settlement markers still present.\n\n**2e. Verify Phase 2 \u2014 HAND_SETTLED removed after settlement retention (~5min):**\n\n```\nsudo journalctl -u ws-server-preview.service --since \"8 min ago\" --no-pager \\\n  | grep \"ws_action_history_cleanup_complete\"\n```\n\nExpected: `phase2Deleted > 0`.\n\n**2f. Verify cleanup logs show no errors:**\n\n```\nsudo journalctl -u ws-server-preview.service --since \"10 min ago\" --no-pager \\\n  | grep \"ws_action_history_cleanup_\"\n```\n\nExpected: at least one `complete` with non-zero counts, zero `failed`.\n\n**2g. Restore retention to 0 after test.** Remove the test env vars and restart.\n"