### PR TITLE
admin: add continuous tables stress health metrics

### DIFF
--- a/.github/workflows/ws-preview-deploy.yml
+++ b/.github/workflows/ws-preview-deploy.yml
@@ -116,6 +116,10 @@ jobs:
             cp -R ws-server/poker "$PREVIEW_STAGE_WS_DIR"/poker
           fi
 
+          if [ -d ws-server/observability ]; then
+            cp -R ws-server/observability "$PREVIEW_STAGE_WS_DIR"/observability
+          fi
+
           if [ -d ws-server/shared/poker-domain ]; then
             mkdir -p "$PREVIEW_STAGE_WS_DIR"/shared
             cp -R ws-server/shared/poker-domain "$PREVIEW_STAGE_WS_DIR"/shared/poker-domain
@@ -302,6 +306,7 @@ jobs:
             sudo -n mkdir -p "$TMP_EXTRACT_DIR"
             sudo -n tar -xzf "$TMP_ARCHIVE" -C "$TMP_EXTRACT_DIR"
             sudo -n test -f "$TMP_EXTRACT_DIR/ws-server/server.mjs"
+            sudo -n test -f "$TMP_EXTRACT_DIR/ws-server/observability/vps-metrics.mjs"
             sudo -n test -f "$TMP_EXTRACT_DIR/shared/poker-domain/join.mjs"
             sudo -n test -f "$TMP_EXTRACT_DIR/ws-server/shared/poker-domain/inactive-cleanup-deps.mjs"
             sudo -n test -f "$TMP_EXTRACT_DIR/netlify/functions/_shared/chips-ledger.mjs"

--- a/.github/workflows/ws-server-deploy.yml
+++ b/.github/workflows/ws-server-deploy.yml
@@ -116,6 +116,10 @@ jobs:
             cp -R ws-server/poker "$STAGE_WS_DIR"/poker
           fi
 
+          if [ -d ws-server/observability ]; then
+            cp -R ws-server/observability "$STAGE_WS_DIR"/observability
+          fi
+
           if [ -d ws-server/shared ]; then
             cp -R ws-server/shared "$STAGE_WS_DIR"/shared
           fi
@@ -246,6 +250,7 @@ jobs:
             sudo -n mkdir -p "$NEW_RELEASE_DIR"
             sudo -n tar -xzf "$TMP_ARCHIVE" -C "$NEW_RELEASE_DIR"
             sudo -n test -f "$NEW_RELEASE_APP_DIR/server.mjs"
+            sudo -n test -f "$NEW_RELEASE_APP_DIR/observability/vps-metrics.mjs"
             sudo -n test -f "$NEW_RELEASE_DIR/shared/profile-avatar-projection.mjs"
             sudo -n test -f "$NEW_RELEASE_DIR/netlify/functions/_shared/chips-ledger.mjs"
             sudo -n test -d "$NEW_RELEASE_DIR/node_modules/postgres"

--- a/admin.html
+++ b/admin.html
@@ -669,6 +669,16 @@
                 <div id="adminOpsMaintenance"></div>
               </section>
 
+              <section class="xp-card admin-card admin-card--wide" aria-labelledby="adminOpsVpsMetricsTitle">
+                <div class="admin-card__head">
+                  <div>
+                    <h2 class="xp-card__title" id="adminOpsVpsMetricsTitle">Continuous tables stress health</h2>
+                    <p class="admin-card__subtitle">Read-only VPS, WS, continuous-table and cleanup metrics for manual stress tests.</p>
+                  </div>
+                </div>
+                <div id="adminOpsVpsMetrics"></div>
+              </section>
+
               <section class="xp-card admin-card" aria-labelledby="adminOpsRuntimeTitle">
                 <div class="admin-card__head">
                   <div>

--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -19,6 +19,11 @@ ws.kcswh.pl {
     reverse_proxy 127.0.0.1:3000
   }
 
+  @vpsMetricsAdmin path /internal/admin/vps-metrics
+  handle @vpsMetricsAdmin {
+    reverse_proxy 127.0.0.1:3000
+  }
+
   handle {
     respond "OK" 200
   }
@@ -47,6 +52,11 @@ ws-preview.kcswh.pl {
 
   @pokerMaintenanceAdmin path /internal/admin/poker-maintenance
   handle @pokerMaintenanceAdmin {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  @vpsMetricsAdmin path /internal/admin/vps-metrics
+  handle @vpsMetricsAdmin {
     reverse_proxy 127.0.0.1:3001
   }
 

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -66,6 +66,9 @@
       pokerMaintenance: null,
       pokerMaintenanceError: null,
       pokerMaintenancePending: false,
+      vpsMetrics: null,
+      vpsMetricsError: null,
+      vpsMetricsStale: false,
       loaded: false,
     },
     pokerAudit: {
@@ -184,6 +187,7 @@
     nodes.opsMaintenanceReconcile = doc.getElementById("adminOpsMaintenanceReconcile");
     nodes.opsMaintenanceCleanup = doc.getElementById("adminOpsMaintenanceCleanup");
     nodes.opsMaintenanceStatus = doc.getElementById("adminOpsMaintenanceStatus");
+    nodes.opsVpsMetrics = doc.getElementById("adminOpsVpsMetrics");
   }
 
   function setVisible(node, visible){
@@ -211,6 +215,20 @@
     var amount = Number(value);
     if (!Number.isFinite(amount)) return "—";
     return amount.toLocaleString();
+  }
+
+  function formatBytes(value){
+    var bytes = Number(value);
+    if (!Number.isFinite(bytes) || bytes < 0) return "—";
+    if (bytes < 1024) return String(Math.round(bytes)) + " B";
+    var units = ["KB", "MB", "GB", "TB"];
+    var index = -1;
+    var scaled = bytes;
+    while (scaled >= 1024 && index < units.length - 1){
+      scaled /= 1024;
+      index += 1;
+    }
+    return scaled.toFixed(scaled >= 10 ? 0 : 1) + " " + units[index];
   }
 
   function formatSignedAmount(value){
@@ -1174,12 +1192,139 @@
     nodes.pokerAuditDetail.innerHTML = html.join("");
   }
 
+  function formatUptime(seconds){
+    var value = Number(seconds);
+    if (!Number.isFinite(value) || value < 0) return "—";
+    var total = Math.floor(value);
+    var days = Math.floor(total / 86400);
+    var hours = Math.floor((total % 86400) / 3600);
+    var minutes = Math.floor((total % 3600) / 60);
+    var parts = [];
+    if (days) parts.push(String(days) + "d");
+    if (hours || days) parts.push(String(hours) + "h");
+    parts.push(String(minutes) + "m");
+    return parts.join(" ");
+  }
+
+  function formatMetricPercent(value){
+    var number = Number(value);
+    return Number.isFinite(number) ? number.toFixed(1) + "%" : "—";
+  }
+
+  function renderVpsMetrics(){
+    if (!nodes.opsVpsMetrics) return;
+    var snapshot = state.ops.vpsMetrics;
+    if (!snapshot){
+      var unavailableMessage = state.ops.vpsMetricsError
+        ? "Stress health metrics unavailable: " + state.ops.vpsMetricsError
+        : "Loading stress health metrics…";
+      nodes.opsVpsMetrics.innerHTML = '<p class="admin-empty">' + escapeHtml(unavailableMessage) + "</p>";
+      return;
+    }
+    var root = snapshot.rootFilesystem || null;
+    var logs = snapshot.logs || {};
+    var runtime = snapshot.runtime || {};
+    var load = runtime.loadAverage || {};
+    var tables = snapshot.continuousTables || null;
+    var cleanup = snapshot.cleanup || null;
+    var backlog = cleanup && cleanup.backlog || null;
+    var lastRun = cleanup && cleanup.lastRun || null;
+    var hostAvailable = Boolean(root)
+      || runtime.wsRssBytes != null
+      || runtime.hostAvailableRamBytes != null
+      || load.one != null;
+    var primarySources = [hostAvailable, Boolean(tables), Boolean(cleanup)].filter(Boolean).length;
+    var missingMetric = !root
+      || !root.inodes
+      || logs.varLogBytes == null
+      || logs.journaldBytes == null
+      || runtime.wsCpuPercent == null
+      || runtime.wsRssBytes == null
+      || runtime.wsUptimeSeconds == null
+      || runtime.hostAvailableRamBytes == null
+      || runtime.hostLogicalCpuCount == null
+      || load.one == null
+      || load.five == null
+      || load.fifteen == null
+      || runtime.ioWaitPercent == null
+      || !tables
+      || tables.active == null
+      || tables.desired == null
+      || tables.enabled == null
+      || !backlog
+      || backlog.ordinaryActionRows == null
+      || backlog.handSettledRows == null;
+    var availabilityLabel = primarySources < 2 ? "Unavailable" : missingMetric ? "Partial" : "Available";
+    var availabilityTone = availabilityLabel === "Available" ? "success" : "info";
+    var diskPercent = root && Number(root.usedPercent);
+    var inodePercent = root && root.inodes && Number(root.inodes.usedPercent);
+    var healthLabel = "Unavailable";
+    var healthTone = "info";
+    if (Number.isFinite(diskPercent) && Number.isFinite(inodePercent)){
+      var highestPercent = Math.max(diskPercent, inodePercent);
+      healthLabel = highestPercent >= 90 ? "Critical" : highestPercent >= 80 ? "Warning" : "Healthy";
+      healthTone = healthLabel === "Critical" ? "danger" : healthLabel === "Healthy" ? "success" : "info";
+    }
+    if (state.ops.vpsMetricsStale) availabilityLabel = "Stale";
+    var loadAvailable = [load.one, load.five, load.fifteen].every(function(value){ return Number.isFinite(Number(value)); });
+    var loadText = loadAvailable
+      ? Number(load.one).toFixed(1) + " / " + Number(load.five).toFixed(1) + " / " + Number(load.fifteen).toFixed(1) + " · " + String(runtime.hostLogicalCpuCount || "—") + " CPUs"
+      : "—";
+    var deletedRows = lastRun && lastRun.deletedRows != null ? formatAmount(lastRun.deletedRows) : "No run recorded";
+    nodes.opsVpsMetrics.innerHTML = [
+      '<div class="admin-surface">',
+      '<div class="admin-list__title"><span>Snapshot</span>' + pill(availabilityLabel, availabilityTone) + " " + pill(healthLabel, healthTone) + "</div>",
+      '<div class="admin-kv">',
+      renderKvRow("Environment", snapshot.environment || "—"),
+      renderKvRow("Measured at", formatTimestamp(snapshot.measuredAt)),
+      renderKvRow("Root used", root ? formatBytes(root.usedBytes) + " / " + formatBytes(root.totalBytes) + " (" + formatMetricPercent(root.usedPercent) + ")" : "—"),
+      renderKvRow("Root available", root ? formatBytes(root.availableBytes) : "—"),
+      renderKvRow("Inodes", root && root.inodes ? formatAmount(root.inodes.used) + " used / " + formatAmount(root.inodes.total) + " (" + formatMetricPercent(root.inodes.usedPercent) + ")" : "—"),
+      renderKvRow("Inodes available", root && root.inodes ? formatAmount(root.inodes.available) : "—"),
+      renderKvRow("/var/log", formatBytes(logs.varLogBytes)),
+      renderKvRow("Journald", formatBytes(logs.journaldBytes)),
+      "</div>",
+      "</div>",
+      '<div class="admin-surface">',
+      '<div class="admin-list__title"><span>WS and host runtime</span></div>',
+      '<div class="admin-kv">',
+      renderKvRow("WS CPU · one-core scale", formatMetricPercent(runtime.wsCpuPercent)),
+      renderKvRow("WS RSS", formatBytes(runtime.wsRssBytes)),
+      renderKvRow("WS uptime", formatUptime(runtime.wsUptimeSeconds)),
+      renderKvRow("Host available RAM", formatBytes(runtime.hostAvailableRamBytes)),
+      renderKvRow("Load average", loadText),
+      renderKvRow("Host I/O wait", formatMetricPercent(runtime.ioWaitPercent)),
+      "</div>",
+      "</div>",
+      '<div class="admin-surface">',
+      '<div class="admin-list__title"><span>Continuous tables</span></div>',
+      '<div class="admin-kv">',
+      renderKvRow("Active", tables ? tables.active : null),
+      renderKvRow("Desired", tables ? tables.desired : null),
+      renderKvRow("Maintenance", tables ? (tables.enabled ? "enabled" : "disabled") : null),
+      "</div>",
+      "</div>",
+      '<div class="admin-surface">',
+      '<div class="admin-list__title"><span>Cleanup</span></div>',
+      '<div class="admin-kv">',
+      renderKvRow("Next cleanup batch · ordinary rows", backlog ? backlog.ordinaryActionRows : null),
+      renderKvRow("Next cleanup batch · HAND_SETTLED", backlog ? backlog.handSettledRows : null),
+      renderKvRow("Batch capped", backlog ? (backlog.cappedAtBatchSize ? "yes" : "no") : null),
+      renderKvRow("Last cleanup", lastRun ? formatTimestamp(lastRun.finishedAt) : "No run recorded"),
+      renderKvRow("Last cleanup deleted", deletedRows),
+      renderKvRow("Last cleanup result", lastRun ? lastRun.result : "No run recorded"),
+      "</div>",
+      "</div>"
+    ].join("");
+  }
+
   function renderOps(){
     var summary = state.ops.summary;
     var identity = state.ops.identity;
     renderBotReactionControl();
     renderPokerLogControl();
     renderPokerMaintenance();
+    renderVpsMetrics();
     if (!summary && !identity){
       if (nodes.opsStats) nodes.opsStats.innerHTML = "";
       if (nodes.opsIdentity) nodes.opsIdentity.innerHTML = "";
@@ -2246,7 +2391,8 @@
         state.maintenance ? Promise.resolve(null) : apiFetch("/.netlify/functions/admin-ws-preview-bot-reaction", { method: "GET", cache: "no-store" }),
         apiFetch("/.netlify/functions/admin-poker-log-control", { method: "GET", cache: "no-store" }),
         apiFetch("/.netlify/functions/admin-tables-list?status=OPEN&sort=last_activity_desc&page=1&limit=100", { method: "GET" }),
-        apiFetch("/.netlify/functions/admin-poker-maintenance", { method: "GET", cache: "no-store" })
+        apiFetch("/.netlify/functions/admin-poker-maintenance", { method: "GET", cache: "no-store" }),
+        apiFetch("/.netlify/functions/admin-vps-metrics", { method: "GET", cache: "no-store" })
       ]);
       if (results[0].status === "fulfilled"){
         state.ops.identity = results[0].value || null;
@@ -2296,6 +2442,15 @@
         state.ops.pokerMaintenance = null;
         state.ops.pokerMaintenanceError = results[5].reason && results[5].reason.code ? results[5].reason.code : "request_failed";
         klog("admin_poker_maintenance_load_failed", { code: state.ops.pokerMaintenanceError });
+      }
+      if (results[6].status === "fulfilled"){
+        state.ops.vpsMetrics = results[6].value || null;
+        state.ops.vpsMetricsError = null;
+        state.ops.vpsMetricsStale = false;
+      } else {
+        state.ops.vpsMetricsError = results[6].reason && results[6].reason.code ? results[6].reason.code : "request_failed";
+        state.ops.vpsMetricsStale = Boolean(state.ops.vpsMetrics);
+        klog("admin_vps_metrics_load_failed", { code: state.ops.vpsMetricsError });
       }
       state.ops.loaded = true;
       renderOps();

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1258,14 +1258,21 @@
     var availabilityTone = availabilityLabel === "Available" ? "success" : "info";
     var diskPercent = root && Number(root.usedPercent);
     var inodePercent = root && root.inodes && Number(root.inodes.usedPercent);
+    var healthPercent = Number.isFinite(diskPercent) ? diskPercent : null;
+    if (Number.isFinite(inodePercent) && (healthPercent == null || inodePercent > healthPercent)){
+      healthPercent = inodePercent;
+    }
     var healthLabel = "Unavailable";
     var healthTone = "info";
-    if (Number.isFinite(diskPercent) && Number.isFinite(inodePercent)){
-      var highestPercent = Math.max(diskPercent, inodePercent);
+    if (healthPercent != null){
+      var highestPercent = healthPercent;
       healthLabel = highestPercent >= 90 ? "Critical" : highestPercent >= 80 ? "Warning" : "Healthy";
       healthTone = healthLabel === "Critical" ? "danger" : healthLabel === "Healthy" ? "success" : "info";
     }
-    if (state.ops.vpsMetricsStale) availabilityLabel = "Stale";
+    if (state.ops.vpsMetricsStale){
+      availabilityLabel = "Stale";
+      availabilityTone = "info";
+    }
     var loadAvailable = [load.one, load.five, load.fifteen].every(function(value){ return Number.isFinite(Number(value)); });
     var loadText = loadAvailable
       ? Number(load.one).toFixed(1) + " / " + Number(load.five).toFixed(1) + " / " + Number(load.fifteen).toFixed(1) + " · " + String(runtime.hostLogicalCpuCount || "—") + " CPUs"
@@ -1301,7 +1308,7 @@
       '<div class="admin-kv">',
       renderKvRow("Active", tables ? tables.active : null),
       renderKvRow("Desired", tables ? tables.desired : null),
-      renderKvRow("Maintenance", tables ? (tables.enabled ? "enabled" : "disabled") : null),
+      renderKvRow("Maintenance", tables && tables.enabled != null ? (tables.enabled ? "enabled" : "disabled") : null),
       "</div>",
       "</div>",
       '<div class="admin-surface">',
@@ -1309,7 +1316,7 @@
       '<div class="admin-kv">',
       renderKvRow("Next cleanup batch · ordinary rows", backlog ? backlog.ordinaryActionRows : null),
       renderKvRow("Next cleanup batch · HAND_SETTLED", backlog ? backlog.handSettledRows : null),
-      renderKvRow("Batch capped", backlog ? (backlog.cappedAtBatchSize ? "yes" : "no") : null),
+      renderKvRow("Batch capped", backlog && backlog.cappedAtBatchSize != null ? (backlog.cappedAtBatchSize ? "yes" : "no") : null),
       renderKvRow("Last cleanup", lastRun ? formatTimestamp(lastRun.finishedAt) : "No run recorded"),
       renderKvRow("Last cleanup deleted", deletedRows),
       renderKvRow("Last cleanup result", lastRun ? lastRun.result : "No run recorded"),

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1254,7 +1254,7 @@
       || !backlog
       || backlog.ordinaryActionRows == null
       || backlog.handSettledRows == null;
-    var availabilityLabel = primarySources < 2 ? "Unavailable" : missingMetric ? "Partial" : "Available";
+    var availabilityLabel = primarySources === 0 ? "Unavailable" : missingMetric ? "Partial" : "Available";
     var availabilityTone = availabilityLabel === "Available" ? "success" : "info";
     var diskPercent = root && Number(root.usedPercent);
     var inodePercent = root && root.inodes && Number(root.inodes.usedPercent);
@@ -1272,6 +1272,8 @@
     if (state.ops.vpsMetricsStale){
       availabilityLabel = "Stale";
       availabilityTone = "info";
+      healthLabel = "Unknown";
+      healthTone = "info";
     }
     var loadAvailable = [load.one, load.five, load.fifteen].every(function(value){ return Number.isFinite(Number(value)); });
     var loadText = loadAvailable

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -1,0 +1,155 @@
+import { adminAuthErrorResponse, requireAdminUser } from "./_shared/admin-auth.mjs";
+import { baseHeaders, corsHeaders, klog } from "./_shared/supabase-admin.mjs";
+import { buildStageIdentity } from "./admin-stage-identity.mjs";
+
+const WS_ORIGINS = Object.freeze({
+  preview: "https://ws-preview.kcswh.pl",
+  production: "https://ws.kcswh.pl",
+});
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+function jsonResponse(statusCode, headers, body) {
+  return {
+    statusCode,
+    headers: { ...headers, "cache-control": "no-store" },
+    body: JSON.stringify(body),
+  };
+}
+
+function controlError(code, status = 400) {
+  const error = new Error(code);
+  error.code = code;
+  error.status = status;
+  return error;
+}
+
+function resolveTarget(identity) {
+  if (
+    identity?.environmentContext === "deploy-preview"
+    && identity?.databaseTarget === "stage"
+    && identity?.stageProjectRefMatches === true
+    && identity?.databaseMatchesSupabaseProjectRef === true
+    && identity?.serviceRoleStageProjectRefMatches === true
+  ) return "preview";
+  if (
+    identity?.environmentContext === "production"
+    && identity?.databaseTarget === "production"
+    && typeof identity?.expectedProductionProjectRef === "string"
+    && identity.expectedProductionProjectRef.length > 0
+    && identity?.supabaseUrlProductionProjectRefMatches === true
+    && identity?.databaseProductionProjectRefMatches === true
+    && identity?.serviceRoleProductionProjectRefMatches === true
+    && identity?.databaseMatchesSupabaseProjectRef === true
+  ) return "production";
+  return null;
+}
+
+function resolveBaseUrl(env, target) {
+  const raw = typeof env?.POKER_WS_INTERNAL_BASE_URL === "string"
+    ? env.POKER_WS_INTERNAL_BASE_URL.trim()
+    : "";
+  if (!raw || !WS_ORIGINS[target]) return null;
+  try {
+    const url = new URL(raw);
+    if (
+      url.origin !== WS_ORIGINS[target]
+      || (url.pathname !== "/" && url.pathname !== "")
+      || url.username || url.password || url.search || url.hash
+    ) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveTimeoutMs(env) {
+  const parsed = Number(env?.POKER_WS_INTERNAL_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed >= 250 && parsed <= 10_000
+    ? Math.trunc(parsed)
+    : DEFAULT_TIMEOUT_MS;
+}
+
+function normalizeMetricsSnapshot(value, target) {
+  if (!value || typeof value !== "object" || value.environment !== target) {
+    throw controlError("ws_vps_metrics_environment_mismatch", 502);
+  }
+  if (typeof value.measuredAt !== "string" || !Number.isFinite(Date.parse(value.measuredAt))) {
+    throw controlError("ws_vps_metrics_invalid_response", 502);
+  }
+  return value;
+}
+
+async function proxyVpsMetrics({ target, env, fetchImpl }) {
+  const baseUrl = resolveBaseUrl(env, target);
+  const token = typeof env?.POKER_WS_INTERNAL_TOKEN === "string" ? env.POKER_WS_INTERNAL_TOKEN.trim() : "";
+  if (!baseUrl || !token || typeof fetchImpl !== "function") {
+    throw controlError("ws_vps_metrics_unavailable", 503);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), resolveTimeoutMs(env));
+  timer?.unref?.();
+  try {
+    const response = await fetchImpl(`${baseUrl}/internal/admin/vps-metrics`, {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      signal: controller.signal,
+    });
+    let body = {};
+    try {
+      body = await response.json();
+    } catch {}
+    if (!response.ok) throw controlError("ws_vps_metrics_unavailable", 502);
+    return normalizeMetricsSnapshot(body, target);
+  } catch (error) {
+    if (error?.name === "AbortError") throw controlError("ws_vps_metrics_timeout", 504);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createAdminVpsMetricsHandler(deps = {}) {
+  const env = deps.env || process.env;
+  const requireAdmin = deps.requireAdminUser || requireAdminUser;
+  const buildIdentity = deps.buildStageIdentity || (() => buildStageIdentity(env));
+  const fetchImpl = deps.fetchImpl || globalThis.fetch;
+  return async function handler(event) {
+    const origin = event.headers?.origin || event.headers?.Origin;
+    const cors = corsHeaders(origin);
+    if (!cors) return jsonResponse(403, baseHeaders(), { error: "forbidden_origin" });
+    if (event.httpMethod === "OPTIONS") {
+      return { statusCode: 204, headers: { ...cors, "cache-control": "no-store" }, body: "" };
+    }
+    if (event.httpMethod !== "GET") return jsonResponse(405, cors, { error: "method_not_allowed" });
+    try {
+      await requireAdmin(event, env);
+      const target = resolveTarget(buildIdentity());
+      if (!target) return jsonResponse(403, cors, { error: "environment_not_allowed" });
+      const result = await proxyVpsMetrics({ target, env, fetchImpl });
+      return jsonResponse(200, cors, result);
+    } catch (error) {
+      if (error?.status === 401 || (error?.status === 403 && error?.code === "admin_required")) {
+        return adminAuthErrorResponse(error, cors);
+      }
+      const status = Number(error?.status) || 500;
+      const code = error?.code || "server_error";
+      klog("admin_vps_metrics_failed", { status, code });
+      return jsonResponse(status, cors, { error: code });
+    }
+  };
+}
+
+const handler = createAdminVpsMetricsHandler();
+
+export {
+  createAdminVpsMetricsHandler,
+  handler,
+  normalizeMetricsSnapshot,
+  proxyVpsMetrics,
+  resolveBaseUrl,
+  resolveTarget,
+};

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -69,6 +69,16 @@ function resolveTimeoutMs(env) {
     : DEFAULT_TIMEOUT_MS;
 }
 
+function projectFields(source, fields) {
+  if (!source || typeof source !== "object" || Array.isArray(source)) return null;
+  return fields.reduce((result, field) => {
+    result[field] = Object.prototype.hasOwnProperty.call(source, field) && source[field] !== undefined
+      ? source[field]
+      : null;
+    return result;
+  }, {});
+}
+
 function normalizeMetricsSnapshot(value, target) {
   if (!value || typeof value !== "object" || value.environment !== target) {
     throw controlError("ws_vps_metrics_environment_mismatch", 502);
@@ -76,7 +86,39 @@ function normalizeMetricsSnapshot(value, target) {
   if (typeof value.measuredAt !== "string" || !Number.isFinite(Date.parse(value.measuredAt))) {
     throw controlError("ws_vps_metrics_invalid_response", 502);
   }
-  return value;
+  const rootFilesystem = projectFields(value.rootFilesystem, [
+    "totalBytes", "usedBytes", "availableBytes", "usedPercent"
+  ]);
+  if (rootFilesystem) {
+    rootFilesystem.inodes = projectFields(value.rootFilesystem.inodes, [
+      "total", "used", "available", "usedPercent"
+    ]);
+  }
+  const runtime = projectFields(value.runtime, [
+    "wsCpuPercent", "wsRssBytes", "wsUptimeSeconds", "hostAvailableRamBytes",
+    "hostLogicalCpuCount", "ioWaitPercent"
+  ]);
+  if (runtime) {
+    runtime.loadAverage = projectFields(value.runtime.loadAverage, ["one", "five", "fifteen"]);
+  }
+  const cleanup = projectFields(value.cleanup, []);
+  if (cleanup) {
+    cleanup.backlog = projectFields(value.cleanup.backlog, [
+      "ordinaryActionRows", "handSettledRows", "cappedAtBatchSize", "measuredAt"
+    ]);
+    cleanup.lastRun = projectFields(value.cleanup.lastRun, [
+      "finishedAt", "durationMs", "deletedRows", "result"
+    ]);
+  }
+  return {
+    environment: target,
+    measuredAt: value.measuredAt,
+    rootFilesystem,
+    logs: projectFields(value.logs, ["varLogBytes", "journaldBytes"]),
+    runtime,
+    continuousTables: projectFields(value.continuousTables, ["active", "desired", "enabled"]),
+    cleanup,
+  };
 }
 
 async function proxyVpsMetrics({ target, env, fetchImpl }) {

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -6,8 +6,9 @@ const WS_ORIGINS = Object.freeze({
   preview: "https://ws-preview.kcswh.pl",
   production: "https://ws.kcswh.pl",
 });
-const WS_ENVIRONMENTS = Object.freeze({
+const WS_ENVIRONMENT_BY_TARGET = Object.freeze({
   preview: "preview",
+  "deploy-preview": "preview",
   production: "production",
 });
 const DEFAULT_TIMEOUT_MS = 4_000;
@@ -28,8 +29,9 @@ function controlError(code, status = 400) {
 }
 
 function resolveWsEnvironment(target) {
-  return Object.prototype.hasOwnProperty.call(WS_ENVIRONMENTS, target)
-    ? WS_ENVIRONMENTS[target]
+  const normalizedTarget = typeof target === "string" ? target.trim() : "";
+  return Object.prototype.hasOwnProperty.call(WS_ENVIRONMENT_BY_TARGET, normalizedTarget)
+    ? WS_ENVIRONMENT_BY_TARGET[normalizedTarget]
     : null;
 }
 
@@ -40,7 +42,7 @@ function resolveTarget(identity) {
     && identity?.stageProjectRefMatches === true
     && identity?.databaseMatchesSupabaseProjectRef === true
     && identity?.serviceRoleStageProjectRefMatches === true
-  ) return WS_ENVIRONMENTS.preview;
+  ) return WS_ENVIRONMENT_BY_TARGET.preview;
   if (
     identity?.environmentContext === "production"
     && identity?.databaseTarget === "production"
@@ -50,19 +52,20 @@ function resolveTarget(identity) {
     && identity?.databaseProductionProjectRefMatches === true
     && identity?.serviceRoleProductionProjectRefMatches === true
     && identity?.databaseMatchesSupabaseProjectRef === true
-  ) return WS_ENVIRONMENTS.production;
+  ) return WS_ENVIRONMENT_BY_TARGET.production;
   return null;
 }
 
 function resolveBaseUrl(env, target) {
+  const wsEnvironment = resolveWsEnvironment(target);
   const raw = typeof env?.POKER_WS_INTERNAL_BASE_URL === "string"
     ? env.POKER_WS_INTERNAL_BASE_URL.trim()
     : "";
-  if (!raw || !WS_ORIGINS[target]) return null;
+  if (!raw || !WS_ORIGINS[wsEnvironment]) return null;
   try {
     const url = new URL(raw);
     if (
-      url.origin !== WS_ORIGINS[target]
+      url.origin !== WS_ORIGINS[wsEnvironment]
       || (url.pathname !== "/" && url.pathname !== "")
       || url.username || url.password || url.search || url.hash
     ) return null;

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -6,6 +6,10 @@ const WS_ORIGINS = Object.freeze({
   preview: "https://ws-preview.kcswh.pl",
   production: "https://ws.kcswh.pl",
 });
+const WS_ENVIRONMENTS = Object.freeze({
+  preview: "preview",
+  production: "production",
+});
 const DEFAULT_TIMEOUT_MS = 4_000;
 
 function jsonResponse(statusCode, headers, body) {
@@ -23,6 +27,12 @@ function controlError(code, status = 400) {
   return error;
 }
 
+function resolveWsEnvironment(target) {
+  return Object.prototype.hasOwnProperty.call(WS_ENVIRONMENTS, target)
+    ? WS_ENVIRONMENTS[target]
+    : null;
+}
+
 function resolveTarget(identity) {
   if (
     identity?.environmentContext === "deploy-preview"
@@ -30,7 +40,7 @@ function resolveTarget(identity) {
     && identity?.stageProjectRefMatches === true
     && identity?.databaseMatchesSupabaseProjectRef === true
     && identity?.serviceRoleStageProjectRefMatches === true
-  ) return "preview";
+  ) return WS_ENVIRONMENTS.preview;
   if (
     identity?.environmentContext === "production"
     && identity?.databaseTarget === "production"
@@ -40,7 +50,7 @@ function resolveTarget(identity) {
     && identity?.databaseProductionProjectRefMatches === true
     && identity?.serviceRoleProductionProjectRefMatches === true
     && identity?.databaseMatchesSupabaseProjectRef === true
-  ) return "production";
+  ) return WS_ENVIRONMENTS.production;
   return null;
 }
 
@@ -80,7 +90,8 @@ function projectFields(source, fields) {
 }
 
 function normalizeMetricsSnapshot(value, target) {
-  if (!value || typeof value !== "object" || value.environment !== target) {
+  const expectedEnvironment = resolveWsEnvironment(target);
+  if (!expectedEnvironment || !value || typeof value !== "object" || value.environment !== expectedEnvironment) {
     throw controlError("ws_vps_metrics_environment_mismatch", 502);
   }
   if (typeof value.measuredAt !== "string" || !Number.isFinite(Date.parse(value.measuredAt))) {
@@ -111,7 +122,7 @@ function normalizeMetricsSnapshot(value, target) {
     ]);
   }
   return {
-    environment: target,
+    environment: expectedEnvironment,
     measuredAt: value.measuredAt,
     rootFilesystem,
     logs: projectFields(value.logs, ["varLogBytes", "journaldBytes"]),
@@ -194,4 +205,5 @@ export {
   proxyVpsMetrics,
   resolveBaseUrl,
   resolveTarget,
+  resolveWsEnvironment,
 };

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -88,6 +88,7 @@ run("node", ["ws-server/poker/persistence/inactive-cleanup-adapter.behavior.test
 run("node", ["ws-server/poker/persistence/deferred-leave-finalization-adapter.behavior.test.mjs"], "ws-deferred-leave-finalization-adapter-behavior");
 run("node", ["ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs"], "ws-persisted-state-writer-behavior");
 run("node", ["ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs"], "ws-continuous-bot-table-repository-behavior");
+run("node", ["ws-server/observability/vps-metrics.behavior.test.mjs"], "ws-vps-metrics-behavior");
 run("node", ["ws-server/poker/idempotency/action-command.behavior.test.mjs"], "ws-action-command-idempotency-behavior");
 run("node", ["ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs"], "ws-authoritative-rebuy-adapter-behavior");
 run("node", ["ws-server/poker/handlers/rebuy.behavior.test.mjs"], "ws-rebuy-handler-behavior");
@@ -104,6 +105,7 @@ run("node", ["tests/admin-tables-list.behavior.test.mjs"], "admin-tables-list-be
 run("node", ["tests/admin-ledger-list.behavior.test.mjs"], "admin-ledger-list-behavior");
 run("node", ["tests/admin-table-actions.behavior.test.mjs"], "admin-table-actions-behavior");
 run("node", ["tests/admin-ops-summary.behavior.test.mjs"], "admin-ops-summary-behavior");
+run("node", ["tests/admin-vps-metrics.behavior.test.mjs"], "admin-vps-metrics-behavior");
 run("node", ["tests/admin-poker-maintenance.behavior.test.mjs"], "admin-poker-maintenance-behavior");
 run("node", ["tests/admin-stage-identity.behavior.test.mjs"], "admin-stage-identity-behavior");
 run("node", ["tests/admin-page.contract.test.mjs"], "admin-page-contract");

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -553,8 +553,8 @@ function buildContext(options = {}) {
           loadAverage: { one: 1.2, five: 0.9, fifteen: 0.7 },
           ioWaitPercent: 3.4,
         },
-        continuousTables: { active: 2, desired: 2, enabled: true },
-        cleanup: {
+        continuousTables: opts.vpsMetricsHostOnly ? null : { active: 2, desired: 2, enabled: true },
+        cleanup: opts.vpsMetricsHostOnly ? null : {
           backlog: { ordinaryActionRows: 0, handSettledRows: 0, cappedAtBatchSize: true, measuredAt: "2026-08-02T18:59:58.000Z" },
           lastRun: { finishedAt: "2026-08-02T18:55:00.000Z", durationMs: 184, deletedRows: 37, result: "success" },
         },
@@ -838,6 +838,20 @@ test("admin page marks the previous VPS metrics snapshot stale after a refresh f
   await flush();
   await flush();
   assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /admin-pill admin-pill--info">Stale/);
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /admin-pill admin-pill--info">Unknown/);
+  assert.doesNotMatch(document.getElementById("adminOpsVpsMetrics").innerHTML, /Healthy/);
+});
+
+test("admin page marks host-only VPS metrics as partial", async () => {
+  const { context, document, tabs } = buildContext({ vpsMetricsHostOnly: true });
+  vm.runInContext(source, context, { filename: "js/admin-page.js" });
+
+  await flush();
+  tabs[5].dispatchEvent({ type: "click", bubbles: true, target: tabs[5], preventDefault() {} });
+  await flush();
+  await flush();
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /admin-pill admin-pill--info">Partial/);
+  assert.doesNotMatch(document.getElementById("adminOpsVpsMetrics").innerHTML, /Unavailable/);
 });
 
 test("admin page still renders ops summary when stage identity request fails", async () => {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -305,6 +305,7 @@ function createAdminDom() {
     "adminOpsStats",
     "adminOpsIdentity",
     "adminOpsRuntime",
+    "adminOpsVpsMetrics",
     "adminOpsPokerEscrow",
     "adminOpsBotReactionSummary",
     "adminOpsBotReactionDelay",
@@ -524,6 +525,34 @@ function buildContext(options = {}) {
         },
         categories: ["autoplay", "persistence", "janitor"],
         overrides: [],
+      }) };
+    }
+    if (text.includes("/.netlify/functions/admin-vps-metrics")) {
+      return { ok: true, json: async () => ({
+        environment: "preview",
+        measuredAt: "2026-08-02T19:00:00.000Z",
+        rootFilesystem: {
+          totalBytes: 50 * 1024 * 1024 * 1024,
+          usedBytes: 10 * 1024 * 1024 * 1024,
+          availableBytes: 40 * 1024 * 1024 * 1024,
+          usedPercent: 20,
+          inodes: { total: 3200000, used: 120000, available: 3080000, usedPercent: 3.8 },
+        },
+        logs: { varLogBytes: 70 * 1024 * 1024, journaldBytes: 50 * 1024 * 1024 },
+        runtime: {
+          wsCpuPercent: 42.5,
+          wsRssBytes: 256 * 1024 * 1024,
+          wsUptimeSeconds: 6580,
+          hostAvailableRamBytes: 4 * 1024 * 1024 * 1024,
+          hostLogicalCpuCount: 2,
+          loadAverage: { one: 1.2, five: 0.9, fifteen: 0.7 },
+          ioWaitPercent: 3.4,
+        },
+        continuousTables: { active: 2, desired: 2, enabled: true },
+        cleanup: {
+          backlog: { ordinaryActionRows: 0, handSettledRows: 0, cappedAtBatchSize: true, measuredAt: "2026-08-02T18:59:58.000Z" },
+          lastRun: { finishedAt: "2026-08-02T18:55:00.000Z", durationMs: 184, deletedRows: 37, result: "success" },
+        },
       }) };
     }
     if (text.includes("/.netlify/functions/admin-stage-identity")) {
@@ -768,6 +797,7 @@ test("admin page tabs switch panels on click and keep ARIA state in sync", async
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-ws-preview-bot-reaction"), true);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-poker-log-control"), true);
   assert.equal(fetchCalls.includes("/.netlify/functions/admin-tables-list?status=OPEN&sort=last_activity_desc&page=1&limit=100"), true);
+  assert.equal(fetchCalls.includes("/.netlify/functions/admin-vps-metrics"), true);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Database target/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /stageabc/);
   assert.match(document.getElementById("adminOpsIdentity").innerHTML, /Service role stage match/);
@@ -782,6 +812,10 @@ test("admin page tabs switch panels on click and keep ARIA state in sync", async
   assert.match(document.getElementById("adminOpsPokerEscrow").innerHTML, /ORPHANED/);
   assert.match(document.getElementById("adminOpsPokerEscrow").innerHTML, /Latest escrow update/);
   assert.doesNotMatch(document.getElementById("adminOpsPokerEscrow").innerHTML, /Healthy/);
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /Continuous tables/);
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /2 CPUs/);
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /WS uptime/);
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /37/);
   assert.equal(document.getElementById("adminOpsBotReactionDelay").value, "2000");
 });
 

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -405,6 +405,7 @@ function buildContext(options = {}) {
   const opts = options || {};
   const { document, tabs, panels } = createAdminDom();
   const fetchCalls = [];
+  var vpsMetricsCalls = 0;
   const fetch = async (url) => {
     fetchCalls.push(String(url || ""));
     const text = String(url || "");
@@ -528,6 +529,10 @@ function buildContext(options = {}) {
       }) };
     }
     if (text.includes("/.netlify/functions/admin-vps-metrics")) {
+      vpsMetricsCalls += 1;
+      if (opts.vpsMetricsFailsAfterFirst && vpsMetricsCalls > 1){
+        return { ok: false, status: 504, json: async () => ({ error: "ws_vps_metrics_timeout" }) };
+      }
       return { ok: true, json: async () => ({
         environment: "preview",
         measuredAt: "2026-08-02T19:00:00.000Z",
@@ -817,6 +822,22 @@ test("admin page tabs switch panels on click and keep ARIA state in sync", async
   assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /WS uptime/);
   assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /37/);
   assert.equal(document.getElementById("adminOpsBotReactionDelay").value, "2000");
+});
+
+test("admin page marks the previous VPS metrics snapshot stale after a refresh failure", async () => {
+  const { context, document, tabs } = buildContext({ vpsMetricsFailsAfterFirst: true });
+  vm.runInContext(source, context, { filename: "js/admin-page.js" });
+
+  await flush();
+  tabs[5].dispatchEvent({ type: "click", bubbles: true, target: tabs[5], preventDefault() {} });
+  await flush();
+  await flush();
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /Available/);
+
+  document.getElementById("adminOpsRefresh").dispatchEvent({ type: "click", preventDefault() {} });
+  await flush();
+  await flush();
+  assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /admin-pill admin-pill--info">Stale/);
 });
 
 test("admin page still renders ops summary when stage identity request fails", async () => {

--- a/tests/admin-vps-metrics.behavior.test.mjs
+++ b/tests/admin-vps-metrics.behavior.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { createAdminVpsMetricsHandler } = await import("../netlify/functions/admin-vps-metrics.mjs");
+
+const adminId = "00000000-0000-4000-8000-000000000010";
+const previewIdentity = {
+  environmentContext: "deploy-preview",
+  databaseTarget: "stage",
+  stageProjectRefMatches: true,
+  databaseMatchesSupabaseProjectRef: true,
+  serviceRoleStageProjectRefMatches: true,
+};
+
+function event(overrides = {}) {
+  return {
+    httpMethod: "GET",
+    headers: {},
+    ...overrides,
+  };
+}
+
+function snapshot(environment = "preview") {
+  return {
+    environment,
+    measuredAt: "2026-08-02T19:00:00.000Z",
+    rootFilesystem: null,
+    logs: { varLogBytes: null, journaldBytes: null },
+    runtime: { wsCpuPercent: null },
+    continuousTables: null,
+    cleanup: null,
+  };
+}
+
+test("admin VPS metrics requires an admin and forwards the verified target", async () => {
+  let capturedUrl = null;
+  let capturedOptions = null;
+  const handler = createAdminVpsMetricsHandler({
+    env: {
+      CHIPS_ENABLED: "0",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token",
+    },
+    requireAdminUser: async () => ({ userId: adminId }),
+    buildStageIdentity: () => previewIdentity,
+    fetchImpl: async (url, options) => {
+      capturedUrl = url;
+      capturedOptions = options;
+      return { ok: true, status: 200, json: async () => snapshot() };
+    },
+  });
+
+  const response = await handler(event());
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["cache-control"], "no-store");
+  assert.equal(capturedUrl, "https://ws-preview.kcswh.pl/internal/admin/vps-metrics");
+  assert.equal(capturedOptions.method, "GET");
+  assert.equal(capturedOptions.headers.authorization, "Bearer preview-token");
+  assert.equal(JSON.parse(response.body).environment, "preview");
+
+  const unauthorized = createAdminVpsMetricsHandler({
+    env: { CHIPS_ENABLED: "0" },
+    requireAdminUser: async () => {
+      const error = new Error("admin_required");
+      error.status = 403;
+      error.code = "admin_required";
+      throw error;
+    },
+  });
+  const unauthorizedResponse = await unauthorized(event());
+  assert.equal(unauthorizedResponse.statusCode, 403);
+  assert.deepEqual(JSON.parse(unauthorizedResponse.body), { error: "admin_required" });
+});
+
+test("admin VPS metrics rejects an upstream environment mismatch", async () => {
+  const handler = createAdminVpsMetricsHandler({
+    env: {
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token",
+    },
+    requireAdminUser: async () => ({ userId: adminId }),
+    buildStageIdentity: () => previewIdentity,
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => snapshot("production") }),
+  });
+  const response = await handler(event());
+  assert.equal(response.statusCode, 502);
+  assert.deepEqual(JSON.parse(response.body), { error: "ws_vps_metrics_environment_mismatch" });
+});

--- a/tests/admin-vps-metrics.behavior.test.mjs
+++ b/tests/admin-vps-metrics.behavior.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-const { createAdminVpsMetricsHandler } = await import("../netlify/functions/admin-vps-metrics.mjs");
+const {
+  createAdminVpsMetricsHandler,
+  normalizeMetricsSnapshot,
+  resolveTarget,
+  resolveWsEnvironment,
+} = await import("../netlify/functions/admin-vps-metrics.mjs");
 
 const adminId = "00000000-0000-4000-8000-000000000010";
 const previewIdentity = {
@@ -73,6 +78,16 @@ test("admin VPS metrics requires an admin and forwards the verified target", asy
   const unauthorizedResponse = await unauthorized(event());
   assert.equal(unauthorizedResponse.statusCode, 403);
   assert.deepEqual(JSON.parse(unauthorizedResponse.body), { error: "admin_required" });
+});
+
+test("admin VPS metrics maps Netlify deploy-preview to the WS preview environment", () => {
+  const target = resolveTarget({
+    ...previewIdentity,
+    environmentContext: "deploy-preview",
+  });
+  assert.equal(target, "preview");
+  assert.equal(resolveWsEnvironment(target), "preview");
+  assert.equal(normalizeMetricsSnapshot(snapshot("preview"), target).environment, "preview");
 });
 
 test("admin VPS metrics rejects an upstream environment mismatch", async () => {

--- a/tests/admin-vps-metrics.behavior.test.mjs
+++ b/tests/admin-vps-metrics.behavior.test.mjs
@@ -24,6 +24,7 @@ function snapshot(environment = "preview") {
   return {
     environment,
     measuredAt: "2026-08-02T19:00:00.000Z",
+    secretDiagnostic: "must-not-forward",
     rootFilesystem: null,
     logs: { varLogBytes: null, journaldBytes: null },
     runtime: { wsCpuPercent: null },
@@ -56,7 +57,9 @@ test("admin VPS metrics requires an admin and forwards the verified target", asy
   assert.equal(capturedUrl, "https://ws-preview.kcswh.pl/internal/admin/vps-metrics");
   assert.equal(capturedOptions.method, "GET");
   assert.equal(capturedOptions.headers.authorization, "Bearer preview-token");
-  assert.equal(JSON.parse(response.body).environment, "preview");
+  const body = JSON.parse(response.body);
+  assert.equal(body.environment, "preview");
+  assert.equal(Object.prototype.hasOwnProperty.call(body, "secretDiagnostic"), false);
 
   const unauthorized = createAdminVpsMetricsHandler({
     env: { CHIPS_ENABLED: "0" },

--- a/tests/admin-vps-metrics.behavior.test.mjs
+++ b/tests/admin-vps-metrics.behavior.test.mjs
@@ -7,6 +7,7 @@ const {
   resolveTarget,
   resolveWsEnvironment,
 } = await import("../netlify/functions/admin-vps-metrics.mjs");
+const { buildStageIdentity } = await import("../netlify/functions/admin-stage-identity.mjs");
 
 const adminId = "00000000-0000-4000-8000-000000000010";
 const previewIdentity = {
@@ -88,6 +89,37 @@ test("admin VPS metrics maps Netlify deploy-preview to the WS preview environmen
   assert.equal(target, "preview");
   assert.equal(resolveWsEnvironment(target), "preview");
   assert.equal(normalizeMetricsSnapshot(snapshot("preview"), target).environment, "preview");
+});
+
+test("admin VPS metrics handler accepts the actual deploy-preview to WS preview flow", async () => {
+  const stageProjectRef = "stage-project";
+  const serviceRolePayload = Buffer.from(JSON.stringify({ ref: stageProjectRef })).toString("base64url");
+  const identityEnv = {
+    CONTEXT: "deploy-preview",
+    SUPABASE_URL: `https://${stageProjectRef}.supabase.co`,
+    SUPABASE_DB_URL: `postgres://postgres.${stageProjectRef}:password@db.${stageProjectRef}.supabase.co:5432/postgres`,
+    SUPABASE_STAGE_PROJECT_REF: stageProjectRef,
+    SUPABASE_SERVICE_ROLE_KEY: `header.${serviceRolePayload}.signature`,
+  };
+  let capturedUrl = null;
+  const handler = createAdminVpsMetricsHandler({
+    env: {
+      ...identityEnv,
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token",
+    },
+    requireAdminUser: async () => ({ userId: adminId }),
+    buildStageIdentity: () => buildStageIdentity(identityEnv, { buildDeployContext: "unknown" }),
+    fetchImpl: async (url) => {
+      capturedUrl = url;
+      return { ok: true, status: 200, json: async () => snapshot("preview") };
+    },
+  });
+
+  const response = await handler(event());
+  assert.equal(response.statusCode, 200);
+  assert.equal(capturedUrl, "https://ws-preview.kcswh.pl/internal/admin/vps-metrics");
+  assert.equal(JSON.parse(response.body).environment, "preview");
 });
 
 test("admin VPS metrics rejects an upstream environment mismatch", async () => {

--- a/ws-server/observability/vps-metrics.behavior.test.mjs
+++ b/ws-server/observability/vps-metrics.behavior.test.mjs
@@ -4,6 +4,7 @@ import {
   createVpsMetricsCollector,
   parseDuBytes,
   parseMemAvailable,
+  parseProcStatCpu,
 } from "./vps-metrics.mjs";
 
 function createDeps({ journalFailure = false } = {}) {
@@ -67,6 +68,10 @@ test("VPS collector returns storage, runtime and host metrics without an aggrega
   assert.equal(parseMemAvailable("MemFree: 10 kB\n"), null);
   assert.equal(parseDuBytes("123\t/var/log\n", "/var/log"), 123);
   assert.equal(parseDuBytes("123\n456\n", "/var/log"), null);
+  assert.deepEqual(
+    parseProcStatCpu("cpu 100 2 3 4 5 6 7 8 90 10\n"),
+    { total: 135, iowait: 5 }
+  );
 
   const snapshot = await createVpsMetricsCollector(createDeps()).collect();
   assert.equal(snapshot.rootFilesystem.usedBytes, 600_000 * 4096);

--- a/ws-server/observability/vps-metrics.behavior.test.mjs
+++ b/ws-server/observability/vps-metrics.behavior.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createVpsMetricsCollector,
+  parseDuBytes,
+  parseMemAvailable,
+} from "./vps-metrics.mjs";
+
+function createDeps({ journalFailure = false } = {}) {
+  let procStatReads = 0;
+  const fsImpl = {
+    promises: {
+      statfs: async () => ({
+        bsize: 4096n,
+        blocks: 1_000_000n,
+        bfree: 400_000n,
+        bavail: 380_000n,
+        files: 3_200_000n,
+        ffree: 3_080_000n,
+      }),
+      stat: async (path) => {
+        if (path === "/run/log/journal") return { isDirectory: () => true };
+        return { isDirectory: () => true };
+      },
+      readFile: async (path) => {
+        if (path === "/proc/meminfo") return "MemAvailable:       4194304 kB\nMemFree: 100 kB\n";
+        if (path === "/proc/stat") {
+          procStatReads += 1;
+          return procStatReads === 1 ? "cpu 100 0 100 1000 0 0 0 0 0 0\n" : "cpu 120 0 110 1100 10 0 0 0 0 0\n";
+        }
+        throw new Error("unexpected_file");
+      },
+    },
+  };
+  const osImpl = {
+    cpus: () => [{}, {}],
+    loadavg: () => [1.2, 0.9, 0.7],
+  };
+  const processImpl = {
+    cpuUsage: (previous) => previous ? { user: 18_000, system: 3_000 } : { user: 0, system: 0 },
+    memoryUsage: () => ({ rss: 256 * 1024 * 1024 }),
+    uptime: () => 6580,
+  };
+  const execFileImpl = (_command, args, _options, callback) => {
+    const path = args[args.length - 1];
+    if (journalFailure && path === "/var/log/journal") {
+      const error = new Error("permission denied");
+      error.code = "EACCES";
+      callback(error, "", "permission denied");
+      return { kill() {} };
+    }
+    callback(null, `123\t${path}\n`, "");
+    return { kill() {} };
+  };
+  return {
+    fsImpl,
+    osImpl,
+    processImpl,
+    execFileImpl,
+    sleepImpl: async () => {},
+  };
+}
+
+test("VPS collector returns storage, runtime and host metrics without an aggregate status", async () => {
+  assert.equal(parseMemAvailable("MemAvailable: 4194304 kB\n"), 4194304 * 1024);
+  assert.equal(parseMemAvailable("MemAvailable: -1 kB\n"), null);
+  assert.equal(parseMemAvailable("MemFree: 10 kB\n"), null);
+  assert.equal(parseDuBytes("123\t/var/log\n", "/var/log"), 123);
+  assert.equal(parseDuBytes("123\n456\n", "/var/log"), null);
+
+  const snapshot = await createVpsMetricsCollector(createDeps()).collect();
+  assert.equal(snapshot.rootFilesystem.usedBytes, 600_000 * 4096);
+  assert.equal(snapshot.runtime.hostLogicalCpuCount, 2);
+  assert.equal(snapshot.runtime.wsUptimeSeconds, 6580);
+  assert.equal(snapshot.runtime.hostAvailableRamBytes, 4194304 * 1024);
+  assert.equal(snapshot.logs.varLogBytes, 123);
+  assert.equal(snapshot.logs.journaldBytes, 246);
+  assert.equal(Object.prototype.hasOwnProperty.call(snapshot, "status"), false);
+});
+
+test("VPS collector keeps independent metrics when journald du fails", async () => {
+  const snapshot = await createVpsMetricsCollector(createDeps({ journalFailure: true })).collect();
+  assert.equal(snapshot.logs.varLogBytes, 123);
+  assert.equal(snapshot.logs.journaldBytes, null);
+  assert.equal(snapshot.rootFilesystem.usedPercent, 60);
+  assert.equal(snapshot.runtime.hostLogicalCpuCount, 2);
+});

--- a/ws-server/observability/vps-metrics.mjs
+++ b/ws-server/observability/vps-metrics.mjs
@@ -41,10 +41,10 @@ export function parseProcStatCpu(text) {
   if (!line) return null;
   const fields = line.trim().split(/\s+/).slice(1).map(Number);
   if (fields.length < 5 || fields.some((value) => !Number.isSafeInteger(value) || value < 0)) return null;
-  const total = fields.reduce((sum, value) => sum + value, 0);
+  const total = fields.slice(0, 8).reduce((sum, value) => sum + value, 0);
   return {
     total,
-    iowait: fields[3],
+    iowait: fields[4],
   };
 }
 

--- a/ws-server/observability/vps-metrics.mjs
+++ b/ws-server/observability/vps-metrics.mjs
@@ -1,0 +1,213 @@
+import fs from "node:fs";
+import os from "node:os";
+import { execFile } from "node:child_process";
+
+const SAMPLE_MS = 750;
+const DU_TIMEOUT_MS = 1_500;
+const DU_ARGS_PREFIX = ["--summarize", "--block-size=1", "--one-file-system", "--"];
+const JOURNAL_PATHS = ["/var/log/journal", "/run/log/journal"];
+const SAFE_INTEGER_MAX = Number.MAX_SAFE_INTEGER;
+
+function asSafeInteger(value) {
+  const number = typeof value === "bigint" ? Number(value) : Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : null;
+}
+
+function percent(value, total) {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) return null;
+  return Number(((value / total) * 100).toFixed(1));
+}
+
+export function parseMemAvailable(text) {
+  const match = String(text || "").match(/^MemAvailable:\s+([0-9]+)\s+kB$/m);
+  if (!match) return null;
+  const kilobytes = Number(match[1]);
+  if (!Number.isSafeInteger(kilobytes) || kilobytes < 0) return null;
+  const bytes = kilobytes * 1024;
+  return Number.isSafeInteger(bytes) && bytes <= SAFE_INTEGER_MAX ? bytes : null;
+}
+
+export function parseDuBytes(stdout, expectedPath) {
+  const lines = String(stdout || "").trim().split(/\r?\n/).filter(Boolean);
+  if (lines.length !== 1) return null;
+  const match = lines[0].match(/^([0-9]+)\s+(.+)$/);
+  if (!match || match[2] !== expectedPath) return null;
+  const bytes = Number(match[1]);
+  return Number.isSafeInteger(bytes) && bytes >= 0 ? bytes : null;
+}
+
+export function parseProcStatCpu(text) {
+  const line = String(text || "").split(/\r?\n/).find((item) => item.startsWith("cpu "));
+  if (!line) return null;
+  const fields = line.trim().split(/\s+/).slice(1).map(Number);
+  if (fields.length < 5 || fields.some((value) => !Number.isSafeInteger(value) || value < 0)) return null;
+  const total = fields.reduce((sum, value) => sum + value, 0);
+  return {
+    total,
+    iowait: fields[3],
+  };
+}
+
+function roundPercent(value) {
+  return Number.isFinite(value) ? Number(value.toFixed(1)) : null;
+}
+
+function readRootFilesystem(fsImpl) {
+  return fsImpl.promises.statfs("/", { bigint: true }).then((stats) => {
+    const blockSize = asSafeInteger(stats.bsize || stats.frsize);
+    const blocks = asSafeInteger(stats.blocks);
+    const freeBlocks = asSafeInteger(stats.bfree);
+    const availableBlocks = asSafeInteger(stats.bavail);
+    const inodeTotal = asSafeInteger(stats.files);
+    const inodeFree = asSafeInteger(stats.ffree);
+    if ([blockSize, blocks, freeBlocks, availableBlocks, inodeTotal, inodeFree].some((value) => value == null)) {
+      return null;
+    }
+    const totalBytes = blocks * blockSize;
+    const usedBytes = (blocks - freeBlocks) * blockSize;
+    const availableBytes = availableBlocks * blockSize;
+    const inodeUsed = inodeTotal - inodeFree;
+    if (
+      ![totalBytes, usedBytes, availableBytes, inodeUsed].every((value) => Number.isSafeInteger(value) && value >= 0)
+      || usedBytes > totalBytes
+      || inodeUsed > inodeTotal
+    ) return null;
+    return {
+      totalBytes,
+      usedBytes,
+      availableBytes,
+      usedPercent: percent(usedBytes, totalBytes),
+      inodes: {
+        total: inodeTotal,
+        used: inodeUsed,
+        available: inodeFree,
+        usedPercent: percent(inodeUsed, inodeTotal),
+      },
+    };
+  }).catch(() => null);
+}
+
+function runDu(path, execFileImpl) {
+  return new Promise((resolve) => {
+    execFileImpl(
+      "du",
+      [...DU_ARGS_PREFIX, path],
+      {
+        encoding: "utf8",
+        maxBuffer: 4 * 1024,
+        timeout: DU_TIMEOUT_MS,
+        killSignal: "SIGTERM",
+        shell: false,
+      },
+      (error, stdout) => {
+        if (error) {
+          resolve(null);
+          return;
+        }
+        resolve(parseDuBytes(stdout, path));
+      }
+    );
+  });
+}
+
+async function readJournalBytes(fsImpl, execFileImpl) {
+  const existing = await Promise.all(JOURNAL_PATHS.map(async (path) => {
+    try {
+      const stat = await fsImpl.promises.stat(path);
+      return stat?.isDirectory?.() === true ? path : null;
+    } catch (error) {
+      return error?.code === "ENOENT" ? null : false;
+    }
+  }));
+  if (existing.includes(false)) return null;
+  const paths = existing.filter(Boolean);
+  if (!paths.length) return 0;
+  const values = await Promise.all(paths.map((path) => runDu(path, execFileImpl)));
+  if (values.some((value) => value == null)) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return Number.isSafeInteger(total) && total >= 0 ? total : null;
+}
+
+function readLogs(fsImpl, execFileImpl) {
+  return Promise.all([
+    runDu("/var/log", execFileImpl),
+    readJournalBytes(fsImpl, execFileImpl),
+  ]).then(([varLogBytes, journaldBytes]) => ({ varLogBytes, journaldBytes }));
+}
+
+async function readRuntime(fsImpl, osImpl, processImpl, sleepImpl) {
+  const startCpu = processImpl.cpuUsage();
+  const startWall = Date.now();
+  const startStatPromise = fsImpl.promises.readFile("/proc/stat", "utf8")
+    .then(parseProcStatCpu)
+    .catch(() => null);
+  await sleepImpl(SAMPLE_MS);
+  const endWall = Date.now();
+  const endCpu = processImpl.cpuUsage(startCpu);
+  const [startStat, endStat] = await Promise.all([
+    startStatPromise,
+    fsImpl.promises.readFile("/proc/stat", "utf8").then(parseProcStatCpu).catch(() => null),
+  ]);
+  const elapsedMs = Math.max(1, endWall - startWall);
+  const cpuMicros = Number(endCpu?.user || 0) + Number(endCpu?.system || 0);
+  const wsCpuPercent = Number.isFinite(cpuMicros)
+    ? roundPercent((cpuMicros / (elapsedMs * 1_000)) * 100)
+    : null;
+  const totalTicks = startStat && endStat ? endStat.total - startStat.total : null;
+  const ioWaitTicks = startStat && endStat ? endStat.iowait - startStat.iowait : null;
+  const ioWaitPercent = Number.isFinite(totalTicks) && Number.isFinite(ioWaitTicks) && totalTicks > 0 && ioWaitTicks >= 0
+    ? roundPercent((ioWaitTicks / totalTicks) * 100)
+    : null;
+  let memory = {};
+  try {
+    memory = processImpl.memoryUsage() || {};
+  } catch {}
+  let load = [];
+  try {
+    load = osImpl.loadavg() || [];
+  } catch {}
+  let logicalCpuCount = null;
+  try {
+    logicalCpuCount = osImpl.cpus()?.length;
+  } catch {}
+  let uptime = null;
+  try {
+    uptime = processImpl.uptime();
+  } catch {}
+  return {
+    wsCpuPercent,
+    wsRssBytes: asSafeInteger(memory?.rss),
+    wsUptimeSeconds: Number.isFinite(uptime) ? Math.max(0, uptime) : null,
+    hostLogicalCpuCount: Number.isInteger(logicalCpuCount) && logicalCpuCount > 0 ? logicalCpuCount : null,
+    loadAverage: {
+      one: Number.isFinite(load?.[0]) ? load[0] : null,
+      five: Number.isFinite(load?.[1]) ? load[1] : null,
+      fifteen: Number.isFinite(load?.[2]) ? load[2] : null,
+    },
+    ioWaitPercent,
+    hostAvailableRamBytes: await fsImpl.promises.readFile("/proc/meminfo", "utf8")
+      .then(parseMemAvailable)
+      .catch(() => null),
+  };
+}
+
+export function createVpsMetricsCollector({
+  fsImpl = fs,
+  osImpl = os,
+  processImpl = process,
+  execFileImpl = execFile,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  return {
+    async collect() {
+      const [rootFilesystem, logs, runtime] = await Promise.all([
+        readRootFilesystem(fsImpl),
+        readLogs(fsImpl, execFileImpl),
+        readRuntime(fsImpl, osImpl, processImpl, sleepImpl),
+      ]);
+      return { rootFilesystem, logs, runtime };
+    },
+  };
+}
+
+export { DU_TIMEOUT_MS, SAMPLE_MS };

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -269,7 +269,9 @@ register("ERROR", "http", [
 register("ERROR", "admin", [
   "ws_admin_poker_maintenance_failed",
   "ws_poker_log_config_invalid",
-  "ws_preview_bot_reaction_failed"
+  "ws_preview_bot_reaction_failed",
+  "ws_vps_metrics_collection_failed",
+  "ws_vps_metrics_failed"
 ]);
 
 register("ERROR", "session", [

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1366,6 +1366,42 @@ test("internal poker maintenance route keeps the Production desired-table cap", 
   }
 });
 
+test("internal VPS metrics route is token-protected, read-only, and returns runtime context", async () => {
+  const token = "internal-vps-metrics-token";
+  const { port, child } = await createServer({
+    env: {
+      POKER_WS_INTERNAL_TOKEN: token,
+      WS_DEPLOY_ENVIRONMENT: "preview",
+      SUPABASE_DB_URL: "",
+      WS_POKER_LOG_LEVEL: "INFO"
+    }
+  });
+  const url = `http://127.0.0.1:${port}/internal/admin/vps-metrics`;
+  try {
+    await waitForListening(child, 5000);
+    assert.equal((await fetch(url)).status, 401);
+
+    const response = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    const body = await response.json();
+    assert.equal(body.environment, "preview");
+    assert.equal(typeof body.measuredAt, "string");
+    assert.equal(typeof body.runtime.hostLogicalCpuCount, "number");
+    assert.equal(typeof body.runtime.wsUptimeSeconds, "number");
+    assert.equal(Object.prototype.hasOwnProperty.call(body, "status"), false);
+
+    const queryResponse = await fetch(`${url}?refresh=1`, {
+      headers: { authorization: `Bearer ${token}` }
+    });
+    assert.equal(queryResponse.status, 400);
+    assert.deepEqual(await queryResponse.json(), { error: "query_not_supported" });
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+});
+
 function getFreePort() {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -3125,7 +3125,9 @@ function projectContinuousTablesMetrics(repositoryResult) {
   return {
     active: Array.isArray(repositoryResult.tables) ? repositoryResult.tables.length : null,
     desired: safeMetricInteger(repositoryResult.profile.desiredTableCount),
-    enabled: repositoryResult.profile.enabled === true
+    enabled: typeof repositoryResult.profile.enabled === "boolean"
+      ? repositoryResult.profile.enabled
+      : null
   };
 }
 
@@ -3142,7 +3144,9 @@ function projectCleanupMetrics(cleanupResult) {
     backlog: backlog && typeof backlog === "object" ? {
       ordinaryActionRows: safeMetricInteger(backlog.ordinaryActionRows),
       handSettledRows: safeMetricInteger(backlog.handSettledRows),
-      cappedAtBatchSize: backlog.cappedAtBatchSize === true,
+      cappedAtBatchSize: typeof backlog.cappedAtBatchSize === "boolean"
+        ? backlog.cappedAtBatchSize
+        : null,
       measuredAt: typeof backlog.measuredAt === "string" ? backlog.measuredAt : null
     } : null,
     lastRun: lastRun && typeof lastRun === "object" ? {

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -61,6 +61,7 @@ import { createContinuousBotTableRepository } from "./poker/persistence/continuo
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 import { handleContinuousBotRotationAtSettled } from "./poker/runtime/continuous-bot-table-rotation.mjs";
 import { createActionHistoryCleanup } from "./poker/persistence/action-history-cleanup.mjs";
+import { createVpsMetricsCollector } from "./observability/vps-metrics.mjs";
 import {
   isManagedReplacementSeatProjectionConflict,
   retireManagedTableAfterReplacementConflict as retireManagedTableAfterReplacementConflictFlow
@@ -309,6 +310,7 @@ function continuousBotMaxDesiredTablesForRuntime() {
   return loadReleaseMetadata().environment === "preview" ? 100 : 2;
 }
 const continuousBotMaxDesiredTables = continuousBotMaxDesiredTablesForRuntime();
+const vpsMetricsCollector = createVpsMetricsCollector();
 const continuousBotTableRepository = hasSupabaseDbUrl
   ? createContinuousBotTableRepository({
       env: process.env,
@@ -3113,6 +3115,109 @@ async function buildInternalPokerMaintenanceStatus(environment) {
   };
 }
 
+function safeMetricInteger(value) {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number >= 0 ? number : null;
+}
+
+function projectContinuousTablesMetrics(repositoryResult) {
+  if (!repositoryResult?.ok || !repositoryResult.profile) return null;
+  return {
+    active: Array.isArray(repositoryResult.tables) ? repositoryResult.tables.length : null,
+    desired: safeMetricInteger(repositoryResult.profile.desiredTableCount),
+    enabled: repositoryResult.profile.enabled === true
+  };
+}
+
+function projectCleanupMetrics(cleanupResult) {
+  if (!cleanupResult || typeof cleanupResult !== "object") return null;
+  const backlog = cleanupResult.backlog;
+  const lastRun = cleanupResult.lastRun;
+  const phase1Deleted = safeMetricInteger(lastRun?.phase1Deleted);
+  const phase2Deleted = safeMetricInteger(lastRun?.phase2Deleted);
+  const deletedRows = phase1Deleted != null && phase2Deleted != null
+    ? phase1Deleted + phase2Deleted
+    : null;
+  return {
+    backlog: backlog && typeof backlog === "object" ? {
+      ordinaryActionRows: safeMetricInteger(backlog.ordinaryActionRows),
+      handSettledRows: safeMetricInteger(backlog.handSettledRows),
+      cappedAtBatchSize: backlog.cappedAtBatchSize === true,
+      measuredAt: typeof backlog.measuredAt === "string" ? backlog.measuredAt : null
+    } : null,
+    lastRun: lastRun && typeof lastRun === "object" ? {
+      finishedAt: typeof lastRun.finishedAt === "string" ? lastRun.finishedAt : null,
+      durationMs: safeMetricInteger(lastRun.durationMs),
+      deletedRows: Number.isSafeInteger(deletedRows) ? deletedRows : null,
+      result: typeof lastRun.result === "string" ? lastRun.result : null
+    } : null
+  };
+}
+
+async function handleInternalVpsMetrics(req, res) {
+  if (req.method !== "GET") {
+    sendInternalJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+  if (!internalRuntimeToken) {
+    sendInternalJson(res, 503, { error: "internal_runtime_token_missing" });
+    return;
+  }
+  const authHeader = typeof req.headers?.authorization === "string" ? req.headers.authorization.trim() : "";
+  if (authHeader !== `Bearer ${internalRuntimeToken}`) {
+    sendInternalJson(res, 401, { error: "unauthorized" });
+    return;
+  }
+  const requestUrl = new URL(req.url || "/", "http://127.0.0.1");
+  if (requestUrl.search) {
+    sendInternalJson(res, 400, { error: "query_not_supported" });
+    return;
+  }
+  const environment = getPokerMaintenanceEnvironment();
+  if (!environment) {
+    klogSafe("ws_vps_metrics_failed", { code: "environment_not_allowed" });
+    sendInternalJson(res, 503, { error: "environment_not_allowed" });
+    return;
+  }
+
+  const [hostResult, tablesResult, cleanupResult] = await Promise.allSettled([
+    vpsMetricsCollector.collect(),
+    continuousBotTableRepository?.readStatus?.() || Promise.resolve(null),
+    actionHistoryCleanup?.status?.() || Promise.resolve(null)
+  ]);
+  if (hostResult.status === "rejected") {
+    klogSafe("ws_vps_metrics_collection_failed", { source: "host", code: "collector_failed" });
+  }
+  const host = hostResult.status === "fulfilled" && hostResult.value ? hostResult.value : {
+    rootFilesystem: null,
+    logs: { varLogBytes: null, journaldBytes: null },
+    runtime: {
+      wsCpuPercent: null,
+      wsRssBytes: null,
+      wsUptimeSeconds: null,
+      hostAvailableRamBytes: null,
+      hostLogicalCpuCount: null,
+      loadAverage: { one: null, five: null, fifteen: null },
+      ioWaitPercent: null
+    }
+  };
+  const tables = tablesResult.status === "fulfilled"
+    ? projectContinuousTablesMetrics(tablesResult.value)
+    : null;
+  const cleanup = cleanupResult.status === "fulfilled"
+    ? projectCleanupMetrics(cleanupResult.value)
+    : null;
+  sendInternalJson(res, 200, {
+    environment,
+    measuredAt: new Date().toISOString(),
+    rootFilesystem: host.rootFilesystem || null,
+    logs: host.logs || { varLogBytes: null, journaldBytes: null },
+    runtime: host.runtime || null,
+    continuousTables: tables,
+    cleanup
+  });
+}
+
 async function handleInternalPokerMaintenance(req, res) {
   if (req.method !== "GET" && req.method !== "POST") {
     sendInternalJson(res, 405, { error: "method_not_allowed" });
@@ -3437,6 +3542,12 @@ async function handleHttpRequest(req, res) {
 
   if (req.url === "/internal/admin/poker-maintenance") {
     await handleInternalPokerMaintenance(req, res);
+    return;
+  }
+
+  const requestUrl = new URL(req.url || "/", "http://127.0.0.1");
+  if (requestUrl.pathname === "/internal/admin/vps-metrics") {
+    await handleInternalVpsMetrics(req, res);
     return;
   }
 

--- a/ws-tests/infra-vps-caddy.guard.test.mjs
+++ b/ws-tests/infra-vps-caddy.guard.test.mjs
@@ -30,6 +30,7 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
   assert.match(prod, /@ws path \/ws\*/);
   assert.match(prod, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(prod, /@pokerMaintenanceAdmin path \/internal\/admin\/poker-maintenance/);
+  assert.match(prod, /@vpsMetricsAdmin path \/internal\/admin\/vps-metrics/);
   assert.match(prod, /reverse_proxy 127\.0\.0\.1:3000/);
   assert.match(prod, /respond "OK" 200/);
 
@@ -38,6 +39,7 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
   assert.match(preview, /@botClaimsRecoveryAdmin path \/internal\/admin\/bot-claims-recovery/);
   assert.match(preview, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(preview, /@pokerMaintenanceAdmin path \/internal\/admin\/poker-maintenance/);
+  assert.match(preview, /@vpsMetricsAdmin path \/internal\/admin\/vps-metrics/);
   assert.match(preview, /@ws path \/ws\*/);
   assert.match(preview, /reverse_proxy 127\.0\.0\.1:3001/);
   assert.match(preview, /respond "OK" 200/);

--- a/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.remote-shape.guard.test.mjs
@@ -28,7 +28,9 @@ test("ws preview deploy remote script matches fixed preview app-dir contract", (
   assert.match(text, /preview deploy user must be allowed to run sudo -n bash for ws-preview deploy/);
   assert.match(text, /sudo -n test -d "\$PREVIEW_APP_DIR"/);
   assert.match(text, /cp -R ws-server\/shared\/poker-domain "\$PREVIEW_STAGE_WS_DIR"\/shared\/poker-domain/);
+  assert.match(text, /cp -R ws-server\/observability "\$PREVIEW_STAGE_WS_DIR"\/observability/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/server\.mjs"/);
+  assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/observability\/vps-metrics\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/shared\/poker-domain\/join\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/ws-server\/shared\/poker-domain\/inactive-cleanup-deps\.mjs"/);
   assert.match(text, /sudo -n test -f "\$TMP_EXTRACT_DIR\/netlify\/functions\/_shared\/chips-ledger\.mjs"/);

--- a/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-preview-deploy.workflow.guard.test.mjs
@@ -115,6 +115,7 @@ test("ws preview deploy workflow packages and validates shared runtime files", (
   assert.match(text, /PREVIEW_STAGE_WS_DIR:/);
   assert.match(text, /mkdir -p "\$PREVIEW_STAGE_WS_DIR"/);
   assert.match(text, /cp -R ws-server\/poker "\$PREVIEW_STAGE_WS_DIR"\/poker/);
+  assert.match(text, /cp -R ws-server\/observability "\$PREVIEW_STAGE_WS_DIR"\/observability/);
   assert.match(text, /cp -R ws-server\/shared\/poker-domain "\$PREVIEW_STAGE_WS_DIR"\/shared\/poker-domain/);
   assert.match(text, /cp -R ws-server\/node_modules "\$PREVIEW_STAGE_WS_DIR"\/node_modules/);
   assert.match(text, /RELEASE_ENVIRONMENT: preview/);

--- a/ws-tests/ws-server-deploy.workflow.guard.test.mjs
+++ b/ws-tests/ws-server-deploy.workflow.guard.test.mjs
@@ -10,6 +10,7 @@ test("ws-server deploy workflow has guarded triggers, secrets and concurrency", 
   const text = workflowText();
 
   assert.match(text, /"ws-server\/\*\*"/);
+  assert.match(text, /cp -R ws-server\/observability "\$STAGE_WS_DIR"\/observability/);
   assert.match(text, /"shared\/\*\*"/);
   assert.match(text, /"netlify\/functions\/_shared\/chips-ledger\.mjs"/);
   assert.match(text, /"netlify\/functions\/_shared\/poker-\*\.mjs"/);


### PR DESCRIPTION
## Summary

Implements the lightweight read-only VPS and continuous-table stress health view for Issues #776 and #777.

### Included

- Added authenticated Netlify proxy and token-protected internal WS endpoint:
  - `/.netlify/functions/admin-vps-metrics`
  - `/internal/admin/vps-metrics`
- Added host metrics:
  - root filesystem and inode usage
  - `/var/log` and journald size
  - WS CPU sample, RSS, uptime
  - MemAvailable, load average, logical CPU count, I/O wait
- Reused existing continuous-table repository status and action-history cleanup status.
- Added one Admin/Ops card using the existing refresh/open-panel flow; no polling or history.
- Added exact Preview/Production Caddy routes.
- Missing individual metrics remain `null`; the UI derives availability/health presentation.
- No SQL migration, environment variable, background worker, metric persistence, or CSP inline-script change.

### Validation

- Full `WS_POKER_LOG_LEVEL=INFO npm test`
- `npm run syntax`
- `npm run check:csp-inline`
- Focused collector, Netlify endpoint, Admin UI, and Caddy guard tests

All passed locally.