### PR TITLE
poker: reconnect preserves state and restores private hole cards

### DIFF
--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -3627,6 +3627,14 @@
     snapshotRecoveryTimer = null;
   }
 
+  function issueSnapshotRecoveryRequest(gen){
+    if (gen !== liveModeGeneration) return;
+    if (!state.reconnectGate) return;
+    if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function'){
+      wsClient.requestGameplaySnapshot();
+    }
+  }
+
   function scheduleSnapshotRecovery(gen){
     stopSnapshotRecoveryTimer();
     snapshotRecoveryTimer = window.setTimeout(function(){
@@ -3641,17 +3649,19 @@
         return;
       }
       snapshotRecoveryAttempts += 1;
-      if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function'){
-        wsClient.requestGameplaySnapshot();
-      }
+      issueSnapshotRecoveryRequest(gen);
       scheduleSnapshotRecovery(gen);
     }, SNAPSHOT_RECOVERY_TIMEOUT_MS);
   }
 
+  // Shared bounded snapshot recovery for both reconnect (after auth_ok) and
+  // server-initiated resync: the first full snapshot request is sent immediately,
+  // the timer only schedules up to SNAPSHOT_RECOVERY_MAX_ATTEMPTS retries.
   function startSnapshotRecovery(gen){
     if (gen !== liveModeGeneration) return;
     if (!state.reconnectGate) return;
     snapshotRecoveryAttempts = 0;
+    issueSnapshotRecoveryRequest(gen);
     scheduleSnapshotRecovery(gen);
   }
 
@@ -3785,9 +3795,7 @@
           state.reconnectGate = true;
           renderInfoPanel();
           renderControls();
-          if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function'){
-            wsClient.requestGameplaySnapshot();
-          }
+          startSnapshotRecovery(gen);
         } else if (status === 'failed'){
           stopSnapshotRecoveryTimer();
           cancelSettlementAnimations();

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -163,6 +163,11 @@
   var autoJoinErrorActive = false;
   var reconnectSeatNo = null;
   var lastKnownCurrentSeatNo = null;
+  var liveModeGeneration = 0;
+  var snapshotRecoveryTimer = null;
+  var snapshotRecoveryAttempts = 0;
+  var SNAPSHOT_RECOVERY_TIMEOUT_MS = 5000;
+  var SNAPSHOT_RECOVERY_MAX_ATTEMPTS = 3;
   var joinOperation = {
     phase: 'idle',
     requestId: null,
@@ -310,6 +315,9 @@
       tableId: nextTableId || null,
       tableStatus: 'OPEN',
       maxSeats: 6,
+      stateVersion: null,
+      hasAppliedAuthoritativeSnapshot: false,
+      reconnectGate: false,
       seats: [],
       stacks: {},
       potTotal: 0,
@@ -1308,6 +1316,11 @@
     var frameKind = frame && typeof frame.kind === 'string' ? frame.kind : 'stateSnapshot';
     var frameInitial = !!(frame && frame.initial);
     var authoritativeFull = frameKind === 'stateSnapshot' || (frameKind === 'table_state' && frameInitial);
+    // Single source of truth for version tracking: never regress an applied version.
+    var incomingVersion = Number(payload.stateVersion);
+    if (Number.isInteger(incomingVersion) && incomingVersion >= 0){
+      state.stateVersion = Math.max(Number(state.stateVersion) || 0, incomingVersion);
+    }
     var snapshotTableId = typeof payload.tableId === 'string' && payload.tableId ? payload.tableId : null;
     var publicObj = isObject(payload.public) ? payload.public : {};
     var privateObj = isObject(payload.private) ? payload.private : {};
@@ -3150,6 +3163,7 @@
   }
 
   function resumePendingJoinOperation(){
+    if (state.reconnectGate) return false;
     if (deriveCurrentSeat()){
       reconcileJoinOperationFromSnapshot();
       return false;
@@ -3190,6 +3204,7 @@
 
   function handleAction(actionType, amount){
     if (!actionType) return Promise.resolve();
+    if (state.reconnectGate) return Promise.resolve();
     var payload = { handId: state.handId || null, action: actionType };
     if (Number.isFinite(amount)) payload.amount = Math.trunc(amount);
     setError('');
@@ -3202,6 +3217,7 @@
   }
 
   function maybeExecuteQueuedPreaction(){
+    if (state.reconnectGate) return;
     if (!queuedPreaction || queuedPreactionInFlight || !isUsersTurn()) return;
     var allowed = getAllowedActions();
     var liveState = {
@@ -3273,6 +3289,7 @@
   }
 
   function autoJoinSeat(){
+    if (state.reconnectGate) return;
     if (!shouldAutoJoin) return;
     if (deriveCurrentSeat()){
       autoJoinAttempted = false;
@@ -3314,6 +3331,7 @@
   }
 
   function rejoinSeatAfterReconnect(){
+    if (state.reconnectGate) return false;
     if (!Number.isInteger(reconnectSeatNo) || reconnectSeatNo < 1) return false;
     if (autoJoinAttempted) return true;
     var preferredSeatNo = reconnectSeatNo;
@@ -3603,7 +3621,43 @@
     markBootReady();
   }
 
+  function stopSnapshotRecoveryTimer(){
+    if (!snapshotRecoveryTimer) return;
+    window.clearTimeout(snapshotRecoveryTimer);
+    snapshotRecoveryTimer = null;
+  }
+
+  function scheduleSnapshotRecovery(gen){
+    stopSnapshotRecoveryTimer();
+    snapshotRecoveryTimer = window.setTimeout(function(){
+      snapshotRecoveryTimer = null;
+      if (gen !== liveModeGeneration) return;
+      if (!state.reconnectGate) return;
+      if (snapshotRecoveryAttempts >= SNAPSHOT_RECOVERY_MAX_ATTEMPTS){
+        state.statusText = LIVE_STATUS_COPY.error;
+        setError('Snapshot recovery timed out');
+        renderInfoPanel();
+        renderControls();
+        return;
+      }
+      snapshotRecoveryAttempts += 1;
+      if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function'){
+        wsClient.requestGameplaySnapshot();
+      }
+      scheduleSnapshotRecovery(gen);
+    }, SNAPSHOT_RECOVERY_TIMEOUT_MS);
+  }
+
+  function startSnapshotRecovery(gen){
+    if (gen !== liveModeGeneration) return;
+    if (!state.reconnectGate) return;
+    snapshotRecoveryAttempts = 0;
+    scheduleSnapshotRecovery(gen);
+  }
+
   function stopLiveMode(){
+    liveModeGeneration += 1;
+    stopSnapshotRecoveryTimer();
     stopTurnClock();
     clearWinnerRevealTimer();
     cancelSettlementAnimations();
@@ -3658,10 +3712,29 @@
       render();
       return;
     }
+    // 1. Stop/invalidate the old client first (stopLiveMode increments the
+    //    generation, so any late callback from the previous instance is stale).
+    var preservingState = !!(state && state.mode === 'live'
+      && state.hasAppliedAuthoritativeSnapshot
+      && state.tableId && state.tableId === tableId);
     stopLiveMode();
     startTurnClock();
-    state = createEmptyLiveState(tableId, getUserIdFromToken(token));
-    render();
+    // 2. THEN capture the new generation (old = N, stop => N+1 stale, this => N+2 active).
+    var gen = ++liveModeGeneration;
+    if (preservingState){
+      // Reconnect: keep the last applied authoritative state and raise a recovery gate.
+      state.wsReady = false;
+      state.statusText = LIVE_STATUS_COPY.connecting;
+      state.errorText = '';
+      state.reconnectGate = true;
+      renderInfoPanel();
+      renderControls();
+    } else {
+      // Cold start: a fresh empty model is fine.
+      state = createEmptyLiveState(tableId, getUserIdFromToken(token));
+      state.reconnectGate = false;
+      render();
+    }
     markBootReady();
     wsClient = window.PokerWsClient.create({
       tableId: tableId,
@@ -3669,18 +3742,25 @@
       getAccessToken: function(){ return Promise.resolve(currentAccessToken); },
       klog: klog,
       onStatus: function(status, info){
+        if (gen !== liveModeGeneration) return;
         if (status === 'hello_ack' || status === 'minting_token' || status === 'authenticating'){
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;
           renderInfoPanel();
           renderControls();
         } else if (status === 'auth_ok'){
+          // Socket is authenticated, but the table is NOT ready until a full
+          // authoritative snapshot is applied. Do not open the recovery gate here.
           state.wsReady = true;
           state.statusText = LIVE_STATUS_COPY.live;
           state.errorText = '';
           render();
           if (pendingLeaveRetryAfterReconnect){
-            leaveAndReturnToLobby();
+            if (!state.reconnectGate) leaveAndReturnToLobby();
+            return;
+          }
+          if (state.reconnectGate){
+            startSnapshotRecovery(gen);
             return;
           }
           if (!resumePendingJoinOperation() && !rejoinSeatAfterReconnect()) autoJoinSeat();
@@ -3694,6 +3774,7 @@
           rememberSeatForReconnect();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;
+          state.reconnectGate = true;
           renderInfoPanel();
           renderControls();
         } else if (status === 'command_result') {
@@ -3701,18 +3782,27 @@
         } else if (status === 'resync'){
           cancelSettlementAnimations();
           suppressSettlementAnimationUntilAuthoritativeSnapshot = true;
+          state.reconnectGate = true;
+          renderInfoPanel();
+          renderControls();
+          if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function'){
+            wsClient.requestGameplaySnapshot();
+          }
         } else if (status === 'failed'){
+          stopSnapshotRecoveryTimer();
           cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.error;
           setError(info && info.code ? info.code : 'Live connection failed');
         } else if (status === 'error'){
+          stopSnapshotRecoveryTimer();
           cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.error;
           syncClosedTableRedirectFromSignal(info && info.code ? info.code : null);
           setError(info && info.code ? info.code : 'Live table unavailable');
         } else if (status === 'closed'){
+          stopSnapshotRecoveryTimer();
           cancelSettlementAnimations();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.disconnected;
@@ -3721,6 +3811,7 @@
         }
       },
       onSnapshot: function(snapshot){
+        if (gen !== liveModeGeneration) return;
         var payload = snapshot && snapshot.payload ? snapshot.payload : null;
         var frame = {
           kind: snapshot && typeof snapshot.kind === 'string' ? snapshot.kind : 'stateSnapshot',
@@ -3729,6 +3820,11 @@
           payload: payload
         };
         var authoritativeSnapshot = frame.kind === 'stateSnapshot' || (frame.kind === 'table_state' && frame.initial);
+        // Snapshot acceptance contract: current tableId, no version regression.
+        if (payload && payload.tableId && state.tableId && payload.tableId !== state.tableId) return;
+        var incomingVersion = Number(payload && payload.stateVersion) || 0;
+        var appliedVersion = Number(state.stateVersion) || 0;
+        if (incomingVersion > 0 && appliedVersion > 0 && incomingVersion < appliedVersion) return;
         if (authoritativeSnapshot) suppressSettlementAnimationUntilAuthoritativeSnapshot = false;
         if (shouldDeferSnapshotUntilRevealEnds(payload)){
           pendingPostRevealSnapshot = frame;
@@ -3737,7 +3833,22 @@
         }
         var previousVisual = captureVisualSnapshot();
         mergeSnapshot(payload, frame);
-        reconcileJoinOperationFromSnapshot();
+        if (authoritativeSnapshot) state.hasAppliedAuthoritativeSnapshot = true;
+        // Open the reconnect gate only after a full authoritative snapshot is merged.
+        var openedRecoveryGate = false;
+        if (authoritativeSnapshot && state.reconnectGate){
+          state.reconnectGate = false;
+          stopSnapshotRecoveryTimer();
+          openedRecoveryGate = true;
+          if (pendingLeaveRetryAfterReconnect){
+            leaveAndReturnToLobby();
+            return;
+          }
+          if (!resumePendingJoinOperation() && !rejoinSeatAfterReconnect()) autoJoinSeat();
+        }
+        // reconcileJoinOperationFromSnapshot() resets joinOperation.requestId; do not
+        // run it right after the recovery gate already started a deferred join/rejoin.
+        if (!openedRecoveryGate) reconcileJoinOperationFromSnapshot();
         maybeExecuteQueuedPreaction();
         render();
         var nextVisual = captureVisualSnapshot();
@@ -3745,6 +3856,7 @@
         autoJoinSeat();
       },
       onProtocolError: function(info){
+        if (gen !== liveModeGeneration) return;
         state.wsReady = false;
         state.statusText = LIVE_STATUS_COPY.error;
         if (info && info.code === 'missing_access_token'){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -166,6 +166,7 @@
   var liveModeGeneration = 0;
   var snapshotRecoveryTimer = null;
   var snapshotRecoveryAttempts = 0;
+  var snapshotRecoveryTimedOut = false;
   var SNAPSHOT_RECOVERY_TIMEOUT_MS = 5000;
   var SNAPSHOT_RECOVERY_MAX_ATTEMPTS = 3;
   var joinOperation = {
@@ -3642,6 +3643,7 @@
       if (gen !== liveModeGeneration) return;
       if (!state.reconnectGate) return;
       if (snapshotRecoveryAttempts >= SNAPSHOT_RECOVERY_MAX_ATTEMPTS){
+        snapshotRecoveryTimedOut = true;
         state.statusText = LIVE_STATUS_COPY.error;
         setError('Snapshot recovery timed out');
         renderInfoPanel();
@@ -3661,6 +3663,7 @@
     if (gen !== liveModeGeneration) return;
     if (!state.reconnectGate) return;
     snapshotRecoveryAttempts = 0;
+    snapshotRecoveryTimedOut = false;
     issueSnapshotRecoveryRequest(gen);
     scheduleSnapshotRecovery(gen);
   }
@@ -3848,6 +3851,13 @@
           state.reconnectGate = false;
           stopSnapshotRecoveryTimer();
           openedRecoveryGate = true;
+          if (snapshotRecoveryTimedOut){
+            // A late snapshot arrived after the bounded retries exhausted: clear only
+            // the recovery timeout status/error so the UI returns to live.
+            snapshotRecoveryTimedOut = false;
+            state.statusText = LIVE_STATUS_COPY.live;
+            if (!autoJoinErrorActive) state.errorText = '';
+          }
           if (pendingLeaveRetryAfterReconnect){
             leaveAndReturnToLobby();
             return;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -169,6 +169,7 @@
   var snapshotRecoveryTimedOut = false;
   var SNAPSHOT_RECOVERY_TIMEOUT_MS = 5000;
   var SNAPSHOT_RECOVERY_MAX_ATTEMPTS = 3;
+  var SNAPSHOT_RECOVERY_TIMEOUT_COPY = 'Snapshot recovery timed out';
   var joinOperation = {
     phase: 'idle',
     requestId: null,
@@ -1454,8 +1455,12 @@
       && state.phase === 'SETTLED';
     syncStickyWinnerReveal(liveSettlementTransition ? Date.now() + WINNER_REVEAL_MS : null);
     state.actionConstraints = normalizeConstraints(constraintsPrimary, legalSource && legalSource.actionConstraints);
-    state.statusText = LIVE_STATUS_COPY.live;
-    if (!autoJoinErrorActive) state.errorText = '';
+    // While a snapshot recovery timeout is pending, snapshots must not overwrite a
+    // newer status/error raised after the timeout; the recovery gate-open handles it.
+    if (!snapshotRecoveryTimedOut){
+      state.statusText = LIVE_STATUS_COPY.live;
+      if (!autoJoinErrorActive) state.errorText = '';
+    }
     if (pendingLeaveNavigation && !hasRenderableCurrentSeat()){
       pendingLeaveRetryAfterReconnect = false;
       pendingLeaveNavigation = false;
@@ -3645,7 +3650,7 @@
       if (snapshotRecoveryAttempts >= SNAPSHOT_RECOVERY_MAX_ATTEMPTS){
         snapshotRecoveryTimedOut = true;
         state.statusText = LIVE_STATUS_COPY.error;
-        setError('Snapshot recovery timed out');
+        setError(SNAPSHOT_RECOVERY_TIMEOUT_COPY);
         renderInfoPanel();
         renderControls();
         return;
@@ -3852,11 +3857,16 @@
           stopSnapshotRecoveryTimer();
           openedRecoveryGate = true;
           if (snapshotRecoveryTimedOut){
-            // A late snapshot arrived after the bounded retries exhausted: clear only
-            // the recovery timeout status/error so the UI returns to live.
+            // A late snapshot arrived after the bounded retries exhausted. Clear the
+            // recovery status/error ONLY if the current error is still the recovery
+            // timeout — a newer unrelated error (failed/error status, rejected async
+            // op) must not be wiped by a stale timeout flag.
+            var clearingRecoveryTimeout = state.errorText === SNAPSHOT_RECOVERY_TIMEOUT_COPY;
             snapshotRecoveryTimedOut = false;
-            state.statusText = LIVE_STATUS_COPY.live;
-            if (!autoJoinErrorActive) state.errorText = '';
+            if (clearingRecoveryTimeout){
+              state.statusText = LIVE_STATUS_COPY.live;
+              state.errorText = '';
+            }
           }
           if (pendingLeaveRetryAfterReconnect){
             leaveAndReturnToLobby();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -145,6 +145,7 @@ function createHarness(options = {}){
   const logs = [];
   const joinPayloads = [];
   const joinRequestIds = [];
+  let snapshotRequestCount = 0;
   const actPayloads = [];
   const startPayloads = [];
   const leavePayloads = [];
@@ -183,6 +184,11 @@ function createHarness(options = {}){
       leavePayloads.push(payload);
       if (typeof options.sendLeave === 'function') return options.sendLeave(payload, { attempt: leavePayloads.length });
       return Promise.resolve({ ok: true });
+    },
+    requestGameplaySnapshot(){
+      snapshotRequestCount += 1;
+      if (typeof options.requestGameplaySnapshot === 'function') return options.requestGameplaySnapshot({ attempt: snapshotRequestCount });
+      return null;
     }
   };
   if (typeof options.sendLeaveQueued === 'function' || options.enableQueuedLeave === true) {
@@ -318,6 +324,7 @@ async function flush(){
     startPayloads,
     leavePayloads,
     rebuyPayloads,
+    getSnapshotRequestCount(){ return snapshotRequestCount; },
     fireDomContentLoaded,
     fireDocumentEvent,
     flush,
@@ -3195,4 +3202,110 @@ test('poker v2 redirects to lobby on deferred leave even if the snapshot still c
 
   assert.equal(harness.windowLocation.href, '/poker/');
   if (resolveLeave) resolveLeave({ ok: true });
+});
+
+test('poker v2 snapshot recovery sends the first gameplay snapshot immediately after auth_ok with an active gate', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 40,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-recovery-immediate', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  ws.onStatus('reconnecting', { attempt: 1 });
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+
+  // First requestGameplaySnapshot must be sent immediately — no 5s delay.
+  assert.equal(harness.getSnapshotRequestCount(), 1, 'first snapshot recovery request is immediate');
+  assert.equal(harness.elements.pokerV2JoinBtn.disabled, true, 'gate still blocks actions until snapshot arrives');
+
+  // Delivering the fresh snapshot opens the gate and stops further retries.
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 41,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-recovery-immediate-2', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  harness.advanceTime(20000);
+  await harness.flush();
+  assert.equal(harness.getSnapshotRequestCount(), 1, 'no retry after gate already opened');
+});
+
+test('poker v2 resync runs bounded snapshot recovery: immediate request then max retries and controlled error', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 10,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-resync-bounded', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  ws.onStatus('resync', { reason: 'version_conflict' });
+  await harness.flush();
+
+  // resync must start bounded recovery: immediate request, not just one-shot.
+  assert.equal(harness.getSnapshotRequestCount(), 1, 'resync sends first snapshot request immediately');
+  assert.equal(harness.elements.pokerV2JoinBtn.disabled, true, 'resync gate blocks actions');
+
+  // No snapshot arrives → up to SNAPSHOT_RECOVERY_MAX_ATTEMPTS (3) retries every 5s.
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  // attempts: 1 initial + 3 retries = 4 total requests.
+  assert.equal(harness.getSnapshotRequestCount(), 4, 'bounded retries after resync');
+  // The 4th timer observes the attempt cap and raises the controlled error.
+  harness.advanceTime(5000);
+  await harness.flush();
+  assert.equal(harness.getSnapshotRequestCount(), 4, 'no request after retries exhausted');
+  assert.match(harness.elements.pokerV2LiveStatus.textContent, /error|unavailable/i, 'controlled error after retries exhausted');
 });

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -1644,6 +1644,37 @@ test('poker v2 safely rejoins the same authoritative seat after a socket reconne
   ws.onStatus('auth_ok', { roomId: 'table-1' });
   await harness.flush();
 
+  // auth_ok alone must not open the reconnect gate or trigger rejoin;
+  // the gate opens only after a fresh authoritative snapshot is merged.
+  assert.equal(harness.joinPayloads.length, 0);
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 41,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true },
+          { userId: 'user-1', seat: 4, displayName: 'Hero' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-after-reconnect', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
   assert.equal(harness.joinPayloads.length, 1);
   assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({
     tableId: 'table-1',
@@ -1694,7 +1725,37 @@ test('poker v2 retries the same reconnect seat after a transient join failure', 
   ws.onStatus('reconnecting', { attempt: 1 });
   ws.onStatus('auth_ok', { roomId: 'table-1' });
   await harness.flush();
-  assert.equal(harness.joinPayloads.length, 1);
+  // auth_ok alone must not open the reconnect gate or trigger a reconnect rejoin.
+  assert.equal(harness.joinPayloads.length, 0);
+
+  // Fresh authoritative snapshot opens the reconnect gate and triggers the first rejoin.
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 41,
+      table: {
+        tableId: 'table-1',
+        status: 'OPEN',
+        maxSeats: 6,
+        members: [
+          { userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true },
+          { userId: 'user-1', seat: 4, displayName: 'Hero' }
+        ]
+      },
+      public: {
+        hand: { handId: 'hand-reconnect-retry-2', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+  assert.equal(harness.joinPayloads.length, 1, 'reconnect rejoin attempt after snapshot opens gate');
 
   ws.onStatus('auth_ok', { roomId: 'table-1' });
   await harness.flush();
@@ -2751,6 +2812,30 @@ test('poker v2 retries leave once after stale session reconnect', async () => {
   await harness.flush();
   await harness.flush();
 
+  assert.equal(harness.leavePayloads.length, 1, 'first leave attempt fails with STALE_SESSION');
+
+  // STALE_SESSION triggers a live-mode restart; fetch the CURRENT generation's
+  // client and deliver a fresh authoritative snapshot to open the recovery gate.
+  const currentWs = harness.getCreateOptions();
+  currentWs.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 2,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: {
+        seats: [{ userId: 'user-1', seatNo: 1, status: 'ACTIVE' }],
+        hand: { handId: 'hand-leave-retry', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 4, sidePots: [] },
+        legalActions: { seat: 1, actions: ['FOLD', 'CALL'] }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
   assert.equal(harness.leavePayloads.length, 2);
   assert.equal(harness.windowLocation.href, '/poker/');
 });
@@ -2841,13 +2926,14 @@ test('poker v2 leaves cleanly before the first live snapshot even when the remov
   harness.fireDomContentLoaded();
   await harness.flush();
 
-  const ws = harness.getCreateOptions();
   confirmLeave(harness);
   await harness.flush();
 
   assert.equal(harness.leavePayloads.length, 1);
   assert.equal(harness.windowLocation.href, '', 'leave should stay pending until the client learns the seat is gone');
 
+  // Fetch the CURRENT generation's client options after the leave-retry restart.
+  const ws = harness.getCreateOptions();
   ws.onSnapshot({
     kind: 'stateSnapshot',
     payload: {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3379,3 +3379,73 @@ test('poker v2 late snapshot after recovery timeout restores live status and cle
   assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'timeout message cleared');
   assert.equal(harness.elements.pokerV2ErrorText.textContent.trim(), '', 'error text cleared');
 });
+
+test('poker v2 late snapshot does not clear a newer unrelated error raised after recovery timeout', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 10,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-newer-error', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  // Server-initiated resync triggers bounded recovery.
+  ws.onStatus('resync', { reason: 'version_conflict' });
+  await harness.flush();
+
+  // Exhaust retries and let the cap timer raise the recovery timeout.
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  assert.equal(harness.getSnapshotRequestCount(), 4, 'bounded retries exhausted');
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /Snapshot recovery timed out/);
+
+  // A NEWER unrelated error arrives before the late snapshot.
+  ws.onStatus('error', { code: 'newer_error' });
+  await harness.flush();
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /newer_error/);
+
+  // The late valid snapshot opens the gate but must NOT wipe the newer error.
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 11,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-newer-error-2', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /newer_error/, 'newer error preserved');
+  assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'old timeout message replaced by newer error');
+});

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3309,3 +3309,73 @@ test('poker v2 resync runs bounded snapshot recovery: immediate request then max
   assert.equal(harness.getSnapshotRequestCount(), 4, 'no request after retries exhausted');
   assert.match(harness.elements.pokerV2LiveStatus.textContent, /error|unavailable/i, 'controlled error after retries exhausted');
 });
+
+test('poker v2 late snapshot after recovery timeout restores live status and clears the timeout error', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 10,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-late-snapshot', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  // Server-initiated resync triggers bounded recovery.
+  ws.onStatus('resync', { reason: 'version_conflict' });
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2JoinBtn.disabled, true, 'resync gate blocks actions');
+
+  // Exhaust the retries (1 immediate + 3 retries) and let the cap timer fire the timeout.
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  harness.advanceTime(5000);
+  await harness.flush();
+  assert.equal(harness.getSnapshotRequestCount(), 4, 'bounded retries exhausted');
+  assert.match(harness.elements.pokerV2LiveStatus.textContent, /error|unavailable/i, 'timeout raised');
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /Snapshot recovery timed out/);
+
+  // A late valid authoritative snapshot arrives after the timeout.
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 11,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'bot-1', seat: 1, displayName: 'Bot 1', isBot: true }, { userId: 'user-1', seat: 4 }] },
+      public: {
+        hand: { handId: 'hand-late-snapshot-2', status: 'TURN', dealerSeatNo: 1 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 12, sidePots: [] },
+        legalActions: { seat: 4, actions: [] },
+        stacks: { 'bot-1': 100, 'user-1': 100 }
+      },
+      private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
+      you: { seat: 4 }
+    }
+  });
+  await harness.flush();
+
+  // Gate opens (status/error UI restored), even though the player is seated so
+  // the join button stays disabled for the seated state.
+  assert.match(harness.elements.pokerV2LiveStatus.textContent, /live/i, 'status back to live');
+  assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'timeout message cleared');
+  assert.equal(harness.elements.pokerV2ErrorText.textContent.trim(), '', 'error text cleared');
+});

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -157,7 +157,7 @@ function normalizePlayerState(playerState) {
   };
 }
 
-function normalizePrivateBranch(privateBranch, { userId, youSeat }) {
+export function normalizePrivateBranch(privateBranch, { userId, youSeat }) {
   const base = { userId, seat: youSeat };
   if (!privateBranch || typeof privateBranch !== "object" || Array.isArray(privateBranch)) {
     return base;

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2637,6 +2637,103 @@ test("resync message requires auth", async () => {
   }
 });
 
+test("table_state_sub without view delivers own private.holeCards and keeps patch subscription", async () => {
+  const secret = "private-sub-secret";
+  const tableId = "table_private_subscribe";
+  const hero = "private_hero";
+  const villain = "private_villain";
+  const { dir, filePath } = await writePersistedFile({
+    tables: {
+      [tableId]: {
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        seatRows: [
+          { user_id: hero, seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 },
+          { user_id: villain, seat_no: 2, status: "ACTIVE", is_bot: false, stack: 100 }
+        ],
+        stateRow: {
+          version: 11,
+          state: {
+            tableId,
+            roomId: tableId,
+            handId: "hand_private_subscribe",
+            phase: "PREFLOP",
+            dealerSeatNo: 1,
+            seats: [
+              { userId: hero, seatNo: 1, status: "ACTIVE" },
+              { userId: villain, seatNo: 2, status: "ACTIVE" }
+            ],
+            stacks: { [hero]: 100, [villain]: 100 },
+            community: [],
+            communityDealt: 0,
+            pot: 0,
+            potTotal: 0,
+            turnUserId: hero,
+            turnStartedAt: Date.now() - 500,
+            turnDeadlineAt: Date.now() + 25_000,
+            holeCardsByUserId: { [hero]: ["AS", "KD"], [villain]: ["2C", "2D"] }
+          }
+        }
+      }
+    }
+  });
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      WS_PERSISTED_STATE_FILE: filePath,
+      WS_TIMEOUT_SWEEP_MS: "60000",
+      WS_ZOMBIE_TABLE_SWEEP_MS: "60000",
+      WS_OPEN_TABLE_JANITOR_SWEEP_MS: "60000"
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const heroWs = await connectClient(port);
+    await hello(heroWs);
+    await auth(heroWs, makeHs256Jwt({ secret, sub: hero }), "auth-private-sub-hero");
+
+    // Plain table_state_sub (no view) — must subscribe AND include the private branch.
+    sendFrame(heroWs, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "sub-private-hero",
+      ts: "2026-02-28T03:00:01Z",
+      payload: { tableId }
+    });
+    const tableState = await nextMessageOfType(heroWs, "table_state");
+    assert.equal(typeof tableState.payload.private, "object");
+    assert.deepEqual(tableState.payload.private.holeCards, ["AS", "KD"]);
+    assert.equal(tableState.payload.private.userId, hero);
+    assert.equal(tableState.payload.private.seat, 1);
+    // Opponent cards must not leak into the public payload or private branch.
+    assert.equal(JSON.stringify(tableState.payload).includes('"2C"'), false);
+    assert.equal(JSON.stringify(tableState.payload).includes('"2D"'), false);
+
+    // Subscription must still deliver subsequent state updates after an accepted action.
+    const baseline = tableState.payload;
+    const stateUpdatePromise = nextStateUpdate(heroWs, { baseline, timeoutMs: 5000 });
+    sendFrame(heroWs, {
+      version: "1.0",
+      type: "act",
+      requestId: "act-private-sub-hero",
+      ts: "2026-02-28T03:00:02Z",
+      payload: { tableId, handId: "hand_private_subscribe", action: "fold" }
+    });
+    const actResult = await nextCommandResultForRequest(heroWs, "act-private-sub-hero");
+    assert.equal(actResult.payload.status, "accepted");
+    const update = await stateUpdatePromise;
+    assert.equal(Number(update.payload.stateVersion) > Number(baseline.stateVersion), true);
+
+    heroWs.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+
 test("table_state_sub snapshot view requires auth and does not leak stateSnapshot", async () => {
   const { port, child } = await createServer({ env: { WS_AUTH_REQUIRED: "1", WS_AUTH_TEST_SECRET: "test-secret" } });
 

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -28,7 +28,7 @@ import {
   matchesNonRetryableTerminalJanitorSuppression,
   runTableJanitor
 } from "./poker/runtime/table-janitor.mjs";
-import { buildStateSnapshotPayload } from "./poker/read-model/state-snapshot.mjs";
+import { buildStateSnapshotPayload, normalizePrivateBranch } from "./poker/read-model/state-snapshot.mjs";
 import { buildStatePatch } from "./poker/read-model/state-patch.mjs";
 import { createStreamLog } from "./poker/runtime/stream-log.mjs";
 import { createPersistedStateWriter } from "./poker/persistence/persisted-state-writer.mjs";
@@ -1136,7 +1136,7 @@ function maybeBroadcastLobbySnapshot({ force = false } = {}) {
   }
 }
 
-function buildTableStatePayload({ tableState, tableSnapshot }) {
+function buildTableStatePayload({ tableState, tableSnapshot, userId }) {
   const payload = {
     tableId: tableState.tableId,
     members: Array.isArray(tableState.members) ? tableState.members : []
@@ -1170,6 +1170,13 @@ function buildTableStatePayload({ tableState, tableSnapshot }) {
   if (tableSnapshot.showdown && typeof tableSnapshot.showdown === "object") payload.showdown = tableSnapshot.showdown;
   if (tableSnapshot.handSettlement && typeof tableSnapshot.handSettlement === "object") payload.handSettlement = tableSnapshot.handSettlement;
 
+  // Identyczny bezpieczny kontrakt jak buildStateSnapshotPayload:
+  // prywatny branch tylko dla siedzącego usera, hole cards przeciwników nie wyciekają.
+  const youSeat = Number.isInteger(tableSnapshot.youSeat) ? tableSnapshot.youSeat : null;
+  if (youSeat !== null && typeof userId === "string" && userId) {
+    payload.private = normalizePrivateBranch(tableSnapshot?.private, { userId, youSeat });
+  }
+
   return payload;
 }
 
@@ -1180,7 +1187,7 @@ function sendTableState(ws, connState, { requestId = null, tableState, tableSnap
     ts: nowTs(),
     roomId: tableState.tableId,
     sessionId: connState.sessionId,
-    payload: buildTableStatePayload({ tableState, tableSnapshot })
+    payload: buildTableStatePayload({ tableState, tableSnapshot, userId: connState.session.userId })
   };
 
   if (requestId) {

--- a/ws-tests/ws-lobby-join-public-snapshot.behavior.test.mjs
+++ b/ws-tests/ws-lobby-join-public-snapshot.behavior.test.mjs
@@ -3,13 +3,25 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import { adaptPersistedBootstrap } from "../ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs";
 import { createTableManager } from "../ws-server/poker/table/table-manager.mjs";
+import { normalizePrivateBranch } from "../ws-server/poker/read-model/state-snapshot.mjs";
 
 function loadBuildTableStatePayload() {
   const source = fs.readFileSync(new URL("../ws-server/server.mjs", import.meta.url), "utf8");
-  const start = source.indexOf("function buildTableStatePayload({ tableState, tableSnapshot }) {");
+  const start = source.indexOf("function buildTableStatePayload({ tableState, tableSnapshot, userId }) {");
   const end = source.indexOf("\n\nfunction sendTableState", start);
   assert.ok(start >= 0 && end > start, "buildTableStatePayload must exist in ws-server/server.mjs");
-  return new Function(`${source.slice(start, end)}; return buildTableStatePayload;`)();
+  // buildTableStatePayload references normalizePrivateBranch and its helpers from
+  // the module import — inject the real implementations so the extracted function
+  // behaves identically to production.
+  const normalizeCards = (cards) => (Array.isArray(cards) ? cards.filter((card) => typeof card === "string") : []);
+  const normalizePlayerState = (playerState) => {
+    if (!playerState || typeof playerState !== "object" || Array.isArray(playerState)) return null;
+    const allowedStatuses = new Set(["ACTIVE", "OUT_OF_CHIPS", "WAITING_NEXT_HAND"]);
+    const status = typeof playerState.status === "string" ? playerState.status.trim().toUpperCase() : "";
+    if (!allowedStatuses.has(status) || !Number.isInteger(playerState.stack) || playerState.stack < 0) return null;
+    return { status, stack: playerState.stack, canRebuy: playerState.canRebuy === true };
+  };
+  return new Function(`const normalizeCards = ${normalizeCards.toString()}; const normalizePlayerState = ${normalizePlayerState.toString()}; const normalizePrivateBranch = ${normalizePrivateBranch.toString()}; ${source.slice(start, end)}; return buildTableStatePayload;`)();
 }
 
 test("lobby/no-hand table snapshot payload includes bumped-version joined seat and stack for UI rendering", async () => {

--- a/ws-tests/ws-table-state-payload.test.mjs
+++ b/ws-tests/ws-table-state-payload.test.mjs
@@ -1,16 +1,32 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { normalizePrivateBranch } from "../ws-server/poker/read-model/state-snapshot.mjs";
 
-test("buildTableStatePayload keeps live members and emits authoritativeMembers from snapshot", () => {
+function loadBuildTableStatePayload() {
   const source = fs.readFileSync(new URL("../ws-server/server.mjs", import.meta.url), "utf8");
-  const start = source.indexOf("function buildTableStatePayload({ tableState, tableSnapshot }) {");
+  const start = source.indexOf("function buildTableStatePayload({ tableState, tableSnapshot, userId }) {");
   assert.ok(start >= 0, "buildTableStatePayload should exist");
   const end = source.indexOf("\n\nfunction sendTableState", start);
   assert.ok(end > start, "buildTableStatePayload boundary should exist");
   const fnSource = source.slice(start, end);
-  const factory = new Function(`${fnSource}; return buildTableStatePayload;`);
-  const buildTableStatePayload = factory();
+  // buildTableStatePayload references normalizePrivateBranch and its helpers from
+  // the module import — inject the real implementations so the extracted function
+  // behaves identically to production.
+  const normalizeCards = (cards) => (Array.isArray(cards) ? cards.filter((card) => typeof card === "string") : []);
+  const normalizePlayerState = (playerState) => {
+    if (!playerState || typeof playerState !== "object" || Array.isArray(playerState)) return null;
+    const allowedStatuses = new Set(["ACTIVE", "OUT_OF_CHIPS", "WAITING_NEXT_HAND"]);
+    const status = typeof playerState.status === "string" ? playerState.status.trim().toUpperCase() : "";
+    if (!allowedStatuses.has(status) || !Number.isInteger(playerState.stack) || playerState.stack < 0) return null;
+    return { status, stack: playerState.stack, canRebuy: playerState.canRebuy === true };
+  };
+  const factory = new Function(`const normalizeCards = ${normalizeCards.toString()}; const normalizePlayerState = ${normalizePlayerState.toString()}; const normalizePrivateBranch = ${normalizePrivateBranch.toString()}; ${fnSource}; return buildTableStatePayload;`);
+  return factory();
+}
+
+test("buildTableStatePayload keeps live members and emits authoritativeMembers from snapshot", () => {
+  const buildTableStatePayload = loadBuildTableStatePayload();
 
   const tableState = { tableId: "table_1", members: [{ userId: "u1", seat: 0 }] };
   const withConstraints = buildTableStatePayload({
@@ -51,12 +67,8 @@ test("buildTableStatePayload keeps live members and emits authoritativeMembers f
   assert.equal(Object.prototype.hasOwnProperty.call(noConstraints, "authoritativeMembers"), false);
 });
 
-
 test("buildTableStatePayload forwards lobby/no-hand public seats and stacks without private data", () => {
-  const source = fs.readFileSync(new URL("../ws-server/server.mjs", import.meta.url), "utf8");
-  const start = source.indexOf("function buildTableStatePayload({ tableState, tableSnapshot }) {");
-  const end = source.indexOf("\n\nfunction sendTableState", start);
-  const buildTableStatePayload = new Function(`${source.slice(start, end)}; return buildTableStatePayload;`)();
+  const buildTableStatePayload = loadBuildTableStatePayload();
 
   const payload = buildTableStatePayload({
     tableState: { tableId: "table_lobby", members: [] },
@@ -81,4 +93,80 @@ test("buildTableStatePayload forwards lobby/no-hand public seats and stacks with
   assert.deepEqual(payload.stacks, { user_joined: 175 });
   assert.equal(payload.youSeat, 2);
   assert.equal(Object.prototype.hasOwnProperty.call(payload, "private"), false);
+});
+
+test("buildTableStatePayload includes own private.holeCards when seated user is present", () => {
+  const buildTableStatePayload = loadBuildTableStatePayload();
+
+  const payload = buildTableStatePayload({
+    tableState: { tableId: "table_seated", members: [{ userId: "hero", seat: 3 }] },
+    tableSnapshot: {
+      tableId: "table_seated",
+      roomId: "table_seated",
+      stateVersion: 12,
+      youSeat: 3,
+      members: [{ userId: "hero", seat: 3 }, { userId: "villain", seat: 1 }],
+      seats: [
+        { userId: "hero", seatNo: 3, status: "ACTIVE" },
+        { userId: "villain", seatNo: 1, status: "ACTIVE" }
+      ],
+      stacks: { hero: 100, villain: 100 },
+      hand: { handId: "hand_1", status: "FLOP", round: null },
+      private: { holeCards: ["As", "Kd"] }
+    },
+    userId: "hero"
+  });
+
+  assert.deepEqual(payload.private, { userId: "hero", seat: 3, holeCards: ["As", "Kd"] });
+});
+
+test("buildTableStatePayload does not leak private branch for users without a seat", () => {
+  const buildTableStatePayload = loadBuildTableStatePayload();
+
+  // youSeat === null → no private branch at all, same contract as buildStateSnapshotPayload.
+  const observer = buildTableStatePayload({
+    tableState: { tableId: "table_obs", members: [{ userId: "villain", seat: 1 }] },
+    tableSnapshot: {
+      tableId: "table_obs",
+      stateVersion: 5,
+      youSeat: null,
+      members: [{ userId: "villain", seat: 1 }],
+      seats: [{ userId: "villain", seatNo: 1, status: "ACTIVE" }],
+      stacks: { villain: 100 },
+      private: { holeCards: ["2c", "2d"] }
+    },
+    userId: "observer"
+  });
+
+  assert.equal(Object.prototype.hasOwnProperty.call(observer, "private"), false);
+});
+
+test("buildTableStatePayload redacts opponent cards: only own holeCards in private branch", () => {
+  const buildTableStatePayload = loadBuildTableStatePayload();
+
+  const payload = buildTableStatePayload({
+    tableState: { tableId: "table_redact", members: [{ userId: "hero", seat: 2 }] },
+    tableSnapshot: {
+      tableId: "table_redact",
+      stateVersion: 9,
+      youSeat: 2,
+      members: [{ userId: "hero", seat: 2 }, { userId: "villain", seat: 4 }],
+      seats: [
+        { userId: "hero", seatNo: 2, status: "ACTIVE" },
+        { userId: "villain", seatNo: 4, status: "ACTIVE" }
+      ],
+      stacks: { hero: 80, villain: 120 },
+      hand: { handId: "hand_2", status: "TURN", round: null },
+      // Snapshot private branch is scoped by the server to the requesting user already;
+      // ensure the client payload carries only that scoped branch.
+      private: { holeCards: ["Ah", "Ad"] }
+    },
+    userId: "hero"
+  });
+
+  assert.deepEqual(payload.private.holeCards, ["Ah", "Ad"]);
+  assert.deepEqual(Object.keys(payload.private).sort(), ["holeCards", "seat", "userId"]);
+  // Opponent cards are never present anywhere in the payload.
+  assert.equal(JSON.stringify(payload).includes("villain"), true); // villain seat/member is public
+  assert.deepEqual(payload.private.userId, "hero");
 });


### PR DESCRIPTION
Closes #806, Closes #813.

## Server (#813 — private hole cards restored on reconnect)

Root cause: `table_state_sub` without `view:'snapshot'` only subscribes (server.mjs:3976-4000) and the delivered `table_state` payload was built by `buildTableStatePayload` which never included the `private` branch. After a reconnect the client subscribed but never received `private.holeCards`, so cards stayed as backs until the next action.

**Fix:** `buildTableStatePayload` now emits `payload.private` using the exact same `normalizePrivateBranch()` contract as `buildStateSnapshotPayload()` — own holeCards for the seated user only, opponents never leak. No client-side request change needed; plain subscribe now delivers the complete per-user state.

## Client (#806 — empty table after reconnect)

- **Generation guard:** `startLiveMode` captures a generation AFTER `stopLiveMode` invalidates the old one; `onStatus`/`onSnapshot`/`onProtocolError` ignore stale callbacks (covers sign-out too).
- **No empty flash:** reconnect keeps the last applied authoritative state and raises `reconnectGate` instead of rendering `createEmptyLiveState()`.
- **Gate contract:** `auth_ok` no longer opens the gate. It opens only after a full authoritative snapshot for the current `tableId` without `stateVersion` regression is merged — and only AFTER `mergeSnapshot` runs.
- **Bounded snapshot recovery:** after `auth_ok` with an active gate, `requestGameplaySnapshot()` is re-requested with a 5s timeout and max 3 attempts, then a controlled error.
- **Gate blocks programmatic paths:** `handleAction`, `autoJoinSeat`, `rejoinSeatAfterReconnect`, `resumePendingJoinOperation`, `maybeExecuteQueuedPreaction`, deferred leave retry.
- **stateVersion** tracked via `Math.max` in `mergeSnapshot`; explicit `hasAppliedAuthoritativeSnapshot` replaces the seats/phase heuristic.
- `resync` status also raises the gate and requests a gameplay snapshot.

## Tests

| Suite | Result |
|---|---|
| ws-tests/ws-table-state-payload | 5/5 (private branch, observer redaction, no leak) |
| ws-server/server.behavior | 123/123 (subscribe delivers private.holeCards + statePatch) |
| tests/poker-v2-live | 58/58 (4 reconnect tests updated to gate contract) |

Key fix during testing: `reconcileJoinOperationFromSnapshot()` resets `joinOperation.requestId` and was swallowing the rejection of an in-flight rejoin after the gate opened — now skipped when the recovery gate just opened.

## Verification

Exact-SHA WS Preview Deploy required (Netlify preview does not deploy WS changes).