### PR TITLE
poker: coalesce disconnect janitor sweeps and gate cleanup diagnostics

### DIFF
--- a/.github/workflows/ws-deploy.yml
+++ b/.github/workflows/ws-deploy.yml
@@ -19,6 +19,7 @@ on:
 env:
   WS_DOCKER_BUILD_CONTEXT: "."
   WS_DOCKERFILE_PATH: "ws-server/Dockerfile"
+  WS_POKER_LOG_LEVEL: "INFO"
 
 jobs:
   ws-harness-main:

--- a/.github/workflows/ws-pr-checks.yml
+++ b/.github/workflows/ws-pr-checks.yml
@@ -22,6 +22,7 @@ on:
 env:
   WS_DOCKER_BUILD_CONTEXT: "."
   WS_DOCKERFILE_PATH: "ws-server/Dockerfile"
+  WS_POKER_LOG_LEVEL: "INFO"
 
 jobs:
   ws-harness:

--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -327,7 +327,6 @@ jobs:
               sudo -n node --input-type=module -e "await import('./ws-server/shared/poker-domain/inactive-cleanup-deps.mjs')"
             )
 
-            RESTART_SINCE="$(date --utc +'%Y-%m-%d %H:%M:%S UTC')"
             sudo -n systemctl restart "$PREVIEW_SERVICE_NAME"
 
             LOCAL_HEALTHZ_BODY=""
@@ -353,32 +352,6 @@ jobs:
               fi
               sleep "$HEALTH_SLEEP_SEC"
             done
-
-            sudo -n journalctl -u "$PREVIEW_SERVICE_NAME" --since "$RESTART_SINCE" --no-pager -o cat \
-              | node -e '
-                  const fs = require("fs");
-                  const [expectedSha, expectedRef, expectedEnvironment] = process.argv.slice(1);
-                  const prefix = "[klog] ws_artifact_start ";
-                  const matched = fs.readFileSync(0, "utf8")
-                    .split(/\r?\n/)
-                    .filter((line) => line.startsWith(prefix))
-                    .some((line) => {
-                      try {
-                        const metadata = JSON.parse(line.slice(prefix.length));
-                        return (
-                          metadata?.releaseSha === expectedSha
-                          && metadata?.deployRef === expectedRef
-                          && metadata?.environment === expectedEnvironment
-                        );
-                      } catch {
-                        return false;
-                      }
-                  });
-                  if (!matched) {
-                    process.stderr.write("expected ws_artifact_start identity not found\n");
-                    process.exit(1);
-                  }
-                ' "$RELEASE_SHA" "$DEPLOY_REF" preview
 
             verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json" installed-after-restart
             BASH

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -344,6 +344,9 @@ function resolveDynamicCleanupPolicy(eventName) {
 
 function resolveJanitorResultPolicy(data) {
   if (data?.ok !== true) return { severity: "ERROR", category: "janitor", classified: true };
+  if (data?.status === "managed_continuous_human_removed") {
+    return { severity: "DEBUG", category: "janitor", classified: true };
+  }
   if (data?.changed === true || data?.closed === true) {
     return { severity: "INFO", category: "janitor", classified: true };
   }

--- a/ws-server/poker/observability/poker-log-runtime-control.mjs
+++ b/ws-server/poker/observability/poker-log-runtime-control.mjs
@@ -58,7 +58,7 @@ export function createPokerLogRuntimeControl({
   audit = () => {}
 } = {}) {
   const configuredLevel = normalizeLevel(env?.WS_POKER_LOG_LEVEL);
-  const defaultLevel = configuredLevel || "INFO";
+  const defaultLevel = configuredLevel || "ERROR";
   const invalidConfiguredLevel = env?.WS_POKER_LOG_LEVEL != null && !configuredLevel;
   const legacyPokerDebug = env?.WS_POKER_VERBOSE_LOGS === "1";
   const legacyAutoplayDebug = env?.WS_BOT_AUTOPLAY_VERBOSE_LOGS === "1";

--- a/ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs
+++ b/ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createDisconnectCleanupRuntime } from './disconnect-cleanup.mjs';
+import { runTableJanitor } from './table-janitor.mjs';
 
 function socketFor(tableId) {
   return { __connState: { joinedTableId: tableId, subscribedTableId: null } };
@@ -301,4 +302,212 @@ test('forgetTable removes only cleanup candidates owned by the evicted table', (
   assert.equal(runtime.forgetTable('t_evicted'), 2);
   assert.equal(runtime.forgetTable('t_evicted'), 0);
   assert.equal(runtime.size(), 1);
+});
+
+
+test('concurrent sweeps coalesce cleanup and emit one janitor result', async () => {
+  let releaseCleanup;
+  let cleanupStartedResolve;
+  const cleanupStarted = new Promise((resolve) => {
+    cleanupStartedResolve = resolve;
+  });
+  const cleanupGate = new Promise((resolve) => {
+    releaseCleanup = resolve;
+  });
+  const cleanupCalls = [];
+  const logs = [];
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async (input) => {
+      cleanupCalls.push(input);
+      cleanupStartedResolve();
+      await cleanupGate;
+      return runTableJanitor({
+        classification: {
+          tableId: input.tableId,
+          healthy: false,
+          classification: 'disconnect_cleanup',
+          action: 'disconnect_cleanup',
+          reasonCode: 'disconnect_candidate',
+          concerns: [],
+          userId: input.userId
+        },
+        trigger: 'disconnect_cleanup',
+        requestId: input.requestId,
+        primitives: {
+          disconnect_cleanup: async () => ({
+            ok: true,
+            changed: true,
+            status: 'managed_continuous_human_removed',
+            retryable: false
+          })
+        },
+        klog: (kind, data) => logs.push({ kind, data }),
+        klogVerbose: () => {}
+      });
+    },
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_coalesced', userId: 'u_coalesced' });
+  const firstSweep = runtime.sweep();
+  await cleanupStarted;
+  const secondSweep = runtime.sweep();
+  assert.strictEqual(firstSweep, secondSweep);
+
+  releaseCleanup();
+  await secondSweep;
+
+  assert.equal(cleanupCalls.length, 1);
+  assert.deepEqual(logs.map((entry) => entry.kind), ['ws_table_janitor_result']);
+  assert.equal(logs[0].data.status, 'managed_continuous_human_removed');
+});
+
+test('sweep requests during an active round schedule one follow-up round', async () => {
+  let releaseFirst;
+  let firstStartedResolve;
+  const firstStarted = new Promise((resolve) => {
+    firstStartedResolve = resolve;
+  });
+  const firstGate = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const calls = [];
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async ({ tableId }) => {
+      calls.push(tableId);
+      if (tableId === 't_first') {
+        firstStartedResolve();
+        await firstGate;
+      }
+      return { ok: true, changed: true, status: 'cleaned', retryable: false };
+    },
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_first', userId: 'u_first' });
+  const firstSweep = runtime.sweep();
+  await firstStarted;
+  runtime.enqueue({ tableId: 't_second', userId: 'u_second' });
+  const secondSweep = runtime.sweep();
+  assert.strictEqual(firstSweep, secondSweep);
+
+  releaseFirst();
+  await firstSweep;
+
+  assert.deepEqual(calls, ['t_first', 't_second']);
+  assert.equal(runtime.size(), 0);
+});
+
+test('sweep state is cleared after a failed round', async () => {
+  let shouldFail = true;
+  let cleanupCalls = 0;
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async () => {
+      cleanupCalls += 1;
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('cleanup_failed');
+      }
+      return { ok: true, changed: true, status: 'cleaned', retryable: false };
+    },
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_failed_round', userId: 'u_failed_round' });
+  await assert.rejects(runtime.sweep(), /cleanup_failed/);
+  assert.equal(runtime.size(), 1);
+
+  await runtime.sweep();
+  assert.equal(cleanupCalls, 2);
+  assert.equal(runtime.size(), 0);
+});
+
+
+test('concurrent janitor failure emits one ERROR result', async () => {
+  let releaseCleanup;
+  let cleanupStartedResolve;
+  const cleanupStarted = new Promise((resolve) => {
+    cleanupStartedResolve = resolve;
+  });
+  const cleanupGate = new Promise((resolve) => {
+    releaseCleanup = resolve;
+  });
+  const cleanupCalls = [];
+  const logs = [];
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async (input) => {
+      cleanupCalls.push(input);
+      cleanupStartedResolve();
+      await cleanupGate;
+      return runTableJanitor({
+        classification: {
+          tableId: input.tableId,
+          healthy: false,
+          classification: 'disconnect_cleanup',
+          action: 'disconnect_cleanup',
+          reasonCode: 'disconnect_candidate',
+          concerns: [],
+          userId: input.userId
+        },
+        trigger: 'disconnect_cleanup',
+        requestId: input.requestId,
+        primitives: {
+          disconnect_cleanup: async () => ({
+            ok: false,
+            changed: false,
+            status: 'cleanup_failed',
+            code: 'inactive_cleanup_failed',
+            retryable: false
+          })
+        },
+        klog: (kind, data) => logs.push({ kind, data }),
+        klogVerbose: () => {}
+      });
+    },
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_failed', userId: 'u_failed' });
+  const firstSweep = runtime.sweep();
+  await cleanupStarted;
+  const secondSweep = runtime.sweep();
+  assert.strictEqual(firstSweep, secondSweep);
+
+  releaseCleanup();
+  await secondSweep;
+
+  assert.equal(cleanupCalls.length, 1);
+  assert.deepEqual(logs.map((entry) => entry.kind), ['ws_table_janitor_result']);
+  assert.equal(logs[0].data.ok, false);
+});
+
+
+test('a requested follow-up round still runs after a failed round', async () => {
+  let shouldFail = true;
+  let cleanupCalls = 0;
+  const runtime = createDisconnectCleanupRuntime({
+    executeCleanup: async () => {
+      cleanupCalls += 1;
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('cleanup_failed');
+      }
+      return { ok: true, changed: true, status: 'cleaned', retryable: false };
+    },
+    listActiveSocketsForUser: () => [],
+    socketMatchesTable: () => false
+  });
+
+  runtime.enqueue({ tableId: 't_failed_rerun', userId: 'u_failed_rerun' });
+  const firstSweep = runtime.sweep();
+  const secondSweep = runtime.sweep();
+  assert.strictEqual(firstSweep, secondSweep);
+  await assert.rejects(firstSweep, /cleanup_failed/);
+
+  assert.equal(cleanupCalls, 2);
+  assert.equal(runtime.size(), 0);
 });

--- a/ws-server/poker/runtime/disconnect-cleanup.mjs
+++ b/ws-server/poker/runtime/disconnect-cleanup.mjs
@@ -11,6 +11,8 @@ export function createDisconnectCleanupRuntime({
   const candidates = new Map();
   const MAX_CLEANUP_FAILURES = 8;
   const CLEANUP_RETRY_BACKOFF_BASE_MS = 1000;
+  let sweepInFlight = null;
+  let sweepAgainRequested = false;
 
   function key(tableId, userId) {
     return `${tableId}:${userId}`;
@@ -37,7 +39,7 @@ export function createDisconnectCleanupRuntime({
     return true;
   }
 
-  async function sweep() {
+  async function sweepOnce() {
     for (const candidate of [...candidates.values()]) {
       const currentNowMs = nowMs();
       const activeSockets = typeof listActiveSocketsForUser === 'function' ? (listActiveSocketsForUser(candidate.userId) || []) : [];
@@ -110,6 +112,35 @@ export function createDisconnectCleanupRuntime({
       candidate.retryNotBeforeMs = currentNowMs + backoffMs;
       candidates.set(key(candidate.tableId, candidate.userId), candidate);
     }
+  }
+
+  function sweep() {
+    if (sweepInFlight) {
+      sweepAgainRequested = true;
+      return sweepInFlight;
+    }
+
+    sweepAgainRequested = false;
+    sweepInFlight = Promise.resolve().then(async () => {
+      let firstError = null;
+      try {
+        while (true) {
+          try {
+            await sweepOnce();
+          } catch (error) {
+            if (firstError === null) firstError = error;
+          }
+          if (!sweepAgainRequested) break;
+          sweepAgainRequested = false;
+        }
+        if (firstError !== null) throw firstError;
+      } finally {
+        sweepAgainRequested = false;
+        sweepInFlight = null;
+      }
+    });
+
+    return sweepInFlight;
   }
 
   function size() {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -676,6 +676,38 @@ test("poker log policy owns envelope metadata and preserves compatibility for un
   );
 });
 
+test("managed continuous human removal is DEBUG-gated and janitor errors remain visible", () => {
+  const success = {
+    ok: true,
+    changed: true,
+    status: "managed_continuous_human_removed"
+  };
+  assert.deepEqual(
+    resolvePokerLogPolicy("ws_table_janitor_result", success),
+    { severity: "DEBUG", category: "janitor", classified: true }
+  );
+
+  const control = createPokerLogRuntimeControl({
+    env: { WS_POKER_LOG_LEVEL: "ERROR" },
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {}
+  });
+  assert.equal(control.shouldEmit("ws_table_janitor_result", success), false);
+  control.enable({ scope: "category", category: "janitor", ttlMs: 60_000 });
+  assert.equal(control.shouldEmit("ws_table_janitor_result", success), true);
+
+  const failure = {
+    ok: false,
+    changed: false,
+    status: "cleanup_failed"
+  };
+  assert.deepEqual(
+    resolvePokerLogPolicy("ws_table_janitor_result", failure),
+    { severity: "ERROR", category: "janitor", classified: true }
+  );
+  assert.equal(control.shouldEmit("ws_table_janitor_result", failure), true);
+});
+
 test("poker log serialization failures use a safe classified fallback", () => {
   const circularPayload = {};
   circularPayload.self = circularPayload;
@@ -785,8 +817,15 @@ test("poker log runtime control rejects invalid scopes, TTLs, categories, and ta
     setTimer: () => ({ unref() {} }),
     clearTimer: () => {}
   });
-  assert.equal(invalidConfig.defaultLevel, "INFO");
+  assert.equal(invalidConfig.defaultLevel, "ERROR");
   assert.equal(invalidConfig.invalidConfiguredLevel, true);
+
+  const defaultConfig = createPokerLogRuntimeControl({
+    env: {},
+    setTimer: () => ({ unref() {} }),
+    clearTimer: () => {}
+  });
+  assert.equal(defaultConfig.defaultLevel, "ERROR");
 
   const control = createPokerLogRuntimeControl({
     tableOverrideLimit: 1,

--- a/ws-tests/ws-container-starts.behavior.test.mjs
+++ b/ws-tests/ws-container-starts.behavior.test.mjs
@@ -60,6 +60,8 @@ function startWsContainer(imageTag, containerName) {
     containerName,
     "-e",
     "PORT=3000",
+    "-e",
+    "WS_POKER_LOG_LEVEL=INFO",
     "-p",
     "0:3000",
     imageTag

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -83,20 +83,15 @@ test("ws preview deploy verifies release identity before and after rsync and aft
   const firstRsync = text.indexOf('sudo -n rsync -a --checksum --delete "$TMP_EXTRACT_DIR/ws-server/" "$PREVIEW_APP_DIR"/');
   const afterRsync = text.indexOf('verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"');
   const restart = text.indexOf('sudo -n systemctl restart "$PREVIEW_SERVICE_NAME"');
-  const journalCheck = text.indexOf('sudo -n journalctl -u "$PREVIEW_SERVICE_NAME" --since "$RESTART_SINCE"');
   const finalMetadataCheck = text.lastIndexOf('verify_release_metadata "$PREVIEW_APP_DIR/release-metadata.json"');
 
   assert.ok(beforeRsync > 0 && beforeRsync < firstRsync, "archive metadata must be verified before rsync");
   assert.ok(afterRsync > firstRsync && afterRsync < restart, "installed metadata must be verified before restart");
-  assert.ok(journalCheck > restart, "runtime startup identity must be verified after restart");
-  assert.ok(finalMetadataCheck > journalCheck, "installed metadata must be verified again after runtime startup");
+  assert.ok(finalMetadataCheck > restart, "installed metadata must be verified again after runtime restart");
   assert.match(text, /metadata\?\.releaseSha !== expectedSha/);
   assert.match(text, /metadata\?\.deployRef !== expectedRef/);
   assert.match(text, /metadata\?\.environment !== expectedEnvironment/);
-  assert.match(text, /metadata\?\.releaseSha === expectedSha/);
-  assert.match(text, /metadata\?\.deployRef === expectedRef/);
-  assert.match(text, /metadata\?\.environment === expectedEnvironment/);
-  assert.match(text, /ws_artifact_start/);
+  assert.doesNotMatch(text, /journalctl -u "\$PREVIEW_SERVICE_NAME"/);
 });
 
 test("ws preview deploy metadata verifier fails closed on a mismatched SHA", () => {


### PR DESCRIPTION
## Summary

- Coalesce concurrent `disconnectCleanupRuntime.sweep()` calls into one in-flight Promise.
- Schedule one follow-up sweep when another request arrives during the active round, including after a failed round.
- Classify `managed_continuous_human_removed` as `DEBUG`.
- Change the default and invalid-configuration fallback log level to `ERROR` while preserving `ws_poker_log_config_invalid`.
- Add coverage for concurrent cleanup/result emission, follow-up rounds, failure cleanup, DEBUG overrides, and ERROR visibility.

## Root cause

Multiple WS message, socket-close, and interval paths could enter the disconnect cleanup runtime concurrently. The per-table command queue deduplicated the underlying cleanup, but each outer janitor invocation could log the shared result again with the same request ID.

## Validation

- `npm test`
- `npm run check:all`
- `npm run syntax`
- Targeted disconnect cleanup, table command queue, table janitor, and poker log runtime-control tests

No gameplay, persistence, accounting, settlement, database schema, or socket lifecycle semantics were changed.

Closes #824