### PR TITLE
admin: allow up to 100 continuous poker tables

### DIFF
--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1531,6 +1531,9 @@
       nodes.opsMaintenance.innerHTML = '<p class="admin-empty">' + escapeHtml(state.ops.pokerMaintenanceError ? "Continuous maintenance unavailable: " + state.ops.pokerMaintenanceError : "Loading continuous maintenance…") + "</p>";
     } else {
       var continuous = snapshot.continuous || {};
+      var maxDesiredTableCount = Number.isInteger(continuous.maxDesiredTableCount)
+        ? continuous.maxDesiredTableCount
+        : 2;
       var supervisor = continuous.supervisor || {};
       var cleanup = snapshot.cleanup || {};
       var lastRun = cleanup.lastRun || {};
@@ -1548,6 +1551,8 @@
         '<div class="admin-list__title"><span>Continuous tables</span>' + pill(continuous.maintenanceEnabled ? "Enabled" : "Disabled — retiring gracefully", continuous.maintenanceEnabled ? "success" : "info") + "</div>",
         '<div class="admin-kv">',
         renderKvRow("Configured desired count", continuous.desiredTableCount),
+        renderKvRow("Maximum desired count", maxDesiredTableCount),
+        renderKvRow("Creation limit per sweep", continuous.creationLimitPerReconcile || 2),
         renderKvRow("Effective desired count", continuous.effectiveDesiredTableCount),
         renderKvRow("Supervisor started", supervisor.started ? "yes" : "no"),
         renderKvRow("Sweep in progress", supervisor.sweepInProgress ? "yes" : "no"),
@@ -1557,9 +1562,10 @@
         '</div>',
         '<form class="admin-adjust" id="adminOpsMaintenanceForm">',
         '<label class="admin-field"><span class="admin-field__label">Maintenance</span><select class="admin-input" id="adminOpsMaintenanceEnabled"><option value="true">Enabled</option><option value="false">Disabled — existing tables retire gracefully</option></select></label>',
-        '<label class="admin-field"><span class="admin-field__label">Desired tables</span><input class="admin-input" id="adminOpsMaintenanceCount" type="number" min="0" max="100" step="1" required></label>',
+        '<label class="admin-field"><span class="admin-field__label">Desired tables</span><input class="admin-input" id="adminOpsMaintenanceCount" type="number" min="0" max="' + String(maxDesiredTableCount) + '" step="1" required></label>',
         '<div class="admin-filter-actions"><button class="admin-btn admin-btn--primary" id="adminOpsMaintenanceApply" type="submit">Apply maintenance state</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceReconcile" type="button">Reconcile now</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceCleanup" type="button">Run cleanup now</button></div>',
         '</form>',
+        '<div class="admin-note">New tables are created at most ' + String(continuous.creationLimitPerReconcile || 2) + ' per reconcile sweep. Preview stress tests should increase the target gradually.</div>',
         '<div class="admin-note" id="adminOpsMaintenanceStatus" aria-live="polite"></div>',
         '<h3 class="admin-section-title">Managed tables</h3>',
         renderMiniList(tableItems),
@@ -1570,6 +1576,7 @@
         renderKvRow("Human actions retention", cleanup.retention && cleanup.retention.humanActionsMs),
         renderKvRow("Human HAND_SETTLED retention", cleanup.retention && cleanup.retention.humanSettledMs),
         renderKvRow("Batch size", cleanup.batchSize),
+        renderKvRow("Cleanup rounds per sweep", cleanup.sweepRounds),
         renderKvRow("Next cleanup batch · ordinary rows", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.ordinaryActionRows : "unavailable"),
         renderKvRow("Next cleanup batch · HAND_SETTLED", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.handSettledRows : "unavailable"),
         renderKvRow("Last cleanup", formatTimestamp(lastRun.finishedAt)),
@@ -2438,11 +2445,18 @@
     event.preventDefault();
     var enabled = nodes.opsMaintenanceEnabled && nodes.opsMaintenanceEnabled.value === "true";
     var desiredTableCount = Number(nodes.opsMaintenanceCount && nodes.opsMaintenanceCount.value);
-    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > 100){
-      state.ops.pokerMaintenanceError = "desired_table_count must be between 0 and 100";
+    var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
+    var maxDesiredTableCount = continuous && Number.isInteger(continuous.maxDesiredTableCount)
+      ? continuous.maxDesiredTableCount
+      : 2;
+    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > maxDesiredTableCount){
+      state.ops.pokerMaintenanceError = "desired_table_count must be between 0 and " + String(maxDesiredTableCount);
       renderPokerMaintenance();
       return;
     }
+    if (desiredTableCount > 10 && typeof window !== "undefined"
+      && typeof window.confirm === "function"
+      && !window.confirm("This is a high-volume Preview stress test. Continue with " + String(desiredTableCount) + " desired tables?")) return;
     runPokerMaintenance("set_desired_state", { enabled: enabled, desiredTableCount: desiredTableCount });
   }
 

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1557,7 +1557,7 @@
         '</div>',
         '<form class="admin-adjust" id="adminOpsMaintenanceForm">',
         '<label class="admin-field"><span class="admin-field__label">Maintenance</span><select class="admin-input" id="adminOpsMaintenanceEnabled"><option value="true">Enabled</option><option value="false">Disabled — existing tables retire gracefully</option></select></label>',
-        '<label class="admin-field"><span class="admin-field__label">Desired tables</span><input class="admin-input" id="adminOpsMaintenanceCount" type="number" min="0" max="2" step="1" required></label>',
+        '<label class="admin-field"><span class="admin-field__label">Desired tables</span><input class="admin-input" id="adminOpsMaintenanceCount" type="number" min="0" max="100" step="1" required></label>',
         '<div class="admin-filter-actions"><button class="admin-btn admin-btn--primary" id="adminOpsMaintenanceApply" type="submit">Apply maintenance state</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceReconcile" type="button">Reconcile now</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceCleanup" type="button">Run cleanup now</button></div>',
         '</form>',
         '<div class="admin-note" id="adminOpsMaintenanceStatus" aria-live="polite"></div>',
@@ -2438,8 +2438,8 @@
     event.preventDefault();
     var enabled = nodes.opsMaintenanceEnabled && nodes.opsMaintenanceEnabled.value === "true";
     var desiredTableCount = Number(nodes.opsMaintenanceCount && nodes.opsMaintenanceCount.value);
-    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > 2){
-      state.ops.pokerMaintenanceError = "desired_table_count must be between 0 and 2";
+    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > 100){
+      state.ops.pokerMaintenanceError = "desired_table_count must be between 0 and 100";
       renderPokerMaintenance();
       return;
     }

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -180,6 +180,7 @@
     nodes.opsMaintenanceEnabled = doc.getElementById("adminOpsMaintenanceEnabled");
     nodes.opsMaintenanceCount = doc.getElementById("adminOpsMaintenanceCount");
     nodes.opsMaintenanceApply = doc.getElementById("adminOpsMaintenanceApply");
+    nodes.opsMaintenanceStop = doc.getElementById("adminOpsMaintenanceStop");
     nodes.opsMaintenanceReconcile = doc.getElementById("adminOpsMaintenanceReconcile");
     nodes.opsMaintenanceCleanup = doc.getElementById("adminOpsMaintenanceCleanup");
     nodes.opsMaintenanceStatus = doc.getElementById("adminOpsMaintenanceStatus");
@@ -1563,7 +1564,7 @@
         '<form class="admin-adjust" id="adminOpsMaintenanceForm">',
         '<label class="admin-field"><span class="admin-field__label">Maintenance</span><select class="admin-input" id="adminOpsMaintenanceEnabled"><option value="true">Enabled</option><option value="false">Disabled — existing tables retire gracefully</option></select></label>',
         '<label class="admin-field"><span class="admin-field__label">Desired tables</span><input class="admin-input" id="adminOpsMaintenanceCount" type="number" min="0" max="' + String(maxDesiredTableCount) + '" step="1" required></label>',
-        '<div class="admin-filter-actions"><button class="admin-btn admin-btn--primary" id="adminOpsMaintenanceApply" type="submit">Apply maintenance state</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceReconcile" type="button">Reconcile now</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceCleanup" type="button">Run cleanup now</button></div>',
+        '<div class="admin-filter-actions"><button class="admin-btn admin-btn--primary" id="adminOpsMaintenanceApply" type="submit">Apply maintenance state</button><button class="admin-btn admin-btn--danger" id="adminOpsMaintenanceStop" type="button" data-maintenance-stop>Stop continuous tables</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceReconcile" type="button">Reconcile now</button><button class="admin-btn admin-btn--ghost" id="adminOpsMaintenanceCleanup" type="button">Run cleanup now</button></div>',
         '</form>',
         '<div class="admin-note">New tables are created at most ' + String(continuous.creationLimitPerReconcile || 2) + ' per reconcile sweep. Preview stress tests should increase the target gradually.</div>',
         '<div class="admin-note" id="adminOpsMaintenanceStatus" aria-live="polite"></div>',
@@ -1588,6 +1589,7 @@
       nodes.opsMaintenanceEnabled = doc.getElementById("adminOpsMaintenanceEnabled");
       nodes.opsMaintenanceCount = doc.getElementById("adminOpsMaintenanceCount");
       nodes.opsMaintenanceApply = doc.getElementById("adminOpsMaintenanceApply");
+      nodes.opsMaintenanceStop = doc.getElementById("adminOpsMaintenanceStop");
       nodes.opsMaintenanceReconcile = doc.getElementById("adminOpsMaintenanceReconcile");
       nodes.opsMaintenanceCleanup = doc.getElementById("adminOpsMaintenanceCleanup");
       nodes.opsMaintenanceStatus = doc.getElementById("adminOpsMaintenanceStatus");
@@ -1598,6 +1600,7 @@
     if (nodes.opsMaintenanceEnabled) nodes.opsMaintenanceEnabled.disabled = disabled;
     if (nodes.opsMaintenanceCount) nodes.opsMaintenanceCount.disabled = disabled;
     if (nodes.opsMaintenanceApply) nodes.opsMaintenanceApply.disabled = disabled;
+    if (nodes.opsMaintenanceStop) nodes.opsMaintenanceStop.disabled = disabled;
     if (nodes.opsMaintenanceReconcile) nodes.opsMaintenanceReconcile.disabled = disabled;
     if (nodes.opsMaintenanceCleanup) nodes.opsMaintenanceCleanup.disabled = disabled;
     if (nodes.opsMaintenanceStatus) nodes.opsMaintenanceStatus.textContent = pending ? "Updating poker maintenance…" : state.ops.pokerMaintenanceError || "";
@@ -2460,6 +2463,17 @@
     runPokerMaintenance("set_desired_state", { enabled: enabled, desiredTableCount: desiredTableCount });
   }
 
+  function stopContinuousTables(){
+    var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
+    var desiredTableCount = continuous && Number.isInteger(continuous.desiredTableCount)
+      ? continuous.desiredTableCount
+      : 0;
+    if (typeof window !== "undefined"
+      && typeof window.confirm === "function"
+      && !window.confirm("Stop continuous tables? Continuous maintenance will be disabled. No new managed tables will be created. Existing managed tables will retire gracefully after their current hand. Tables with active human presence may remain alive until they can safely retire.")) return;
+    runPokerMaintenance("set_desired_state", { enabled: false, desiredTableCount: desiredTableCount });
+  }
+
   function handleApiError(err, fallback){
     if (err && (err.status === 401 || (err.status === 403 && err.code === "admin_required"))){
       showUnauthorized(getUnauthorizedMessage(err));
@@ -2767,6 +2781,11 @@
       var maintenanceRotateButton = closestEventTarget(event.target, "[data-maintenance-rotate]");
       if (maintenanceRotateButton){
         runPokerMaintenance("request_rotation", { tableId: maintenanceRotateButton.getAttribute("data-maintenance-rotate") });
+        return;
+      }
+      var maintenanceStopButton = closestEventTarget(event.target, "[data-maintenance-stop]");
+      if (maintenanceStopButton){
+        stopContinuousTables();
         return;
       }
       if (event.target && event.target.id === "adminOpsMaintenanceReconcile"){

--- a/netlify/functions/admin-poker-maintenance.mjs
+++ b/netlify/functions/admin-poker-maintenance.mjs
@@ -13,6 +13,7 @@ const EXPOSED_ERRORS = new Set([
   "invalid_request",
   "invalid_enabled",
   "invalid_desired_table_count",
+  "invalid_desired_table_count_step",
   "invalid_table_id",
   "table_not_found",
   "not_managed_table",
@@ -52,12 +53,12 @@ function exactKeys(value, expected) {
   return keys.length === wanted.length && keys.every((key, index) => key === wanted[index]);
 }
 
-function parseBody(body) {
+function parseBody(body, { maxDesiredTableCount = 2 } = {}) {
   const value = parseJsonObject(body);
   const operation = typeof value.operation === "string" ? value.operation.trim().toLowerCase() : "";
   if (operation === "set_desired_state" && exactKeys(value, ["operation", "enabled", "desiredTableCount"])) {
     if (typeof value.enabled !== "boolean" || !Number.isInteger(value.desiredTableCount)
-      || value.desiredTableCount < 0 || value.desiredTableCount > 100) {
+      || value.desiredTableCount < 0 || value.desiredTableCount > maxDesiredTableCount) {
       throw controlError("invalid_desired_table_count");
     }
     return { operation, enabled: value.enabled, desiredTableCount: value.desiredTableCount };
@@ -175,7 +176,9 @@ function createAdminPokerMaintenanceHandler(deps = {}) {
       const admin = await requireAdmin(event, env);
       const target = resolveTarget(buildIdentity());
       if (!target) return jsonResponse(403, cors, { error: "environment_not_allowed" });
-      const payload = event.httpMethod === "POST" ? parseBody(event.body) : null;
+      const payload = event.httpMethod === "POST"
+        ? parseBody(event.body, { maxDesiredTableCount: target === "preview" ? 100 : 2 })
+        : null;
       const result = await proxyMaintenance({
         method: event.httpMethod,
         payload,

--- a/netlify/functions/admin-poker-maintenance.mjs
+++ b/netlify/functions/admin-poker-maintenance.mjs
@@ -57,7 +57,7 @@ function parseBody(body) {
   const operation = typeof value.operation === "string" ? value.operation.trim().toLowerCase() : "";
   if (operation === "set_desired_state" && exactKeys(value, ["operation", "enabled", "desiredTableCount"])) {
     if (typeof value.enabled !== "boolean" || !Number.isInteger(value.desiredTableCount)
-      || value.desiredTableCount < 0 || value.desiredTableCount > 2) {
+      || value.desiredTableCount < 0 || value.desiredTableCount > 100) {
       throw controlError("invalid_desired_table_count");
     }
     return { operation, enabled: value.enabled, desiredTableCount: value.desiredTableCount };

--- a/supabase/migrations/20260802130000_poker_managed_table_profiles_desired_count_100.sql
+++ b/supabase/migrations/20260802130000_poker_managed_table_profiles_desired_count_100.sql
@@ -1,0 +1,4 @@
+alter table public.poker_managed_table_profiles
+  drop constraint poker_managed_table_profiles_desired_count_chk,
+  add constraint poker_managed_table_profiles_desired_count_chk
+    check (desired_table_count between 0 and 100);

--- a/tests/admin-page.contract.test.mjs
+++ b/tests/admin-page.contract.test.mjs
@@ -61,6 +61,10 @@ test("admin ops exposes continuous maintenance and cleanup controls", () => {
   assert.match(adminHtml, /Disabling maintenance does not interrupt an active human hand/);
   assert.match(adminJs, /Run cleanup now/);
   assert.match(adminJs, /Reconcile now/);
+  assert.match(adminJs, /id="adminOpsMaintenanceStop"[^>]+data-maintenance-stop[^>]*>Stop continuous tables/);
+  assert.match(adminJs, /Stop continuous tables\? Continuous maintenance will be disabled\./);
+  assert.match(adminJs, /runPokerMaintenance\("set_desired_state", \{ enabled: false, desiredTableCount: desiredTableCount \}\)/);
+  assert.doesNotMatch(adminJs, /requestRetirement/);
   assert.match(adminJs, /Next cleanup batch · ordinary rows/);
   assert.match(adminJs, /Next cleanup batch · HAND_SETTLED/);
 });

--- a/tests/admin-poker-maintenance.behavior.test.mjs
+++ b/tests/admin-poker-maintenance.behavior.test.mjs
@@ -49,7 +49,7 @@ test("maintenance parser accepts the 100-table bound and rejects browser actor f
     operation: "set_desired_state",
     enabled: false,
     desiredTableCount: 100,
-  })), {
+  }), { maxDesiredTableCount: 100 }), {
     operation: "set_desired_state",
     enabled: false,
     desiredTableCount: 100,
@@ -59,7 +59,8 @@ test("maintenance parser accepts the 100-table bound and rejects browser actor f
     tableId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   });
   assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 2, actorUserId: "spoofed" })), { code: "invalid_request" });
-  assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 101 })), { code: "invalid_desired_table_count" });
+  assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 100 })), { code: "invalid_desired_table_count" });
+  assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 101 }), { maxDesiredTableCount: 100 }), { code: "invalid_desired_table_count" });
 });
 
 test("maintenance proxy selects verified Preview/Production target and signs actor context internally", async () => {
@@ -95,6 +96,33 @@ test("maintenance proxy selects verified Preview/Production target and signs act
   const productionResponse = await production(event("GET"));
   assert.equal(productionResponse.statusCode, 502);
   assert.equal(seen[1].url, "https://ws.kcswh.pl/internal/admin/poker-maintenance");
+});
+
+test("maintenance proxy rejects a 100-table request for the verified Production target", async () => {
+  let fetchCalls = 0;
+  const handler = createAdminPokerMaintenanceHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "production-token"
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: productionIdentity,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error("unexpected_fetch");
+    }
+  });
+
+  const response = await handler(event("POST", JSON.stringify({
+    operation: "set_desired_state",
+    enabled: true,
+    desiredTableCount: 100
+  })));
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), { error: "invalid_desired_table_count" });
+  assert.equal(fetchCalls, 0);
 });
 
 function getFreePort() {

--- a/tests/admin-poker-maintenance.behavior.test.mjs
+++ b/tests/admin-poker-maintenance.behavior.test.mjs
@@ -44,22 +44,22 @@ function productionIdentity() {
   };
 }
 
-test("maintenance parser keeps operations bounded and rejects browser actor fields", () => {
+test("maintenance parser accepts the 100-table bound and rejects browser actor fields", () => {
   assert.deepEqual(parseBody(JSON.stringify({
     operation: "set_desired_state",
     enabled: false,
-    desiredTableCount: 2,
+    desiredTableCount: 100,
   })), {
     operation: "set_desired_state",
     enabled: false,
-    desiredTableCount: 2,
+    desiredTableCount: 100,
   });
   assert.deepEqual(parseBody(JSON.stringify({ operation: "request_rotation", tableId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" })), {
     operation: "request_rotation",
     tableId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   });
   assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 2, actorUserId: "spoofed" })), { code: "invalid_request" });
-  assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 3 })), { code: "invalid_desired_table_count" });
+  assert.throws(() => parseBody(JSON.stringify({ operation: "set_desired_state", enabled: true, desiredTableCount: 101 })), { code: "invalid_desired_table_count" });
 });
 
 test("maintenance proxy selects verified Preview/Production target and signs actor context internally", async () => {

--- a/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
@@ -333,6 +333,36 @@ test("skips sweep when previous sweep is still in progress", async () => {
   assert.equal(firstResult.ok, true);
 });
 
+test("preview stress cleanup repeats bounded batches without changing the production default", async () => {
+  let phase1Calls = 0;
+  const cleanup = createActionHistoryCleanup({
+    maxSweepRounds: 3,
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("candidate_hands")) {
+          phase1Calls += 1;
+          return phase1Calls < 3 ? [{ id: 1 }] : [];
+        }
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  const status = await cleanup.status();
+  assert.equal(result.phase1Deleted, 2);
+  assert.equal(phase1Calls, 3);
+  assert.equal(status.sweepRounds, 3);
+});
+
 test("status exposes effective cleanup configuration and phase-2-only HAND_SETTLED backlog", async () => {
   const queries = [];
   const cleanup = createActionHistoryCleanup({
@@ -357,6 +387,7 @@ test("status exposes effective cleanup configuration and phase-2-only HAND_SETTL
   assert.equal(status.retention.botActionsMs, HOUR);
   assert.equal(status.retention.humanSettledMs, 7 * DAY);
   assert.equal(status.batchSize, 10);
+  assert.equal(status.sweepRounds, 1);
   assert.equal(status.backlog.available, true);
   assert.equal(status.backlog.ordinaryActionRows, 4);
   assert.equal(status.backlog.handSettledRows, 2);

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -13,6 +13,9 @@
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 
 const BACKLOG_CACHE_TTL_MS = 15_000;
+const DEFAULT_MAX_SWEEP_ROUNDS = 1;
+const MAX_SWEEP_ROUNDS = 20;
+// Preview uses bounded repeated batches for stress tests; Production stays at one round.
 
 function resolveCutoff(retentionMs) {
   if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
@@ -160,6 +163,7 @@ returning id;`,
 
 export function createActionHistoryCleanup({
   env = process.env,
+  maxSweepRounds = DEFAULT_MAX_SWEEP_ROUNDS,
   beginSql = beginSqlWs,
   klog = () => {}
 } = {}) {
@@ -211,6 +215,11 @@ export function createActionHistoryCleanup({
 
   const batchSize = resolveBatchSize(env.WS_POKER_ACTION_HISTORY_BATCH_SIZE);
   const lockLimit = batchSize * 2;
+  const sweepRounds = Number.isInteger(maxSweepRounds)
+    && maxSweepRounds >= DEFAULT_MAX_SWEEP_ROUNDS
+    && maxSweepRounds <= MAX_SWEEP_ROUNDS
+    ? maxSweepRounds
+    : DEFAULT_MAX_SWEEP_ROUNDS;
 
   function buildCutoffs() {
 
@@ -368,32 +377,37 @@ select
 
       try {
         result = await beginSql(async (tx) => {
-        // Phase 1 — ordinary actions (must run before Phase 2)
-        const phase1Deleted = await sweepPhase1({
-          tx,
-          botActionCutoff: cutoffs.botActionCutoff,
-          humanActionCutoff: cutoffs.humanActionCutoff,
-          batchSize,
-          lockLimit,
-          klog
-        });
-
-        // Phase 2 — HAND_SETTLED rows whose ordinary actions are already gone
-        const phase2Deleted = await sweepPhase2({
-          tx,
-          botSettledCutoff: cutoffs.botSettledCutoff,
-          humanSettledCutoff: cutoffs.humanSettledCutoff,
-          batchSize,
-          lockLimit,
-          klog
-        });
+        let phase1Deleted = 0;
+        let phase2Deleted = 0;
+        for (let round = 0; round < sweepRounds; round += 1) {
+          const phase1RoundDeleted = await sweepPhase1({
+            tx,
+            botActionCutoff: cutoffs.botActionCutoff,
+            humanActionCutoff: cutoffs.humanActionCutoff,
+            batchSize,
+            lockLimit,
+            klog
+          });
+          const phase2RoundDeleted = await sweepPhase2({
+            tx,
+            botSettledCutoff: cutoffs.botSettledCutoff,
+            humanSettledCutoff: cutoffs.humanSettledCutoff,
+            batchSize,
+            lockLimit,
+            klog
+          });
+          phase1Deleted += phase1RoundDeleted;
+          phase2Deleted += phase2RoundDeleted;
+          if (phase1RoundDeleted === 0 && phase2RoundDeleted === 0) break;
+        }
 
         if (phase1Deleted > 0 || phase2Deleted > 0) {
           klog("ws_action_history_cleanup_complete", {
             phase1Deleted,
             phase2Deleted,
             batchSize,
-            lockLimit
+            lockLimit,
+            sweepRounds
           });
         }
 
@@ -434,6 +448,7 @@ select
         humanSettledMs: humanSettledMs
       },
       batchSize,
+      sweepRounds,
       sweepInProgress,
       lastRun,
       lastError,

--- a/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
@@ -20,12 +20,13 @@ test("setDesiredState persists a bounded profile and keeps configured desired co
   let updatedParams = null;
   const repository = createContinuousBotTableRepository({
     env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    maxDesiredTables: 100,
     beginSql: async (run) => run({
       unsafe: async (sql, params) => {
         if (sql.includes("from public.poker_managed_table_profiles")) return [{ ...PROFILE }];
         if (sql.includes("update public.poker_managed_table_profiles")) {
           updatedParams = params;
-          return [{ ...PROFILE, desired_table_count: 100, updated_at: "2026-08-01T00:00:00.000Z" }];
+          return [{ ...PROFILE, desired_table_count: 10, updated_at: "2026-08-01T00:00:00.000Z" }];
         }
         return [];
       }
@@ -34,14 +35,72 @@ test("setDesiredState persists a bounded profile and keeps configured desired co
 
   const result = await repository.setDesiredState({
     enabled: false,
-    desiredTableCount: 100,
+    desiredTableCount: 10,
     updatedBy: "00000000-0000-4000-8000-000000000010"
   });
 
   assert.equal(result.ok, true);
   assert.equal(result.profile.enabled, false);
-  assert.equal(result.profile.desiredTableCount, 100);
-  assert.deepEqual(updatedParams.slice(1, 4), [false, 100, "00000000-0000-4000-8000-000000000010"]);
+  assert.equal(result.profile.desiredTableCount, 10);
+  assert.deepEqual(updatedParams.slice(1, 4), [false, 10, "00000000-0000-4000-8000-000000000010"]);
+});
+
+test("setDesiredState rejects a desired-count jump larger than the ramp-up step", async () => {
+  let updateCalled = false;
+  const repository = createContinuousBotTableRepository({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db" },
+    maxDesiredTables: 100,
+    beginSql: async (run) => run({
+      unsafe: async (sql) => {
+        if (sql.includes("from public.poker_managed_table_profiles")) return [{ ...PROFILE }];
+        if (sql.includes("update public.poker_managed_table_profiles")) updateCalled = true;
+        return [];
+      }
+    })
+  });
+
+  const result = await repository.setDesiredState({
+    enabled: true,
+    desiredTableCount: 13,
+    updatedBy: "00000000-0000-4000-8000-000000000010"
+  });
+
+  assert.deepEqual(result, { ok: false, reason: "invalid_desired_table_count_step" });
+  assert.equal(updateCalled, false);
+});
+
+test("reconcile creates at most two missing tables per sweep", async () => {
+  const createdTableIds = [
+    "00000000-0000-4000-8000-000000000821",
+    "00000000-0000-4000-8000-000000000822"
+  ];
+  let createIndex = 0;
+  const repository = createContinuousBotTableRepository({
+    env: { SUPABASE_DB_URL: "postgres://example.invalid/db", POKER_BOTS_ENABLED: "1" },
+    maxDesiredTables: 100,
+    beginSql: async (run) => run({
+      unsafe: async (sql) => {
+        if (sql.includes("from public.poker_managed_table_profiles")) {
+          return [{ ...PROFILE, enabled: true, desired_table_count: 100, min_bot_count: 0, target_bot_count: 0, max_bot_count: 0 }];
+        }
+        if (sql.includes("from public.poker_tables") && sql.includes("for update")) return [];
+        if (sql.includes("insert into public.poker_tables")) return [{ id: createdTableIds[createIndex++] }];
+        if (sql.includes("from public.poker_seats") && sql.includes("order by seat_no asc")) return [];
+        if (sql.includes("select state from public.poker_state")) return [{ state: { tableId: createdTableIds[createIndex - 1], phase: "INIT", seats: [], stacks: {} } }];
+        if (sql.includes("update public.poker_state")) return [{ table_id: createdTableIds[createIndex - 1] }];
+        if (sql.includes("insert into public.chips_accounts")) return [{ id: "escrow-id" }];
+        return [];
+      }
+    })
+  });
+
+  const result = await repository.reconcile();
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.createdTableIds, createdTableIds);
+  assert.equal(result.creationLimitPerReconcile, 2);
+  assert.equal(result.creationLimited, true);
+  assert.equal(result.remainingTableCount, 98);
 });
 
 test("requestRetirement persists a due rotation for the exact managed table", async () => {

--- a/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs
@@ -25,7 +25,7 @@ test("setDesiredState persists a bounded profile and keeps configured desired co
         if (sql.includes("from public.poker_managed_table_profiles")) return [{ ...PROFILE }];
         if (sql.includes("update public.poker_managed_table_profiles")) {
           updatedParams = params;
-          return [{ ...PROFILE, updated_at: "2026-08-01T00:00:00.000Z" }];
+          return [{ ...PROFILE, desired_table_count: 100, updated_at: "2026-08-01T00:00:00.000Z" }];
         }
         return [];
       }
@@ -34,14 +34,14 @@ test("setDesiredState persists a bounded profile and keeps configured desired co
 
   const result = await repository.setDesiredState({
     enabled: false,
-    desiredTableCount: 2,
+    desiredTableCount: 100,
     updatedBy: "00000000-0000-4000-8000-000000000010"
   });
 
   assert.equal(result.ok, true);
   assert.equal(result.profile.enabled, false);
-  assert.equal(result.profile.desiredTableCount, 2);
-  assert.deepEqual(updatedParams.slice(1, 4), [false, 2, "00000000-0000-4000-8000-000000000010"]);
+  assert.equal(result.profile.desiredTableCount, 100);
+  assert.deepEqual(updatedParams.slice(1, 4), [false, 100, "00000000-0000-4000-8000-000000000010"]);
 });
 
 test("requestRetirement persists a due rotation for the exact managed table", async () => {

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -9,7 +9,10 @@ import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 
 export const CONTINUOUS_BOT_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
-const MAX_DESIRED_TABLES = 100;
+const DEFAULT_MAX_DESIRED_TABLES = 2;
+const ABSOLUTE_MAX_DESIRED_TABLES = 100;
+const MAX_DESIRED_TABLE_COUNT_INCREASE = 10;
+const MAX_TABLES_CREATED_PER_RECONCILE = 2;
 const MAX_SEATS = 6;
 const MAX_INTERVAL_SECONDS = 86_400;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -23,9 +26,14 @@ function intInRange(value, min, max) {
   return Number.isInteger(parsed) && parsed >= min && parsed <= max ? parsed : null;
 }
 
-export function normalizeContinuousBotProfile(row) {
+export function normalizeContinuousBotProfile(row, { maxDesiredTables = DEFAULT_MAX_DESIRED_TABLES } = {}) {
+  const desiredTableLimit = Number.isInteger(maxDesiredTables)
+    && maxDesiredTables >= DEFAULT_MAX_DESIRED_TABLES
+    && maxDesiredTables <= ABSOLUTE_MAX_DESIRED_TABLES
+    ? maxDesiredTables
+    : DEFAULT_MAX_DESIRED_TABLES;
   const profileKey = typeof row?.profile_key === "string" ? row.profile_key.trim().toUpperCase() : "";
-  const desiredTableCount = intInRange(row?.desired_table_count, 0, MAX_DESIRED_TABLES);
+  const desiredTableCount = intInRange(row?.desired_table_count, 0, desiredTableLimit);
   const maxSeats = intInRange(row?.max_seats, 2, MAX_SEATS);
   const minBotCount = intInRange(row?.min_bot_count, 0, MAX_SEATS - 1);
   const targetBotCount = intInRange(row?.target_bot_count, 0, MAX_SEATS - 1);
@@ -133,9 +141,15 @@ async function createManagedTable(tx, { profile, botConfig, klog }) {
 
 export function createContinuousBotTableRepository({
   env = process.env,
+  maxDesiredTables = DEFAULT_MAX_DESIRED_TABLES,
   beginSql = beginSqlWs,
   klog = () => {}
 } = {}) {
+  const desiredTableLimit = Number.isInteger(maxDesiredTables)
+    && maxDesiredTables >= DEFAULT_MAX_DESIRED_TABLES
+    && maxDesiredTables <= ABSOLUTE_MAX_DESIRED_TABLES
+    ? maxDesiredTables
+    : DEFAULT_MAX_DESIRED_TABLES;
   let lastKnownProfile = null;
 
   async function reconcile() {
@@ -144,7 +158,7 @@ export function createContinuousBotTableRepository({
       const result = await beginSql(async (tx) => {
         await tx.unsafe("select pg_advisory_xact_lock(hashtext($1));", ["poker:continuous-bot-supervisor:v1"]);
         const profileRows = await tx.unsafe(PROFILE_SELECT, [CONTINUOUS_BOT_PROFILE_KEY]);
-        const profile = normalizeContinuousBotProfile(profileRows?.[0]);
+        const profile = normalizeContinuousBotProfile(profileRows?.[0], { maxDesiredTables: desiredTableLimit });
         if (!profile) throw Object.assign(new Error("managed_profile_invalid"), { code: "managed_profile_invalid" });
         const tableRows = await tx.unsafe(
           `select id, status, max_players, stakes, managed_profile_key, rotation_due_at, created_at
@@ -194,13 +208,18 @@ export function createContinuousBotTableRepository({
         }
         const createdTableIds = [];
         const retainedCount = openTables.length;
-        for (let index = retainedCount; index < desiredCount; index += 1) {
+        const creationTarget = Math.min(
+          desiredCount,
+          retainedCount + MAX_TABLES_CREATED_PER_RECONCILE
+        );
+        for (let index = retainedCount; index < creationTarget; index += 1) {
           if (!botConfig.enabled) throw Object.assign(new Error("bots_disabled"), { code: "bots_disabled" });
           const created = await createManagedTable(tx, { profile, botConfig, klog });
           createdTableIds.push(created.tableId);
           rotationScheduledTableIds.push(created.tableId);
           rotationDueAtByTableId[created.tableId] = created.rotationDueAt;
         }
+        const remainingTableCount = Math.max(0, desiredCount - (retainedCount + createdTableIds.length));
         return {
           profile,
           createdTableIds,
@@ -210,7 +229,10 @@ export function createContinuousBotTableRepository({
           ],
           retirementTableIds: uniqueRetirements,
           rotationScheduledTableIds,
-          rotationDueAtByTableId
+          rotationDueAtByTableId,
+          creationLimitPerReconcile: MAX_TABLES_CREATED_PER_RECONCILE,
+          creationLimited: remainingTableCount > 0,
+          remainingTableCount
         };
       }, { env });
       lastKnownProfile = result.profile;
@@ -328,7 +350,7 @@ export function createContinuousBotTableRepository({
 
   async function setDesiredState({ enabled, desiredTableCount, updatedBy } = {}) {
     if (typeof enabled !== "boolean") return { ok: false, reason: "invalid_enabled" };
-    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > MAX_DESIRED_TABLES) {
+    if (!Number.isInteger(desiredTableCount) || desiredTableCount < 0 || desiredTableCount > desiredTableLimit) {
       return { ok: false, reason: "invalid_desired_table_count" };
     }
     const actorUserId = typeof updatedBy === "string" ? updatedBy.trim() : "";
@@ -337,8 +359,11 @@ export function createContinuousBotTableRepository({
       const result = await beginSql(async (tx) => {
         await tx.unsafe("select pg_advisory_xact_lock(hashtext($1));", ["poker:continuous-bot-supervisor:v1"]);
         const previousRows = await tx.unsafe(PROFILE_SELECT, [CONTINUOUS_BOT_PROFILE_KEY]);
-        const previous = normalizeContinuousBotProfile(previousRows?.[0]);
+        const previous = normalizeContinuousBotProfile(previousRows?.[0], { maxDesiredTables: desiredTableLimit });
         if (!previous) throw Object.assign(new Error("managed_profile_invalid"), { code: "managed_profile_invalid" });
+        if (desiredTableCount > previous.desiredTableCount + MAX_DESIRED_TABLE_COUNT_INCREASE) {
+          throw Object.assign(new Error("invalid_desired_table_count_step"), { code: "invalid_desired_table_count_step" });
+        }
         const rows = await tx.unsafe(
           `update public.poker_managed_table_profiles
               set enabled = $2,
@@ -350,7 +375,7 @@ export function createContinuousBotTableRepository({
                       rotation_interval_seconds, postpone_interval_seconds, small_blind, big_blind, max_seats, updated_at;`,
           [CONTINUOUS_BOT_PROFILE_KEY, enabled, desiredTableCount, actorUserId]
         );
-        const profile = normalizeContinuousBotProfile(rows?.[0]);
+        const profile = normalizeContinuousBotProfile(rows?.[0], { maxDesiredTables: desiredTableLimit });
         if (!profile) throw Object.assign(new Error("managed_profile_invalid"), { code: "managed_profile_invalid" });
         return {
           profile,
@@ -387,10 +412,12 @@ export function createContinuousBotTableRepository({
             [CONTINUOUS_BOT_PROFILE_KEY]
           )
         ]);
-        const profile = normalizeContinuousBotProfile(profileRows?.[0]);
+        const profile = normalizeContinuousBotProfile(profileRows?.[0], { maxDesiredTables: desiredTableLimit });
         if (!profile) throw Object.assign(new Error("managed_profile_invalid"), { code: "managed_profile_invalid" });
         return {
           profile,
+          maxDesiredTableCount: desiredTableLimit,
+          creationLimitPerReconcile: MAX_TABLES_CREATED_PER_RECONCILE,
           tables: (Array.isArray(tableRows) ? tableRows : []).map((table) => ({
             tableId: table.id,
             status: table.status || null,
@@ -417,6 +444,8 @@ export function createContinuousBotTableRepository({
     postponeRotation,
     setDesiredState,
     readStatus,
-    currentProfile: () => lastKnownProfile
+    currentProfile: () => lastKnownProfile,
+    maxDesiredTables: desiredTableLimit,
+    creationLimitPerReconcile: MAX_TABLES_CREATED_PER_RECONCILE
   };
 }

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -9,7 +9,7 @@ import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
 
 export const CONTINUOUS_BOT_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
-const MAX_DESIRED_TABLES = 2;
+const MAX_DESIRED_TABLES = 100;
 const MAX_SEATS = 6;
 const MAX_INTERVAL_SECONDS = 86_400;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/ws-server/poker/runtime/continuous-bot-table-supervisor.mjs
+++ b/ws-server/poker/runtime/continuous-bot-table-supervisor.mjs
@@ -54,6 +54,9 @@ export function createContinuousBotTableSupervisor({
       lastSweepResult = {
         ok: true,
         createdCount: Array.isArray(result.createdTableIds) ? result.createdTableIds.length : 0,
+        creationLimitPerReconcile: Number(result.creationLimitPerReconcile || 0),
+        creationLimited: result.creationLimited === true,
+        remainingTableCount: Number(result.remainingTableCount || 0),
         retirementCount: Array.isArray(result.retirementTableIds) ? result.retirementTableIds.length : 0,
         rotationScheduledCount: Array.isArray(result.rotationScheduledTableIds)
           ? result.rotationScheduledTableIds.length

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -47,7 +47,7 @@ const FIXED_RANDOM_BOT_AUTOPLAY_ADAPTER_URL = new URL(
   import.meta.url
 ).href;
 
-test("continuous bot profile validation accepts only the bounded V1 singleton", () => {
+test("continuous bot profile validation accepts desired counts up to 100", () => {
   const valid = normalizeContinuousBotProfile({
     profile_key: "CONTINUOUS_BOT_DEFAULT",
     enabled: true,
@@ -67,7 +67,7 @@ test("continuous bot profile validation accepts only the bounded V1 singleton", 
   assert.equal(normalizeContinuousBotProfile({
     profile_key: "CONTINUOUS_BOT_DEFAULT",
     enabled: true,
-    desired_table_count: 3,
+    desired_table_count: 101,
     min_bot_count: 2,
     target_bot_count: 3,
     max_bot_count: 3,
@@ -77,6 +77,20 @@ test("continuous bot profile validation accepts only the bounded V1 singleton", 
     big_blind: 2,
     max_seats: 6
   }), null);
+  const maxProfile = normalizeContinuousBotProfile({
+    profile_key: "CONTINUOUS_BOT_DEFAULT",
+    enabled: true,
+    desired_table_count: 100,
+    min_bot_count: 2,
+    target_bot_count: 3,
+    max_bot_count: 3,
+    rotation_interval_seconds: 900,
+    postpone_interval_seconds: 300,
+    small_blind: 1,
+    big_blind: 2,
+    max_seats: 6
+  });
+  assert.equal(maxProfile?.desiredTableCount, 100);
 });
 
 test("continuous bot profile comparison accepts Postgres stringified jsonb stakes", () => {

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -89,7 +89,7 @@ test("continuous bot profile validation accepts desired counts up to 100", () =>
     small_blind: 1,
     big_blind: 2,
     max_seats: 6
-  });
+  }, { maxDesiredTables: 100 });
   assert.equal(maxProfile?.desiredTableCount, 100);
 });
 
@@ -1328,6 +1328,38 @@ test("internal poker maintenance route rejects an unknown WS environment before 
     });
     assert.equal(postResponse.status, 503);
     assert.deepEqual(await postResponse.json(), { error: "environment_not_allowed" });
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
+test("internal poker maintenance route keeps the Production desired-table cap", async () => {
+  const token = "internal-production-maintenance-token";
+  const { port, child } = await createServer({
+    env: {
+      POKER_WS_INTERNAL_TOKEN: token,
+      WS_DEPLOY_ENVIRONMENT: "production",
+      SUPABASE_DB_URL: "",
+      WS_POKER_LOG_LEVEL: "INFO"
+    }
+  });
+  const url = `http://127.0.0.1:${port}/internal/admin/poker-maintenance`;
+  try {
+    await waitForListening(child, 5000);
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        operation: "set_desired_state",
+        enabled: true,
+        desiredTableCount: 100,
+        actorUserId: "00000000-0000-4000-8000-000000000010",
+        requestId: "production-cap-request"
+      })
+    });
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), { error: "invalid_desired_table_count" });
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -305,8 +305,16 @@ const durableActionStore = hasSupabaseDbUrl && persistedStateWriter?.readDurable
   ? persistedStateWriter
   : null;
 const botFundingSystemKey = getBotConfig(process.env).bankrollSystemKey;
+function continuousBotMaxDesiredTablesForRuntime() {
+  return loadReleaseMetadata().environment === "preview" ? 100 : 2;
+}
+const continuousBotMaxDesiredTables = continuousBotMaxDesiredTablesForRuntime();
 const continuousBotTableRepository = hasSupabaseDbUrl
-  ? createContinuousBotTableRepository({ env: process.env, klog: klogSafe })
+  ? createContinuousBotTableRepository({
+      env: process.env,
+      maxDesiredTables: continuousBotMaxDesiredTables,
+      klog: klogSafe
+    })
   : null;
 const lastSnapshotBySessionAndTable = new Map();
 const persistedSeatTouchByTableUser = new Map();
@@ -3085,6 +3093,8 @@ async function buildInternalPokerMaintenanceStatus(environment) {
     continuous: {
       maintenanceEnabled: repositoryStatus.profile.enabled,
       desiredTableCount: repositoryStatus.profile.desiredTableCount,
+      maxDesiredTableCount: repositoryStatus.maxDesiredTableCount || continuousBotMaxDesiredTables,
+      creationLimitPerReconcile: repositoryStatus.creationLimitPerReconcile || 2,
       effectiveDesiredTableCount: repositoryStatus.profile.enabled
         ? repositoryStatus.profile.desiredTableCount
         : 0,
@@ -3145,6 +3155,10 @@ async function handleInternalPokerMaintenance(req, res) {
       && typeof payload.enabled === "boolean"
       && Number.isInteger(payload.desiredTableCount)
     ) {
+      if (payload.desiredTableCount < 0 || payload.desiredTableCount > continuousBotMaxDesiredTables) {
+        sendInternalJson(res, 400, { error: "invalid_desired_table_count" });
+        return;
+      }
       const profileResult = await continuousBotTableRepository?.setDesiredState?.({
         enabled: payload.enabled,
         desiredTableCount: payload.desiredTableCount,
@@ -3162,6 +3176,10 @@ async function handleInternalPokerMaintenance(req, res) {
         reconciliationStarted: reconciliation?.skipped !== true,
         reconciliationSkipped: reconciliation?.skipped === true,
         effectiveDesiredTableCount: profileResult.profile.enabled ? profileResult.profile.desiredTableCount : 0,
+        maxDesiredTableCount: continuousBotMaxDesiredTables,
+        creationLimitPerReconcile: reconciliation?.creationLimitPerReconcile || 2,
+        creationLimited: reconciliation?.creationLimited === true,
+        remainingTableCount: Number(reconciliation?.remainingTableCount || 0),
         reconciliationResult: reconciliation?.ok === true ? "ok" : "failed"
       };
     } else if (
@@ -4595,7 +4613,11 @@ const actionHistoryCleanupSweepMs = resolvePositiveInt(
 );
 
 const actionHistoryCleanup = hasSupabaseDbUrl
-  ? createActionHistoryCleanup({ env: process.env, klog: klogSafe })
+  ? createActionHistoryCleanup({
+      env: process.env,
+      maxSweepRounds: loadReleaseMetadata().environment === "preview" ? 10 : 1,
+      klog: klogSafe
+    })
   : null;
 
 if (actionHistoryCleanup) {


### PR DESCRIPTION
## Summary

- allow desired continuous-table counts up to 100 only on verified WS Preview;
- keep Production hard-capped at 2 in both the Netlify proxy and WS runtime;
- update the persisted database constraint to 0..100 through a forward-only migration;
- limit reconcile to creating at most 2 missing tables per sweep;
- require desired-count increases of at most 10 per admin change and show a confirmation for high-volume values;
- keep the active configured desired count unchanged.

## Safety and stress-test behavior

The admin status now exposes the environment-specific maximum and creation limit. The UI derives its input maximum from that status, so Production cannot present a 100-table control.

Preview ramp-up is incremental: a single reconcile transaction creates no more than 2 tables, and a desired-count increase is limited to +10. A persistence failure rolls back the current reconcile transaction and reports the failure; it does not continue creating more tables in that sweep.

Preview cleanup performs up to 10 bounded batch rounds per scheduled sweep, while Production keeps one round and the existing batch-size limit. This preserves the Production cleanup behavior and gives the Preview stress test enough cleanup throughput for the measured action rate. Cleanup status exposes the effective round count.

The intended Preview sequence is gradual (for example 2 → 5 → 10 → 20, then increments of at most 10 through 100). No table count, retention, logging, service, or environment configuration was changed by this PR.

## Validation

- 30 targeted proxy, repository, and cleanup behavior tests passed;
- Production proxy rejects 100 and WS internal Production route rejects 100;
- Preview parser accepts 100 and rejects 101;
- reconcile creation cap test passed;
- desired-count ramp-up step test passed;
- Preview repeated-cleanup-round test passed;
- admin page contract test passed;
- npm run syntax passed;
- npm run check:csp-inline passed;
- no new CSP hash is required because only the already-served external js/admin-page.js changed.

The full ws-server behavior file still contains unrelated process-startup failures in this environment when run without the test database configuration. The changed Production-cap route and profile-boundary tests pass independently.