### PR TITLE
poker: extend HAND_SETTLED audit metadata to v2

### DIFF
--- a/docs/poker-hand-audit-v2.md
+++ b/docs/poker-hand-audit-v2.md
@@ -1,0 +1,55 @@
+# Poker hand audit record v2
+
+`HAND_SETTLED` remains the single compact per-hand audit record in
+`public.poker_actions`, uniquely identified by `(table_id, hand_id)`. The
+writer stores `meta.auditVersion = 2` and serializes the authoritative
+settlement result already present in `state.showdown.potsAwarded`.
+
+The v2 additions are:
+
+- `participants[]`: `userId`, `seatNo`, `folded`, `startingStack`,
+  `endingStack`, `contribution`, `payout`;
+- `potsAwarded[]`: the existing pot fields plus internal `returnUserId` on an
+  uncalled-return pot;
+- `integrity`: status, flags, totals, and conservation deltas.
+
+`participants[]` is built only from `state.handSeats`, so a player joining
+after hand start is not included. Start stacks come from
+`handStartStacksByUserId`, captured before blinds. If an older state does not
+have that map, the writer may derive a value for diagnostics but marks the
+record `INCOMPLETE` with `STARTING_STACK_DERIVED`.
+
+For each participant:
+
+```text
+startingStack = endingStack + contribution - payout
+```
+
+Global conservation uses the returned amount separately from contestable
+pools:
+
+```text
+contributionTotal = contestablePotTotal + returnedTotal
+awardedPotTotal = contestablePotTotal + returnedTotal
+payoutTotal = awardedPotTotal
+startingStackTotal = endingStackTotal + contributionTotal - payoutTotal
+```
+
+For example, with user 1 starting at 500 and contributing 240, user 2
+starting at 500 and contributing 50, a 100-chip contestable pot and a
+190-chip return to user 1 produce ending stacks 550 and 450. The totals are
+`starting=1000`, `ending=1000`, `contribution=290`, `returned=190`,
+`contestable=100`, `awarded=290`, `payout=290`; every conservation delta is
+zero.
+
+The persistence path does not call `buildSidePots()`. It does not reconstruct
+domain state and does not write a per-hand ledger settlement. `HAND_SETTLED`
+remains best-effort for now; fail-closed persistence is a separate follow-up
+because it would change settlement runtime semantics. The existing cleanup
+continues to retain human settlement markers for seven days and uses the
+configured bot retention for bot-only tables.
+
+The admin reader accepts both v1 and v2 records. Public WS projections expose
+only `amount`, `winners`, and `eligibleUserIds` for awarded pots;
+`returnUserId` is internal audit data and is removed by both public read
+models.

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1073,9 +1073,16 @@
     var potRows = settlement && Array.isArray(settlement.potsAwarded) ? settlement.potsAwarded.map(function(pot){
       return {
         title: escapeHtml("pot " + formatAmount(pot && pot.amount)),
-        meta: escapeHtml("eligible " + joinList(pot && pot.eligibleUserIds || []) + " · winners " + joinList(pot && pot.winners || [])),
+        meta: escapeHtml("eligible " + joinList(pot && pot.eligibleUserIds || []) + " · winners " + joinList(pot && pot.winners || []) + (pot && pot.returnUserId ? " · return " + pot.returnUserId : "")),
       };
     }) : [];
+    var participantRows = settlement && Array.isArray(settlement.participants) ? settlement.participants.map(function(participant){
+      return {
+        title: escapeHtml((participant && participant.userId || "user") + " · seat " + (participant && participant.seatNo == null ? "—" : participant.seatNo)),
+        meta: escapeHtml("start " + formatAmount(participant && participant.startingStack) + " · end " + formatAmount(participant && participant.endingStack) + " · contribution " + formatAmount(participant && participant.contribution) + " · payout " + formatAmount(participant && participant.payout) + (participant && participant.folded ? " · folded" : "")),
+      };
+    }) : [];
+    var integrity = settlement && settlement.integrity ? settlement.integrity : null;
     var evaluatedRows = settlement && Array.isArray(settlement.evaluatedHands) ? settlement.evaluatedHands.map(function(item){
       return {
         title: escapeHtml((item && item.userId || "user") + " · " + formatEvaluatedHandLabel(item)),
@@ -1104,6 +1111,8 @@
     html.push('<div><h3 class="admin-section-title">Board</h3>' + renderCardCodes(settlement && settlement.communityCards || []) + "</div>");
     html.push('<div><h3 class="admin-section-title">Winners / payouts</h3>' + renderMiniList(payoutRows) + "</div>");
     html.push('<div><h3 class="admin-section-title">Pots</h3>' + renderMiniList(potRows) + "</div>");
+    html.push('<div><h3 class="admin-section-title">Participants</h3>' + renderMiniList(participantRows) + "</div>");
+    html.push('<div><h3 class="admin-section-title">Integrity</h3>' + (integrity ? '<div class="admin-kv">' + renderKvRow("status", integrity.status || "—") + renderKvRow("stack delta", formatAmount(integrity.stackConservationDelta)) + renderKvRow("pot delta", formatAmount(integrity.potConservationDelta)) + renderKvRow("payout delta", formatAmount(integrity.payoutConservationDelta)) + renderKvRow("flags", joinList(integrity.flags || [])) + "</div>" : '<p class="admin-empty">No v2 integrity summary recorded.</p>') + "</div>");
     html.push('<div><h3 class="admin-section-title">Evaluated hands</h3>' + renderMiniList(evaluatedRows) + "</div>");
     html.push('<div><h3 class="admin-section-title">Private cards</h3>');
     html.push('<p class="admin-note admin-note--danger">Private cards are sensitive. Reveal only for audit/debugging.</p>');

--- a/netlify/functions/_shared/poker-payout.mjs
+++ b/netlify/functions/_shared/poker-payout.mjs
@@ -101,7 +101,7 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       }
       nextStacks[returnUserId] = baseStack + amount;
       potAwardedTotal += amount;
-      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId], returnUserId });
       continue;
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);

--- a/netlify/functions/_shared/poker-start-hand-core.mjs
+++ b/netlify/functions/_shared/poker-start-hand-core.mjs
@@ -98,6 +98,7 @@ export const startHandCore = async ({
     });
     throw makeError(409, "state_invalid");
   }
+  const handStartStacksByUserId = { ...nextStacks };
 
   const toCallByUserId = Object.fromEntries(activeUserIdList.map((activeId) => [activeId, 0]));
   const betThisRoundByUserId = Object.fromEntries(activeUserIdList.map((activeId) => [activeId, 0]));
@@ -174,6 +175,7 @@ export const startHandCore = async ({
     seats: derivedSeats,
     handSeats: derivedSeats.slice(),
     stacks: nextStacks,
+    handStartStacksByUserId,
     dealerSeatNo,
     turnUserId,
     toCallByUserId,

--- a/netlify/functions/_shared/poker-state-utils.mjs
+++ b/netlify/functions/_shared/poker-state-utils.mjs
@@ -180,7 +180,7 @@ const upgradeLegacyInitStateWithSeats = (state, seatsOrdered) => {
 
 const withoutPrivateState = (state) => {
   if (!state || typeof state !== "object" || Array.isArray(state)) return state;
-  const { holeCardsByUserId, deck, handSeed, ...rest } = state;
+  const { holeCardsByUserId, deck, handSeed, handStartStacksByUserId, ...rest } = state;
   return rest;
 };
 

--- a/netlify/functions/admin-poker-audit.mjs
+++ b/netlify/functions/admin-poker-audit.mjs
@@ -107,11 +107,47 @@ function payoutTotal(payoutByUserId) {
   return Object.values(payoutByUserId || {}).reduce((sum, amount) => sum + (Number.isFinite(Number(amount)) ? Number(amount) : 0), 0);
 }
 
+function normalizeAuditParticipants(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((participant) => participant && typeof participant === "object" && !Array.isArray(participant))
+    .map((participant) => ({
+      userId: normalizeText(participant.userId),
+      seatNo: Number.isInteger(participant.seatNo) ? participant.seatNo : null,
+      folded: participant.folded === true,
+      startingStack: normalizeNumber(participant.startingStack),
+      endingStack: normalizeNumber(participant.endingStack),
+      contribution: normalizeNumber(participant.contribution),
+      payout: normalizeNumber(participant.payout)
+    }))
+    .filter((participant) => participant.userId);
+}
+
+function normalizeAuditIntegrity(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const status = typeof value.status === "string" ? value.status : null;
+  return {
+    status,
+    flags: normalizeStringList(value.flags),
+    startingStackTotal: normalizeNumber(value.startingStackTotal),
+    endingStackTotal: normalizeNumber(value.endingStackTotal),
+    contributionTotal: normalizeNumber(value.contributionTotal),
+    contestablePotTotal: normalizeNumber(value.contestablePotTotal),
+    returnedTotal: normalizeNumber(value.returnedTotal),
+    awardedPotTotal: normalizeNumber(value.awardedPotTotal),
+    payoutTotal: normalizeNumber(value.payoutTotal),
+    stackConservationDelta: normalizeNumber(value.stackConservationDelta),
+    potConservationDelta: normalizeNumber(value.potConservationDelta),
+    payoutConservationDelta: normalizeNumber(value.payoutConservationDelta)
+  };
+}
+
 function normalizeSettlement(row) {
   if (!row) return null;
   const meta = parseMeta(row.meta);
   const payoutByUserId = normalizePayoutMap(meta.payoutByUserId);
   return {
+    auditVersion: Number.isInteger(Number(meta.auditVersion)) ? Number(meta.auditVersion) : null,
     reason: typeof meta.reason === "string" ? meta.reason : null,
     settledAt: typeof meta.settledAt === "string" ? meta.settledAt : (row.created_at || null),
     communityCards: normalizeStringList(meta.communityCards),
@@ -119,6 +155,8 @@ function normalizeSettlement(row) {
     payoutByUserId,
     payoutTotal: payoutTotal(payoutByUserId),
     potsAwarded: Array.isArray(meta.potsAwarded) ? meta.potsAwarded : [],
+    participants: normalizeAuditParticipants(meta.participants),
+    integrity: normalizeAuditIntegrity(meta.integrity),
     evaluatedHands: Array.isArray(meta.evaluatedHands) ? meta.evaluatedHands : []
   };
 }

--- a/tests/admin-poker-audit.behavior.test.mjs
+++ b/tests/admin-poker-audit.behavior.test.mjs
@@ -51,12 +51,15 @@ const rows = [
     phase_to: "SETTLED",
     created_at: "2026-07-01T10:01:00.000Z",
     meta: JSON.stringify({
+      auditVersion: 2,
       reason: "computed",
       settledAt: "2026-07-01T10:01:00.000Z",
       communityCards: ["6C", "4S", "4C", "9D", "TD"],
       winners: ["00000000-0000-4000-8000-0000000000a1"],
       payoutByUserId: { "00000000-0000-4000-8000-0000000000a1": 44 },
       potsAwarded: [{ amount: 44, eligibleUserIds: ["00000000-0000-4000-8000-0000000000a1"], winners: ["00000000-0000-4000-8000-0000000000a1"] }],
+      participants: [{ userId: "00000000-0000-4000-8000-0000000000a1", seatNo: 1, folded: false, startingStack: 100, endingStack: 144, contribution: 44, payout: 44 }],
+      integrity: { status: "OK", flags: [], startingStackTotal: 100, endingStackTotal: 144, contributionTotal: 44, contestablePotTotal: 44, returnedTotal: 0, awardedPotTotal: 44, payoutTotal: 44, stackConservationDelta: 0, potConservationDelta: 0, payoutConservationDelta: 0 },
       evaluatedHands: [{ userId: "00000000-0000-4000-8000-0000000000a1", name: "Pair", category: 1, ranks: [10, 9], bestFiveCards: ["TD", "TC", "9D", "6C", "4S"] }],
       deck: ["3H"]
     })
@@ -129,8 +132,11 @@ test("search by handId returns selected hand and parses action plus settlement m
   assert.equal(payload.selectedHand.actions[0].source, "human");
   assert.equal(payload.selectedHand.actions[0].potTotalBefore, 8);
   assert.equal(payload.selectedHand.settlement.reason, "computed");
+  assert.equal(payload.selectedHand.settlement.auditVersion, 2);
   assert.deepEqual(payload.selectedHand.settlement.communityCards, ["6C", "4S", "4C", "9D", "TD"]);
   assert.equal(payload.selectedHand.settlement.payoutByUserId["00000000-0000-4000-8000-0000000000a1"], 44);
+  assert.equal(payload.selectedHand.settlement.participants[0].startingStack, 100);
+  assert.equal(payload.selectedHand.settlement.integrity.status, "OK");
   assert.equal(payload.selectedHand.settlement.evaluatedHands[0].name, "Pair");
   assert.equal(Object.prototype.hasOwnProperty.call(payload.selectedHand, "privateCardsByUserId"), false);
 });
@@ -187,6 +193,40 @@ test("response does not expose raw hole cards or deck keys", async () => {
   assert.equal(serialized.includes("AS"), false);
   assert.equal(serialized.includes("AD"), false);
   assert.equal(serialized.includes("3H"), false);
+});
+
+test("admin reader keeps v1 compatibility while exposing v2 audit fields", async () => {
+  const legacyRow = {
+    ...rows[1],
+    meta: JSON.stringify({
+      auditVersion: 1,
+      reason: "all_folded",
+      winners: ["legacy-user"],
+      payoutByUserId: { "legacy-user": 5 },
+      potsAwarded: [{ amount: 5, winners: ["legacy-user"], eligibleUserIds: ["legacy-user"] }]
+    })
+  };
+  const currentRow = {
+    ...rows[1],
+    meta: JSON.stringify({
+      auditVersion: 2,
+      reason: "computed",
+      winners: ["current-user"],
+      payoutByUserId: { "current-user": 5 },
+      potsAwarded: [{ amount: 5, winners: ["current-user"], eligibleUserIds: ["current-user"], returnUserId: "current-user" }],
+      participants: [{ userId: "current-user", seatNo: 1, folded: false, startingStack: 10, endingStack: 10, contribution: 5, payout: 5 }],
+      integrity: { status: "OK", flags: [], stackConservationDelta: 0, potConservationDelta: 0, payoutConservationDelta: 0 }
+    })
+  };
+  const payload = await loadPokerAudit({
+    handId: "hand-audit-1",
+    executeSqlFn: async () => [legacyRow, currentRow]
+  });
+
+  assert.equal(payload.ok, true);
+  assert.equal(payload.selectedHand.settlement.auditVersion, 1);
+  assert.deepEqual(payload.selectedHand.settlement.participants, []);
+  assert.equal(payload.selectedHand.settlement.integrity, null);
 });
 
 test("parseMeta defensively handles json strings and strips hidden state keys", () => {

--- a/tests/poker-dead-money-settlement.behavior.test.mjs
+++ b/tests/poker-dead-money-settlement.behavior.test.mjs
@@ -73,7 +73,7 @@ for (const [label, awardPotsAtShowdown] of implementations) {
     assert.deepEqual(nextState.showdown.winners, ["player_a"]);
     assert.deepEqual(nextState.showdown.potsAwarded, [
       { amount: 30, winners: ["player_a"], eligibleUserIds: ["player_a", "player_b"] },
-      { amount: 90, winners: ["folded"], eligibleUserIds: ["folded"] }
+      { amount: 90, winners: ["folded"], eligibleUserIds: ["folded"], returnUserId: "folded" }
     ]);
     assert.deepEqual(nextState.stacks, { folded: 90, player_a: 120, player_b: 90 });
     assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);
@@ -137,7 +137,7 @@ for (const [label, awardPotsAtShowdown] of implementations) {
     assert.deepEqual(nextState.showdown.winners, ["active_c"]);
     assert.deepEqual(nextState.showdown.potsAwarded, [
       { amount: 170, winners: ["active_c"], eligibleUserIds: ["active_c"] },
-      { amount: 20, winners: ["folded_a"], eligibleUserIds: ["folded_a"] }
+      { amount: 20, winners: ["folded_a"], eligibleUserIds: ["folded_a"], returnUserId: "folded_a" }
     ]);
     assert.deepEqual(nextState.stacks, { folded_a: 20, folded_b: 20, active_c: 260 });
     assert.equal(Object.values(nextState.stacks).reduce((total, stack) => total + stack, 0), 300);

--- a/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
@@ -39,6 +39,7 @@ test("engine bootstrap creates deterministic preflop hand with expected invarian
   assert.ok(pokerState.turnDeadlineAt > nowMs);
   assert.equal(Array.isArray(pokerState.seats), true);
   assert.deepEqual(pokerState.handSeats, pokerState.seats);
+  assert.deepEqual(pokerState.handStartStacksByUserId, { user_a: 100, user_b: 100, user_c: 100 });
   assert.equal(typeof pokerState.roomId, "string");
 });
 
@@ -55,6 +56,7 @@ for (const stakes of [{ sb: 1, bb: 2 }, { sb: 5, bb: 10 }]) {
     });
 
     const state = result.coreState.pokerState;
+    assert.deepEqual(state.handStartStacksByUserId, { user_a: 100, user_b: 100, user_c: 100 });
     assert.equal(state.betThisRoundByUserId.user_b, stakes.sb);
     assert.equal(state.betThisRoundByUserId.user_c, stakes.bb);
     assert.equal(state.contributionsByUserId.user_b, stakes.sb);

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -142,6 +142,7 @@ export function buildBootstrappedPokerState({
     const stack = Number(startingStacks?.[userId]);
     return [userId, Number.isFinite(stack) && stack >= 0 ? Math.trunc(stack) : 100];
   }));
+  const handStartStacksByUserId = { ...stacks };
   const betThisRoundByUserId = Object.fromEntries(userIds.map((userId) => [userId, 0]));
   const toCallByUserId = Object.fromEntries(userIds.map((userId) => [userId, 0]));
   const actedThisRoundByUserId = Object.fromEntries(userIds.map((userId) => [userId, false]));
@@ -188,6 +189,7 @@ export function buildBootstrappedPokerState({
     bigBlind,
     lastRaiseSize: bigBlind,
     stacks,
+    handStartStacksByUserId,
     toCallByUserId,
     betThisRoundByUserId,
     actedThisRoundByUserId,

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -691,17 +691,24 @@ test("persisted state writer appends exactly one HAND_SETTLED audit event with s
       handId: "hand_settled",
       phase: "SETTLED",
       community: ["3H", "4H", "5H", "6H", "7H"],
+      handSeats: [{ userId: "u1", seatNo: 1 }, { userId: "u2", seatNo: 2 }],
       seats: [{ userId: "u1", seatNo: 1, status: "ACTIVE" }, { userId: "u2", seatNo: 2, status: "ACTIVE" }],
-      stacks: { u1: 110, u2: 90 },
+      stacks: { u1: 550, u2: 450 },
+      handStartStacksByUserId: { u1: 500, u2: 500 },
+      contributionsByUserId: { u1: 240, u2: 50 },
+      foldedByUserId: { u1: false, u2: false },
       handSettlement: {
         handId: "hand_settled",
         settledAt: "2026-07-01T18:00:00.000Z",
-        payouts: { u1: 10 }
+        payouts: { u1: 290 }
       },
       showdown: {
         reason: "computed",
         winners: ["u1"],
-        potsAwarded: [{ amount: 10, winners: ["u1"], eligibleUserIds: ["u1", "u2"] }],
+        potsAwarded: [
+          { amount: 100, winners: ["u1"], eligibleUserIds: ["u1", "u2"] },
+          { amount: 190, winners: ["u1"], eligibleUserIds: ["u1"], returnUserId: "u1" }
+        ],
         handsByUserId: {
           u1: { category: 4, name: "Straight", ranks: [7], best5: [{ r: 3, s: "H" }, { r: 4, s: "H" }, { r: 5, s: "H" }, { r: 6, s: "H" }, { r: 7, s: "H" }] },
           u2: { category: 1, name: "Pair", ranks: [2, 7, 6, 5], best5: [{ r: 2, s: "C" }, { r: 2, s: "D" }, { r: 7, s: "H" }, { r: 6, s: "H" }, { r: 5, s: "H" }] }
@@ -722,19 +729,36 @@ test("persisted state writer appends exactly one HAND_SETTLED audit event with s
   assert.equal(auditInsert.params[3], "HAND_SETTLED");
   const auditMeta = auditInsert.params[9];
   assert.deepEqual(auditMeta, {
-    auditVersion: 1,
+    auditVersion: 2,
     tableId: "t_settled",
     handId: "hand_settled",
     settledAt: "2026-07-01T18:00:00.000Z",
     reason: "computed",
     communityCards: ["3H", "4H", "5H", "6H", "7H"],
     winners: ["u1"],
-    payoutByUserId: { u1: 10 },
-    potsAwarded: [{ amount: 10, winners: ["u1"], eligibleUserIds: ["u1", "u2"] }],
-    evaluatedHands: [
-      { userId: "u1", category: 4, name: "Straight", ranks: [7], bestFiveCards: ["3H", "4H", "5H", "6H", "7H"] },
-      { userId: "u2", category: 1, name: "Pair", ranks: [2, 7, 6, 5], bestFiveCards: ["2C", "2D", "7H", "6H", "5H"] }
-    ]
+    payoutByUserId: { u1: 290 },
+    potsAwarded: [
+      { amount: 100, winners: ["u1"], eligibleUserIds: ["u1", "u2"] },
+      { amount: 190, winners: ["u1"], eligibleUserIds: ["u1"], returnUserId: "u1" }
+    ],
+    participants: [
+      { userId: "u1", seatNo: 1, folded: false, startingStack: 500, endingStack: 550, contribution: 240, payout: 290 },
+      { userId: "u2", seatNo: 2, folded: false, startingStack: 500, endingStack: 450, contribution: 50, payout: 0 }
+    ],
+    integrity: {
+      status: "OK",
+      flags: [],
+      startingStackTotal: 1000,
+      endingStackTotal: 1000,
+      contributionTotal: 290,
+      contestablePotTotal: 100,
+      returnedTotal: 190,
+      awardedPotTotal: 290,
+      payoutTotal: 290,
+      stackConservationDelta: 0,
+      potConservationDelta: 0,
+      payoutConservationDelta: 0
+    }
   });
 });
 

--- a/ws-server/poker/persistence/persisted-state-writer.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.mjs
@@ -5,7 +5,7 @@ import { writePersistedTableToFile } from "./persisted-state-file-store.mjs";
 import { projectDurableActionResult } from "../idempotency/action-command.mjs";
 
 const HAND_SETTLED_ACTION_TYPE = "HAND_SETTLED";
-const SETTLEMENT_AUDIT_VERSION = 1;
+const SETTLEMENT_AUDIT_VERSION = 2;
 const ACCEPTED_ACTION_AUDIT_VERSION = 1;
 const ACCEPTED_ACTION_TYPES = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE", "ALL_IN"]);
 const MAX_REPLACEMENT_FUNDINGS = 10;
@@ -223,6 +223,21 @@ function normalizeAuditNumber(value) {
   return Number.isFinite(numberValue) ? numberValue : null;
 }
 
+function normalizeAuditChipAmount(value) {
+  const numberValue = normalizeAuditNumber(value);
+  return numberValue !== null && Number.isInteger(numberValue) && numberValue >= 0 ? numberValue : null;
+}
+
+function hasOwn(value, key) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? Object.prototype.hasOwnProperty.call(value, key)
+    : false;
+}
+
+function sumAuditAmounts(values) {
+  return values.reduce((total, value) => total + value, 0);
+}
+
 function readActorStack(state, actorUserId) {
   if (!state || typeof state !== "object" || Array.isArray(state) || !actorUserId) {
     return null;
@@ -290,27 +305,162 @@ function normalizePotsAwarded(potsAwarded) {
   }
   return potsAwarded
     .filter((pot) => pot && typeof pot === "object" && !Array.isArray(pot))
-    .map((pot) => ({
-      amount: Number.isFinite(Number(pot.amount)) ? Number(pot.amount) : 0,
-      winners: normalizeStringList(pot.winners),
-      eligibleUserIds: normalizeStringList(pot.eligibleUserIds)
-    }));
+    .map((pot) => {
+      const normalized = {
+        amount: Number.isFinite(Number(pot.amount)) ? Number(pot.amount) : 0,
+        winners: normalizeStringList(pot.winners),
+        eligibleUserIds: normalizeStringList(pot.eligibleUserIds)
+      };
+      const returnUserId = normalizeAuditString(pot.returnUserId);
+      if (returnUserId) normalized.returnUserId = returnUserId;
+      return normalized;
+    });
 }
 
-function normalizeEvaluatedHands(handsByUserId) {
-  if (!handsByUserId || typeof handsByUserId !== "object" || Array.isArray(handsByUserId)) {
-    return [];
+function buildSettlementAuditDetails({ state, potsAwarded, payoutByUserId }) {
+  const flags = new Set();
+  const handSeats = Array.isArray(state?.handSeats) ? state.handSeats : [];
+  if (handSeats.length === 0) flags.add("HAND_SEATS_MISSING");
+
+  const foldedByUserId = state?.foldedByUserId;
+  const contributionsByUserId = state?.contributionsByUserId;
+  const stacks = state?.stacks;
+  const handStartStacksByUserId = state?.handStartStacksByUserId;
+  const participants = [];
+  const participantUserIds = new Set();
+
+  for (const seat of handSeats) {
+    const userId = normalizeAuditString(seat?.userId);
+    const seatNo = Number.isInteger(seat?.seatNo) ? seat.seatNo : null;
+    if (!userId || seatNo === null || participantUserIds.has(userId)) {
+      flags.add("HAND_SEATS_INVALID");
+      continue;
+    }
+    participantUserIds.add(userId);
+
+    const contribution = normalizeAuditChipAmount(contributionsByUserId?.[userId]);
+    const endingStack = normalizeAuditChipAmount(stacks?.[userId]);
+    const payout = hasOwn(payoutByUserId, userId)
+      ? normalizeAuditChipAmount(payoutByUserId[userId])
+      : 0;
+    const persistedStartingStack = hasOwn(handStartStacksByUserId, userId)
+      ? normalizeAuditChipAmount(handStartStacksByUserId[userId])
+      : null;
+    let startingStack = persistedStartingStack;
+
+    if (persistedStartingStack === null) {
+      flags.add("STARTING_STACK_DERIVED");
+      const derivedStartingStack = endingStack !== null && contribution !== null && payout !== null
+        ? endingStack + contribution - payout
+        : null;
+      startingStack = derivedStartingStack !== null && derivedStartingStack >= 0 ? derivedStartingStack : null;
+      if (startingStack === null) flags.add("STARTING_STACK_MISSING");
+    }
+    if (contribution === null) flags.add("CONTRIBUTION_MISSING");
+    if (endingStack === null) flags.add("ENDING_STACK_MISSING");
+    if (payout === null) flags.add("PAYOUT_INVALID");
+
+    participants.push({
+      userId,
+      seatNo,
+      folded: foldedByUserId?.[userId] === true,
+      startingStack,
+      endingStack,
+      contribution,
+      payout
+    });
   }
-  return Object.entries(handsByUserId)
-    .filter(([userId, hand]) => typeof userId === "string" && userId.trim() && hand && typeof hand === "object" && !Array.isArray(hand))
-    .map(([userId, hand]) => ({
-      userId: userId.trim(),
-      category: hand.category ?? null,
-      name: typeof hand.name === "string" ? hand.name : null,
-      ranks: Array.isArray(hand.ranks) ? hand.ranks.filter((rank) => Number.isFinite(Number(rank))).map((rank) => Number(rank)) : [],
-      bestFiveCards: normalizeCardList(hand.best5)
-    }))
-    .sort((left, right) => left.userId.localeCompare(right.userId));
+
+  for (const userId of Object.keys(payoutByUserId)) {
+    if (!participantUserIds.has(userId)) flags.add("PAYOUT_USER_NOT_IN_HAND_SEATS");
+  }
+
+  let contestablePotTotal = 0;
+  let returnedTotal = 0;
+  let awardedPotTotal = 0;
+  for (const pot of potsAwarded) {
+    const amount = normalizeAuditChipAmount(pot.amount);
+    if (amount === null) {
+      flags.add("POT_AMOUNT_INVALID");
+      continue;
+    }
+    awardedPotTotal += amount;
+    const returnUserId = normalizeAuditString(pot.returnUserId);
+    if (returnUserId) {
+      returnedTotal += amount;
+      if (pot.eligibleUserIds.length !== 1 || pot.eligibleUserIds[0] !== returnUserId) {
+        flags.add("RETURN_POT_INVALID");
+      }
+    } else {
+      contestablePotTotal += amount;
+    }
+  }
+
+  const startingStackTotal = participants.length > 0 && participants.every((participant) => participant.startingStack !== null)
+    ? sumAuditAmounts(participants.map((participant) => participant.startingStack))
+    : null;
+  const endingStackTotal = participants.length > 0 && participants.every((participant) => participant.endingStack !== null)
+    ? sumAuditAmounts(participants.map((participant) => participant.endingStack))
+    : null;
+  const contributionTotal = participants.length > 0 && participants.every((participant) => participant.contribution !== null)
+    ? sumAuditAmounts(participants.map((participant) => participant.contribution))
+    : null;
+  const payoutTotal = Object.values(payoutByUserId).every((amount) => normalizeAuditChipAmount(amount) !== null)
+    ? sumAuditAmounts(Object.values(payoutByUserId).map((amount) => normalizeAuditChipAmount(amount)))
+    : null;
+
+  let stackConservationDelta = null;
+  let potConservationDelta = null;
+  let payoutConservationDelta = null;
+  if (startingStackTotal !== null && endingStackTotal !== null && contributionTotal !== null && payoutTotal !== null) {
+    stackConservationDelta = startingStackTotal - endingStackTotal - contributionTotal + payoutTotal;
+  }
+  if (contributionTotal !== null) {
+    potConservationDelta = contributionTotal - contestablePotTotal - returnedTotal;
+  }
+  if (payoutTotal !== null) {
+    payoutConservationDelta = awardedPotTotal - payoutTotal;
+  }
+
+  for (const participant of participants) {
+    if ([participant.startingStack, participant.endingStack, participant.contribution, participant.payout].every((value) => value !== null)
+      && participant.startingStack !== participant.endingStack + participant.contribution - participant.payout) {
+      flags.add("PLAYER_STACK_CONSERVATION_MISMATCH");
+    }
+  }
+
+  const deltas = [stackConservationDelta, potConservationDelta, payoutConservationDelta];
+  const hasMismatch = deltas.some((delta) => delta !== null && delta !== 0)
+    || flags.has("PLAYER_STACK_CONSERVATION_MISMATCH")
+    || flags.has("RETURN_POT_INVALID")
+    || flags.has("POT_AMOUNT_INVALID");
+  const hasIncompleteData = deltas.some((delta) => delta === null)
+    || flags.has("HAND_SEATS_MISSING")
+    || flags.has("HAND_SEATS_INVALID")
+    || flags.has("STARTING_STACK_DERIVED")
+    || flags.has("STARTING_STACK_MISSING")
+    || flags.has("CONTRIBUTION_MISSING")
+    || flags.has("ENDING_STACK_MISSING")
+    || flags.has("PAYOUT_INVALID")
+    || flags.has("PAYOUT_USER_NOT_IN_HAND_SEATS");
+
+  return {
+    participants,
+    integrity: {
+      status: hasMismatch ? "MISMATCH" : hasIncompleteData ? "INCOMPLETE" : "OK",
+      flags: [...flags].sort(),
+      startingStackTotal,
+      endingStackTotal,
+      contributionTotal,
+      contestablePotTotal,
+      returnedTotal,
+      awardedPotTotal,
+      payoutTotal,
+      stackConservationDelta,
+      potConservationDelta,
+      payoutConservationDelta
+    }
+  };
 }
 
 function buildSettlementAuditMeta({ tableId, state }) {
@@ -331,10 +481,13 @@ function buildSettlementAuditMeta({ tableId, state }) {
     payoutByUserId: normalizePayoutMap(state?.handSettlement?.payouts),
     potsAwarded: normalizePotsAwarded(state?.showdown?.potsAwarded)
   };
-  const evaluatedHands = normalizeEvaluatedHands(state?.showdown?.handsByUserId);
-  if (evaluatedHands.length > 0) {
-    meta.evaluatedHands = evaluatedHands;
-  }
+  const details = buildSettlementAuditDetails({
+    state,
+    potsAwarded: meta.potsAwarded,
+    payoutByUserId: meta.payoutByUserId
+  });
+  meta.participants = details.participants;
+  meta.integrity = details.integrity;
   return meta;
 }
 

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -306,6 +306,7 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
       roomId: "table_settled",
       handId: "hand_settled_1",
       phase: "SETTLED",
+      handStartStacksByUserId: { seated_user: 100, other_user: 100 },
       turnUserId: "seated_user",
       community: ["2H", "3H", "4H", "9C", "KD"],
       potTotal: 0,
@@ -313,7 +314,7 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
       showdown: {
         handId: "hand_settled_1",
         winners: ["other_user"],
-        potsAwarded: [{ amount: 6, winners: ["other_user"], eligibleUserIds: ["seated_user", "other_user"] }],
+        potsAwarded: [{ amount: 6, winners: ["other_user"], eligibleUserIds: ["seated_user", "other_user"], returnUserId: "other_user" }],
         potAwardedTotal: 6,
         reason: "computed"
       },
@@ -360,7 +361,9 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   ]);
   assert.deepEqual(seated.handSettlement.payouts, { other_user: 6 });
   assert.equal(observer.private, null);
+  assert.equal("handStartStacksByUserId" in seated, false);
   assert.equal(observer.showdown.potsAwarded[0].eligibleUserIds.includes("seated_user"), true);
+  assert.equal("returnUserId" in observer.showdown.potsAwarded[0], false);
   assert.deepEqual(seated.private, { userId: "seated_user", seat: 1, holeCards: ["AH", "AD"] });
 });
 

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -9,7 +9,7 @@ function withoutPrivateState(state) {
   if (!state || typeof state !== "object" || Array.isArray(state)) {
     return state;
   }
-  const { holeCardsByUserId, deck, handSeed, ...rest } = state;
+  const { holeCardsByUserId, deck, handSeed, handStartStacksByUserId, ...rest } = state;
   return rest;
 }
 
@@ -186,13 +186,26 @@ function resolveTurnIdentity({ statePublic, turnUserId, turnSeat }) {
   return { userId: turnUserId, seat: turnSeat };
 }
 
+function normalizeAwardedPots(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((pot) => pot && typeof pot === "object" && !Array.isArray(pot))
+    .map((pot) => ({
+      amount: Number.isFinite(Number(pot.amount)) ? Number(pot.amount) : 0,
+      winners: Array.isArray(pot.winners) ? pot.winners.filter((userId) => typeof userId === "string") : [],
+      eligibleUserIds: Array.isArray(pot.eligibleUserIds)
+        ? pot.eligibleUserIds.filter((userId) => typeof userId === "string")
+        : []
+    }));
+}
+
 function normalizeShowdown(showdown) {
   if (!showdown || typeof showdown !== "object" || Array.isArray(showdown)) {
     return null;
   }
   const normalized = {
     winners: Array.isArray(showdown.winners) ? showdown.winners.filter((userId) => typeof userId === "string") : [],
-    potsAwarded: Array.isArray(showdown.potsAwarded) ? showdown.potsAwarded : [],
+    potsAwarded: normalizeAwardedPots(showdown.potsAwarded),
     potAwardedTotal: Number.isFinite(showdown.potAwardedTotal)
       ? showdown.potAwardedTotal
       : Number.isFinite(showdown.potAwarded)

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -364,7 +364,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
       showdown: {
         handId: "h_terminal",
         winners: ["user_a"],
-        potsAwarded: [{ amount: 5, winners: ["user_a"] }],
+        potsAwarded: [{ amount: 5, winners: ["user_a"], eligibleUserIds: ["user_a"], returnUserId: "user_a" }],
         potAwardedTotal: 5,
         reason: "computed",
         revealedShowdownParticipants: [{ userId: "user_a", holeCards: ["AS", "AD"] }]
@@ -380,6 +380,7 @@ test("buildStateSnapshotPayload includes terminal showdown/settlement fields whe
   assert.deepEqual(payload.public.showdown.winners, ["user_a"]);
   assert.deepEqual(payload.public.showdown.revealedShowdownParticipants, [{ userId: "user_a", holeCards: ["AS", "AD"] }]);
   assert.equal(payload.public.showdown.potAwardedTotal, 5);
+  assert.equal("returnUserId" in payload.public.showdown.potsAwarded[0], false);
   assert.deepEqual(payload.public.turn, { userId: null, seat: null, startedAt: null, deadlineAt: null });
   assert.deepEqual(payload.public.actionConstraints, { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null, minBetAmount: null });
   assert.deepEqual(payload.public.handSettlement.payouts, { user_a: 5 });

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -101,13 +101,26 @@ function normalizeLastBettingRoundActionByUserId(value) {
   );
 }
 
+function normalizeAwardedPots(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((pot) => pot && typeof pot === "object" && !Array.isArray(pot))
+    .map((pot) => ({
+      amount: Number.isFinite(Number(pot.amount)) ? Number(pot.amount) : 0,
+      winners: Array.isArray(pot.winners) ? pot.winners.filter((userId) => typeof userId === "string") : [],
+      eligibleUserIds: Array.isArray(pot.eligibleUserIds)
+        ? pot.eligibleUserIds.filter((userId) => typeof userId === "string")
+        : []
+    }));
+}
+
 function normalizeShowdown(showdown) {
   if (!showdown || typeof showdown !== "object" || Array.isArray(showdown)) {
     return null;
   }
   const normalized = {
     winners: Array.isArray(showdown.winners) ? showdown.winners.filter((userId) => typeof userId === "string") : [],
-    potsAwarded: Array.isArray(showdown.potsAwarded) ? showdown.potsAwarded : [],
+    potsAwarded: normalizeAwardedPots(showdown.potsAwarded),
     potAwardedTotal: Number.isFinite(showdown.potAwardedTotal)
       ? showdown.potAwardedTotal
       : Number.isFinite(showdown.potAwarded)

--- a/ws-server/poker/shared/settlement/poker-payout.mjs
+++ b/ws-server/poker/shared/settlement/poker-payout.mjs
@@ -108,7 +108,7 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       }
       nextStacks[returnUserId] = baseStack + amount;
       potAwardedTotal += amount;
-      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId], returnUserId });
       continue;
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);

--- a/ws-server/poker/shared/settlement/poker-state-utils.mjs
+++ b/ws-server/poker/shared/settlement/poker-state-utils.mjs
@@ -182,7 +182,7 @@ const upgradeLegacyInitStateWithSeats = (state, seatsOrdered) => {
 
 const withoutPrivateState = (state) => {
   if (!state || typeof state !== "object" || Array.isArray(state)) return state;
-  const { holeCardsByUserId, deck, handSeed, ...rest } = state;
+  const { holeCardsByUserId, deck, handSeed, handStartStacksByUserId, ...rest } = state;
   return rest;
 };
 

--- a/ws-server/poker/snapshot-runtime/poker-payout.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-payout.mjs
@@ -108,7 +108,7 @@ const awardPotsAtShowdown = ({ state, seatUserIdsInOrder, computeShowdown, nowIs
       }
       nextStacks[returnUserId] = baseStack + amount;
       potAwardedTotal += amount;
-      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId] });
+      potsAwarded.push({ amount, winners: [returnUserId], eligibleUserIds: [returnUserId], returnUserId });
       continue;
     }
     const eligibleSet = new Set(Array.isArray(pot.eligibleUserIds) ? pot.eligibleUserIds : []);

--- a/ws-server/poker/snapshot-runtime/poker-state-utils.mjs
+++ b/ws-server/poker/snapshot-runtime/poker-state-utils.mjs
@@ -182,7 +182,7 @@ const upgradeLegacyInitStateWithSeats = (state, seatsOrdered) => {
 
 const withoutPrivateState = (state) => {
   if (!state || typeof state !== "object" || Array.isArray(state)) return state;
-  const { holeCardsByUserId, deck, handSeed, ...rest } = state;
+  const { holeCardsByUserId, deck, handSeed, handStartStacksByUserId, ...rest } = state;
   return rest;
 };
 

--- a/ws-tests/ws-table-state-payload.test.mjs
+++ b/ws-tests/ws-table-state-payload.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { normalizePrivateBranch } from "../ws-server/poker/read-model/state-snapshot.mjs";
+import { projectRoomCoreSnapshot } from "../ws-server/poker/read-model/room-core-snapshot.mjs";
 
 function loadBuildTableStatePayload() {
   const source = fs.readFileSync(new URL("../ws-server/server.mjs", import.meta.url), "utf8");
@@ -169,4 +170,39 @@ test("buildTableStatePayload redacts opponent cards: only own holeCards in priva
   // Opponent cards are never present anywhere in the payload.
   assert.equal(JSON.stringify(payload).includes("villain"), true); // villain seat/member is public
   assert.deepEqual(payload.private.userId, "hero");
+});
+
+test("final table_state payload excludes internal returnUserId from normalized showdown", () => {
+  const buildTableStatePayload = loadBuildTableStatePayload();
+  const tableSnapshot = projectRoomCoreSnapshot({
+    tableId: "table_return_projection",
+    roomId: "table_return_projection",
+    coreState: {
+      seats: { hero: 1, villain: 2 },
+      pokerState: {
+        tableId: "table_return_projection",
+        handId: "hand_return_projection",
+        phase: "SETTLED",
+        seats: [{ userId: "hero", seatNo: 1 }, { userId: "villain", seatNo: 2 }],
+        stacks: { hero: 110, villain: 90 },
+        showdown: {
+          handId: "hand_return_projection",
+          winners: ["hero"],
+          potsAwarded: [{ amount: 20, winners: ["hero"], eligibleUserIds: ["hero"], returnUserId: "hero" }],
+          potAwardedTotal: 20,
+          reason: "computed"
+        }
+      }
+    },
+    members: [{ userId: "hero", seat: 1 }, { userId: "villain", seat: 2 }],
+    userId: "observer",
+    youSeat: null
+  });
+  const payload = buildTableStatePayload({
+    tableState: { tableId: "table_return_projection", members: [] },
+    tableSnapshot,
+    userId: "observer"
+  });
+
+  assert.equal("returnUserId" in payload.showdown.potsAwarded[0], false);
 });


### PR DESCRIPTION
## Summary

- extends the existing `HAND_SETTLED` record in `public.poker_actions` to `meta.auditVersion: 2`;
- records participants, pre-blind starting stacks, ending stacks, contributions, payouts, full awarded pots, uncalled returns, and conservation integrity;
- preserves `returnUserId` internally while removing it from both public WS read models;
- keeps v1 admin-reader compatibility and existing cleanup/retention behavior;
- keeps settlement audit best-effort; fail-closed persistence remains a separate follow-up.

The persistence writer serializes the authoritative settlement output and does not reconstruct side pots.

## Validation

- `npm test`
- `npm run syntax`
- targeted settlement, persistence, admin-reader, read-model, and final `table_state` payload tests

Refs #826