### PR TITLE
Poker: Show current slider amount on Bet/Raise buttons (#821)

### DIFF
--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -2818,6 +2818,28 @@
     return value;
   }
 
+  // Show the current slider amount on the dynamic Bet/Raise button (and the
+  // queued pre-action label). The amount is the raise-to value for RAISE and
+  // the opening-bet value for BET; the caller supplies it (renderControls
+  // passes the value returned by syncAmountInput, the slider input listener
+  // passes the live slider value).
+  function syncAmountActionLabels(amount){
+    if (!Number.isFinite(amount)) return;
+    var compact = formatCompactAmount(amount);
+    if (els.amountBtn){
+      var liveAction = els.amountBtn.dataset.action || '';
+      if (liveAction === 'BET' || liveAction === 'RAISE'){
+        els.amountBtn.textContent = (liveAction === 'RAISE' ? 'Raise' : 'Bet') + ' (' + compact + ')';
+      }
+    }
+    if (els.amountPreactionText){
+      var preAction = els.amountPreaction ? (els.amountPreaction.dataset.action || '') : '';
+      if (preAction === 'BET' || preAction === 'RAISE'){
+        els.amountPreactionText.textContent = (preAction === 'RAISE' ? 'Raise' : 'Bet') + ' (' + compact + ')';
+      }
+    }
+  }
+
   function clearQueuedPreaction(){
     queuedPreaction = null;
   }
@@ -3065,6 +3087,10 @@
     if (els.amountValue && !(usersTurn ? amountAction : preactionMode ? preactionAmountAction : null)) {
       els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput && els.amountInput.value ? els.amountInput.value : '20', 10) || 20);
     }
+    // Keep Bet/Raise labels in sync with the authoritative (clamped) slider
+    // value; syncAmountInput returns undefined when no amount action is active,
+    // in which case the base Bet/Raise label set above is preserved.
+    syncAmountActionLabels(syncedAmount);
   }
 
   function resolveSettlementRecipientName(userId){
@@ -3590,6 +3616,7 @@
     });
     if (els.amountInput) els.amountInput.addEventListener('input', function(){
       if (els.amountValue) els.amountValue.textContent = formatCompactAmount(parseInt(els.amountInput.value, 10) || 0);
+      syncAmountActionLabels(readQueuedAmount());
       if (queuedPreaction && queuedPreaction.slot === 'amount'){
         var queuedAmount = readQueuedAmount();
         if (Number.isFinite(queuedAmount)) queuedPreaction.amount = queuedAmount;

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -1170,7 +1170,7 @@ test('poker v2 keeps action buttons stable while exposing single-select preactio
   assert.equal(harness.elements.pokerV2AmountPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2AllInPreactionWrap.hidden, false);
   assert.equal(harness.elements.pokerV2PrimaryPreactionText.textContent, 'Call (6)');
-  assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise');
+  assert.equal(harness.elements.pokerV2AmountPreactionText.textContent, 'Raise (20)');
   assert.equal(harness.elements.pokerV2AllInPreaction.disabled, false);
 
   harness.elements.pokerV2PrimaryPreaction.click();
@@ -3865,4 +3865,60 @@ test('off-turn RAISE stays disabled when the server projection withholds raising
   await harness.flush();
   assert.equal(harness.elements.pokerV2AllInPreaction.checked, false, 'ALL IN must not be queueable');
   assert.equal(harness.actPayloads.length, 0, 'no action may be sent from the disabled pre-actions');
+});
+
+test('poker v2 shows the current slider amount on Bet/Raise buttons', async () => {
+  const { harness, ws } = await bootSeatedHarness();
+
+  // 1. BET shows the current slider value.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-btn-amounts',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 10, maxBetAmount: 100 },
+    stateVersion: 30
+  }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Bet (20)', 'BET button must show the current slider value');
+
+  // 2. The input event updates the label immediately while the slider moves.
+  harness.elements.pokerV2AmountInput.value = '45';
+  (harness.elements.pokerV2AmountInput._listeners.input || []).forEach((fn) => fn({ target: harness.elements.pokerV2AmountInput }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Bet (45)', 'input event must update the label immediately');
+
+  // 3. Snapshot-driven clamp synchronizes slider and label to the same value.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-btn-amounts',
+    phase: 'FLOP',
+    board: ['As', 'Kd', '3h'],
+    potTotal: 42,
+    actions: ['FOLD', 'CHECK', 'BET'],
+    constraints: { toCall: 0, minBetAmount: 60, maxBetAmount: 100 },
+    stateVersion: 31
+  }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountInput.value, '60', 'slider must clamp to the new minimum');
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Bet (60)', 'label must follow the clamped slider value');
+
+  // 4. Switching to RAISE shows the exact raise-to amount.
+  ws.onSnapshot(amountSnapshot({
+    handId: 'hand-btn-amounts',
+    phase: 'TURN',
+    board: ['As', 'Kd', '3h', '2c'],
+    potTotal: 60,
+    actions: ['FOLD', 'CALL', 'RAISE'],
+    constraints: { toCall: 10, minRaiseTo: 80, maxRaiseTo: 200 },
+    stateVersion: 32
+  }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountInput.min, '80', 'raise slider min should come from minRaiseTo');
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Raise (80)', 'RAISE button must show the exact raise-to value');
+
+  harness.elements.pokerV2AmountInput.value = '120';
+  (harness.elements.pokerV2AmountInput._listeners.input || []).forEach((fn) => fn({ target: harness.elements.pokerV2AmountInput }));
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2AmountBtn.textContent, 'Raise (120)', 'RAISE label must follow the slider');
 });


### PR DESCRIPTION
Closes #821

## Summary

The dynamic Bet/Raise button and the queued pre-action label now display the
current slider amount, mirroring the existing `Call (10)` button:

- `Bet (25)` / `Raise (100)`
- RAISE shows the exact raise-to value represented by the slider and sent in
  the action payload.
- Labels update immediately on slider input and after snapshot-driven clamps
  (`syncAmountInput`).
- Applies both on the player's turn and while configuring queued pre-actions.
- Reuses `formatCompactAmount`; no amounts on Fold/Check/All In; Call behavior
  unchanged; single dynamic Bet/Raise button preserved.

## Implementation (client-only)

- `poker/poker-v2.js`:
  - new helper `syncAmountActionLabels(amount)` — updates the Bet/Raise button
    and the pre-action label from the current amount;
  - `renderControls` passes the value returned by `syncAmountInput()` (the
    authoritative clamped value);
  - the slider `input` listener passes the live slider value.
- No game logic, payload, server, migration, env, or CSP changes.

## Tests

- One fundamental `poker-v2-live` test covering: BET shows the current slider
  value; input event updates the label immediately; snapshot-driven clamp
  synchronizes slider and label to the same value; switching to RAISE shows the
  exact raise-to value.
- Updated the existing pre-action label assertion (`Raise` -> `Raise (20)`).

## Verification

- `node scripts/syntax-check.mjs` ✔
- `tests/poker-v2-live.behavior.test.mjs` 75/75 ✔
- No WS Preview Deploy needed (client-only change); Netlify preview suffices.