### PR TITLE
Poker: enforce big-blind minimum opening bet and full-raise rules (#814)

### DIFF
--- a/netlify/functions/_shared/poker-legal-actions.mjs
+++ b/netlify/functions/_shared/poker-legal-actions.mjs
@@ -31,6 +31,18 @@ const deriveLastRaiseSize = (state, currentBet) => {
   return lastRaiseSize;
 };
 
+const deriveBigBlind = (state) => {
+  const bigBlind = toSafeInt(state?.bigBlind, 0);
+  return bigBlind > 0 ? bigBlind : 1;
+};
+
+// A player who already acted this round may RAISE only when facing at least a
+// full raise (toCall >= lastRaiseSize). Players who have not acted yet always
+// retain their option. Cumulative short all-ins are handled because toCall
+// grows while lastRaiseSize is only updated on full bets/raises.
+const canRaise = (state, userId, toCall, lastRaiseSize) =>
+  !state?.actedThisRoundByUserId?.[userId] || toCall >= lastRaiseSize;
+
 const isActivePlayer = (state, userId) => {
   if (!state || !userId) return false;
   if (state.leftTableByUserId && state.leftTableByUserId[userId]) return false;
@@ -43,21 +55,21 @@ const isActivePlayer = (state, userId) => {
 const computeLegalActions = ({ statePublic, userId } = {}) => {
   const state = statePublic || {};
   if (!state || typeof state !== "object" || Array.isArray(state)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const phase = typeof state.phase === "string" ? state.phase : "";
   if (!ACTION_PHASES.has(phase)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!userId || typeof userId !== "string") {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId : "";
   if (!turnUserId) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!isActivePlayer(state, userId)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   const stack = toSafeInt(state.stacks?.[userId], 0);
@@ -66,10 +78,10 @@ const computeLegalActions = ({ statePublic, userId } = {}) => {
   const lastRaiseSize = deriveLastRaiseSize(state, currentBet);
   const toCall = Math.max(0, currentBet - currentUserBet);
   if (stack <= 0) {
-    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (turnUserId !== userId) {
-    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   if (toCall > 0) {
@@ -77,30 +89,34 @@ const computeLegalActions = ({ statePublic, userId } = {}) => {
     const maxRaiseTo = stack + currentUserBet;
     const rawMinRaiseTo = currentBet + lastRaiseSize;
     const minRaiseTo = maxRaiseTo > 0 ? Math.min(rawMinRaiseTo, maxRaiseTo) : rawMinRaiseTo;
-    if (maxRaiseTo > currentBet) actions.push("RAISE");
+    const mayRaise = canRaise(state, userId, toCall, lastRaiseSize) && maxRaiseTo > currentBet;
+    if (mayRaise) actions.push("RAISE");
     return {
       actions,
       toCall,
-      minRaiseTo: maxRaiseTo > currentBet ? minRaiseTo : null,
+      minRaiseTo: mayRaise ? minRaiseTo : null,
       maxRaiseTo,
       maxBetAmount: null,
+      minBetAmount: null,
     };
   }
 
   const actions = ["FOLD", "CHECK"];
   if (stack > 0) actions.push("BET");
-  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack };
+  const minBetAmount = Math.min(deriveBigBlind(state), stack);
+  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack, minBetAmount };
 };
 
 const buildActionConstraints = (legalInfo) => {
   if (!legalInfo) {
-    return { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const toCall = Number.isFinite(legalInfo.toCall) ? legalInfo.toCall : null;
   const minRaiseTo = Number.isFinite(legalInfo.minRaiseTo) ? legalInfo.minRaiseTo : null;
   const maxRaiseTo = Number.isFinite(legalInfo.maxRaiseTo) ? legalInfo.maxRaiseTo : null;
   const maxBetAmount = Number.isFinite(legalInfo.maxBetAmount) ? legalInfo.maxBetAmount : null;
-  return { toCall, minRaiseTo, maxRaiseTo, maxBetAmount };
+  const minBetAmount = Number.isFinite(legalInfo.minBetAmount) ? legalInfo.minBetAmount : null;
+  return { toCall, minRaiseTo, maxRaiseTo, maxBetAmount, minBetAmount };
 };
 
 export { buildActionConstraints, computeLegalActions };

--- a/netlify/functions/_shared/poker-reducer.mjs
+++ b/netlify/functions/_shared/poker-reducer.mjs
@@ -204,6 +204,18 @@ const deriveLastRaiseSize = (state, currentBet) => {
   return lastRaiseSize;
 };
 
+const deriveBigBlind = (state) => {
+  const bigBlind = toSafeInt(state?.bigBlind, 0);
+  return bigBlind > 0 ? bigBlind : 1;
+};
+
+// A player who already acted this round may RAISE only when facing at least a
+// full raise (toCall >= lastRaiseSize). Players who have not acted yet always
+// retain their option. Cumulative short all-ins are handled because toCall
+// grows while lastRaiseSize is only updated on full bets/raises.
+const canRaise = (state, userId, toCall, lastRaiseSize) =>
+  !state?.actedThisRoundByUserId?.[userId] || toCall >= lastRaiseSize;
+
 const makeHandId = () => {
   if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
@@ -545,8 +557,9 @@ const getLegalActions = (state, userId) => {
     const raiseMax = stack + currentUserBet;
     const raiseMin = Math.min(currentBet + lastRaiseSize, raiseMax);
 
-    // Only include RAISE if it is actually possible.
-    if (raiseMax > currentBet) {
+    // Only include RAISE if it is actually possible and the player retains the
+    // right to raise (already-acted players need to face at least a full raise).
+    if (canRaise(state, userId, toCall, lastRaiseSize) && raiseMax > currentBet) {
       actions.push({ type: "RAISE", min: raiseMin, max: raiseMax });
     }
 
@@ -555,7 +568,7 @@ const getLegalActions = (state, userId) => {
   return [
     { type: "FOLD" },
     { type: "CHECK" },
-    { type: "BET", min: 1, max: stack },
+    { type: "BET", min: Math.min(deriveBigBlind(state), stack), max: stack },
   ];
 };
 
@@ -629,13 +642,17 @@ const applyAction = (state, action) => {
   } else if (action.type === "BET") {
     if (toCall > 0) throw new Error("invalid_action");
     const amount = Number(action.amount);
-    if (!Number.isFinite(amount) || amount <= 0 || amount > stack) throw new Error("invalid_action");
+    const minBetAmount = Math.min(deriveBigBlind(next), stack);
+    if (!Number.isFinite(amount) || amount < minBetAmount || amount > stack) throw new Error("invalid_action");
     next.stacks[userId] = stack - amount;
     next.betThisRoundByUserId[userId] = currentBet + amount;
     next.pot += amount;
     next.contributionsByUserId[userId] = (next.contributionsByUserId[userId] || 0) + amount;
     next.currentBet = amount;
-    next.lastRaiseSize = amount;
+    // Opening bet contract: a full opening bet sets the full-raise size to the
+    // bet amount; a short all-in opening bet must not lower the floor below the
+    // big blind.
+    next.lastRaiseSize = Math.max(deriveBigBlind(next), amount);
     next.lastAggressorUserId = userId;
     for (const seat of getActiveSeats(next)) {
       if (seat.userId !== userId) {
@@ -645,6 +662,7 @@ const applyAction = (state, action) => {
     next.toCallByUserId[userId] = 0;
   } else if (action.type === "RAISE") {
     if (toCall <= 0) throw new Error("invalid_action");
+    if (!canRaise(next, userId, toCall, roundLastRaiseSize)) throw new Error("invalid_action");
     const amount = Number(action.amount);
     const available = stack + currentBet;
     const rawMinRaiseTo = roundCurrentBet + roundLastRaiseSize;

--- a/netlify/functions/_shared/poker-reducer.mjs
+++ b/netlify/functions/_shared/poker-reducer.mjs
@@ -644,11 +644,15 @@ const applyAction = (state, action) => {
     const amount = Number(action.amount);
     const minBetAmount = Math.min(deriveBigBlind(next), stack);
     if (!Number.isFinite(amount) || amount < minBetAmount || amount > stack) throw new Error("invalid_action");
+    const nextBet = currentBet + amount;
     next.stacks[userId] = stack - amount;
-    next.betThisRoundByUserId[userId] = currentBet + amount;
+    next.betThisRoundByUserId[userId] = nextBet;
     next.pot += amount;
     next.contributionsByUserId[userId] = (next.contributionsByUserId[userId] || 0) + amount;
-    next.currentBet = amount;
+    // BET.amount is always an increment over the player's current wager; the
+    // global wager is the max (e.g. big-blind preflop option: posted 10,
+    // BET 10 -> total 20, currentBet 20).
+    next.currentBet = Math.max(roundCurrentBet, nextBet);
     // Opening bet contract: a full opening bet sets the full-raise size to the
     // bet amount; a short all-in opening bet must not lower the floor below the
     // big blind.
@@ -656,7 +660,7 @@ const applyAction = (state, action) => {
     next.lastAggressorUserId = userId;
     for (const seat of getActiveSeats(next)) {
       if (seat.userId !== userId) {
-        next.toCallByUserId[seat.userId] = amount - (next.betThisRoundByUserId[seat.userId] || 0);
+        next.toCallByUserId[seat.userId] = nextBet - (next.betThisRoundByUserId[seat.userId] || 0);
       }
     }
     next.toCallByUserId[userId] = 0;

--- a/netlify/functions/_shared/poker-start-hand-core.mjs
+++ b/netlify/functions/_shared/poker-start-hand-core.mjs
@@ -182,6 +182,7 @@ export const startHandCore = async ({
     foldedByUserId,
     contributionsByUserId,
     currentBet,
+    bigBlind: bbAmount,
     lastRaiseSize,
     lastActionRequestIdByUserId: {},
     lastStartHandRequestId: requestId || null,

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -125,6 +125,7 @@
     lastBettingRoundActionByUserId: { victor: 'call', marcus: 'raise', nico: 'fold' },
     legalActions: ['FOLD', 'CHECK', 'BET'],
     actionConstraints: { toCall: 0, maxBetAmount: 240, minRaiseTo: null, maxRaiseTo: null },
+    bigBlind: null,
     currentUserId: 'hero',
     youSeat: 3,
     statusText: LIVE_STATUS_COPY.demo,
@@ -1367,6 +1368,11 @@
 
     var nextStacks = normalizeStacks(payload);
     if (nextStacks) state.stacks = nextStacks;
+
+    // Authoritative big blind for the current hand; used to derive legal BET
+    // minimums off-turn (min(bigBlind, stack)) when minBetAmount is absent.
+    var bigBlindRaw = hasOwn(payload, 'bigBlind') ? payload.bigBlind : (hasOwn(publicObj, 'bigBlind') ? publicObj.bigBlind : undefined);
+    if (Number.isFinite(Number(bigBlindRaw)) && Number(bigBlindRaw) > 0) state.bigBlind = Math.trunc(Number(bigBlindRaw));
 
     var previousHandId = state.handId;
     var previousPhase = state.phase;
@@ -2760,9 +2766,11 @@
   function resolveAmountBounds(amountAction, stackAmount){
     if (!amountAction) return null;
     var constraints = state.actionConstraints || {};
+    var bigBlindAmount = Number.isFinite(state.bigBlind) ? Math.max(1, Math.trunc(state.bigBlind)) : null;
     var min = amountAction === 'RAISE'
       ? (Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1)
-      : (Number.isFinite(constraints.minBetAmount) ? Math.max(1, Math.trunc(constraints.minBetAmount)) : 1);
+      : (Number.isFinite(constraints.minBetAmount) ? Math.max(1, Math.trunc(constraints.minBetAmount))
+        : (bigBlindAmount != null && Number.isFinite(stackAmount) ? Math.min(bigBlindAmount, Math.max(0, Math.trunc(stackAmount))) : 1));
     var max = amountAction === 'RAISE'
       ? (Number.isFinite(constraints.maxRaiseTo) ? Math.max(min, Math.trunc(constraints.maxRaiseTo)) : null)
       : (Number.isFinite(constraints.maxBetAmount) ? Math.max(1, Math.trunc(constraints.maxBetAmount)) : stackAmount);
@@ -2790,6 +2798,13 @@
 
   function clearQueuedPreaction(){
     queuedPreaction = null;
+  }
+
+  function notifyPreactionCancelled(amountAction, bounds){
+    if (amountAction !== 'RAISE' && amountAction !== 'BET') return;
+    if (!bounds || !Number.isFinite(bounds.min)) return;
+    var noun = amountAction === 'RAISE' ? 'raise' : 'bet';
+    setError('Pre-action cancelled: minimum ' + noun + ' is now ' + Math.trunc(bounds.min) + '.');
   }
 
   function resetQueuedPreactionState(){
@@ -2842,6 +2857,7 @@
       }
       var queuedAmount = readQueuedAmount();
       if (!Number.isFinite(queuedAmount) || queuedAmount < preactionState.amountBounds.min || (preactionState.amountBounds.max != null && queuedAmount > preactionState.amountBounds.max)){
+        notifyPreactionCancelled(queuedPreaction.action, preactionState.amountBounds);
         clearQueuedPreaction();
         return;
       }
@@ -2891,6 +2907,12 @@
     var preactionPrimary = resolvePrimaryAction(projectedAllowed);
     var preactionAmountAction = resolveAmountAction(projectedAllowed);
     var preactionAllInAvailable = preactionMode && canQueueAllInPreaction();
+    // A short stack below the big blind cannot make an ordinary opening bet; the
+    // only legal opening bet is the all-in, which the ALL IN pre-action already
+    // represents. Do not offer a selectable BET amount for it.
+    if (preactionMode && preactionAmountAction === 'BET' && Number.isFinite(stackAmount) && Number.isFinite(state.bigBlind) && stackAmount < Math.trunc(state.bigBlind) && preactionAllInAvailable){
+      preactionAmountAction = null;
+    }
     var preactionAmountBounds = resolveAmountBounds(preactionAmountAction, stackAmount);
     var displayPrimary = primary || preactionPrimary || 'CHECK';
     var displayAmountAction = amountAction || preactionAmountAction || 'BET';
@@ -3237,6 +3259,12 @@
       amountBounds: resolveAmountBounds(resolveAmountAction(allowed), resolveStack(state.currentUserId))
     };
     var nextAction = resolveQueuedPreactionExecution(liveState);
+    if (!nextAction && queuedPreaction && queuedPreaction.slot === 'amount' && queuedPreaction.action === liveState.amountAction && liveState.amountBounds){
+      var queuedAmountValue = queuedPreaction.amount;
+      if (!Number.isFinite(queuedAmountValue) || queuedAmountValue < liveState.amountBounds.min || (liveState.amountBounds.max != null && queuedAmountValue > liveState.amountBounds.max)){
+        notifyPreactionCancelled(queuedPreaction.action, liveState.amountBounds);
+      }
+    }
     clearQueuedPreaction();
     if (!nextAction || !nextAction.action) return;
     queuedPreactionInFlight = true;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1374,6 +1374,19 @@
     var bigBlindRaw = hasOwn(payload, 'bigBlind') ? payload.bigBlind : (hasOwn(publicObj, 'bigBlind') ? publicObj.bigBlind : undefined);
     if (Number.isFinite(Number(bigBlindRaw)) && Number(bigBlindRaw) > 0) state.bigBlind = Math.trunc(Number(bigBlindRaw));
 
+    // Authoritative projected pre-action list for a seated off-turn viewer; the
+    // server honors reopening rights, so the browser must not re-derive RAISE
+    // availability from numeric constraints.
+    var projectedLegalSource = payload.projectedLegalActions != null ? payload.projectedLegalActions : publicObj.projectedLegalActions;
+    if (projectedLegalSource && typeof projectedLegalSource === 'object'){
+      state.projectedLegalActions = {
+        seat: Number.isInteger(projectedLegalSource.seat) ? projectedLegalSource.seat : null,
+        actions: Array.isArray(projectedLegalSource.actions)
+          ? projectedLegalSource.actions.filter((action) => typeof action === 'string')
+          : []
+      };
+    }
+
     var previousHandId = state.handId;
     var previousPhase = state.phase;
     if (typeof handObj.status === 'string' && handObj.status) state.phase = handObj.status.toUpperCase();
@@ -1641,6 +1654,14 @@
 
   function resolveProjectedAllowedActions(){
     if (!isFoldAvailable()) return [];
+    // Authoritative projected action list from the server (honors reopening
+    // rights); do not re-derive RAISE availability from numeric constraints.
+    var projected = state.projectedLegalActions;
+    if (projected && Array.isArray(projected.actions) && projected.actions.length){
+      return projected.actions.slice();
+    }
+    // Legacy fallback: reconstruct from constraints. Only a finite minRaiseTo
+    // signals raising rights; maxRaiseTo or stack never imply a raise.
     var allowed = ['FOLD'];
     var constraints = state.actionConstraints || {};
     var stackAmount = resolveStack(state.currentUserId);
@@ -1648,9 +1669,7 @@
     if (toCall > 0) allowed.push('CALL');
     else allowed.push('CHECK');
     if (toCall > 0){
-      if (Number.isFinite(constraints.maxRaiseTo) || Number.isFinite(constraints.minRaiseTo) || (Number.isFinite(stackAmount) && stackAmount > toCall)){
-        allowed.push('RAISE');
-      }
+      if (Number.isFinite(constraints.minRaiseTo)) allowed.push('RAISE');
     } else if ((Number.isFinite(constraints.maxBetAmount) && Math.max(0, Math.trunc(constraints.maxBetAmount)) > 0) || (Number.isFinite(stackAmount) && stackAmount > 0)){
       allowed.push('BET');
     }

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1376,15 +1376,22 @@
 
     // Authoritative projected pre-action list for a seated off-turn viewer; the
     // server honors reopening rights, so the browser must not re-derive RAISE
-    // availability from numeric constraints.
-    var projectedLegalSource = payload.projectedLegalActions != null ? payload.projectedLegalActions : publicObj.projectedLegalActions;
-    if (projectedLegalSource && typeof projectedLegalSource === 'object'){
-      state.projectedLegalActions = {
-        seat: Number.isInteger(projectedLegalSource.seat) ? projectedLegalSource.seat : null,
-        actions: Array.isArray(projectedLegalSource.actions)
-          ? projectedLegalSource.actions.filter((action) => typeof action === 'string')
-          : []
-      };
+    // availability from numeric constraints. Field presence (not list length)
+    // is authoritative: an intentionally empty projected list must not fall
+    // back to browser reconstruction.
+    var projectedLegalPresent = hasOwn(payload, 'projectedLegalActions') || hasOwn(publicObj, 'projectedLegalActions');
+    if (projectedLegalPresent){
+      var projectedLegalSource = payload.projectedLegalActions != null ? payload.projectedLegalActions : publicObj.projectedLegalActions;
+      state.projectedLegalActions = (projectedLegalSource && typeof projectedLegalSource === 'object')
+        ? {
+            seat: Number.isInteger(projectedLegalSource.seat) ? projectedLegalSource.seat : null,
+            actions: Array.isArray(projectedLegalSource.actions)
+              ? projectedLegalSource.actions.filter((action) => typeof action === 'string')
+              : []
+          }
+        : { seat: null, actions: [] };
+    } else {
+      state.projectedLegalActions = undefined;
     }
 
     var previousHandId = state.handId;
@@ -1655,10 +1662,11 @@
   function resolveProjectedAllowedActions(){
     if (!isFoldAvailable()) return [];
     // Authoritative projected action list from the server (honors reopening
-    // rights); do not re-derive RAISE availability from numeric constraints.
+    // rights). Field presence decides authority: an intentionally empty list
+    // means no pre-actions and must NOT fall back to browser reconstruction.
     var projected = state.projectedLegalActions;
-    if (projected && Array.isArray(projected.actions) && projected.actions.length){
-      return projected.actions.slice();
+    if (projected !== undefined && projected !== null){
+      return Array.isArray(projected.actions) ? projected.actions.slice() : [];
     }
     // Legacy fallback: reconstruct from constraints. Only a finite minRaiseTo
     // signals raising rights; maxRaiseTo or stack never imply a raise.
@@ -2777,11 +2785,6 @@
     return null;
   }
 
-  function canQueueAllInPreaction(){
-    var stackAmount = resolveStack(state.currentUserId);
-    return stackAmount == null || stackAmount > 0;
-  }
-
   function resolveAmountBounds(amountAction, stackAmount){
     if (!amountAction) return null;
     var constraints = state.actionConstraints || {};
@@ -2925,7 +2928,11 @@
     var projectedAllowed = preactionMode ? resolveProjectedAllowedActions() : [];
     var preactionPrimary = resolvePrimaryAction(projectedAllowed);
     var preactionAmountAction = resolveAmountAction(projectedAllowed);
-    var preactionAllInAvailable = preactionMode && canQueueAllInPreaction();
+    // Off-turn ALL IN availability follows the authoritative projected actions
+    // (CALL all-in when stack <= toCall, RAISE/BET all-in when those are legal);
+    // a positive stack alone never implies an all-in.
+    var preactionAllInPlan = preactionMode ? resolveAllInPlan(projectedAllowed) : null;
+    var preactionAllInAvailable = !!preactionAllInPlan;
     // A short stack below the big blind cannot make an ordinary opening bet; the
     // only legal opening bet is the all-in, which the ALL IN pre-action already
     // represents. Do not offer a selectable BET amount for it.

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -975,7 +975,8 @@
       toCall: raw.toCall != null ? Number(raw.toCall) : null,
       minRaiseTo: raw.minRaiseTo != null ? Number(raw.minRaiseTo) : null,
       maxRaiseTo: raw.maxRaiseTo != null ? Number(raw.maxRaiseTo) : null,
-      maxBetAmount: raw.maxBetAmount != null ? Number(raw.maxBetAmount) : null
+      maxBetAmount: raw.maxBetAmount != null ? Number(raw.maxBetAmount) : null,
+      minBetAmount: raw.minBetAmount != null ? Number(raw.minBetAmount) : null
     };
   }
 
@@ -2759,7 +2760,9 @@
   function resolveAmountBounds(amountAction, stackAmount){
     if (!amountAction) return null;
     var constraints = state.actionConstraints || {};
-    var min = amountAction === 'RAISE' && Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1;
+    var min = amountAction === 'RAISE'
+      ? (Number.isFinite(constraints.minRaiseTo) ? Math.max(1, Math.trunc(constraints.minRaiseTo)) : 1)
+      : (Number.isFinite(constraints.minBetAmount) ? Math.max(1, Math.trunc(constraints.minBetAmount)) : 1);
     var max = amountAction === 'RAISE'
       ? (Number.isFinite(constraints.maxRaiseTo) ? Math.max(min, Math.trunc(constraints.maxRaiseTo)) : null)
       : (Number.isFinite(constraints.maxBetAmount) ? Math.max(1, Math.trunc(constraints.maxBetAmount)) : stackAmount);

--- a/tests/poker-reducer.test.mjs
+++ b/tests/poker-reducer.test.mjs
@@ -836,6 +836,61 @@ const run = async () => {
     assert.ok(advanced.events.some((event) => event.type === "HAND_RESET"));
   }
 
+  {
+    // Big-blind minimum opening bet, full-raise contract and reopening rights.
+    const { seats, stacks } = makeBase();
+    const { state } = initHandState({ tableId: "t-bb-min", seats, stacks, rng: makeRng(31) });
+    const flop = {
+      ...state,
+      phase: "FLOP",
+      community: ["3H", "4H", "5H"],
+      communityDealt: 3,
+      turnUserId: "user-1",
+      currentBet: 0,
+      lastRaiseSize: 10,
+      bigBlind: 10,
+      toCallByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+      betThisRoundByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+      actedThisRoundByUserId: { "user-1": false, "user-2": false, "user-3": false },
+      foldedByUserId: { "user-1": false, "user-2": false, "user-3": false },
+    };
+
+    const betAction = getLegalActions(flop, "user-1").find((action) => action.type === "BET");
+    assert.equal(betAction.min, 10);
+    assert.equal(betAction.max, 100);
+
+    assert.throws(
+      () => applyAction(flop, { type: "BET", userId: "user-1", amount: 1 }),
+      (error) => error?.message === "invalid_action"
+    );
+
+    const betResult = applyAction(flop, { type: "BET", userId: "user-1", amount: 10 });
+    assert.equal(betResult.state.currentBet, 10);
+    assert.equal(betResult.state.lastRaiseSize, 10);
+    assert.equal(betResult.state.betThisRoundByUserId["user-1"], 10);
+
+    // A player with a stack below the big blind may only bet all-in.
+    const shortFlop = { ...flop, turnUserId: "user-2", stacks: { ...flop.stacks, "user-2": 3 } };
+    const shortBetAction = getLegalActions(shortFlop, "user-2").find((action) => action.type === "BET");
+    assert.equal(shortBetAction.min, 3);
+    assert.equal(shortBetAction.max, 3);
+    const shortAllIn = applyAction(shortFlop, { type: "BET", userId: "user-2", amount: 3 });
+    assert.equal(shortAllIn.state.betThisRoundByUserId["user-2"], 3);
+    assert.equal(shortAllIn.state.lastRaiseSize, 10);
+
+    // A short all-in raise does not reopen RAISE for already-acted players.
+    let reopened = applyAction(flop, { type: "BET", userId: "user-1", amount: 10 }).state;
+    reopened = applyAction(reopened, { type: "CALL", userId: "user-2" }).state;
+    reopened = applyAction({ ...reopened, stacks: { ...reopened.stacks, "user-3": 13 } }, { type: "RAISE", userId: "user-3", amount: 13 }).state;
+    assert.equal(reopened.currentBet, 13);
+    assert.equal(reopened.lastRaiseSize, 10);
+    assert.deepEqual(getLegalActions(reopened, "user-1").map((action) => action.type), ["FOLD", "CALL"]);
+    assert.throws(
+      () => applyAction(reopened, { type: "RAISE", userId: "user-1", amount: 25 }),
+      (error) => error?.message === "invalid_action"
+    );
+  }
+
 };
 
 await run();

--- a/tests/poker-reducer.test.mjs
+++ b/tests/poker-reducer.test.mjs
@@ -891,6 +891,34 @@ const run = async () => {
     );
   }
 
+  {
+    // Big-blind preflop option: BET is an increment over the posted blind and
+    // must raise the global currentBet to the new total.
+    const { seats, stacks } = makeBase();
+    const { state } = initHandState({ tableId: "t-bb-option", seats, stacks, rng: makeRng(32) });
+    const preflop = {
+      ...state,
+      phase: "PREFLOP",
+      turnUserId: "user-1",
+      currentBet: 10,
+      lastRaiseSize: 10,
+      bigBlind: 10,
+      toCallByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+      betThisRoundByUserId: { "user-1": 10, "user-2": 10, "user-3": 10 },
+      actedThisRoundByUserId: { "user-1": false, "user-2": true, "user-3": true },
+      foldedByUserId: { "user-1": false, "user-2": false, "user-3": false },
+      stacks: { "user-1": 90, "user-2": 90, "user-3": 90 },
+    };
+
+    const betResult = applyAction(preflop, { type: "BET", userId: "user-1", amount: 10 });
+    assert.equal(betResult.state.betThisRoundByUserId["user-1"], 20);
+    assert.equal(betResult.state.currentBet, 20);
+    assert.equal(betResult.state.lastRaiseSize, 10);
+    assert.equal(betResult.state.stacks["user-1"], 80);
+    assert.equal(betResult.state.toCallByUserId["user-2"], 10);
+    assert.equal(betResult.state.toCallByUserId["user-3"], 10);
+  }
+
 };
 
 await run();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3604,30 +3604,11 @@ test('poker v2 keeps the BET slider minimum across turns in the same hand', asyn
   assert.ok(Number.isFinite(laterValue) && laterValue >= 10, 'later BET turn slider value must stay within the legal range');
 });
 
-test('queued BET pre-action outside the authoritative range is cancelled and never sent', async () => {
+test('queued BET pre-action is cancelled when the authoritative minimum rises above it', async () => {
   const { harness, ws } = await bootSeatedHarness();
 
-  // Another player's turn; the current snapshot lacks minBetAmount (legacy/stale
-  // server shape), so the pre-action slider still allows 1.
-  ws.onSnapshot(amountSnapshot({
-    handId: 'hand-queued-bet',
-    phase: 'FLOP',
-    board: ['As', 'Kd', '3h'],
-    potTotal: 42,
-    actions: ['FOLD', 'CHECK', 'BET'],
-    constraints: { toCall: 0, maxBetAmount: 100 },
-    stateVersion: 10,
-    turnUserId: 'villain-1'
-  }));
-  await harness.flush();
-
-  assert.equal(harness.elements.pokerV2AmountPreaction.disabled, false, 'BET pre-action should be available off-turn');
-  harness.elements.pokerV2AmountInput.value = '1';
-  harness.elements.pokerV2AmountPreaction.click();
-  await harness.flush();
-  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued BET should be selected');
-
-  // Authoritative turn arrives: BET legal with minBetAmount=10, maxBetAmount=100.
+  // Another player's turn; the projected constraints (real server path) give
+  // the viewer a legal BET range of 10..100, so the slider cannot offer 1.
   ws.onSnapshot(amountSnapshot({
     handId: 'hand-queued-bet',
     phase: 'FLOP',
@@ -3635,39 +3616,42 @@ test('queued BET pre-action outside the authoritative range is cancelled and nev
     potTotal: 42,
     actions: ['FOLD', 'CHECK', 'BET'],
     constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
-    stateVersion: 11
-  }));
-  await harness.flush();
-
-  assert.equal(harness.actPayloads.length, 0, 'out-of-range queued BET must never be sent');
-  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued BET must be cancelled when the stored amount is out of range');
-  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'slider must sync back to the authoritative minimum');
-  assert.equal(harness.elements.pokerV2AmountBtn.disabled, false, 'normal BET controls must remain active');
-});
-
-test('queued RAISE pre-action outside the authoritative range is cancelled and never sent', async () => {
-  const { harness, ws } = await bootSeatedHarness();
-
-  // Another player's turn facing a bet; the snapshot lacks minRaiseTo, so the
-  // pre-action slider still allows 1.
-  ws.onSnapshot(amountSnapshot({
-    handId: 'hand-queued-raise',
-    phase: 'TURN',
-    board: ['As', 'Kd', '3h', '2c'],
-    potTotal: 60,
-    actions: ['FOLD', 'CALL', 'RAISE'],
-    constraints: { toCall: 10, maxRaiseTo: 90 },
-    stateVersion: 12,
+    stateVersion: 10,
     turnUserId: 'villain-1'
   }));
   await harness.flush();
 
-  harness.elements.pokerV2AmountInput.value = '1';
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'projected BET minimum must be legal off-turn');
+  assert.equal(harness.elements.pokerV2AmountPreaction.disabled, false, 'BET pre-action should be available off-turn');
+  harness.elements.pokerV2AmountInput.value = '20';
   harness.elements.pokerV2AmountPreaction.click();
   await harness.flush();
-  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued RAISE should be selected');
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued BET 20 should be selected');
 
-  // Authoritative turn arrives: RAISE legal with minRaiseTo=20, maxRaiseTo=90.
+  // Authoritative turn arrives with a higher minimum: the queued 20 is illegal.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-bet',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 30, maxBetAmount: 100 },
+    stateVersion: 11
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0, 'illegal queued BET must never be sent');
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued BET must be cancelled when the stored amount is out of range');
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /Pre-action cancelled: minimum bet is now 30\./, 'cancellation message must be shown');
+  assert.equal(harness.elements.pokerV2AmountInput.min, '30', 'slider must sync back to the authoritative minimum');
+  assert.equal(harness.elements.pokerV2AmountBtn.disabled, false, 'normal BET controls must remain active');
+});
+
+test('queued RAISE pre-action is cancelled when the authoritative minimum rises above it', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // Another player's turn facing a bet; the projected constraints (real server
+  // path) give the viewer a legal RAISE range of 20..90.
   ws.onSnapshot(amountSnapshot({
     handId: 'hand-queued-raise',
     phase: 'TURN',
@@ -3675,13 +3659,56 @@ test('queued RAISE pre-action outside the authoritative range is cancelled and n
     potTotal: 60,
     actions: ['FOLD', 'CALL', 'RAISE'],
     constraints: { toCall: 10, minRaiseTo: 20, maxRaiseTo: 90 },
+    stateVersion: 12,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '20', 'projected RAISE minimum must be legal off-turn');
+  harness.elements.pokerV2AmountInput.value = '50';
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued RAISE 50 should be selected');
+
+  // Authoritative turn arrives with a higher minimum: the queued 50 is illegal.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 80, maxRaiseTo: 90 },
     stateVersion: 13
   }));
   await harness.flush();
 
-  assert.equal(harness.actPayloads.length, 0, 'out-of-range queued RAISE must never be sent');
+  assert.equal(harness.actPayloads.length, 0, 'illegal queued RAISE must never be sent');
   assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued RAISE must be cancelled when the stored amount is out of range');
-  assert.equal(harness.elements.pokerV2AmountInput.min, '20', 'slider must sync back to the authoritative raise minimum');
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /Pre-action cancelled: minimum raise is now 80\./, 'cancellation message must be shown');
+  assert.equal(harness.elements.pokerV2AmountInput.min, '80', 'slider must sync back to the authoritative raise minimum');
+});
+
+test('off-turn RAISE slider minimum comes from the projected snapshot constraints, never 1', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // The exact projected payload the room-core snapshot now emits for a seated
+  // viewer who is not acting: real toCall/minRaiseTo/maxRaiseTo.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-proj',
+    phase: 'PREFLOP',
+    board: [],
+    potTotal: 6,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 2, minRaiseTo: 6, maxRaiseTo: 100, maxBetAmount: null, minBetAmount: null },
+    bigBlind: 2,
+    stateVersion: 20,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '6', 'off-turn RAISE min must be the real projected minimum raise-to');
+  const raiseValue = Number(harness.elements.pokerV2AmountInput.value);
+  assert.ok(raiseValue >= 6, 'off-turn RAISE slider value must stay within the legal range');
 });
 
 test('off-turn BET slider minimum comes from the big blind, never 1', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3450,7 +3450,7 @@ test('poker v2 late snapshot does not clear a newer unrelated error raised after
   assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'old timeout message replaced by newer error');
 });
 
-function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion, turnUserId = 'user-1' }){
+function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion, turnUserId = 'user-1', bigBlind = null, stacks }){
   return {
     kind: 'stateSnapshot',
     payload: {
@@ -3462,7 +3462,8 @@ function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, 
         turn: { userId: turnUserId, deadlineAt: Date.now() + 5000 },
         board,
         pot: { total: potTotal, sidePots: [] },
-        stacks: { 'user-1': 100 },
+        stacks: stacks || { 'user-1': 100 },
+        ...(bigBlind != null ? { bigBlind } : {}),
         legalActions: { seat: 1, actions },
         actionConstraints: constraints
       },
@@ -3681,4 +3682,122 @@ test('queued RAISE pre-action outside the authoritative range is cancelled and n
   assert.equal(harness.actPayloads.length, 0, 'out-of-range queued RAISE must never be sent');
   assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued RAISE must be cancelled when the stored amount is out of range');
   assert.equal(harness.elements.pokerV2AmountInput.min, '20', 'slider must sync back to the authoritative raise minimum');
+});
+
+test('off-turn BET slider minimum comes from the big blind, never 1', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // Another player's turn; constraints carry no minBetAmount, so the BET min
+  // must be derived from the authoritative bigBlind (10), not a generic 1.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-bb-min',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, maxBetAmount: 100 },
+    bigBlind: 10,
+    stateVersion: 14,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'off-turn BET min must be the big blind when minBetAmount is absent');
+});
+
+test('short stack below the big blind is represented as all-in off-turn', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // 7 CH with BB=10: an ordinary opening BET is impossible; the legal bet is
+  // the all-in, so the ALL IN pre-action represents it and the BET amount
+  // pre-action must not offer an ordinary selectable range.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-bb-short',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, maxBetAmount: 7 },
+    bigBlind: 10,
+    stacks: { 'user-1': 7 },
+    stateVersion: 15,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountPreaction.disabled, true, 'ordinary BET pre-action must not be offered below the big blind');
+  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, false, 'all-in pre-action must represent the short-stack bet');
+});
+
+test('queued RAISE 100 executes unchanged when the live range becomes 80..200', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-ok',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 50, maxRaiseTo: 200 },
+    stateVersion: 16,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  harness.elements.pokerV2AmountInput.value = '100';
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued RAISE 100 should be selected');
+
+  // Turn arrives: minimum raise is now 80, but 100 is still legal.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-ok',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 80, maxRaiseTo: 200 },
+    stateVersion: 17
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 1);
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-raise-ok', action: 'RAISE', amount: 100 }), 'legal queued amount must execute unchanged');
+});
+
+test('queued RAISE 100 is cancelled with a message when the live minimum becomes 120', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-cancel',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 50, maxRaiseTo: 200 },
+    stateVersion: 18,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  harness.elements.pokerV2AmountInput.value = '100';
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued RAISE 100 should be selected');
+
+  // Turn arrives: minimum raise is now 120, so the queued 100 is illegal.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-cancel',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 120, maxRaiseTo: 200 },
+    stateVersion: 19
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0, 'cancelled queued RAISE must never be sent (no silent 100->120)');
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued RAISE must be cancelled');
+  assert.match(harness.elements.pokerV2ErrorText.textContent, /Pre-action cancelled: minimum raise is now 120\./, 'cancellation message must be shown');
 });

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -1143,6 +1143,7 @@ test('poker v2 keeps action buttons stable while exposing single-select preactio
         hand: { handId: 'hand-stable-controls-off-turn', status: 'TURN', dealerSeatNo: 2 },
         turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 18, sidePots: [] },
+        stacks: { 'user-1': 100, 'villain-1': 80 },
         legalActions: { seat: 1, actions: [] },
         actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 120 }
       },
@@ -1258,7 +1259,7 @@ test('poker v2 auto-executes a queued preaction without moving the live action b
   assert.equal(harness.elements.pokerV2AllInBtn.hidden, false);
 });
 
-test('poker v2 queues all-in intent without pre-turn raise limits and resolves it from live turn constraints', async () => {
+test('poker v2 queues all-in intent from projected actions and resolves it from live turn constraints', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();
   await harness.flush();
@@ -1283,7 +1284,8 @@ test('poker v2 queues all-in intent without pre-turn raise limits and resolves i
         turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 18, sidePots: [] },
         legalActions: { seat: 1, actions: ['FOLD'] },
-        actionConstraints: { toCall: 6, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 100, maxBetAmount: null },
+        projectedLegalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
         stacks: { 'user-1': 100, 'villain-1': 80 }
       },
       private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
@@ -1353,7 +1355,8 @@ test('poker v2 clears queued all-in intent when the live turn has no legal all-i
         turn: { userId: 'villain-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 18, sidePots: [] },
         legalActions: { seat: 1, actions: ['FOLD'] },
-        actionConstraints: { toCall: 6, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+        actionConstraints: { toCall: 6, minRaiseTo: 18, maxRaiseTo: 100, maxBetAmount: null },
+        projectedLegalActions: { seat: 1, actions: ['FOLD', 'CALL', 'RAISE'] },
         stacks: { 'user-1': 100, 'villain-1': 80 }
       },
       private: { holeCards: [{ r: 'A', s: 'S' }, { r: 'K', s: 'S' }] },
@@ -3854,22 +3857,12 @@ test('off-turn RAISE stays disabled when the server projection withholds raising
 
   assert.equal(harness.elements.pokerV2AmountPreaction.disabled, true, 'RAISE pre-action must stay disabled without reopening rights');
 
-  // ALL IN cannot bypass the closed raising rights either.
+  // ALL IN cannot bypass the closed raising rights: with stack (90) above
+  // toCall (5) and no RAISE/BET in the projection, an all-in would be an
+  // illegal raise to 90, so the pre-action must be disabled and unqueueable.
+  assert.equal(harness.elements.pokerV2AllInPreaction.disabled, true, 'ALL IN pre-action must be disabled when it would be an illegal raise');
   harness.elements.pokerV2AllInPreaction.click();
   await harness.flush();
-  assert.equal(harness.elements.pokerV2AllInPreaction.checked, true, 'ALL IN pre-action should be queueable');
-
-  ws.onSnapshot(amountSnapshot({
-    handId: 'hand-no-raise',
-    phase: 'TURN',
-    board: ['As', 'Kd', 'Qc', '3h'],
-    potTotal: 60,
-    actions: ['FOLD', 'CALL'],
-    constraints: { toCall: 5, minRaiseTo: null, maxRaiseTo: 110, maxBetAmount: null, minBetAmount: null },
-    stateVersion: 22
-  }));
-  await harness.flush();
-
-  assert.equal(harness.actPayloads.length, 0, 'ALL IN must not bypass closed raising rights');
-  assert.equal(harness.elements.pokerV2AllInPreaction.checked, false, 'queued ALL IN must be cancelled at turn arrival');
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, false, 'ALL IN must not be queueable');
+  assert.equal(harness.actPayloads.length, 0, 'no action may be sent from the disabled pre-actions');
 });

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3449,3 +3449,115 @@ test('poker v2 late snapshot does not clear a newer unrelated error raised after
   assert.match(harness.elements.pokerV2ErrorText.textContent, /newer_error/, 'newer error preserved');
   assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'old timeout message replaced by newer error');
 });
+
+function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion }){
+  return {
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: {
+        hand: { handId, status: phase, dealerSeatNo: 2 },
+        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        board,
+        pot: { total: potTotal, sidePots: [] },
+        stacks: { 'user-1': 100 },
+        legalActions: { seat: 1, actions },
+        actionConstraints: constraints
+      },
+      private: { holeCards: [{ r: 'Q', s: 'S' }, { r: 'Q', s: 'D' }] },
+      you: { seat: 1 }
+    }
+  };
+}
+
+async function bootSeatedHarness(){
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  await waitFor(() => harness.elements.pokerV2JoinBtn.disabled === false);
+  harness.elements.pokerV2SeatNo.value = '1';
+  harness.elements.pokerV2JoinBtn.click();
+  await harness.flush();
+  return { harness, ws };
+}
+
+test('poker v2 amount slider reflects BET constraints (minBetAmount/maxBetAmount)', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-bet-min',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 4
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'BET slider min should come from actionConstraints.minBetAmount');
+  assert.equal(harness.elements.pokerV2AmountInput.max, '100', 'BET slider max should come from actionConstraints.maxBetAmount');
+  const betValue = Number(harness.elements.pokerV2AmountInput.value);
+  assert.ok(Number.isFinite(betValue) && betValue >= 10 && betValue <= 100, 'BET slider value should stay within the legal range');
+});
+
+test('poker v2 amount slider reflects RAISE constraints (minRaiseTo/maxRaiseTo)', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-raise-min',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 20, maxRaiseTo: 90 },
+    stateVersion: 5
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '20', 'RAISE slider min should come from actionConstraints.minRaiseTo');
+  assert.equal(harness.elements.pokerV2AmountInput.max, '90', 'RAISE slider max should come from actionConstraints.maxRaiseTo');
+  const raiseValue = Number(harness.elements.pokerV2AmountInput.value);
+  assert.ok(Number.isFinite(raiseValue) && raiseValue >= 20 && raiseValue <= 90, 'RAISE slider value should stay within the legal range');
+});
+
+test('poker v2 amount button sends the selected legal boundary amount', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-amount-bet',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 6
+  }));
+  await harness.flush();
+
+  harness.elements.pokerV2AmountInput.value = '10';
+  harness.elements.pokerV2AmountBtn.click();
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 1);
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-amount-bet', action: 'BET', amount: 10 }));
+
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-amount-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 20, maxRaiseTo: 90 },
+    stateVersion: 7
+  }));
+  await harness.flush();
+
+  harness.elements.pokerV2AmountInput.value = '90';
+  harness.elements.pokerV2AmountBtn.click();
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 2);
+  assert.equal(JSON.stringify(harness.actPayloads[1]), JSON.stringify({ handId: 'hand-amount-raise', action: 'RAISE', amount: 90 }));
+});

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3450,7 +3450,7 @@ test('poker v2 late snapshot does not clear a newer unrelated error raised after
   assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'old timeout message replaced by newer error');
 });
 
-function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion, turnUserId = 'user-1', bigBlind = null, stacks }){
+function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion, turnUserId = 'user-1', bigBlind = null, stacks, projectedActions = null }){
   return {
     kind: 'stateSnapshot',
     payload: {
@@ -3464,6 +3464,7 @@ function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, 
         pot: { total: potTotal, sidePots: [] },
         stacks: stacks || { 'user-1': 100 },
         ...(bigBlind != null ? { bigBlind } : {}),
+        ...(projectedActions ? { projectedLegalActions: { seat: 1, actions: projectedActions } } : {}),
         legalActions: { seat: 1, actions },
         actionConstraints: constraints
       },
@@ -3827,4 +3828,48 @@ test('queued RAISE 100 is cancelled with a message when the live minimum becomes
   assert.equal(harness.actPayloads.length, 0, 'cancelled queued RAISE must never be sent (no silent 100->120)');
   assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued RAISE must be cancelled');
   assert.match(harness.elements.pokerV2ErrorText.textContent, /Pre-action cancelled: minimum raise is now 120\./, 'cancellation message must be shown');
+});
+
+test('off-turn RAISE stays disabled when the server projection withholds raising rights', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // Real projected room-core payload: the viewer already acted, lastRaiseSize
+  // is 10, a cumulative short all-in left toCall 5, and reopening rights are
+  // closed -> projectedLegalActions has no RAISE and minRaiseTo is null while
+  // maxRaiseTo stays numeric.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-no-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', 'Qc', '3h'],
+    potTotal: 60,
+    actions: ['FOLD'],
+    constraints: { toCall: 5, minRaiseTo: null, maxRaiseTo: 110, maxBetAmount: null, minBetAmount: null },
+    projectedActions: ['FOLD', 'CALL'],
+    bigBlind: 10,
+    stacks: { 'user-1': 90 },
+    stateVersion: 21,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountPreaction.disabled, true, 'RAISE pre-action must stay disabled without reopening rights');
+
+  // ALL IN cannot bypass the closed raising rights either.
+  harness.elements.pokerV2AllInPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, true, 'ALL IN pre-action should be queueable');
+
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-no-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', 'Qc', '3h'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL'],
+    constraints: { toCall: 5, minRaiseTo: null, maxRaiseTo: 110, maxBetAmount: null, minBetAmount: null },
+    stateVersion: 22
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0, 'ALL IN must not bypass closed raising rights');
+  assert.equal(harness.elements.pokerV2AllInPreaction.checked, false, 'queued ALL IN must be cancelled at turn arrival');
 });

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3561,3 +3561,44 @@ test('poker v2 amount button sends the selected legal boundary amount', async ()
   assert.equal(harness.actPayloads.length, 2);
   assert.equal(JSON.stringify(harness.actPayloads[1]), JSON.stringify({ handId: 'hand-amount-raise', action: 'RAISE', amount: 90 }));
 });
+
+test('poker v2 keeps the BET slider minimum across turns in the same hand', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // First BET turn: constraints carry minBetAmount=10.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-multiturn',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 8
+  }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'first BET turn slider min should be minBetAmount');
+
+  // The user submits a legal boundary bet.
+  harness.elements.pokerV2AmountInput.value = '10';
+  harness.elements.pokerV2AmountBtn.click();
+  await harness.flush();
+  assert.equal(harness.actPayloads.length, 1);
+  assert.equal(JSON.stringify(harness.actPayloads[0]), JSON.stringify({ handId: 'hand-multiturn', action: 'BET', amount: 10 }));
+
+  // Subsequent snapshots from other players/street lead to another BET turn for
+  // the same user in the same hand; the slider must keep the server minimum.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-multiturn',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 62,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 9
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'later BET turn must keep minBetAmount');
+  const laterValue = Number(harness.elements.pokerV2AmountInput.value);
+  assert.ok(Number.isFinite(laterValue) && laterValue >= 10, 'later BET turn slider value must stay within the legal range');
+});

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -3450,7 +3450,7 @@ test('poker v2 late snapshot does not clear a newer unrelated error raised after
   assert.equal(harness.elements.pokerV2ErrorText.textContent.indexOf('Snapshot recovery timed out'), -1, 'old timeout message replaced by newer error');
 });
 
-function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion }){
+function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, stateVersion, turnUserId = 'user-1' }){
   return {
     kind: 'stateSnapshot',
     payload: {
@@ -3459,7 +3459,7 @@ function amountSnapshot({ handId, phase, board, potTotal, actions, constraints, 
       table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
       public: {
         hand: { handId, status: phase, dealerSeatNo: 2 },
-        turn: { userId: 'user-1', deadlineAt: Date.now() + 5000 },
+        turn: { userId: turnUserId, deadlineAt: Date.now() + 5000 },
         board,
         pot: { total: potTotal, sidePots: [] },
         stacks: { 'user-1': 100 },
@@ -3601,4 +3601,84 @@ test('poker v2 keeps the BET slider minimum across turns in the same hand', asyn
   assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'later BET turn must keep minBetAmount');
   const laterValue = Number(harness.elements.pokerV2AmountInput.value);
   assert.ok(Number.isFinite(laterValue) && laterValue >= 10, 'later BET turn slider value must stay within the legal range');
+});
+
+test('queued BET pre-action outside the authoritative range is cancelled and never sent', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // Another player's turn; the current snapshot lacks minBetAmount (legacy/stale
+  // server shape), so the pre-action slider still allows 1.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-bet',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, maxBetAmount: 100 },
+    stateVersion: 10,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2AmountPreaction.disabled, false, 'BET pre-action should be available off-turn');
+  harness.elements.pokerV2AmountInput.value = '1';
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued BET should be selected');
+
+  // Authoritative turn arrives: BET legal with minBetAmount=10, maxBetAmount=100.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-bet',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 11
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0, 'out-of-range queued BET must never be sent');
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued BET must be cancelled when the stored amount is out of range');
+  assert.equal(harness.elements.pokerV2AmountInput.min, '10', 'slider must sync back to the authoritative minimum');
+  assert.equal(harness.elements.pokerV2AmountBtn.disabled, false, 'normal BET controls must remain active');
+});
+
+test('queued RAISE pre-action outside the authoritative range is cancelled and never sent', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // Another player's turn facing a bet; the snapshot lacks minRaiseTo, so the
+  // pre-action slider still allows 1.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, maxRaiseTo: 90 },
+    stateVersion: 12,
+    turnUserId: 'villain-1'
+  }));
+  await harness.flush();
+
+  harness.elements.pokerV2AmountInput.value = '1';
+  harness.elements.pokerV2AmountPreaction.click();
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, true, 'queued RAISE should be selected');
+
+  // Authoritative turn arrives: RAISE legal with minRaiseTo=20, maxRaiseTo=90.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-queued-raise',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 20, maxRaiseTo: 90 },
+    stateVersion: 13
+  }));
+  await harness.flush();
+
+  assert.equal(harness.actPayloads.length, 0, 'out-of-range queued RAISE must never be sent');
+  assert.equal(harness.elements.pokerV2AmountPreaction.checked, false, 'queued RAISE must be cancelled when the stored amount is out of range');
+  assert.equal(harness.elements.pokerV2AmountInput.min, '20', 'slider must sync back to the authoritative raise minimum');
 });

--- a/ws-server/poker/engine/engine-act.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-act.behavior.test.mjs
@@ -418,3 +418,81 @@ test("engine legality gate rejects invalid bet amount with no mutation", () => {
   assert.equal(invalidBet.stateVersion, coreState.version);
   assert.equal(invalidBet.coreState, coreState);
 });
+
+test("engine bootstraps a 5/10 hand with bigBlind persisted in state", () => {
+  const boot = bootstrapCoreStateHand({
+    tableId: "table_engine_act",
+    coreState: initialCore(),
+    nowMs: 8_000,
+    stakes: { sb: 5, bb: 10 }
+  });
+  assert.equal(boot.ok, true);
+  assert.equal(boot.coreState.pokerState.bigBlind, 10);
+  assert.equal(boot.coreState.pokerState.lastRaiseSize, 10);
+});
+
+test("engine rejects a flop opening bet below the big blind without mutation", () => {
+  let coreState = bootstrapCoreStateHand({
+    tableId: "table_engine_act",
+    coreState: initialCore(),
+    nowMs: 8_100,
+    stakes: { sb: 5, bb: 10 }
+  }).coreState;
+
+  const preflopCall = applyCoreStateAction({
+    tableId: "table_engine_act",
+    coreState,
+    handId: coreState.pokerState.handId,
+    userId: "user_a",
+    action: "CALL",
+    nowIso: new Date(8_101).toISOString(),
+    nowMs: 8_101
+  });
+  assert.equal(preflopCall.accepted, true);
+  coreState = preflopCall.coreState;
+
+  const preflopCheck = applyCoreStateAction({
+    tableId: "table_engine_act",
+    coreState,
+    handId: coreState.pokerState.handId,
+    userId: "user_b",
+    action: "CHECK",
+    nowIso: new Date(8_102).toISOString(),
+    nowMs: 8_102
+  });
+  assert.equal(preflopCheck.accepted, true);
+  coreState = preflopCheck.coreState;
+  assert.equal(coreState.pokerState.phase, "FLOP");
+
+  const bettor = coreState.pokerState.turnUserId;
+  const versionBefore = coreState.version;
+
+  const below = applyCoreStateAction({
+    tableId: "table_engine_act",
+    coreState,
+    handId: coreState.pokerState.handId,
+    userId: bettor,
+    action: "BET",
+    amount: 1,
+    nowIso: new Date(8_103).toISOString(),
+    nowMs: 8_103
+  });
+  assert.equal(below.accepted, false);
+  assert.equal(below.reason, "invalid_amount");
+  assert.equal(below.stateVersion, versionBefore);
+  assert.equal(below.coreState, coreState);
+
+  const atBb = applyCoreStateAction({
+    tableId: "table_engine_act",
+    coreState,
+    handId: coreState.pokerState.handId,
+    userId: bettor,
+    action: "BET",
+    amount: 10,
+    nowIso: new Date(8_103).toISOString(),
+    nowMs: 8_103
+  });
+  assert.equal(atBb.accepted, true);
+  assert.equal(atBb.coreState.pokerState.currentBet, 10);
+  assert.equal(atBb.coreState.pokerState.lastRaiseSize, 10);
+});

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -185,6 +185,7 @@ export function buildBootstrappedPokerState({
     potTotal: sbPosted + bbPosted,
     sidePots: [],
     currentBet,
+    bigBlind,
     lastRaiseSize: bigBlind,
     stacks,
     toCallByUserId,
@@ -576,7 +577,8 @@ export function applyCoreStateAction({ tableId, coreState, handId, userId, actio
   if (normalizedAction === "BET") {
     const betAmount = toInt(amount);
     const maxBetAmount = Number(legalInfo.maxBetAmount ?? 0);
-    if (!Number.isInteger(betAmount) || betAmount < 1 || betAmount > maxBetAmount) {
+    const minBetAmount = Number(legalInfo.minBetAmount ?? 1);
+    if (!Number.isInteger(betAmount) || betAmount < minBetAmount || betAmount > maxBetAmount) {
       return { ok: true, accepted: false, changed: false, reason: "invalid_amount", stateVersion: coreState.version, coreState };
     }
     if (!Number.isFinite(stack) || betAmount > stack) {

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -679,3 +679,51 @@ test("projectRoomCoreSnapshot derives OUT_OF_CHIPS, canRebuy, and WAITING_NEXT_H
   assert.equal(waiting.seats.find((seat) => seat.userId === "human")?.status, "WAITING_NEXT_HAND");
   assert.deepEqual(waiting.private.playerState, { status: "WAITING_NEXT_HAND", stack: 100, canRebuy: false });
 });
+
+test("projectRoomCoreSnapshot projects no raise for a viewer who already acted without reopening rights", () => {
+  const coreState = {
+    seats: { viewer: 1, player_b: 2, player_c: 3 },
+    publicStacks: { viewer: 90, player_b: 80, player_c: 70 },
+    pokerState: {
+      roomId: "table_proj_closed_raise",
+      handId: "hand_proj_closed_raise",
+      phase: "TURN",
+      turnUserId: "player_c",
+      community: ["AS", "KD", "QC", "3H"],
+      potTotal: 60,
+      bigBlind: 10,
+      currentBet: 25,
+      lastRaiseSize: 10,
+      stacks: { viewer: 90, player_b: 80, player_c: 70 },
+      betThisRoundByUserId: { viewer: 20, player_b: 25, player_c: 25 },
+      toCallByUserId: { viewer: 5, player_b: 0, player_c: 0 },
+      actedThisRoundByUserId: { viewer: true, player_b: true, player_c: true },
+      foldedByUserId: { viewer: false, player_b: false, player_c: false },
+      leftTableByUserId: { viewer: false, player_b: false, player_c: false },
+      sitOutByUserId: { viewer: false, player_b: false, player_c: false },
+      holeCardsByUserId: { viewer: ["AH", "AD"], player_b: ["2C", "2D"], player_c: ["3C", "3D"] },
+      handSeed: "sensitive",
+      deck: []
+    }
+  };
+
+  const snapshot = projectRoomCoreSnapshot({
+    tableId: "table_proj_closed_raise",
+    roomId: "table_proj_closed_raise",
+    coreState,
+    members: [
+      { userId: "viewer", seat: 1 },
+      { userId: "player_b", seat: 2 },
+      { userId: "player_c", seat: 3 }
+    ],
+    userId: "viewer",
+    youSeat: 1
+  });
+
+  // Viewer already acted; toCall 5 < lastRaiseSize 10 -> no reopening.
+  assert.deepEqual(snapshot.projectedLegalActions, { seat: 1, actions: ["FOLD", "CALL"] }, "projected actions must not include RAISE");
+  assert.equal(snapshot.actionConstraints.toCall, 5);
+  assert.equal(snapshot.actionConstraints.minRaiseTo, null, "minRaiseTo must be null without raising rights");
+  assert.equal(snapshot.actionConstraints.maxRaiseTo, 110, "maxRaiseTo may stay numeric without implying a raise");
+  assert.deepEqual(snapshot.legalActions.actions, ["FOLD"], "current-turn legalActions keep their semantics");
+});

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -1,4 +1,4 @@
-import { computeSharedLegalActions } from "../shared/poker-primitives.mjs";
+import { computeProjectedLegalActions, computeSharedLegalActions } from "../shared/poker-primitives.mjs";
 import { normalizePublicPokerIdentity } from "./public-poker-identity.mjs";
 
 function asObject(value) {
@@ -361,9 +361,17 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
   const turnSeat = Number.isInteger(seatByUserId[turnUserId]) ? seatByUserId[turnUserId] : null;
   const turnIdentity = resolveTurnIdentity({ statePublic, turnUserId, turnSeat });
   const turnTimer = resolveTurnTimer({ statePublic, turnUserId: turnIdentity.userId });
+  const isTurnPlayer = Number.isInteger(effectiveYouSeat) && turnUserId === userId;
   const legalInfo = Number.isInteger(effectiveYouSeat)
     ? computeSharedLegalActions({ statePublic, userId })
     : { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  // For a seated viewer who is not acting, expose the projected pre-action
+  // amount constraints (real toCall/minRaiseTo/minBetAmount from the same
+  // authoritative rules) instead of nulls, so the client never falls back to
+  // an invented 1 CH minimum for a queued BET/RAISE.
+  const constraintsInfo = Number.isInteger(effectiveYouSeat) && !isTurnPlayer
+    ? computeProjectedLegalActions({ statePublic, userId })
+    : legalInfo;
 
   const snapshot = {
     roomId: typeof statePublic.roomId === "string" ? statePublic.roomId : roomId || tableId,
@@ -394,11 +402,11 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
       actions: Number.isInteger(effectiveYouSeat) ? normalizeActions(legalInfo.actions) : []
     },
     actionConstraints: {
-      toCall: Number.isFinite(legalInfo.toCall) ? legalInfo.toCall : null,
-      minRaiseTo: Number.isFinite(legalInfo.minRaiseTo) ? legalInfo.minRaiseTo : null,
-      maxRaiseTo: Number.isFinite(legalInfo.maxRaiseTo) ? legalInfo.maxRaiseTo : null,
-      maxBetAmount: Number.isFinite(legalInfo.maxBetAmount) ? legalInfo.maxBetAmount : null,
-      minBetAmount: Number.isFinite(legalInfo.minBetAmount) ? legalInfo.minBetAmount : null
+      toCall: Number.isFinite(constraintsInfo.toCall) ? constraintsInfo.toCall : null,
+      minRaiseTo: Number.isFinite(constraintsInfo.minRaiseTo) ? constraintsInfo.minRaiseTo : null,
+      maxRaiseTo: Number.isFinite(constraintsInfo.maxRaiseTo) ? constraintsInfo.maxRaiseTo : null,
+      maxBetAmount: Number.isFinite(constraintsInfo.maxBetAmount) ? constraintsInfo.maxBetAmount : null,
+      minBetAmount: Number.isFinite(constraintsInfo.minBetAmount) ? constraintsInfo.minBetAmount : null
     },
     betThisRoundByUserId: normalizeNumericUserMap(statePublic.betThisRoundByUserId),
     committedByUserId: normalizeNumericUserMap(statePublic.committedByUserId),

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -362,7 +362,7 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
   const turnTimer = resolveTurnTimer({ statePublic, turnUserId: turnIdentity.userId });
   const legalInfo = Number.isInteger(effectiveYouSeat)
     ? computeSharedLegalActions({ statePublic, userId })
-    : { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    : { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
 
   const snapshot = {
     roomId: typeof statePublic.roomId === "string" ? statePublic.roomId : roomId || tableId,
@@ -395,7 +395,8 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
       toCall: Number.isFinite(legalInfo.toCall) ? legalInfo.toCall : null,
       minRaiseTo: Number.isFinite(legalInfo.minRaiseTo) ? legalInfo.minRaiseTo : null,
       maxRaiseTo: Number.isFinite(legalInfo.maxRaiseTo) ? legalInfo.maxRaiseTo : null,
-      maxBetAmount: Number.isFinite(legalInfo.maxBetAmount) ? legalInfo.maxBetAmount : null
+      maxBetAmount: Number.isFinite(legalInfo.maxBetAmount) ? legalInfo.maxBetAmount : null,
+      minBetAmount: Number.isFinite(legalInfo.minBetAmount) ? legalInfo.minBetAmount : null
     },
     betThisRoundByUserId: normalizeNumericUserMap(statePublic.betThisRoundByUserId),
     committedByUserId: normalizeNumericUserMap(statePublic.committedByUserId),

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -320,6 +320,7 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
       roomId,
       seats: publicSeats,
       stacks: publicStacks,
+      bigBlind: null,
       hand: {
         handId: null,
         status: members.length > 0 ? "LOBBY" : "EMPTY",
@@ -368,6 +369,7 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
     roomId: typeof statePublic.roomId === "string" ? statePublic.roomId : roomId || tableId,
     seats: publicSeats,
     stacks: publicStacks,
+    bigBlind: Number.isInteger(statePublic?.bigBlind) && statePublic.bigBlind > 0 ? statePublic.bigBlind : null,
     hand: {
       handId: typeof statePublic.handId === "string" && statePublic.handId.trim() ? statePublic.handId : null,
       status: typeof statePublic.phase === "string" ? statePublic.phase : null,

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -344,6 +344,10 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
         seat: null,
         actions: []
       },
+      projectedLegalActions: {
+        seat: null,
+        actions: []
+      },
       betThisRoundByUserId: {},
       committedByUserId: {},
       private: Number.isInteger(effectiveYouSeat)
@@ -401,6 +405,13 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
       seat: Number.isInteger(effectiveYouSeat) ? effectiveYouSeat : null,
       actions: Number.isInteger(effectiveYouSeat) ? normalizeActions(legalInfo.actions) : []
     },
+    // Authoritative pre-action action list for a seated viewer who is not
+    // acting (e.g. RAISE presence honors reopening rights); empty for the
+    // current actor and observers. The browser uses this instead of inferring
+    // raising rights from numeric constraints.
+    projectedLegalActions: Number.isInteger(effectiveYouSeat) && !isTurnPlayer
+      ? { seat: effectiveYouSeat, actions: normalizeActions(constraintsInfo.actions) }
+      : { seat: null, actions: [] },
     actionConstraints: {
       toCall: Number.isFinite(constraintsInfo.toCall) ? constraintsInfo.toCall : null,
       minRaiseTo: Number.isFinite(constraintsInfo.minRaiseTo) ? constraintsInfo.minRaiseTo : null,

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -499,3 +499,32 @@ test("buildStateSnapshotPayload keeps next-hand timer metadata and omits stale t
   assert.equal("showdown" in payload.public, false);
   assert.equal("handSettlement" in payload.public, false);
 });
+
+test("buildStateSnapshotPayload keeps minBetAmount for a later BET turn in the same hand", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const wsA = {};
+  const wsB = {};
+  const tableId = "table_bet_min_live";
+
+  assert.equal(tableManager.join({ ws: wsA, userId: "user_a", tableId, requestId: "join-a" }).ok, true);
+  assert.equal(tableManager.join({ ws: wsB, userId: "user_b", tableId, requestId: "join-b" }).ok, true);
+  assert.equal(tableManager.bootstrapHand(tableId).ok, true);
+
+  const preflopHandId = tableManager.tableSnapshot(tableId, "user_a").hand.handId;
+  assert.equal(typeof preflopHandId, "string");
+
+  // First turn: user_a calls preflop, user_b checks -> FLOP, action returns to
+  // user_a with a legal opening BET on the flop.
+  const callA = tableManager.applyAction({ tableId, handId: preflopHandId, userId: "user_a", requestId: "a-call", action: "CALL" });
+  assert.equal(callA.accepted, true);
+  const checkB = tableManager.applyAction({ tableId, handId: preflopHandId, userId: "user_b", requestId: "b-check", action: "CHECK" });
+  assert.equal(checkB.accepted, true);
+  assert.equal(tableManager.tableSnapshot(tableId, "user_b").hand.status, "FLOP");
+
+  const snapshot = tableManager.tableSnapshot(tableId, "user_a");
+  const payload = buildStateSnapshotPayload({ tableSnapshot: snapshot, userId: "user_a" });
+
+  assert.equal(payload.public.turn.userId, "user_a");
+  assert.ok(payload.public.legalActions.actions.includes("BET"));
+  assert.equal(payload.public.actionConstraints.minBetAmount, 2, "live BET turn must keep minBetAmount from legalInfo");
+});

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -239,7 +239,7 @@ test("buildStateSnapshotPayload projects bootstrapped PREFLOP state from table m
     { userId: "user_b", seatNo: 2, status: "ACTIVE" }
   ]);
   assert.deepEqual(seatedPayload.public.legalActions, { seat: 1, actions: ["FOLD", "CALL", "RAISE"] });
-  assert.deepEqual(seatedPayload.public.actionConstraints, { toCall: 1, minRaiseTo: 4, maxRaiseTo: 100, maxBetAmount: null });
+  assert.deepEqual(seatedPayload.public.actionConstraints, { toCall: 1, minRaiseTo: 4, maxRaiseTo: 100, maxBetAmount: null, minBetAmount: null });
   assert.deepEqual(seatedPayload.public.betThisRoundByUserId, { user_a: 1, user_b: 2 });
   assert.deepEqual(seatedPayload.public.committedByUserId, {});
   assert.deepEqual(seatedPayload.public.lastBettingRoundActionByUserId, {});
@@ -249,7 +249,7 @@ test("buildStateSnapshotPayload projects bootstrapped PREFLOP state from table m
   assert.deepEqual(observerPayload.public, {
     ...seatedPayload.public,
     legalActions: { seat: null, actions: [] },
-    actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null }
+    actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null }
   });
   assert.equal(seatedPayload.table.memberCount, seatedPayload.table.members.length);
 });
@@ -275,7 +275,7 @@ test("buildStateSnapshotPayload keeps committed chips distinct from current-roun
       pot: { total: 23, sidePots: [] },
       turn: { userId: "user_a", seat: 1, startedAt: null, deadlineAt: null },
       legalActions: { seat: 1, actions: ["CHECK"] },
-      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null },
       private: { holeCards: ["AS", "AD"] }
     }
   });
@@ -302,7 +302,7 @@ test("buildStateSnapshotPayload serializes last betting-round action labels", ()
       pot: { total: 14, sidePots: [] },
       turn: { userId: "user_b", seat: 2, startedAt: 1710000000000, deadlineAt: 1710000015000 },
       legalActions: { seat: 1, actions: ["FOLD", "CALL"] },
-      actionConstraints: { toCall: 4, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      actionConstraints: { toCall: 4, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null },
       lastBettingRoundActionByUserId: { user_a: "call", user_b: "raise", ignored: "bad" },
       private: { holeCards: ["AS", "AD"] }
     }
@@ -333,7 +333,7 @@ test("buildStateSnapshotPayload serializes folded seat statuses for live table s
       pot: { total: 14, sidePots: [] },
       turn: { userId: "user_b", seat: 2, startedAt: 1710000000000, deadlineAt: 1710000015000 },
       legalActions: { seat: 1, actions: [] },
-      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null },
       private: { holeCards: ["AS", "AD"] }
     }
   });
@@ -359,7 +359,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
       pot: { total: 0, sidePots: [] },
       turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
       legalActions: { seat: 1, actions: [] },
-      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null },
       private: { holeCards: ["AS", "AD"] },
       showdown: {
         handId: "h_terminal",
@@ -381,7 +381,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
   assert.deepEqual(payload.public.showdown.revealedShowdownParticipants, [{ userId: "user_a", holeCards: ["AS", "AD"] }]);
   assert.equal(payload.public.showdown.potAwardedTotal, 5);
   assert.deepEqual(payload.public.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
-  assert.deepEqual(payload.public.actionConstraints, { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null });
+  assert.deepEqual(payload.public.actionConstraints, { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null });
   assert.deepEqual(payload.public.handSettlement.payouts, { user_a: 5 });
   assert.deepEqual(payload.private, { userId: "user_a", seat: 1, holeCards: ["AS", "AD"] });
 });
@@ -401,7 +401,7 @@ test("buildStateSnapshotPayload omits revealed showdown participant cards for al
       pot: { total: 0, sidePots: [] },
       turn: { userId: null, seat: null, startedAt: null, deadlineAt: null },
       legalActions: { seat: 1, actions: [] },
-      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null },
       showdown: {
         handId: "h_terminal_folded",
         winners: ["user_a"],

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -528,3 +528,30 @@ test("buildStateSnapshotPayload keeps minBetAmount for a later BET turn in the s
   assert.ok(payload.public.legalActions.actions.includes("BET"));
   assert.equal(payload.public.actionConstraints.minBetAmount, 2, "live BET turn must keep minBetAmount from legalInfo");
 });
+
+test("buildStateSnapshotPayload exposes projected RAISE minimum for a seated viewer who is not acting", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const ws = {};
+  const tableId = "table_proj_raise";
+
+  for (const [index, userId] of ["user_a", "user_b", "user_c"].entries()) {
+    assert.equal(tableManager.join({ ws, userId, tableId, requestId: "join-" + index }).ok, true);
+  }
+  assert.equal(tableManager.bootstrapHand(tableId).ok, true);
+  const handId = tableManager.tableSnapshot(tableId, "user_a").hand.handId;
+  assert.equal(typeof handId, "string");
+
+  // Advance preflop until another player (user_c) is acting while user_a is a
+  // seated viewer who already faces a call.
+  assert.equal(tableManager.applyAction({ tableId, handId, userId: "user_a", requestId: "a-call", action: "CALL" }).accepted, true);
+  assert.equal(tableManager.applyAction({ tableId, handId, userId: "user_b", requestId: "b-raise", action: "RAISE", amount: 4 }).accepted, true);
+
+  const snapshot = tableManager.tableSnapshot(tableId, "user_a");
+  const payload = buildStateSnapshotPayload({ tableSnapshot: snapshot, userId: "user_a" });
+
+  assert.equal(payload.public.turn.userId, "user_c", "another player must be acting");
+  assert.deepEqual(payload.public.legalActions.actions, ["FOLD"], "legalActions must keep current-turn semantics");
+  assert.equal(payload.public.actionConstraints.toCall, 2, "viewer toCall must be the real viewer call amount");
+  assert.equal(payload.public.actionConstraints.minRaiseTo, 6, "projected raise minimum must be the real minimum raise-to, not null or 1");
+  assert.equal(payload.public.actionConstraints.maxRaiseTo, 100, "projected raise maximum must be the real all-in amount");
+});

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -216,6 +216,7 @@ export function buildStateSnapshotPayload({ tableSnapshot, userId, publicProfile
       },
       seats: normalizeSeatRows(tableSnapshot?.seats, { publicProfileStorageBaseUrl }),
       stacks: normalizeStacks(tableSnapshot?.stacks),
+      bigBlind: Number.isInteger(tableSnapshot?.bigBlind) && tableSnapshot.bigBlind > 0 ? tableSnapshot.bigBlind : null,
       betThisRoundByUserId: normalizeNumericUserMap(tableSnapshot?.betThisRoundByUserId),
       committedByUserId: normalizeNumericUserMap(tableSnapshot?.committedByUserId),
       pot: {

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -233,6 +233,10 @@ export function buildStateSnapshotPayload({ tableSnapshot, userId, publicProfile
         seat: normalizeSeat(tableSnapshot?.legalActions?.seat),
         actions: normalizeActionList(tableSnapshot?.legalActions?.actions)
       },
+      projectedLegalActions: {
+        seat: normalizeSeat(tableSnapshot?.projectedLegalActions?.seat),
+        actions: normalizeActionList(tableSnapshot?.projectedLegalActions?.actions)
+      },
       actionConstraints: {
         toCall: Number.isFinite(tableSnapshot?.actionConstraints?.toCall) ? Number(tableSnapshot.actionConstraints.toCall) : null,
         minRaiseTo: Number.isFinite(tableSnapshot?.actionConstraints?.minRaiseTo) ? Number(tableSnapshot.actionConstraints.minRaiseTo) : null,

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -236,7 +236,8 @@ export function buildStateSnapshotPayload({ tableSnapshot, userId, publicProfile
         toCall: Number.isFinite(tableSnapshot?.actionConstraints?.toCall) ? Number(tableSnapshot.actionConstraints.toCall) : null,
         minRaiseTo: Number.isFinite(tableSnapshot?.actionConstraints?.minRaiseTo) ? Number(tableSnapshot.actionConstraints.minRaiseTo) : null,
         maxRaiseTo: Number.isFinite(tableSnapshot?.actionConstraints?.maxRaiseTo) ? Number(tableSnapshot.actionConstraints.maxRaiseTo) : null,
-        maxBetAmount: Number.isFinite(tableSnapshot?.actionConstraints?.maxBetAmount) ? Number(tableSnapshot.actionConstraints.maxBetAmount) : null
+        maxBetAmount: Number.isFinite(tableSnapshot?.actionConstraints?.maxBetAmount) ? Number(tableSnapshot.actionConstraints.maxBetAmount) : null,
+        minBetAmount: Number.isFinite(tableSnapshot?.actionConstraints?.minBetAmount) ? Number(tableSnapshot.actionConstraints.minBetAmount) : null
       },
       lastBettingRoundActionByUserId: normalizeLastBettingRoundActionByUserId(tableSnapshot?.lastBettingRoundActionByUserId)
     }

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs
@@ -234,6 +234,53 @@ test("accepted bot autoplay enriches legal bet with a positive amount", async ()
   assert.equal(observed.action.amount > 0, true);
 });
 
+test("accepted bot autoplay bets the server-provided big-blind minimum", async () => {
+  const observed = { action: null };
+  const state = {
+    version: 2,
+    tableId: "t-bb-min",
+    handId: "h-bb-min",
+    phase: "FLOP",
+    turnUserId: "bot_2",
+    seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true }],
+    stacks: { human_1: 100, bot_2: 100 },
+    holeCardsByUserId: { bot_2: ["AS", "AD"] },
+    community: ["3H", "4H", "5H"],
+    communityDealt: 3,
+    deck: ["6S", "7S", "8S", "9S", "TS"],
+    currentBet: 0,
+    lastRaiseSize: 10,
+    bigBlind: 10,
+    toCallByUserId: { bot_2: 0, human_1: 0 },
+    betThisRoundByUserId: { bot_2: 0, human_1: 0 },
+    actedThisRoundByUserId: { bot_2: false, human_1: true },
+    foldedByUserId: { bot_2: false, human_1: false }
+  };
+  const tableManager = {
+    persistedPokerState: () => ({ ...state }),
+    persistedStateVersion: () => 2,
+    tableSnapshot: () => ({ seats: [{ userId: "human_1", seatNo: 1 }, { userId: "bot_2", seatNo: 2, isBot: true, botProfile: "NORMAL" }] }),
+    applyAction: ({ action, amount }) => {
+      observed.action = { action, amount };
+      return { accepted: true, changed: true, replayed: false, stateVersion: 3 };
+    }
+  };
+
+  const run = createAcceptedBotAutoplayExecutor({
+    tableManager,
+    random: () => 0,
+    persistMutatedState: async () => ({ ok: true }),
+    restoreTableFromPersisted: async () => ({ ok: true }),
+    broadcastResyncRequired: () => {},
+    klog: () => {}
+  });
+
+  const result = await run({ tableId: "t-bb-min", trigger: "act", requestId: "r-bb-min" });
+  assert.equal(result.ok, true);
+  assert.equal(observed.action?.action, "BET");
+  assert.equal(observed.action?.amount, 10);
+});
+
 test("accepted bot autoplay enriches legal raise with a positive amount", async () => {
   const observed = { action: null };
   const state = {

--- a/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
+++ b/ws-server/poker/runtime/accepted-bot-autoplay-adapter.mjs
@@ -148,9 +148,12 @@ function enrichBotLegalActions(legalInfo = {}) {
   const minRaiseTo = Number(legalInfo?.minRaiseTo);
   const maxRaiseTo = Number(legalInfo?.maxRaiseTo);
   const maxBetAmount = Number(legalInfo?.maxBetAmount);
+  const minBetAmount = Number(legalInfo?.minBetAmount);
   const normalizedMinRaiseTo = Number.isFinite(minRaiseTo) ? Math.trunc(minRaiseTo) : null;
   const normalizedMaxRaiseTo = Number.isFinite(maxRaiseTo) ? Math.trunc(maxRaiseTo) : null;
   const normalizedMaxBetAmount = Number.isFinite(maxBetAmount) ? Math.trunc(maxBetAmount) : null;
+  const normalizedMinBetAmount = Number.isFinite(minBetAmount) ? Math.trunc(minBetAmount) : null;
+  const botMinBet = normalizedMinBetAmount > 0 ? normalizedMinBetAmount : 1;
   return actions.map((action) => {
     const type = typeof action === "string"
       ? action.toUpperCase()
@@ -158,9 +161,9 @@ function enrichBotLegalActions(legalInfo = {}) {
     if (type === "BET" && normalizedMaxBetAmount > 0) {
       return {
         type: "BET",
-        min: 1,
-        minAmount: 1,
-        amount: 1,
+        min: botMinBet,
+        minAmount: botMinBet,
+        amount: botMinBet,
         max: normalizedMaxBetAmount,
         maxAmount: normalizedMaxBetAmount
       };

--- a/ws-server/poker/shared/poker-action-reducer.behavior.test.mjs
+++ b/ws-server/poker/shared/poker-action-reducer.behavior.test.mjs
@@ -550,3 +550,246 @@ test("applyAction rejects invalid actor/phase/amount deterministically", () => {
   assert.equal(invalidAmount.ok, false);
   assert.equal(invalidAmount.reason, "invalid_amount");
 });
+
+// ---------------------------------------------------------------------------
+// Big-blind minimum opening bet, full-raise contract and reopening rights
+// (Issue #814). Fixtures model a 5/10 table: bigBlind = 10.
+// ---------------------------------------------------------------------------
+
+function bbFlop(overrides = {}) {
+  return {
+    roomId: "table_bb",
+    handId: "h_bb",
+    phase: "FLOP",
+    dealerSeatNo: 1,
+    turnUserId: "a",
+    seats: [
+      { userId: "a", seatNo: 1 },
+      { userId: "b", seatNo: 2 },
+      { userId: "c", seatNo: 3 }
+    ],
+    community: ["3H", "4H", "5H"],
+    communityDealt: 3,
+    deck: ["6S", "7S", "8S", "9S", "TS"],
+    potTotal: 30,
+    sidePots: [],
+    currentBet: 0,
+    lastRaiseSize: 10,
+    bigBlind: 10,
+    stacks: { a: 100, b: 100, c: 100 },
+    toCallByUserId: { a: 0, b: 0, c: 0 },
+    betThisRoundByUserId: { a: 0, b: 0, c: 0 },
+    actedThisRoundByUserId: { a: false, b: false, c: false },
+    foldedByUserId: { a: false, b: false, c: false },
+    contributionsByUserId: { a: 10, b: 10, c: 10 },
+    holeCardsByUserId: { a: ["AS", "KD"], b: ["2C", "2D"], c: ["3C", "3D"] },
+    ...overrides
+  };
+}
+
+test("BET below the big blind is rejected; BET at the big blind is accepted", () => {
+  const legal = computeSharedLegalActions({ statePublic: bbFlop(), userId: "a" });
+  assert.deepEqual(legal.actions, ["FOLD", "CHECK", "BET"]);
+  assert.equal(legal.minBetAmount, 10);
+  assert.equal(legal.maxBetAmount, 100);
+
+  const below = applyAction({ pokerState: bbFlop(), userId: "a", action: "BET", amount: 1 });
+  assert.equal(below.ok, false);
+  assert.equal(below.reason, "invalid_amount");
+
+  const atBb = applyAction({ pokerState: bbFlop(), userId: "a", action: "BET", amount: 10 });
+  assert.equal(atBb.ok, true);
+  assert.equal(atBb.state.currentBet, 10);
+  assert.equal(atBb.state.lastRaiseSize, 10);
+});
+
+test("a player with a stack below the big blind may bet all-in only", () => {
+  const short = bbFlop({ turnUserId: "c", stacks: { a: 100, b: 100, c: 3 } });
+  const legal = computeSharedLegalActions({ statePublic: short, userId: "c" });
+  assert.equal(legal.minBetAmount, 3);
+  assert.equal(legal.maxBetAmount, 3);
+
+  const rejected = applyAction({ pokerState: short, userId: "c", action: "BET", amount: 2 });
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.reason, "invalid_amount");
+
+  const allIn = applyAction({ pokerState: short, userId: "c", action: "BET", amount: 3 });
+  assert.equal(allIn.ok, true);
+  assert.equal(allIn.state.betThisRoundByUserId.c, 3);
+  assert.equal(allIn.state.lastRaiseSize, 10);
+});
+
+test("BB preflop option: BET is an increment over the posted blind", () => {
+  // 5/10 preflop: dealer a, sb b (posted 5), bb c (posted 10); everyone called,
+  // action is back on the big blind with toCall = 0.
+  const preflop = {
+    roomId: "table_bb_preflop",
+    handId: "h_bb_preflop",
+    phase: "PREFLOP",
+    dealerSeatNo: 1,
+    turnUserId: "c",
+    seats: [
+      { userId: "a", seatNo: 1 },
+      { userId: "b", seatNo: 2 },
+      { userId: "c", seatNo: 3 }
+    ],
+    community: [],
+    communityDealt: 0,
+    deck: ["6S", "7S", "8S", "9S", "TS"],
+    potTotal: 30,
+    sidePots: [],
+    currentBet: 10,
+    lastRaiseSize: 10,
+    bigBlind: 10,
+    stacks: { a: 90, b: 90, c: 90 },
+    toCallByUserId: { a: 0, b: 0, c: 0 },
+    betThisRoundByUserId: { a: 10, b: 10, c: 10 },
+    actedThisRoundByUserId: { a: true, b: true, c: false },
+    foldedByUserId: { a: false, b: false, c: false },
+    contributionsByUserId: { a: 10, b: 10, c: 10 },
+    holeCardsByUserId: { a: ["AS", "KD"], b: ["2C", "2D"], c: ["3C", "3D"] }
+  };
+
+  const legal = computeSharedLegalActions({ statePublic: preflop, userId: "c" });
+  assert.equal(legal.minBetAmount, 10);
+  assert.equal(legal.maxBetAmount, 90);
+
+  const miniRaise = applyAction({ pokerState: preflop, userId: "c", action: "BET", amount: 1 });
+  assert.equal(miniRaise.ok, false);
+  assert.equal(miniRaise.reason, "invalid_amount");
+
+  const fullRaise = applyAction({ pokerState: preflop, userId: "c", action: "BET", amount: 10 });
+  assert.equal(fullRaise.ok, true);
+  assert.equal(fullRaise.state.betThisRoundByUserId.c, 20);
+  assert.equal(fullRaise.state.currentBet, 20);
+
+  const shortStack = { ...preflop, stacks: { a: 90, b: 90, c: 3 } };
+  const allInBet = applyAction({ pokerState: shortStack, userId: "c", action: "BET", amount: 3 });
+  assert.equal(allInBet.ok, true);
+  assert.equal(allInBet.state.betThisRoundByUserId.c, 13);
+});
+
+test("full raise minimum stays based on the previous full bet/raise", () => {
+  const bet = applyAction({ pokerState: bbFlop(), userId: "a", action: "BET", amount: 10 });
+  assert.equal(bet.ok, true);
+
+  const shortRaise = applyAction({ pokerState: bet.state, userId: "b", action: "RAISE", amount: 15 });
+  assert.equal(shortRaise.ok, false);
+  assert.equal(shortRaise.reason, "invalid_amount");
+
+  const fullRaise = applyAction({ pokerState: bet.state, userId: "b", action: "RAISE", amount: 20 });
+  assert.equal(fullRaise.ok, true);
+  assert.equal(fullRaise.state.currentBet, 20);
+  assert.equal(fullRaise.state.lastRaiseSize, 10);
+});
+
+test("short all-in raise does not lower the full-raise size", () => {
+  const three = bbFlop({ stacks: { a: 100, b: 13, c: 100 } });
+  const bet = applyAction({ pokerState: three, userId: "a", action: "BET", amount: 10 });
+  assert.equal(bet.ok, true);
+
+  const shortAllIn = applyAction({ pokerState: bet.state, userId: "b", action: "RAISE", amount: 13 });
+  assert.equal(shortAllIn.ok, true);
+  assert.equal(shortAllIn.state.currentBet, 13);
+  assert.equal(shortAllIn.state.lastRaiseSize, 10);
+
+  const legalC = computeSharedLegalActions({ statePublic: shortAllIn.state, userId: "c" });
+  assert.equal(legalC.minRaiseTo, 23);
+});
+
+test("short all-in does not reopen RAISE for already-acted players", () => {
+  const three = bbFlop({ stacks: { a: 100, b: 100, c: 13 } });
+  const betA = applyAction({ pokerState: three, userId: "a", action: "BET", amount: 10 });
+  assert.equal(betA.ok, true);
+  const callB = applyAction({ pokerState: betA.state, userId: "b", action: "CALL", amount: 0 });
+  assert.equal(callB.ok, true);
+  const allInC = applyAction({ pokerState: callB.state, userId: "c", action: "RAISE", amount: 13 });
+  assert.equal(allInC.ok, true);
+  assert.equal(allInC.state.currentBet, 13);
+  assert.equal(allInC.state.lastRaiseSize, 10);
+
+  const legalA = computeSharedLegalActions({ statePublic: allInC.state, userId: "a" });
+  assert.deepEqual(legalA.actions, ["FOLD", "CALL"]);
+
+  const raiseA = applyAction({ pokerState: allInC.state, userId: "a", action: "RAISE", amount: 25 });
+  assert.equal(raiseA.ok, false);
+  assert.equal(raiseA.reason, "illegal_action");
+
+  const callA = applyAction({ pokerState: allInC.state, userId: "a", action: "CALL", amount: 0 });
+  assert.equal(callA.ok, true);
+  const legalB = computeSharedLegalActions({ statePublic: callA.state, userId: "b" });
+  assert.deepEqual(legalB.actions, ["FOLD", "CALL"]);
+});
+
+test("check-raise stays legal for a player who already acted but faces a full bet", () => {
+  const flop = bbFlop({
+    seats: [
+      { userId: "a", seatNo: 1 },
+      { userId: "b", seatNo: 2 }
+    ],
+    stacks: { a: 100, b: 100 },
+    toCallByUserId: { a: 0, b: 0 },
+    betThisRoundByUserId: { a: 0, b: 0 },
+    actedThisRoundByUserId: { a: false, b: false },
+    foldedByUserId: { a: false, b: false },
+    contributionsByUserId: { a: 10, b: 10 },
+    holeCardsByUserId: { a: ["AS", "KD"], b: ["2C", "2D"] }
+  });
+  const checkA = applyAction({ pokerState: flop, userId: "a", action: "CHECK", amount: 0 });
+  assert.equal(checkA.ok, true);
+  const betB = applyAction({ pokerState: checkA.state, userId: "b", action: "BET", amount: 10 });
+  assert.equal(betB.ok, true);
+
+  const legalA = computeSharedLegalActions({ statePublic: betB.state, userId: "a" });
+  assert.ok(legalA.actions.includes("RAISE"));
+  assert.equal(legalA.minRaiseTo, 20);
+});
+
+test("cumulative short all-ins reopen betting once toCall reaches a full raise", () => {
+  const four = bbFlop({
+    seats: [
+      { userId: "a", seatNo: 1 },
+      { userId: "b", seatNo: 2 },
+      { userId: "c", seatNo: 3 },
+      { userId: "d", seatNo: 4 }
+    ],
+    stacks: { a: 100, b: 100, c: 14, d: 20 },
+    toCallByUserId: { a: 0, b: 0, c: 0, d: 0 },
+    betThisRoundByUserId: { a: 0, b: 0, c: 0, d: 0 },
+    actedThisRoundByUserId: { a: false, b: false, c: false, d: false },
+    foldedByUserId: { a: false, b: false, c: false, d: false },
+    contributionsByUserId: { a: 10, b: 10, c: 10, d: 10 },
+    holeCardsByUserId: {
+      a: ["AS", "KD"],
+      b: ["2C", "2D"],
+      c: ["3C", "3D"],
+      d: ["4C", "4D"]
+    }
+  });
+
+  const betA = applyAction({ pokerState: four, userId: "a", action: "BET", amount: 10 });
+  assert.equal(betA.ok, true);
+  const callB = applyAction({ pokerState: betA.state, userId: "b", action: "CALL", amount: 0 });
+  assert.equal(callB.ok, true);
+  const allInC = applyAction({ pokerState: callB.state, userId: "c", action: "RAISE", amount: 14 });
+  assert.equal(allInC.ok, true);
+  assert.equal(allInC.state.lastRaiseSize, 10);
+  const allInD = applyAction({ pokerState: allInC.state, userId: "d", action: "RAISE", amount: 20 });
+  assert.equal(allInD.ok, true);
+
+  const after = allInD.state;
+  assert.equal(after.currentBet, 20);
+  assert.equal(after.lastRaiseSize, 10);
+
+  const legalA = computeSharedLegalActions({ statePublic: after, userId: "a" });
+  assert.ok(legalA.actions.includes("RAISE"));
+  assert.equal(legalA.toCall, 10);
+  assert.equal(legalA.minRaiseTo, 30);
+
+  const callA = applyAction({ pokerState: after, userId: "a", action: "CALL", amount: 0 });
+  assert.equal(callA.ok, true);
+  const legalB = computeSharedLegalActions({ statePublic: callA.state, userId: "b" });
+  assert.ok(legalB.actions.includes("RAISE"));
+  assert.equal(legalB.toCall, 10);
+  assert.equal(legalB.minRaiseTo, 30);
+});

--- a/ws-server/poker/shared/poker-action-reducer.mjs
+++ b/ws-server/poker/shared/poker-action-reducer.mjs
@@ -1,4 +1,4 @@
-import { computeSharedLegalActions, dealHoleCards, deriveDeck, toCardCodes } from "./poker-primitives.mjs";
+import { computeSharedLegalActions, dealHoleCards, deriveBigBlind, deriveDeck, toCardCodes } from "./poker-primitives.mjs";
 import { materializeShowdownAndPayout } from "./settlement/poker-materialize-showdown.mjs";
 import { awardPotsAtShowdown } from "./settlement/poker-payout.mjs";
 import { computeShowdown } from "./settlement/poker-showdown.mjs";
@@ -416,7 +416,8 @@ export function applyAction({ pokerState, userId, action, amount, nowIso = "1970
     nextState.actedThisRoundByUserId[userId] = true;
   } else if (normalizedAction === "BET") {
     const betAmount = toInt(amount);
-    if (!Number.isInteger(betAmount) || betAmount < 1 || betAmount > stack) {
+    const minBetAmount = Number(legalInfo.minBetAmount ?? 1);
+    if (!Number.isInteger(betAmount) || betAmount < minBetAmount || betAmount > stack) {
       return { ok: false, reason: "invalid_amount" };
     }
 
@@ -425,7 +426,10 @@ export function applyAction({ pokerState, userId, action, amount, nowIso = "1970
     nextState.stacks[userId] = stack - contribution;
     nextState.betThisRoundByUserId[userId] = nextBet;
     nextState.currentBet = Math.max(Number(nextState.currentBet ?? 0), nextBet);
-    nextState.lastRaiseSize = contribution;
+    // Opening bet contract: a full opening bet sets the full-raise size to the
+    // bet amount; a short all-in opening bet must not lower the floor below the
+    // big blind.
+    nextState.lastRaiseSize = Math.max(deriveBigBlind(nextState), contribution);
     nextState.contributionsByUserId[userId] = Number(nextState.contributionsByUserId[userId] ?? 0) + contribution;
     nextState.potTotal = Number(nextState.potTotal ?? 0) + contribution;
     nextState.actedThisRoundByUserId[userId] = true;
@@ -442,7 +446,13 @@ export function applyAction({ pokerState, userId, action, amount, nowIso = "1970
     nextState.betThisRoundByUserId[userId] = raiseTo;
     const previousCurrentBet = Number(nextState.currentBet ?? 0);
     nextState.currentBet = Math.max(previousCurrentBet, raiseTo);
-    nextState.lastRaiseSize = Math.max(1, raiseTo - previousCurrentBet);
+    // Only a full raise updates the full-raise size; a short all-in raise must
+    // not lower the minimum increment for subsequent raises.
+    const raiseSize = raiseTo - previousCurrentBet;
+    const previousLastRaiseSize = Number(nextState.lastRaiseSize ?? 0);
+    if (raiseSize >= previousLastRaiseSize) {
+      nextState.lastRaiseSize = raiseSize;
+    }
     nextState.contributionsByUserId[userId] = Number(nextState.contributionsByUserId[userId] ?? 0) + contribution;
     nextState.potTotal = Number(nextState.potTotal ?? 0) + contribution;
     nextState.actedThisRoundByUserId[userId] = true;

--- a/ws-server/poker/shared/poker-primitives.behavior.test.mjs
+++ b/ws-server/poker/shared/poker-primitives.behavior.test.mjs
@@ -58,7 +58,8 @@ test("computeSharedLegalActions allows fold outside the current turn for an acti
     toCall: 0,
     minRaiseTo: null,
     maxRaiseTo: null,
-    maxBetAmount: null
+    maxBetAmount: null,
+    minBetAmount: null
   });
 });
 
@@ -86,6 +87,7 @@ test("computeSharedLegalActions keeps fold available when check is legal on the 
     toCall: 0,
     minRaiseTo: null,
     maxRaiseTo: null,
-    maxBetAmount: 90
+    maxBetAmount: 90,
+    minBetAmount: 1
   });
 });

--- a/ws-server/poker/shared/poker-primitives.mjs
+++ b/ws-server/poker/shared/poker-primitives.mjs
@@ -179,26 +179,7 @@ function isSeatedPlayer(state, userId) {
   return !!(state.stacks && typeof state.stacks === "object" && Object.prototype.hasOwnProperty.call(state.stacks, userId));
 }
 
-function computeSharedLegalActions({ statePublic, userId } = {}) {
-  const state = statePublic || {};
-  if (!state || typeof state !== "object" || Array.isArray(state)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-  const phase = typeof state.phase === "string" ? state.phase : "";
-  if (!ACTION_PHASES.has(phase)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-  if (!userId || typeof userId !== "string") {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-  if (!isSeatedPlayer(state, userId) || !isActivePlayer(state, userId)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-  const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId : "";
-  if (!turnUserId) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-
+function computeLegalActionsForSeatedPlayer(state, userId) {
   const stack = toSafeInt(state.stacks?.[userId], 0);
   const currentUserBet = toSafeInt(state.betThisRoundByUserId?.[userId], 0);
   const currentBet = deriveCurrentBet(state);
@@ -206,9 +187,6 @@ function computeSharedLegalActions({ statePublic, userId } = {}) {
   const toCall = Math.max(0, currentBet - currentUserBet);
   if (stack <= 0) {
     return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
-  }
-  if (turnUserId !== userId) {
-    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   if (toCall > 0) {
@@ -234,9 +212,58 @@ function computeSharedLegalActions({ statePublic, userId } = {}) {
   return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack, minBetAmount };
 }
 
+function computeSharedLegalActions({ statePublic, userId } = {}) {
+  const state = statePublic || {};
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  const phase = typeof state.phase === "string" ? state.phase : "";
+  if (!ACTION_PHASES.has(phase)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  if (!userId || typeof userId !== "string") {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  if (!isSeatedPlayer(state, userId) || !isActivePlayer(state, userId)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId : "";
+  if (!turnUserId) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  if (turnUserId !== userId) {
+    const toCall = Math.max(0, deriveCurrentBet(state) - toSafeInt(state.betThisRoundByUserId?.[userId], 0));
+    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  return computeLegalActionsForSeatedPlayer(state, userId);
+}
+
+// Projected amount constraints for a seated viewer who is not currently acting:
+// the legal actions the viewer would face if the action came to them at the
+// current betting-round state. Uses the same authoritative NLHE rules as the
+// live computation so the client never has to derive minimums itself.
+function computeProjectedLegalActions({ statePublic, userId } = {}) {
+  const state = statePublic || {};
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  const phase = typeof state.phase === "string" ? state.phase : "";
+  if (!ACTION_PHASES.has(phase)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  if (!userId || typeof userId !== "string") {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  if (!isSeatedPlayer(state, userId) || !isActivePlayer(state, userId)) {
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
+  }
+  return computeLegalActionsForSeatedPlayer(state, userId);
+}
+
 export {
   asCardCode,
   computeSharedLegalActions,
+  computeProjectedLegalActions,
   createDeck,
   dealHoleCards,
   deriveBigBlind,

--- a/ws-server/poker/shared/poker-primitives.mjs
+++ b/ws-server/poker/shared/poker-primitives.mjs
@@ -143,6 +143,19 @@ function deriveLastRaiseSize(state, currentBet) {
   return lastRaiseSize;
 }
 
+function deriveBigBlind(state) {
+  const bigBlind = toSafeInt(state?.bigBlind, 0);
+  return bigBlind > 0 ? bigBlind : 1;
+}
+
+// A player who already acted this round may RAISE only when facing at least a
+// full raise (toCall >= lastRaiseSize). Players who have not acted yet always
+// retain their option. Cumulative short all-ins are handled because toCall
+// grows while lastRaiseSize is only updated on full bets/raises.
+function canRaise(state, userId, toCall, lastRaiseSize) {
+  return !state?.actedThisRoundByUserId?.[userId] || toCall >= lastRaiseSize;
+}
+
 function isActivePlayer(state, userId) {
   if (!state || !userId) return false;
   if (state.leftTableByUserId && state.leftTableByUserId[userId]) return false;
@@ -169,21 +182,21 @@ function isSeatedPlayer(state, userId) {
 function computeSharedLegalActions({ statePublic, userId } = {}) {
   const state = statePublic || {};
   if (!state || typeof state !== "object" || Array.isArray(state)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const phase = typeof state.phase === "string" ? state.phase : "";
   if (!ACTION_PHASES.has(phase)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!userId || typeof userId !== "string") {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!isSeatedPlayer(state, userId) || !isActivePlayer(state, userId)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId : "";
   if (!turnUserId) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   const stack = toSafeInt(state.stacks?.[userId], 0);
@@ -192,10 +205,10 @@ function computeSharedLegalActions({ statePublic, userId } = {}) {
   const lastRaiseSize = deriveLastRaiseSize(state, currentBet);
   const toCall = Math.max(0, currentBet - currentUserBet);
   if (stack <= 0) {
-    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (turnUserId !== userId) {
-    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   if (toCall > 0) {
@@ -203,19 +216,22 @@ function computeSharedLegalActions({ statePublic, userId } = {}) {
     const maxRaiseTo = stack + currentUserBet;
     const rawMinRaiseTo = currentBet + lastRaiseSize;
     const minRaiseTo = maxRaiseTo > 0 ? Math.min(rawMinRaiseTo, maxRaiseTo) : rawMinRaiseTo;
-    if (maxRaiseTo > currentBet) actions.push("RAISE");
+    const mayRaise = canRaise(state, userId, toCall, lastRaiseSize) && maxRaiseTo > currentBet;
+    if (mayRaise) actions.push("RAISE");
     return {
       actions,
       toCall,
-      minRaiseTo: maxRaiseTo > currentBet ? minRaiseTo : null,
+      minRaiseTo: mayRaise ? minRaiseTo : null,
       maxRaiseTo,
-      maxBetAmount: null
+      maxBetAmount: null,
+      minBetAmount: null
     };
   }
 
   const actions = ["FOLD", "CHECK"];
   if (stack > 0) actions.push("BET");
-  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack };
+  const minBetAmount = Math.min(deriveBigBlind(state), stack);
+  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack, minBetAmount };
 }
 
 export {
@@ -223,6 +239,7 @@ export {
   computeSharedLegalActions,
   createDeck,
   dealHoleCards,
+  deriveBigBlind,
   deriveDeck,
   toCardCodes,
   toHoleCardCodeMap

--- a/ws-server/poker/snapshot-runtime/poker-legal-actions.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-legal-actions.mjs
@@ -31,6 +31,18 @@ const deriveLastRaiseSize = (state, currentBet) => {
   return lastRaiseSize;
 };
 
+const deriveBigBlind = (state) => {
+  const bigBlind = toSafeInt(state?.bigBlind, 0);
+  return bigBlind > 0 ? bigBlind : 1;
+};
+
+// A player who already acted this round may RAISE only when facing at least a
+// full raise (toCall >= lastRaiseSize). Players who have not acted yet always
+// retain their option. Cumulative short all-ins are handled because toCall
+// grows while lastRaiseSize is only updated on full bets/raises.
+const canRaise = (state, userId, toCall, lastRaiseSize) =>
+  !state?.actedThisRoundByUserId?.[userId] || toCall >= lastRaiseSize;
+
 const isActivePlayer = (state, userId) => {
   if (!state || !userId) return false;
   if (state.leftTableByUserId && state.leftTableByUserId[userId]) return false;
@@ -43,21 +55,21 @@ const isActivePlayer = (state, userId) => {
 const computeLegalActions = ({ statePublic, userId } = {}) => {
   const state = statePublic || {};
   if (!state || typeof state !== "object" || Array.isArray(state)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const phase = typeof state.phase === "string" ? state.phase : "";
   if (!ACTION_PHASES.has(phase)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!userId || typeof userId !== "string") {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const turnUserId = typeof state.turnUserId === "string" ? state.turnUserId : "";
   if (!turnUserId) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (!isActivePlayer(state, userId)) {
-    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   const stack = toSafeInt(state.stacks?.[userId], 0);
@@ -66,10 +78,10 @@ const computeLegalActions = ({ statePublic, userId } = {}) => {
   const lastRaiseSize = deriveLastRaiseSize(state, currentBet);
   const toCall = Math.max(0, currentBet - currentUserBet);
   if (stack <= 0) {
-    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: [], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   if (turnUserId !== userId) {
-    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { actions: ["FOLD"], toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
 
   if (toCall > 0) {
@@ -77,30 +89,34 @@ const computeLegalActions = ({ statePublic, userId } = {}) => {
     const maxRaiseTo = stack + currentUserBet;
     const rawMinRaiseTo = currentBet + lastRaiseSize;
     const minRaiseTo = maxRaiseTo > 0 ? Math.min(rawMinRaiseTo, maxRaiseTo) : rawMinRaiseTo;
-    if (maxRaiseTo > currentBet) actions.push("RAISE");
+    const mayRaise = canRaise(state, userId, toCall, lastRaiseSize) && maxRaiseTo > currentBet;
+    if (mayRaise) actions.push("RAISE");
     return {
       actions,
       toCall,
-      minRaiseTo: maxRaiseTo > currentBet ? minRaiseTo : null,
+      minRaiseTo: mayRaise ? minRaiseTo : null,
       maxRaiseTo,
       maxBetAmount: null,
+      minBetAmount: null,
     };
   }
 
   const actions = ["FOLD", "CHECK"];
   if (stack > 0) actions.push("BET");
-  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack };
+  const minBetAmount = Math.min(deriveBigBlind(state), stack);
+  return { actions, toCall, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: stack, minBetAmount };
 };
 
 const buildActionConstraints = (legalInfo) => {
   if (!legalInfo) {
-    return { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null };
+    return { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null };
   }
   const toCall = Number.isFinite(legalInfo.toCall) ? legalInfo.toCall : null;
   const minRaiseTo = Number.isFinite(legalInfo.minRaiseTo) ? legalInfo.minRaiseTo : null;
   const maxRaiseTo = Number.isFinite(legalInfo.maxRaiseTo) ? legalInfo.maxRaiseTo : null;
   const maxBetAmount = Number.isFinite(legalInfo.maxBetAmount) ? legalInfo.maxBetAmount : null;
-  return { toCall, minRaiseTo, maxRaiseTo, maxBetAmount };
+  const minBetAmount = Number.isFinite(legalInfo.minBetAmount) ? legalInfo.minBetAmount : null;
+  return { toCall, minRaiseTo, maxRaiseTo, maxBetAmount, minBetAmount };
 };
 
 export { buildActionConstraints, computeLegalActions };

--- a/ws-server/poker/snapshot-runtime/poker-reducer.min-bet.behavior.test.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-reducer.min-bet.behavior.test.mjs
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyAction, getLegalActions, initHandState } from "./poker-reducer.mjs";
+
+const makeRng = (seed) => {
+  let value = seed;
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+};
+
+const makeBase = () => {
+  const seats = [
+    { userId: "user-1", seatNo: 1 },
+    { userId: "user-2", seatNo: 3 },
+    { userId: "user-3", seatNo: 5 },
+  ];
+  const stacks = { "user-1": 100, "user-2": 100, "user-3": 100 };
+  return { seats, stacks };
+};
+
+const makeFlop = (overrides = {}) => {
+  const { seats, stacks } = makeBase();
+  const { state } = initHandState({ tableId: "t-snap-bb", seats, stacks, rng: makeRng(41) });
+  return {
+    ...state,
+    phase: "FLOP",
+    community: ["3H", "4H", "5H"],
+    communityDealt: 3,
+    turnUserId: "user-1",
+    currentBet: 0,
+    lastRaiseSize: 10,
+    bigBlind: 10,
+    toCallByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+    betThisRoundByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+    actedThisRoundByUserId: { "user-1": false, "user-2": false, "user-3": false },
+    foldedByUserId: { "user-1": false, "user-2": false, "user-3": false },
+    ...overrides,
+  };
+};
+
+test("snapshot-runtime: opening BET below the big blind is rejected; at the big blind accepted", () => {
+  const flop = makeFlop();
+  const betAction = getLegalActions(flop, "user-1").find((action) => action.type === "BET");
+  assert.equal(betAction.min, 10);
+
+  assert.throws(
+    () => applyAction(flop, { type: "BET", userId: "user-1", amount: 1 }),
+    (error) => error?.message === "invalid_action"
+  );
+
+  const betResult = applyAction(flop, { type: "BET", userId: "user-1", amount: 10 });
+  assert.equal(betResult.state.currentBet, 10);
+  assert.equal(betResult.state.lastRaiseSize, 10);
+});
+
+test("snapshot-runtime: big-blind preflop option records the raised total as currentBet", () => {
+  const { seats, stacks } = makeBase();
+  const { state } = initHandState({ tableId: "t-snap-bb-option", seats, stacks, rng: makeRng(42) });
+  const preflop = {
+    ...state,
+    phase: "PREFLOP",
+    turnUserId: "user-1",
+    currentBet: 10,
+    lastRaiseSize: 10,
+    bigBlind: 10,
+    toCallByUserId: { "user-1": 0, "user-2": 0, "user-3": 0 },
+    betThisRoundByUserId: { "user-1": 10, "user-2": 10, "user-3": 10 },
+    actedThisRoundByUserId: { "user-1": false, "user-2": true, "user-3": true },
+    foldedByUserId: { "user-1": false, "user-2": false, "user-3": false },
+    stacks: { "user-1": 90, "user-2": 90, "user-3": 90 },
+  };
+
+  const betResult = applyAction(preflop, { type: "BET", userId: "user-1", amount: 10 });
+  assert.equal(betResult.state.betThisRoundByUserId["user-1"], 20);
+  assert.equal(betResult.state.currentBet, 20);
+  assert.equal(betResult.state.lastRaiseSize, 10);
+  assert.equal(betResult.state.stacks["user-1"], 80);
+  assert.equal(betResult.state.toCallByUserId["user-2"], 10);
+  assert.equal(betResult.state.toCallByUserId["user-3"], 10);
+});
+
+test("snapshot-runtime: short all-in does not reopen RAISE for already-acted players", () => {
+  const three = makeFlop({
+    stacks: { "user-1": 100, "user-2": 100, "user-3": 13 },
+  });
+  const betA = applyAction(three, { type: "BET", userId: "user-1", amount: 10 });
+  assert.equal(betA.state.currentBet, 10);
+  const callB = applyAction(betA.state, { type: "CALL", userId: "user-2" });
+  assert.equal(callB.state.currentBet, 10);
+  const allInC = applyAction({ ...callB.state, stacks: { ...callB.state.stacks, "user-3": 13 } }, { type: "RAISE", userId: "user-3", amount: 13 });
+  assert.equal(allInC.state.currentBet, 13);
+  assert.equal(allInC.state.lastRaiseSize, 10);
+  assert.deepEqual(getLegalActions(allInC.state, "user-1").map((action) => action.type), ["FOLD", "CALL"]);
+});

--- a/ws-server/poker/snapshot-runtime/poker-reducer.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-reducer.mjs
@@ -204,6 +204,18 @@ const deriveLastRaiseSize = (state, currentBet) => {
   return lastRaiseSize;
 };
 
+const deriveBigBlind = (state) => {
+  const bigBlind = toSafeInt(state?.bigBlind, 0);
+  return bigBlind > 0 ? bigBlind : 1;
+};
+
+// A player who already acted this round may RAISE only when facing at least a
+// full raise (toCall >= lastRaiseSize). Players who have not acted yet always
+// retain their option. Cumulative short all-ins are handled because toCall
+// grows while lastRaiseSize is only updated on full bets/raises.
+const canRaise = (state, userId, toCall, lastRaiseSize) =>
+  !state?.actedThisRoundByUserId?.[userId] || toCall >= lastRaiseSize;
+
 const makeHandId = () => {
   if (globalThis.crypto && typeof globalThis.crypto.randomUUID === "function") {
     return globalThis.crypto.randomUUID();
@@ -555,8 +567,9 @@ const getLegalActions = (state, userId) => {
     const raiseMax = stack + currentUserBet;
     const raiseMin = Math.min(currentBet + lastRaiseSize, raiseMax);
 
-    // Only include RAISE if it is actually possible.
-    if (raiseMax > currentBet) {
+    // Only include RAISE if it is actually possible and the player retains the
+    // right to raise (already-acted players need to face at least a full raise).
+    if (canRaise(state, userId, toCall, lastRaiseSize) && raiseMax > currentBet) {
       actions.push({ type: "RAISE", min: raiseMin, max: raiseMax });
     }
 
@@ -564,7 +577,7 @@ const getLegalActions = (state, userId) => {
   }
   return [
     { type: "CHECK" },
-    { type: "BET", min: 1, max: stack },
+    { type: "BET", min: Math.min(deriveBigBlind(state), stack), max: stack },
   ];
 };
 
@@ -639,13 +652,17 @@ const applyAction = (state, action) => {
   } else if (action.type === "BET") {
     if (toCall > 0) throw new Error("invalid_action");
     const amount = Number(action.amount);
-    if (!Number.isFinite(amount) || amount <= 0 || amount > stack) throw new Error("invalid_action");
+    const minBetAmount = Math.min(deriveBigBlind(next), stack);
+    if (!Number.isFinite(amount) || amount < minBetAmount || amount > stack) throw new Error("invalid_action");
     next.stacks[userId] = stack - amount;
     next.betThisRoundByUserId[userId] = currentBet + amount;
     next.pot += amount;
     next.contributionsByUserId[userId] = (next.contributionsByUserId[userId] || 0) + amount;
     next.currentBet = amount;
-    next.lastRaiseSize = amount;
+    // Opening bet contract: a full opening bet sets the full-raise size to the
+    // bet amount; a short all-in opening bet must not lower the floor below the
+    // big blind.
+    next.lastRaiseSize = Math.max(deriveBigBlind(next), amount);
     next.lastAggressorUserId = userId;
     for (const seat of getActiveSeats(next)) {
       if (seat.userId !== userId) {
@@ -655,6 +672,7 @@ const applyAction = (state, action) => {
     next.toCallByUserId[userId] = 0;
   } else if (action.type === "RAISE") {
     if (toCall <= 0) throw new Error("invalid_action");
+    if (!canRaise(next, userId, toCall, roundLastRaiseSize)) throw new Error("invalid_action");
     const amount = Number(action.amount);
     const available = stack + currentBet;
     const rawMinRaiseTo = roundCurrentBet + roundLastRaiseSize;

--- a/ws-server/poker/snapshot-runtime/poker-reducer.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-reducer.mjs
@@ -654,11 +654,15 @@ const applyAction = (state, action) => {
     const amount = Number(action.amount);
     const minBetAmount = Math.min(deriveBigBlind(next), stack);
     if (!Number.isFinite(amount) || amount < minBetAmount || amount > stack) throw new Error("invalid_action");
+    const nextBet = currentBet + amount;
     next.stacks[userId] = stack - amount;
-    next.betThisRoundByUserId[userId] = currentBet + amount;
+    next.betThisRoundByUserId[userId] = nextBet;
     next.pot += amount;
     next.contributionsByUserId[userId] = (next.contributionsByUserId[userId] || 0) + amount;
-    next.currentBet = amount;
+    // BET.amount is always an increment over the player's current wager; the
+    // global wager is the max (e.g. big-blind preflop option: posted 10,
+    // BET 10 -> total 20, currentBet 20).
+    next.currentBet = Math.max(roundCurrentBet, nextBet);
     // Opening bet contract: a full opening bet sets the full-raise size to the
     // bet amount; a short all-in opening bet must not lower the floor below the
     // big blind.
@@ -666,7 +670,7 @@ const applyAction = (state, action) => {
     next.lastAggressorUserId = userId;
     for (const seat of getActiveSeats(next)) {
       if (seat.userId !== userId) {
-        next.toCallByUserId[seat.userId] = amount - (next.betThisRoundByUserId[seat.userId] || 0);
+        next.toCallByUserId[seat.userId] = nextBet - (next.betThisRoundByUserId[seat.userId] || 0);
       }
     }
     next.toCallByUserId[userId] = 0;

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -6506,7 +6506,7 @@ test("observer snapshot stays public-state consistent with seated snapshot after
     assert.deepEqual(observerSnapshot.payload.public, {
       ...seatedPayload.public,
       legalActions: { seat: null, actions: [] },
-      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null }
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null }
     });
     assert.equal(observerSnapshot.payload.table.memberCount, observerSnapshot.payload.table.members.length);
     assert.equal(Object.prototype.hasOwnProperty.call(observerSnapshot.payload.public, "holeCardsByUserId"), false);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1166,6 +1166,7 @@ function buildTableStatePayload({ tableState, tableSnapshot, userId }) {
   if (tableSnapshot.pot && typeof tableSnapshot.pot === "object") payload.pot = tableSnapshot.pot;
   if (tableSnapshot.turn && typeof tableSnapshot.turn === "object") payload.turn = tableSnapshot.turn;
   if (tableSnapshot.legalActions && typeof tableSnapshot.legalActions === "object") payload.legalActions = tableSnapshot.legalActions;
+  if (tableSnapshot.projectedLegalActions && typeof tableSnapshot.projectedLegalActions === "object") payload.projectedLegalActions = tableSnapshot.projectedLegalActions;
   if (tableSnapshot.actionConstraints && typeof tableSnapshot.actionConstraints === "object") payload.actionConstraints = tableSnapshot.actionConstraints;
   if (Array.isArray(tableSnapshot.members)) payload.authoritativeMembers = tableSnapshot.members;
   if (tableSnapshot.showdown && typeof tableSnapshot.showdown === "object") payload.showdown = tableSnapshot.showdown;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1155,6 +1155,7 @@ function buildTableStatePayload({ tableState, tableSnapshot, userId }) {
   if (Number.isInteger(tableSnapshot.dealerSeatNo)) payload.dealerSeatNo = tableSnapshot.dealerSeatNo;
   if (Array.isArray(tableSnapshot.seats)) payload.seats = tableSnapshot.seats;
   if (tableSnapshot.stacks && typeof tableSnapshot.stacks === "object" && !Array.isArray(tableSnapshot.stacks)) payload.stacks = tableSnapshot.stacks;
+  if (Number.isInteger(tableSnapshot.bigBlind) && tableSnapshot.bigBlind > 0) payload.bigBlind = tableSnapshot.bigBlind;
   if (tableSnapshot.hand && typeof tableSnapshot.hand === "object") {
     payload.hand = { ...tableSnapshot.hand };
     if (!Number.isInteger(payload.hand.dealerSeatNo) && Number.isInteger(tableSnapshot.dealerSeatNo)) {

--- a/ws-tests/ws-table-state-payload.test.mjs
+++ b/ws-tests/ws-table-state-payload.test.mjs
@@ -42,7 +42,7 @@ test("buildTableStatePayload keeps live members and emits authoritativeMembers f
       pot: { total: 90, sidePots: [] },
       turn: { userId: "u1", seat: 0, deadlineAt: 123 },
       legalActions: { seat: 0, actions: ["CHECK", "BET"] },
-      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: 500 },
+      actionConstraints: { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: 500, minBetAmount: 10 },
       members: [{ userId: "seed_user", seat: 2 }],
       private: { shouldNotBeIncluded: true }
     }
@@ -55,7 +55,7 @@ test("buildTableStatePayload keeps live members and emits authoritativeMembers f
   assert.deepEqual(withConstraints.seats, [{ userId: "seed_user", seatNo: 2, status: "ACTIVE" }]);
   assert.deepEqual(withConstraints.stacks, { seed_user: 180 });
   assert.deepEqual(withConstraints.legalActions, { seat: 0, actions: ["CHECK", "BET"] });
-  assert.deepEqual(withConstraints.actionConstraints, { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: 500 });
+  assert.deepEqual(withConstraints.actionConstraints, { toCall: 0, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: 500, minBetAmount: 10 });
   assert.deepEqual(withConstraints.authoritativeMembers, [{ userId: "seed_user", seat: 2 }]);
   assert.equal(Object.prototype.hasOwnProperty.call(withConstraints, "private"), false);
 


### PR DESCRIPTION
## Problem

Closes #814. No-limit tables allowed an opening `BET` of `1 CH` even when the configured blinds were e.g. `5/10`:
- `netlify/functions/_shared/poker-reducer.mjs` exposed `{ type: "BET", min: 1, max: stack }`;
- the authoritative WS engine accepted any `BET > 0`;
- the WS shared reducer overwrote `lastRaiseSize` on short all-ins, lowering the next full-raise minimum.

## Changes

Server-authoritative engine and client constraints now follow standard NLHE rules:

- **Minimum opening bet** = big blind; `minBetAmount = min(bigBlind, stack)` (all-in exception for stacks below the BB).
  - `ws-server/poker/shared/poker-primitives.mjs` (`computeSharedLegalActions`, exported `deriveBigBlind`, private `canRaise`)
  - `ws-server/poker/shared/poker-action-reducer.mjs` (BET validated via `legalInfo.minBetAmount`)
  - `ws-server/poker/engine/poker-engine.mjs` (engine gate via `legalInfo.minBetAmount`; `bigBlind` persisted in bootstrapped state)
- **Full-raise contract**: opening BET sets `lastRaiseSize = max(bigBlind, betAmount)`; RAISE updates `lastRaiseSize` only on a full raise (short all-ins no longer lower the increment).
- **Reopening rights (TDA 45-B)**: a player who already acted may `RAISE` only when facing at least a full raise (`toCall >= lastRaiseSize`), including cumulative short all-ins. Not-yet-acted players keep their option; new street resets rights.
- **Client/bot contract**: `actionConstraints.minBetAmount` added (additive, client fallback 1); UI clamps BET to the server minimum; bots bet the server minimum (positive integer normalization).
- **Legacy tree** kept in sync: `netlify/functions/_shared/{poker-reducer,poker-legal-actions,poker-start-hand-core}.mjs` + `ws-server/poker/snapshot-runtime/` copies.

No DB migration. In-flight legacy states without `bigBlind` keep the old floor (1) until the hand ends.

## Tests

- Reducer/legal actions: BET below BB rejected / at BB accepted, all-in below BB, BB preflop option (increment over posted blind), full-raise minimum, short all-in preserves `lastRaiseSize`, no reopening for already-acted players, check-raise, cumulative short all-ins (`lastRaiseSize === 10`, reopen at `toCall === 10`).
- Engine boundary: illegal BET rejected without mutation; legal bet passes; `bigBlind` persisted.
- Snapshot payload: `minBetAmount` propagated to `actionConstraints` (deepEqual contract updated).
- Bot adapter: bot bets the server-provided big-blind minimum.

## Verification

- `node scripts/syntax-check.mjs` ✔
- WS server behavior suite (123 tests) ✔
- `poker-action-reducer`, `poker-primitives`, `engine-act`, `table-snapshot`, `accepted-bot-autoplay-adapter`, `ws-table-state-payload`, legacy `poker-reducer` and poker suites ✔
- Pre-existing failures on main (street-advance/timeout/guest-mode) unchanged.

Requires manual WS Preview Deploy (touches authoritative WS runtime + snapshot contract).

## Snapshot contract (projected constraints for seated off-turn viewers)

- `actionConstraints` now contains **projected pre-action values for a seated
  viewer who is not currently acting** (real `toCall`, `minRaiseTo`,
  `maxRaiseTo`, `minBetAmount`, `maxBetAmount` computed by the server from the
  same authoritative NLHE rules, including reopening rights).
- `projectedLegalActions` (`{ seat, actions }`) exposes the authoritative
  projected action list for off-turn viewers; the browser uses it instead of
  re-deriving RAISE availability from numeric constraints. `legalActions`
  keeps current-turn semantics; observers still receive null constraints.
