### PR TITLE
feat: add predefined poker reactions

### DIFF
--- a/docs/ws-poker-protocol.md
+++ b/docs/ws-poker-protocol.md
@@ -59,6 +59,7 @@ Example envelope:
 | `leave` | `{ "reason": string }` | Requests leave/cashout workflow. |
 | `ack` | `{ "seq": integer }` | Acknowledges latest processed server sequence (flow-control aid). |
 | `table_snapshot` | `{ "tableId": string }` (or envelope `roomId`) | Protected read-only gameplay snapshot command. **Requires `requestId`** like other stateful protected commands. Returns viewer-scoped poker state and does not mutate presence membership. |
+| `reaction_send` | `{ "tableId": string, "reactionKey": "hello"|"nice_hand"|"well_played"|"thinking"|"haha"|"wow"|"bad_beat"|"nice_bluff"|"good_luck"|"thanks" }` | Requests one predefined ephemeral reaction. Requires an authenticated seated human sender and `requestId`; the server enforces a four-second sender cooldown. |
 
 ### Server → Client
 
@@ -73,8 +74,9 @@ Example envelope:
 | `commandResult` | `{ "requestId": string, "status": "accepted"|"rejected", "reason": string|null }` | Deterministic outcome for a client command. |
 | `resync` | `{ "mode": "required", "reason": string, "expectedSeq": integer }` | Signals that client must request/accept full snapshot. |
 | `error` | `{ "code": string, "message": string, "retryable": boolean, "requestId": string|null }` | Protocol or domain error (see Errors). |
+| `table_reaction` | `{ "seatNo": integer, "reactionKey": string }` | Ephemeral table event delivered to the current table connections supported by the runtime. It is not stored in `streamLog`, snapshots, Supabase, or reconnect replay. Future spectator delivery can use the same event and payload without a protocol change. |
 
-Minimal server-initiated events in v1 include: `error`, `resync`, `pong`, and state updates (`stateSnapshot`/`statePatch`).
+Minimal server-initiated events in v1 include: `error`, `resync`, `pong`, state updates (`stateSnapshot`/`statePatch`), and ephemeral `table_reaction` events.
 
 Examples:
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -27,8 +27,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
 .poker-seat-action-badge{position:absolute; transform:translate(-50%, -50%); min-width:42px; padding:4px 7px 5px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); background:rgba(14,19,30,0.92); color:#eef4ff; font-size:0.56rem; font-weight:800; letter-spacing:0.04em; line-height:1; text-transform:uppercase; white-space:nowrap; box-shadow:0 6px 14px rgba(0,0,0,0.36); z-index:6; pointer-events:none;}
-.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;animation:poker-reaction-bubble-in 160ms ease-out;}
-@keyframes poker-reaction-bubble-in{from{opacity:0;transform:translateX(-50%) translateY(4px) scale(.94);}to{opacity:1;transform:translateX(-50%) translateY(0) scale(1);}}
+.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;animation:poker-reaction-bubble-flyout 360ms cubic-bezier(.22,.8,.28,1);}
+@keyframes poker-reaction-bubble-flyout{0%{opacity:0;transform:translateX(-50%) translateY(14px) scale(.72);}55%{opacity:1;transform:translateX(-50%) translateY(-4px) scale(1.04);}100%{opacity:1;transform:translateX(-50%) translateY(0) scale(1);}}
 .poker-seat-action-badge--fold{background:linear-gradient(180deg, rgba(140,29,29,0.95), rgba(86,16,16,0.94)); color:#ffd6d6;}
 .poker-seat-action-badge--check,.poker-seat-action-badge--call{background:linear-gradient(180deg, rgba(36,93,189,0.96), rgba(24,58,118,0.96)); color:#e5f1ff;}
 .poker-seat-action-badge--raise{background:linear-gradient(180deg, rgba(214,116,25,0.96), rgba(140,72,16,0.96)); color:#fff0d7;}
@@ -193,6 +193,11 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-reaction-option:active{background:rgba(65,91,138,0.72);}
 .poker-reaction-hint{flex-basis:100%;color:#b9c6dc;font-size:0.72rem;font-weight:600;}
 .poker-reaction-hint[hidden]{display:none;}
+.poker-action-reaction{position:relative;grid-column:2;grid-row:1;min-width:0;}
+.poker-action-reaction .poker-reaction-btn{width:100%;min-height:42px;padding:0 10px;border-radius:14px;background:linear-gradient(180deg,rgba(111,77,184,0.98),rgba(61,39,113,0.98));}
+.poker-action-reaction .poker-reaction-menu{top:auto;bottom:calc(100% + 8px);right:0;animation:poker-reaction-menu-flyout 180ms ease-out;}
+.poker-action-reaction .poker-reaction-hint{display:block;margin-top:4px;text-align:center;}
+@keyframes poker-reaction-menu-flyout{from{opacity:0;transform:translateY(8px) scale(.96);transform-origin:bottom right;}to{opacity:1;transform:translateY(0) scale(1);transform-origin:bottom right;}}
 
 .poker-guest-panel{margin-top:12px; padding:14px 14px 12px; border-radius:18px; border:1px solid rgba(255,223,180,0.2); background:rgba(8,13,22,0.72);}
 
@@ -270,7 +275,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-bar{position:fixed; right:max(10px, env(safe-area-inset-right)); bottom:max(10px, env(safe-area-inset-bottom)); width:min(33vw, 196px); display:grid; grid-template-columns:40px minmax(0, 1fr); align-items:end; gap:8px; padding:8px; border-radius:20px; border:1px solid rgba(255,223,180,0.24); background:linear-gradient(180deg, rgba(9,12,20,0.94), rgba(2,4,8,0.98)); box-shadow:0 12px 22px rgba(0,0,0,0.56), inset 0 1px 1px rgba(255,255,255,0.12); z-index:25;}
 
-.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px;}
+.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px; grid-column:2; grid-row:2;}
 
 .poker-action-btn{min-height:50px; border:none; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
 
@@ -314,7 +319,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn.is-selected{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
 
-.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86);}
+.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86); grid-column:1; grid-row:1 / span 2;}
 
 .poker-action-amount-input strong{font-size:0.78rem; font-weight:700; color:#fff;}
 
@@ -330,7 +335,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (max-width:479px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 
-@media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before{animation:none!important;}}
+@media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before,.poker-seat-reaction-bubble,.poker-action-reaction .poker-reaction-menu{animation:none!important;}}
 
 .poker-v2-xp-badge{position:fixed; top:calc(env(safe-area-inset-top) + 14px); right:calc(env(safe-area-inset-right) + 12px); z-index:30; min-width:58px; padding:8px 10px; border-radius:14px; border:1px solid rgba(255,223,180,0.34); background:linear-gradient(180deg, rgba(16,24,37,0.88), rgba(7,10,15,0.96)); color:#e8eefb; text-decoration:none; font-size:0.88rem; font-weight:700; text-align:center; box-shadow:0 9px 17px rgba(0,0,0,0.48), inset 0 1px 1px rgba(255,255,255,0.2);}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -23,11 +23,13 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat-layer{position:absolute; inset:0; z-index:3;}
 .poker-seat-chip-layer{position:absolute; inset:0; z-index:4; pointer-events:none;}
 .poker-chip-fx-layer{position:absolute; inset:0; z-index:12; pointer-events:none; overflow:hidden;}
+.poker-reaction-layer{position:absolute; inset:0; z-index:14; pointer-events:none;}
+.poker-reaction-anchor{position:absolute; width:0; height:0; transform:translate(-50%, -50%);}
 
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
 .poker-seat-action-badge{position:absolute; transform:translate(-50%, -50%); min-width:42px; padding:4px 7px 5px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); background:rgba(14,19,30,0.92); color:#eef4ff; font-size:0.56rem; font-weight:800; letter-spacing:0.04em; line-height:1; text-transform:uppercase; white-space:nowrap; box-shadow:0 6px 14px rgba(0,0,0,0.36); z-index:6; pointer-events:none;}
-.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;}
+.poker-seat-reaction-bubble{position:absolute;left:0;top:-42px;z-index:30;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;}
 .poker-seat-reaction-bubble--enter{animation:poker-reaction-bubble-flyout 360ms cubic-bezier(.22,.8,.28,1);}
 @keyframes poker-reaction-bubble-flyout{0%{opacity:0;transform:translateX(-50%) translateY(14px) scale(.72);}55%{opacity:1;transform:translateX(-50%) translateY(-4px) scale(1.04);}100%{opacity:1;transform:translateX(-50%) translateY(0) scale(1);}}
 .poker-seat-action-badge--fold{background:linear-gradient(180deg, rgba(140,29,29,0.95), rgba(86,16,16,0.94)); color:#ffd6d6;}
@@ -192,7 +194,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-reaction-menu[hidden]{display:none;}
 .poker-reaction-option{min-height:40px;padding:7px 8px;border:1px solid rgba(255,223,180,0.16);border-radius:10px;background:rgba(26,38,61,0.76);color:#eef4ff;font-size:0.78rem;font-weight:700;text-align:left;}
 .poker-reaction-option:active{background:rgba(65,91,138,0.72);}
-.poker-reaction-hint{flex-basis:100%;color:#b9c6dc;font-size:0.72rem;font-weight:600;}
+.poker-reaction-hint{flex-basis:100%;color:#b9c6dc;font-size:0.62rem;font-weight:600;line-height:1.15;}
 .poker-reaction-hint[hidden]{display:none;}
 .poker-action-reaction{position:relative;grid-column:2;grid-row:1;min-width:0;}
 .poker-action-reaction .poker-reaction-btn{width:100%;min-height:42px;padding:0 10px;border-radius:14px;background:linear-gradient(180deg,rgba(111,77,184,0.98),rgba(61,39,113,0.98));}

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -27,6 +27,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
 .poker-seat-action-badge{position:absolute; transform:translate(-50%, -50%); min-width:42px; padding:4px 7px 5px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); background:rgba(14,19,30,0.92); color:#eef4ff; font-size:0.56rem; font-weight:800; letter-spacing:0.04em; line-height:1; text-transform:uppercase; white-space:nowrap; box-shadow:0 6px 14px rgba(0,0,0,0.36); z-index:6; pointer-events:none;}
+.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;animation:poker-reaction-bubble-in 160ms ease-out;}
+@keyframes poker-reaction-bubble-in{from{opacity:0;transform:translateX(-50%) translateY(4px) scale(.94);}to{opacity:1;transform:translateX(-50%) translateY(0) scale(1);}}
 .poker-seat-action-badge--fold{background:linear-gradient(180deg, rgba(140,29,29,0.95), rgba(86,16,16,0.94)); color:#ffd6d6;}
 .poker-seat-action-badge--check,.poker-seat-action-badge--call{background:linear-gradient(180deg, rgba(36,93,189,0.96), rgba(24,58,118,0.96)); color:#e5f1ff;}
 .poker-seat-action-badge--raise{background:linear-gradient(180deg, rgba(214,116,25,0.96), rgba(140,72,16,0.96)); color:#fff0d7;}
@@ -184,6 +186,13 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-live-btn{min-height:42px; padding:0 16px; border-radius:14px; border:1px solid rgba(255,223,180,0.22); background:linear-gradient(180deg, rgba(29,41,64,0.96), rgba(12,18,31,0.98)); color:#f7f9fe; font-size:0.96rem; font-weight:700; box-shadow:0 9px 16px rgba(0,0,0,0.34);}
 
 .poker-live-btn--accent{background:linear-gradient(180deg, #2f79df, #1c4497);}
+.poker-live-actions{position:relative;}
+.poker-reaction-menu{position:absolute;top:50px;right:0;z-index:35;width:min(260px,calc(100vw - 32px));padding:8px;border:1px solid rgba(255,223,180,0.24);border-radius:14px;background:linear-gradient(180deg,rgba(12,18,31,0.98),rgba(5,9,16,0.99));box-shadow:0 14px 28px rgba(0,0,0,0.48);display:grid;grid-template-columns:1fr 1fr;gap:6px;}
+.poker-reaction-menu[hidden]{display:none;}
+.poker-reaction-option{min-height:40px;padding:7px 8px;border:1px solid rgba(255,223,180,0.16);border-radius:10px;background:rgba(26,38,61,0.76);color:#eef4ff;font-size:0.78rem;font-weight:700;text-align:left;}
+.poker-reaction-option:active{background:rgba(65,91,138,0.72);}
+.poker-reaction-hint{flex-basis:100%;color:#b9c6dc;font-size:0.72rem;font-weight:600;}
+.poker-reaction-hint[hidden]{display:none;}
 
 .poker-guest-panel{margin-top:12px; padding:14px 14px 12px; border-radius:18px; border:1px solid rgba(255,223,180,0.2); background:rgba(8,13,22,0.72);}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -27,7 +27,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-seat{position:absolute; width:113px; transform:translate(-50%, -50%); text-align:center;}
 
 .poker-seat-action-badge{position:absolute; transform:translate(-50%, -50%); min-width:42px; padding:4px 7px 5px; border-radius:999px; border:1px solid rgba(255,255,255,0.16); background:rgba(14,19,30,0.92); color:#eef4ff; font-size:0.56rem; font-weight:800; letter-spacing:0.04em; line-height:1; text-transform:uppercase; white-space:nowrap; box-shadow:0 6px 14px rgba(0,0,0,0.36); z-index:6; pointer-events:none;}
-.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;animation:poker-reaction-bubble-flyout 360ms cubic-bezier(.22,.8,.28,1);}
+.poker-seat-reaction-bubble{position:absolute;left:50%;top:-42px;z-index:8;max-width:150px;padding:6px 9px;border:1px solid rgba(255,223,180,0.34);border-radius:999px;background:rgba(7,13,24,0.94);box-shadow:0 7px 16px rgba(0,0,0,0.38);color:#fff4dc;font-size:0.68rem;font-weight:700;line-height:1.1;white-space:nowrap;transform:translateX(-50%);pointer-events:none;}
+.poker-seat-reaction-bubble--enter{animation:poker-reaction-bubble-flyout 360ms cubic-bezier(.22,.8,.28,1);}
 @keyframes poker-reaction-bubble-flyout{0%{opacity:0;transform:translateX(-50%) translateY(14px) scale(.72);}55%{opacity:1;transform:translateX(-50%) translateY(-4px) scale(1.04);}100%{opacity:1;transform:translateX(-50%) translateY(0) scale(1);}}
 .poker-seat-action-badge--fold{background:linear-gradient(180deg, rgba(140,29,29,0.95), rgba(86,16,16,0.94)); color:#ffd6d6;}
 .poker-seat-action-badge--check,.poker-seat-action-badge--call{background:linear-gradient(180deg, rgba(36,93,189,0.96), rgba(24,58,118,0.96)); color:#e5f1ff;}
@@ -335,7 +336,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (max-width:479px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 
-@media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before,.poker-seat-reaction-bubble,.poker-action-reaction .poker-reaction-menu{animation:none!important;}}
+@media (prefers-reduced-motion:reduce){.poker-chip-fly,.poker-seat-turn-clock--warning,.poker-seat--active .poker-seat-avatar::before,.poker-seat-reaction-bubble--enter,.poker-action-reaction .poker-reaction-menu{animation:none!important;}}
 
 .poker-v2-xp-badge{position:fixed; top:calc(env(safe-area-inset-top) + 14px); right:calc(env(safe-area-inset-right) + 12px); z-index:30; min-width:58px; padding:8px 10px; border-radius:14px; border:1px solid rgba(255,223,180,0.34); background:linear-gradient(180deg, rgba(16,24,37,0.88), rgba(7,10,15,0.96)); color:#e8eefb; text-decoration:none; font-size:0.88rem; font-weight:700; text-align:center; box-shadow:0 9px 17px rgba(0,0,0,0.48), inset 0 1px 1px rgba(255,255,255,0.2);}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1802,6 +1802,7 @@
     var seated = !!deriveCurrentSeat();
     var cooldownActive = reactionControlUntilMs > Date.now();
     var canUse = signedIn && seated && isWsReady() && !state.reconnectGate;
+    if (els.reactionControl) els.reactionControl.hidden = !signedIn || !seated;
     els.reactionBtn.hidden = !signedIn || !seated;
     els.reactionBtn.disabled = !canUse || cooldownActive;
     if (els.reactionHint){
@@ -3865,6 +3866,7 @@
     els.joinBuyIn = document.getElementById('pokerV2BuyIn');
     els.leaveBtn = document.getElementById('pokerV2LeaveBtn');
     els.reactionBtn = document.getElementById('pokerV2ReactionBtn');
+    els.reactionControl = document.getElementById('pokerV2ReactionControl');
     els.reactionMenu = document.getElementById('pokerV2ReactionMenu');
     els.reactionHint = document.getElementById('pokerV2ReactionHint');
     els.leaveConfirmModal = document.getElementById('pokerV2LeaveConfirmModal');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1765,6 +1765,7 @@
       if (bubble && bubble.timer) window.clearTimeout(bubble.timer);
     });
     reactionBubblesBySeatNo = {};
+    if (els.reactionLayer) els.reactionLayer.innerHTML = '';
   }
 
   function currentSeatOwnerUserId(seatNo){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -2660,19 +2660,6 @@
       status.style.top = statusPosition.top;
 
       article.appendChild(avatar);
-      var reactionBubble = seat && reactionBubblesBySeatNo[seat.seatNo];
-      if (reactionBubble && reactionBubble.ownerUserId !== currentSeatOwnerUserId(seat.seatNo)){
-        clearReactionBubble(seat.seatNo);
-        reactionBubble = null;
-      }
-      var reactionEntry = reactionBubble ? findReactionEntry(reactionBubble.reactionKey) : null;
-      if (reactionEntry){
-        var bubble = document.createElement('div');
-        bubble.className = 'poker-seat-reaction-bubble' + (reactionBubble.animate ? ' poker-seat-reaction-bubble--enter' : '');
-        bubble.setAttribute('role', 'status');
-        bubble.textContent = reactionEntry.emoji + ' ' + reactionEntry.label;
-        article.appendChild(bubble);
-      }
       if (seat && lastAction){
         var actionBadge = document.createElement('div');
         var badgePosition = getSeatActionBadgePosition(rotatedIndex, hero);
@@ -2718,9 +2705,36 @@
       }
       els.seatLayer.appendChild(article);
     }
+    renderReactionBubbles();
     Object.keys(reactionBubblesBySeatNo).forEach(function(seatNo){
       var reactionBubble = reactionBubblesBySeatNo[seatNo];
       if (reactionBubble) reactionBubble.animate = false;
+    });
+  }
+
+  function renderReactionBubbles(){
+    if (!els.reactionLayer) return;
+    els.reactionLayer.innerHTML = '';
+    Object.keys(reactionBubblesBySeatNo).forEach(function(seatNoKey){
+      var seatNo = Number(seatNoKey);
+      var reactionBubble = reactionBubblesBySeatNo[seatNoKey];
+      var ownerUserId = currentSeatOwnerUserId(seatNo);
+      var anchor = renderedSeatAnchors[seatNo];
+      var reactionEntry = reactionBubble ? findReactionEntry(reactionBubble.reactionKey) : null;
+      if (!reactionBubble || !ownerUserId || reactionBubble.ownerUserId !== ownerUserId || !anchor || !reactionEntry){
+        clearReactionBubble(seatNo);
+        return;
+      }
+      var anchorNode = document.createElement('div');
+      anchorNode.className = 'poker-reaction-anchor';
+      anchorNode.style.left = anchor.x + '%';
+      anchorNode.style.top = anchor.y + '%';
+      var bubble = document.createElement('div');
+      bubble.className = 'poker-seat-reaction-bubble' + (reactionBubble.animate ? ' poker-seat-reaction-bubble--enter' : '');
+      bubble.setAttribute('role', 'status');
+      bubble.textContent = reactionEntry.emoji + ' ' + reactionEntry.label;
+      anchorNode.appendChild(bubble);
+      els.reactionLayer.appendChild(anchorNode);
     });
   }
 
@@ -3852,6 +3866,7 @@
     els.seatLayer = document.getElementById('pokerSeatLayer');
     els.seatChipLayer = document.getElementById('pokerSeatChipLayer');
     els.chipFxLayer = document.getElementById('pokerChipFxLayer');
+    els.reactionLayer = document.getElementById('pokerReactionLayer');
     els.potPill = document.getElementById('pokerPotPill');
     els.potChipStack = document.getElementById('pokerPotChipStack');
     els.communityCards = document.getElementById('pokerCommunityCards');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1767,6 +1767,29 @@
     reactionBubblesBySeatNo = {};
   }
 
+  function currentSeatOwnerUserId(seatNo){
+    for (var i = 0; i < state.seats.length; i++){
+      var seat = state.seats[i];
+      if (!seat || seat.seatNo !== seatNo) continue;
+      return typeof seat.userId === 'string' && seat.userId.trim() ? seat.userId.trim() : null;
+    }
+    return null;
+  }
+
+  function clearReactionBubble(seatNo){
+    var bubble = reactionBubblesBySeatNo[seatNo];
+    if (bubble && bubble.timer) window.clearTimeout(bubble.timer);
+    delete reactionBubblesBySeatNo[seatNo];
+  }
+
+  function clearReactionBubblesWithChangedOwners(){
+    Object.keys(reactionBubblesBySeatNo).forEach(function(seatNo){
+      var bubble = reactionBubblesBySeatNo[seatNo];
+      var ownerUserId = currentSeatOwnerUserId(Number(seatNo));
+      if (!bubble || !ownerUserId || bubble.ownerUserId !== ownerUserId) clearReactionBubble(seatNo);
+    });
+  }
+
   function closeReactionMenu(){
     if (!els.reactionMenu || !els.reactionBtn) return;
     els.reactionMenu.hidden = true;
@@ -1804,10 +1827,11 @@
     var seatNo = Number(payload.seatNo);
     var reactionKey = typeof payload.reactionKey === 'string' ? payload.reactionKey : '';
     var entry = findReactionEntry(reactionKey);
-    if (!Number.isInteger(seatNo) || seatNo < 1 || !entry) return;
+    var ownerUserId = currentSeatOwnerUserId(seatNo);
+    if (!Number.isInteger(seatNo) || seatNo < 1 || !entry || !ownerUserId) return;
     var previous = reactionBubblesBySeatNo[seatNo];
     if (previous && previous.timer) window.clearTimeout(previous.timer);
-    var bubble = { reactionKey: reactionKey, timer: null };
+    var bubble = { reactionKey: reactionKey, ownerUserId: ownerUserId, timer: null };
     bubble.timer = window.setTimeout(function(){
       if (reactionBubblesBySeatNo[seatNo] !== bubble) return;
       delete reactionBubblesBySeatNo[seatNo];
@@ -1827,7 +1851,10 @@
       return result;
     }).catch(function(error){
       var code = normalizeSignalCode(error && (error.code || error.message));
-      if (code === 'reaction_rate_limited') return null;
+      if (code === 'reaction_rate_limited'){
+        startReactionCooldown();
+        return null;
+      }
       if (code === 'not_seated' || code === 'table_closed'){
         renderControls();
         if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function') wsClient.requestGameplaySnapshot();
@@ -2555,6 +2582,7 @@
 
   function renderSeats(){
     if (!els.seatLayer) return;
+    clearReactionBubblesWithChangedOwners();
     els.seatLayer.innerHTML = '';
     renderedSeatAnchors = {};
     renderedSeatSlots = {};
@@ -2632,6 +2660,10 @@
 
       article.appendChild(avatar);
       var reactionBubble = seat && reactionBubblesBySeatNo[seat.seatNo];
+      if (reactionBubble && reactionBubble.ownerUserId !== currentSeatOwnerUserId(seat.seatNo)){
+        clearReactionBubble(seat.seatNo);
+        reactionBubble = null;
+      }
       var reactionEntry = reactionBubble ? findReactionEntry(reactionBubble.reactionKey) : null;
       if (reactionEntry){
         var bubble = document.createElement('div');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -1832,7 +1832,7 @@
     if (!Number.isInteger(seatNo) || seatNo < 1 || !entry || !ownerUserId) return;
     var previous = reactionBubblesBySeatNo[seatNo];
     if (previous && previous.timer) window.clearTimeout(previous.timer);
-    var bubble = { reactionKey: reactionKey, ownerUserId: ownerUserId, timer: null };
+    var bubble = { reactionKey: reactionKey, ownerUserId: ownerUserId, animate: true, timer: null };
     bubble.timer = window.setTimeout(function(){
       if (reactionBubblesBySeatNo[seatNo] !== bubble) return;
       delete reactionBubblesBySeatNo[seatNo];
@@ -2668,7 +2668,7 @@
       var reactionEntry = reactionBubble ? findReactionEntry(reactionBubble.reactionKey) : null;
       if (reactionEntry){
         var bubble = document.createElement('div');
-        bubble.className = 'poker-seat-reaction-bubble';
+        bubble.className = 'poker-seat-reaction-bubble' + (reactionBubble.animate ? ' poker-seat-reaction-bubble--enter' : '');
         bubble.setAttribute('role', 'status');
         bubble.textContent = reactionEntry.emoji + ' ' + reactionEntry.label;
         article.appendChild(bubble);
@@ -2718,6 +2718,10 @@
       }
       els.seatLayer.appendChild(article);
     }
+    Object.keys(reactionBubblesBySeatNo).forEach(function(seatNo){
+      var reactionBubble = reactionBubblesBySeatNo[seatNo];
+      if (reactionBubble) reactionBubble.animate = false;
+    });
   }
 
   function renderCommunityCards(){

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -84,6 +84,18 @@
     raise: 'Raise',
     all_in: 'All in'
   };
+  var REACTION_CATALOG = [
+    { key: 'hello', emoji: '👋', label: 'Hello' },
+    { key: 'nice_hand', emoji: '👍', label: 'Nice hand!' },
+    { key: 'well_played', emoji: '👏', label: 'Well played!' },
+    { key: 'thinking', emoji: '🤔', label: 'Thinking...' },
+    { key: 'haha', emoji: '😄', label: 'Haha' },
+    { key: 'wow', emoji: '😮', label: 'Wow!' },
+    { key: 'bad_beat', emoji: '😢', label: 'Bad beat' },
+    { key: 'nice_bluff', emoji: '😎', label: 'Nice bluff' },
+    { key: 'good_luck', emoji: '🤝', label: 'Good luck' },
+    { key: 'thanks', emoji: '❤️', label: 'Thanks' }
+  ];
   var seatAnchors = [
     { x: 50, y: 10 },
     { x: 86, y: 28 },
@@ -199,6 +211,9 @@
   var settlementAnimationTimers = [];
   var settlementAnimationNodes = [];
   var suppressSettlementAnimationUntilAuthoritativeSnapshot = false;
+  var reactionBubblesBySeatNo = {};
+  var reactionControlTimer = null;
+  var reactionControlUntilMs = 0;
   var els = {};
 
   function cloneState(source){
@@ -1730,6 +1745,115 @@
     return Math.round(num).toLocaleString();
   }
 
+  function findReactionEntry(reactionKey){
+    for (var i = 0; i < REACTION_CATALOG.length; i++){
+      if (REACTION_CATALOG[i].key === reactionKey) return REACTION_CATALOG[i];
+    }
+    return null;
+  }
+
+  function clearReactionControlTimer(){
+    if (reactionControlTimer){
+      window.clearTimeout(reactionControlTimer);
+      reactionControlTimer = null;
+    }
+  }
+
+  function clearReactionBubbles(){
+    Object.keys(reactionBubblesBySeatNo).forEach(function(seatNo){
+      var bubble = reactionBubblesBySeatNo[seatNo];
+      if (bubble && bubble.timer) window.clearTimeout(bubble.timer);
+    });
+    reactionBubblesBySeatNo = {};
+  }
+
+  function closeReactionMenu(){
+    if (!els.reactionMenu || !els.reactionBtn) return;
+    els.reactionMenu.hidden = true;
+    els.reactionBtn.setAttribute('aria-expanded', 'false');
+  }
+
+  function renderReactionControl(){
+    if (!els.reactionBtn) return;
+    var signedIn = isSignedIn();
+    var seated = !!deriveCurrentSeat();
+    var cooldownActive = reactionControlUntilMs > Date.now();
+    var canUse = signedIn && seated && isWsReady() && !state.reconnectGate;
+    els.reactionBtn.hidden = !signedIn || !seated;
+    els.reactionBtn.disabled = !canUse || cooldownActive;
+    if (els.reactionHint){
+      els.reactionHint.hidden = !cooldownActive;
+      els.reactionHint.textContent = cooldownActive ? 'You can react once every 4 seconds' : '';
+    }
+    if (!canUse) closeReactionMenu();
+  }
+
+  function startReactionCooldown(){
+    clearReactionControlTimer();
+    reactionControlUntilMs = Date.now() + 4_000;
+    renderReactionControl();
+    reactionControlTimer = window.setTimeout(function(){
+      reactionControlTimer = null;
+      reactionControlUntilMs = 0;
+      renderReactionControl();
+    }, 4_000);
+  }
+
+  function handleTableReaction(event){
+    var payload = event && event.payload && typeof event.payload === 'object' ? event.payload : {};
+    var seatNo = Number(payload.seatNo);
+    var reactionKey = typeof payload.reactionKey === 'string' ? payload.reactionKey : '';
+    var entry = findReactionEntry(reactionKey);
+    if (!Number.isInteger(seatNo) || seatNo < 1 || !entry) return;
+    var previous = reactionBubblesBySeatNo[seatNo];
+    if (previous && previous.timer) window.clearTimeout(previous.timer);
+    var bubble = { reactionKey: reactionKey, timer: null };
+    bubble.timer = window.setTimeout(function(){
+      if (reactionBubblesBySeatNo[seatNo] !== bubble) return;
+      delete reactionBubblesBySeatNo[seatNo];
+      renderSeats();
+    }, 3_500);
+    reactionBubblesBySeatNo[seatNo] = bubble;
+    renderSeats();
+  }
+
+  function sendReaction(reactionKey){
+    if (!wsClient || typeof wsClient.sendReaction !== 'function' || !isWsReady() || !deriveCurrentSeat()) {
+      return Promise.resolve(null);
+    }
+    closeReactionMenu();
+    return wsClient.sendReaction(reactionKey).then(function(result){
+      startReactionCooldown();
+      return result;
+    }).catch(function(error){
+      var code = normalizeSignalCode(error && (error.code || error.message));
+      if (code === 'reaction_rate_limited') return null;
+      if (code === 'not_seated' || code === 'table_closed'){
+        renderControls();
+        if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function') wsClient.requestGameplaySnapshot();
+        return null;
+      }
+      klog('poker_reaction_error', { code: code || 'reaction_failed' });
+      return null;
+    });
+  }
+
+  function buildReactionMenu(){
+    if (!els.reactionMenu) return;
+    els.reactionMenu.innerHTML = '';
+    REACTION_CATALOG.forEach(function(entry){
+      var option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'poker-reaction-option';
+      option.setAttribute('role', 'menuitem');
+      option.setAttribute('aria-label', entry.label);
+      option.dataset.reactionKey = entry.key;
+      option.textContent = entry.emoji + ' ' + entry.label;
+      option.addEventListener('click', function(){ sendReaction(entry.key); });
+      els.reactionMenu.appendChild(option);
+    });
+  }
+
   function formatCompactAmount(value){
     var num = Number(value || 0);
     if (!Number.isFinite(num) || num <= 0) return '0';
@@ -2507,6 +2631,15 @@
       status.style.top = statusPosition.top;
 
       article.appendChild(avatar);
+      var reactionBubble = seat && reactionBubblesBySeatNo[seat.seatNo];
+      var reactionEntry = reactionBubble ? findReactionEntry(reactionBubble.reactionKey) : null;
+      if (reactionEntry){
+        var bubble = document.createElement('div');
+        bubble.className = 'poker-seat-reaction-bubble';
+        bubble.setAttribute('role', 'status');
+        bubble.textContent = reactionEntry.emoji + ' ' + reactionEntry.label;
+        article.appendChild(bubble);
+      }
       if (seat && lastAction){
         var actionBadge = document.createElement('div');
         var badgePosition = getSeatActionBadgePosition(rotatedIndex, hero);
@@ -3106,6 +3239,7 @@
     // value; syncAmountInput returns undefined when no amount action is active,
     // in which case the base Bet/Raise label set above is preserved.
     syncAmountActionLabels(syncedAmount);
+    renderReactionControl();
   }
 
   function resolveSettlementRecipientName(userId){
@@ -3645,6 +3779,23 @@
       if (!plan) return;
       handleAction(plan.type, plan.amount == null ? undefined : plan.amount);
     });
+    buildReactionMenu();
+    if (els.reactionBtn) els.reactionBtn.addEventListener('click', function(){
+      if (els.reactionBtn.disabled || !els.reactionMenu) return;
+      var hidden = els.reactionMenu.hidden;
+      els.reactionMenu.hidden = !hidden;
+      els.reactionBtn.setAttribute('aria-expanded', hidden ? 'true' : 'false');
+    });
+    document.addEventListener('click', function(event){
+      var target = event && event.target;
+      if (!target || target === els.reactionBtn || target === els.reactionMenu) return;
+      if (els.reactionBtn && typeof els.reactionBtn.contains === 'function' && els.reactionBtn.contains(target)) return;
+      if (els.reactionMenu && typeof els.reactionMenu.contains === 'function' && els.reactionMenu.contains(target)) return;
+      closeReactionMenu();
+    });
+    document.addEventListener('keydown', function(event){
+      if (event && event.key === 'Escape') closeReactionMenu();
+    });
     bindPreaction('fold');
     bindPreaction('primary');
     bindPreaction('amount');
@@ -3681,6 +3832,9 @@
     els.joinSeat = document.getElementById('pokerV2SeatNo');
     els.joinBuyIn = document.getElementById('pokerV2BuyIn');
     els.leaveBtn = document.getElementById('pokerV2LeaveBtn');
+    els.reactionBtn = document.getElementById('pokerV2ReactionBtn');
+    els.reactionMenu = document.getElementById('pokerV2ReactionMenu');
+    els.reactionHint = document.getElementById('pokerV2ReactionHint');
     els.leaveConfirmModal = document.getElementById('pokerV2LeaveConfirmModal');
     els.leaveConfirmYes = document.getElementById('pokerV2LeaveConfirmYes');
     els.leaveConfirmCancel = document.getElementById('pokerV2LeaveConfirmCancel');
@@ -3776,6 +3930,9 @@
     liveModeGeneration += 1;
     stopSnapshotRecoveryTimer();
     stopTurnClock();
+    clearReactionControlTimer();
+    reactionControlUntilMs = 0;
+    clearReactionBubbles();
     clearWinnerRevealTimer();
     cancelSettlementAnimations();
     cancelClosedTableRedirect();
@@ -3858,6 +4015,10 @@
       guestToken: isGuestMode && currentGuestSession ? currentGuestSession.token : null,
       getAccessToken: function(){ return Promise.resolve(currentAccessToken); },
       klog: klog,
+      onReaction: function(event){
+        if (gen !== liveModeGeneration) return;
+        handleTableReaction(event);
+      },
       onStatus: function(status, info){
         if (gen !== liveModeGeneration) return;
         if (status === 'hello_ack' || status === 'minting_token' || status === 'authenticating'){
@@ -3888,6 +4049,7 @@
         } else if (status === 'reconnecting'){
           cancelSettlementAnimations();
           suppressSettlementAnimationUntilAuthoritativeSnapshot = true;
+          clearReactionBubbles();
           rememberSeatForReconnect();
           state.wsReady = false;
           state.statusText = LIVE_STATUS_COPY.connecting;

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -87,6 +87,7 @@
     var onStatus = typeof options.onStatus === 'function' ? options.onStatus : function(){};
     var onSnapshot = typeof options.onSnapshot === 'function' ? options.onSnapshot : function(){};
     var onLobbySnapshot = typeof options.onLobbySnapshot === 'function' ? options.onLobbySnapshot : function(){};
+    var onReaction = typeof options.onReaction === 'function' ? options.onReaction : function(){};
     var onProtocolError = typeof options.onProtocolError === 'function' ? options.onProtocolError : function(){};
     var log = typeof options.klog === 'function' ? options.klog : klog;
     var mintUrl = typeof options.mintUrl === 'string' && options.mintUrl ? options.mintUrl : DEFAULT_MINT_URL;
@@ -358,6 +359,17 @@
         return;
       }
       if (isSnapshotFrameType(frame.type)) { var initial = !initialSnapshotDelivered; initialSnapshotDelivered = true; var normalized = normalizeSnapshot(frame, initial); if (normalized) onSnapshot(normalized); return; }
+      if (frame.type === 'table_reaction') {
+        try {
+          onReaction({
+            roomId: frame.roomId || tableId || null,
+            sessionId: frame.sessionId || null,
+            ts: frame.ts || null,
+            payload: frame.payload || {}
+          });
+        } catch (_err){}
+        return;
+      }
       if (frame.type === 'commandResult') { handleCommandResult(frame); emitStatus('command_result', { status: frame.payload && frame.payload.status ? frame.payload.status : null, reason: frame.payload && frame.payload.reason ? frame.payload.reason : null }); return; }
       if (frame.type === 'resync') {
         emitStatus('resync', {
@@ -467,7 +479,8 @@
       sendRebuy: function(payload, requestId){ return sendCommand('rebuy', payload || { tableId: tableId, amount: 100 }, requestId); },
       sendLeave: function(payload, requestId){ return sendCommand('leave', payload || { tableId: tableId }, requestId); },
       sendLeaveQueued: function(payload, requestId){ return queueCommand('leave', payload || { tableId: tableId }, requestId); },
-      sendStartHand: function(payload, requestId){ return sendCommand('start_hand', payload || { tableId: tableId }, requestId); }
+      sendStartHand: function(payload, requestId){ return sendCommand('start_hand', payload || { tableId: tableId }, requestId); },
+      sendReaction: function(reactionKey, requestId){ return sendCommand('reaction_send', { tableId: tableId, reactionKey: reactionKey }, requestId); }
     };
   }
 

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -58,9 +58,6 @@
         <button type="button" class="poker-live-btn" id="pokerV2SignInBtn">Create account and get 500 CH Welcome Bonus</button>
         <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2JoinBtn">Join</button>
         <button type="button" class="poker-live-btn" id="pokerV2LeaveBtn" hidden>Leave</button>
-        <button type="button" class="poker-live-btn poker-reaction-btn" id="pokerV2ReactionBtn" aria-haspopup="menu" aria-expanded="false" aria-controls="pokerV2ReactionMenu" hidden>React</button>
-        <div class="poker-reaction-menu" id="pokerV2ReactionMenu" role="menu" aria-label="Reactions" hidden></div>
-        <div class="poker-reaction-hint" id="pokerV2ReactionHint" role="status" aria-live="polite" hidden></div>
         <input type="hidden" id="pokerV2SeatNo" value="1">
         <input type="hidden" id="pokerV2BuyIn" value="100">
       </div>
@@ -105,6 +102,11 @@
       <div class="poker-action-amount-input" id="pokerV2AmountInputWrap">
         <strong id="pokerV2AmountValue">20</strong>
         <input type="range" id="pokerV2AmountInput" value="20" min="1" max="20" step="1">
+      </div>
+      <div class="poker-action-reaction" id="pokerV2ReactionControl" hidden>
+        <button type="button" class="poker-live-btn poker-reaction-btn" id="pokerV2ReactionBtn" aria-haspopup="menu" aria-expanded="false" aria-controls="pokerV2ReactionMenu" hidden>React</button>
+        <div class="poker-reaction-menu" id="pokerV2ReactionMenu" role="menu" aria-label="Reactions" hidden></div>
+        <div class="poker-reaction-hint" id="pokerV2ReactionHint" role="status" aria-live="polite" hidden></div>
       </div>
       <div class="poker-action-buttons">
         <button type="button" class="poker-action-btn poker-action-btn--fold" id="pokerV2FoldBtn" hidden>Fold</button>

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -87,6 +87,7 @@
       <div class="poker-seat-layer" id="pokerSeatLayer"></div>
       <div class="poker-seat-chip-layer" id="pokerSeatChipLayer"></div>
       <div class="poker-dealer-chip" id="pokerDealerChip">D</div>
+      <div class="poker-reaction-layer" id="pokerReactionLayer"></div>
 
       <div class="poker-center-layer">
         <div class="poker-pot-pill" id="pokerPotPill">Pot 1,350</div>

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -58,6 +58,9 @@
         <button type="button" class="poker-live-btn" id="pokerV2SignInBtn">Create account and get 500 CH Welcome Bonus</button>
         <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2JoinBtn">Join</button>
         <button type="button" class="poker-live-btn" id="pokerV2LeaveBtn" hidden>Leave</button>
+        <button type="button" class="poker-live-btn poker-reaction-btn" id="pokerV2ReactionBtn" aria-haspopup="menu" aria-expanded="false" aria-controls="pokerV2ReactionMenu" hidden>React</button>
+        <div class="poker-reaction-menu" id="pokerV2ReactionMenu" role="menu" aria-label="Reactions" hidden></div>
+        <div class="poker-reaction-hint" id="pokerV2ReactionHint" role="status" aria-live="polite" hidden></div>
         <input type="hidden" id="pokerV2SeatNo" value="1">
         <input type="hidden" id="pokerV2BuyIn" value="100">
       </div>

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -92,6 +92,7 @@ run("node", ["ws-server/observability/vps-metrics.behavior.test.mjs"], "ws-vps-m
 run("node", ["ws-server/poker/idempotency/action-command.behavior.test.mjs"], "ws-action-command-idempotency-behavior");
 run("node", ["ws-server/poker/persistence/authoritative-rebuy-adapter.behavior.test.mjs"], "ws-authoritative-rebuy-adapter-behavior");
 run("node", ["ws-server/poker/handlers/rebuy.behavior.test.mjs"], "ws-rebuy-handler-behavior");
+run("node", ["ws-server/poker/handlers/reaction.behavior.test.mjs"], "ws-reaction-handler-behavior");
 run("node", ["ws-server/poker/runtime/disconnect-cleanup.behavior.test.mjs"], "ws-disconnect-cleanup-runtime-behavior");
 run("node", ["ws-server/poker/runtime/table-janitor.behavior.test.mjs"], "ws-table-janitor-behavior");
 run("node", ["ws-server/poker/runtime/accepted-bot-autoplay-adapter.behavior.test.mjs"], "ws-accepted-bot-autoplay-adapter-behavior");

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -115,6 +115,7 @@ function createHarness(options = {}){
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
     'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
+    'pokerV2ReactionBtn', 'pokerV2ReactionMenu', 'pokerV2ReactionHint',
     'pokerV2RebuyPanel', 'pokerV2RebuyTitle', 'pokerV2RebuyCopy', 'pokerV2RebuyBalance', 'pokerV2RebuyBtn', 'pokerV2RebuyLobbyBtn', 'pokerV2RebuyWatchBtn', 'pokerV2RebuyAccountLink',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',
@@ -150,6 +151,7 @@ function createHarness(options = {}){
   const startPayloads = [];
   const leavePayloads = [];
   const rebuyPayloads = [];
+  const reactionPayloads = [];
   let createOptions = null;
 
   const token = Object.prototype.hasOwnProperty.call(options, 'token')
@@ -183,6 +185,11 @@ function createHarness(options = {}){
     sendLeave(payload){
       leavePayloads.push(payload);
       if (typeof options.sendLeave === 'function') return options.sendLeave(payload, { attempt: leavePayloads.length });
+      return Promise.resolve({ ok: true });
+    },
+    sendReaction(reactionKey){
+      reactionPayloads.push(reactionKey);
+      if (typeof options.sendReaction === 'function') return options.sendReaction(reactionKey, { attempt: reactionPayloads.length });
       return Promise.resolve({ ok: true });
     },
     requestGameplaySnapshot(){
@@ -324,6 +331,7 @@ async function flush(){
     startPayloads,
     leavePayloads,
     rebuyPayloads,
+    reactionPayloads,
     getSnapshotRequestCount(){ return snapshotRequestCount; },
     fireDomContentLoaded,
     fireDocumentEvent,
@@ -447,6 +455,46 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   assert.equal(harness.leavePayloads.length, 1);
   assert.equal(JSON.stringify(harness.leavePayloads[0]), JSON.stringify({ tableId: 'table-1' }));
   assert.equal(harness.windowLocation.href, '/poker/');
+});
+
+test('poker v2 disables reactions for four seconds after an accepted reaction', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: { hand: { handId: null, status: 'LOBBY' }, pot: { total: 0 } },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2ReactionBtn.hidden, false);
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, false);
+  harness.elements.pokerV2ReactionBtn.click();
+  const wowOption = harness.elements.pokerV2ReactionMenu.children.find((child) => child.dataset.reactionKey === 'wow');
+  assert.ok(wowOption);
+  wowOption.click();
+  await harness.flush();
+
+  assert.deepEqual(harness.reactionPayloads, ['wow']);
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, true);
+  assert.equal(harness.elements.pokerV2ReactionHint.hidden, false);
+  assert.equal(harness.elements.pokerV2ReactionHint.textContent, 'You can react once every 4 seconds');
+
+  harness.advanceTime(3_999);
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, true);
+  harness.advanceTime(1);
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, false);
+  assert.equal(harness.elements.pokerV2ReactionHint.hidden, true);
 });
 
 test('poker v2 shows one reserved next-hand join without cards, actions, or folded styling', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -115,7 +115,7 @@ function createHarness(options = {}){
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
     'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
-    'pokerV2ReactionBtn', 'pokerV2ReactionMenu', 'pokerV2ReactionHint',
+    'pokerV2ReactionControl', 'pokerV2ReactionBtn', 'pokerV2ReactionMenu', 'pokerV2ReactionHint',
     'pokerV2RebuyPanel', 'pokerV2RebuyTitle', 'pokerV2RebuyCopy', 'pokerV2RebuyBalance', 'pokerV2RebuyBtn', 'pokerV2RebuyLobbyBtn', 'pokerV2RebuyWatchBtn', 'pokerV2RebuyAccountLink',
     'pokerV2ClosedTableModal', 'pokerV2ClosedTableTitle', 'pokerV2ClosedTableCountdown',
     'pokerV2DemoPill', 'pokerV2FoldBtn', 'pokerV2PrimaryBtn', 'pokerV2AmountBtn',

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -540,6 +540,35 @@ test('poker v2 removes a reaction bubble when the seat owner changes', async () 
   assert.equal(harness.elements.pokerReactionLayer.children.length, 0);
 });
 
+test('poker v2 clears reaction bubbles immediately when reconnecting starts', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: {
+        hand: { handId: null, status: 'LOBBY' },
+        pot: { total: 0 },
+        seats: [{ userId: 'user-1', seatNo: 1, status: 'ACTIVE' }]
+      },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
+  await harness.flush();
+  assert.equal(harness.elements.pokerReactionLayer.children.length, 1);
+
+  ws.onStatus('reconnecting', { attempt: 1 });
+  assert.equal(harness.elements.pokerReactionLayer.children.length, 0);
+});
+
 test('poker v2 animates a reaction bubble only on its first render', async () => {
   const harness = createHarness();
   harness.fireDomContentLoaded();

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -497,6 +497,84 @@ test('poker v2 disables reactions for four seconds after an accepted reaction', 
   assert.equal(harness.elements.pokerV2ReactionHint.hidden, true);
 });
 
+test('poker v2 removes a reaction bubble when the seat owner changes', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: {
+        hand: { handId: null, status: 'LOBBY' },
+        pot: { total: 0 },
+        seats: [{ userId: 'user-1', seatNo: 1, status: 'ACTIVE' }]
+      },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
+  await harness.flush();
+  assert.ok(harness.elements.pokerSeatLayer.children.some((seat) => findSeatChild(seat, 'poker-seat-reaction-bubble')));
+
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 2,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-2', seat: 1 }] },
+      public: {
+        hand: { handId: null, status: 'LOBBY' },
+        pot: { total: 0 },
+        seats: [{ userId: 'user-2', seatNo: 1, status: 'ACTIVE' }]
+      },
+      you: { seat: null }
+    }
+  });
+  await harness.flush();
+  assert.equal(harness.elements.pokerSeatLayer.children.some((seat) => findSeatChild(seat, 'poker-seat-reaction-bubble')), false);
+});
+
+test('poker v2 applies local cooldown after a server reaction rate limit', async () => {
+  const harness = createHarness({
+    sendReaction: () => {
+      const error = new Error('reaction_rate_limited');
+      error.code = 'reaction_rate_limited';
+      return Promise.reject(error);
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: { hand: { handId: null, status: 'LOBBY' }, pot: { total: 0 } },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+  harness.elements.pokerV2ReactionBtn.click();
+  const wowOption = harness.elements.pokerV2ReactionMenu.children.find((child) => child.dataset.reactionKey === 'wow');
+  wowOption.click();
+  await harness.flush();
+
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, true);
+  assert.equal(harness.elements.pokerV2ReactionHint.hidden, false);
+  harness.advanceTime(4_000);
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2ReactionBtn.disabled, false);
+});
+
 test('poker v2 shows one reserved next-hand join without cards, actions, or folded styling', async () => {
   const unresolvedJoin = new Promise(() => {});
   const harness = createHarness({

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -111,7 +111,7 @@ function createHarness(options = {}){
   [
     'xpBadge',
     'pokerMenuToggle', 'pokerMenuPanel', 'pokerLobbyLink',
-    'pokerSeatLayer', 'pokerSeatChipLayer', 'pokerChipFxLayer', 'pokerPotPill', 'pokerPotChipStack', 'pokerCommunityCards', 'pokerDealerChip',
+    'pokerSeatLayer', 'pokerSeatChipLayer', 'pokerChipFxLayer', 'pokerReactionLayer', 'pokerPotPill', 'pokerPotChipStack', 'pokerCommunityCards', 'pokerDealerChip',
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
     'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
     'pokerV2BuyIn', 'pokerV2JoinBtn', 'pokerV2StartBtn', 'pokerV2LeaveBtn', 'pokerV2LeaveConfirmModal', 'pokerV2LeaveConfirmYes', 'pokerV2LeaveConfirmCancel',
@@ -520,7 +520,7 @@ test('poker v2 removes a reaction bubble when the seat owner changes', async () 
   await harness.flush();
   ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
   await harness.flush();
-  assert.ok(harness.elements.pokerSeatLayer.children.some((seat) => (seat.children || []).some((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'))));
+  assert.ok(harness.elements.pokerReactionLayer.children.some((anchor) => (anchor.children || []).some((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'))));
 
   ws.onSnapshot({
     kind: 'stateSnapshot',
@@ -537,7 +537,7 @@ test('poker v2 removes a reaction bubble when the seat owner changes', async () 
     }
   });
   await harness.flush();
-  assert.equal(harness.elements.pokerSeatLayer.children.some((seat) => findSeatChild(seat, 'poker-seat-reaction-bubble')), false);
+  assert.equal(harness.elements.pokerReactionLayer.children.length, 0);
 });
 
 test('poker v2 animates a reaction bubble only on its first render', async () => {
@@ -566,8 +566,8 @@ test('poker v2 animates a reaction bubble only on its first render', async () =>
   await harness.flush();
 
   const findReactionBubble = () => {
-    for (const seat of harness.elements.pokerSeatLayer.children) {
-      const bubble = (seat.children || []).find((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'));
+    for (const anchor of harness.elements.pokerReactionLayer.children) {
+      const bubble = (anchor.children || []).find((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'));
       if (bubble) return bubble;
     }
     return null;

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -520,7 +520,7 @@ test('poker v2 removes a reaction bubble when the seat owner changes', async () 
   await harness.flush();
   ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
   await harness.flush();
-  assert.ok(harness.elements.pokerSeatLayer.children.some((seat) => findSeatChild(seat, 'poker-seat-reaction-bubble')));
+  assert.ok(harness.elements.pokerSeatLayer.children.some((seat) => (seat.children || []).some((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'))));
 
   ws.onSnapshot({
     kind: 'stateSnapshot',
@@ -538,6 +538,49 @@ test('poker v2 removes a reaction bubble when the seat owner changes', async () 
   });
   await harness.flush();
   assert.equal(harness.elements.pokerSeatLayer.children.some((seat) => findSeatChild(seat, 'poker-seat-reaction-bubble')), false);
+});
+
+test('poker v2 animates a reaction bubble only on its first render', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+
+  const ws = harness.getCreateOptions();
+  const snapshot = (stateVersion) => ({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }] },
+      public: {
+        hand: { handId: null, status: 'LOBBY' },
+        pot: { total: 0 },
+        seats: [{ userId: 'user-1', seatNo: 1, status: 'ACTIVE' }]
+      },
+      you: { seat: 1 }
+    }
+  });
+  ws.onSnapshot(snapshot(1));
+  await harness.flush();
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
+  await harness.flush();
+
+  const findReactionBubble = () => {
+    for (const seat of harness.elements.pokerSeatLayer.children) {
+      const bubble = (seat.children || []).find((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'));
+      if (bubble) return bubble;
+    }
+    return null;
+  };
+  const firstBubble = findReactionBubble();
+  assert.ok(firstBubble);
+  assert.equal(firstBubble.className, 'poker-seat-reaction-bubble poker-seat-reaction-bubble--enter', 'the received reaction should animate on entry');
+
+  ws.onSnapshot(snapshot(2));
+  await harness.flush();
+  const secondBubble = findReactionBubble();
+  assert.ok(secondBubble);
+  assert.equal(secondBubble.className, 'poker-seat-reaction-bubble');
 });
 
 test('poker v2 applies local cooldown after a server reaction rate limit', async () => {

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -10,6 +10,7 @@ function loadClientHarness(options = {}){
   const statuses = [];
   const snapshots = [];
   const lobbySnapshots = [];
+  const reactions = [];
   const protocolErrors = [];
   let fetchCalls = [];
 
@@ -77,10 +78,11 @@ function loadClientHarness(options = {}){
     onStatus: (status, data) => statuses.push({ status, data }),
     onSnapshot: (snapshot) => snapshots.push(snapshot),
     onLobbySnapshot: (snapshot) => lobbySnapshots.push(snapshot),
+    onReaction: (reaction) => reactions.push(reaction),
     onProtocolError: (info) => protocolErrors.push(info)
   }, options.clientOptions || {}));
 
-  return { client, FakeWebSocket, sentFrames, logs, statuses, snapshots, lobbySnapshots, protocolErrors, getFetchCalls: () => fetchCalls };
+  return { client, FakeWebSocket, sentFrames, logs, statuses, snapshots, lobbySnapshots, reactions, protocolErrors, getFetchCalls: () => fetchCalls };
 }
 
 function getLogEntries(logs, kind){
@@ -182,6 +184,42 @@ test('poker ws client gameplay commands including rebuy resolve and reject by co
   const actPromise = h.client.sendAct({ handId: 'h1', action: 'CHECK' }, 'act_req_1');
   ws.message({ type: 'commandResult', requestId: 'act_req_1', payload: { requestId: 'act_req_1', status: 'rejected', reason: 'hand_not_live' } });
   await assert.rejects(actPromise, (err) => err && err.code === 'hand_not_live');
+});
+
+test('poker ws client sends reactions and handles table reactions outside the snapshot stream', async () => {
+  const h = loadClientHarness();
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const reactionPromise = h.client.sendReaction('wow', 'reaction_req_1');
+  assert.equal(h.sentFrames.at(-1).type, 'reaction_send');
+  assert.deepEqual(h.sentFrames.at(-1).payload, { tableId: 'table_test_1', reactionKey: 'wow' });
+  ws.message({
+    type: 'commandResult',
+    requestId: 'reaction_req_1',
+    payload: { requestId: 'reaction_req_1', status: 'accepted', reason: null }
+  });
+  assert.equal((await reactionPromise).ok, true);
+
+  ws.message({
+    version: '1.0',
+    type: 'table_reaction',
+    roomId: 'table_test_1',
+    sessionId: 'session_1',
+    ts: '2026-08-03T00:00:00Z',
+    payload: { seatNo: 2, reactionKey: 'haha' }
+  });
+  assert.equal(h.snapshots.length, 0);
+  assert.equal(h.reactions.length, 1);
+  assert.equal(h.reactions[0].roomId, 'table_test_1');
+  assert.equal(h.reactions[0].sessionId, 'session_1');
+  assert.equal(h.reactions[0].ts, '2026-08-03T00:00:00Z');
+  assert.equal(h.reactions[0].payload.seatNo, 2);
+  assert.equal(h.reactions[0].payload.reactionKey, 'haha');
 });
 
 test('poker ws client keeps an ambiguous join pending after a command-scoped attach error', async () => {

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -60,6 +60,13 @@ assert.doesNotMatch(tableV2Css, /\.poker-seat--hero \.poker-seat-avatar\{[^}]*bo
 assert.match(tableV2Css, /\.poker-seat--hero\.poker-seat--active \.poker-seat-avatar\{border-color:rgba\(84,245,152,0\.88\);/, 'hero avatar should turn green only on the active turn');
 assert.match(tableV2Html, /id="pokerBootSplash"/, 'poker table v2 should render a boot splash to avoid raw HTML flash');
 assert.match(tableV2Html, /id="pokerV2AmountValue"/, 'poker table v2 should render a compact amount value for the action slider');
+const reactionControlIndex = tableV2Html.indexOf('id="pokerV2ReactionControl"');
+const actionBarIndex = tableV2Html.indexOf('class="poker-action-bar"');
+const actionButtonsIndex = tableV2Html.indexOf('class="poker-action-buttons"');
+assert.equal(actionBarIndex < reactionControlIndex && reactionControlIndex < actionButtonsIndex, true, 'reaction control should live above the poker action buttons');
+assert.match(tableV2Html, /id="pokerV2ReactionControl" hidden/, 'reaction control should stay hidden until a seated player can use it');
+assert.match(tableV2Css, /\.poker-seat-reaction-bubble\{[^}]*animation:poker-reaction-bubble-flyout/, 'reaction bubbles should have a flyout animation');
+assert.match(tableV2Css, /\.poker-action-reaction \.poker-reaction-menu\{[^}]*bottom:calc\(100% \+ 8px\)/, 'reaction menu should fly out above the poker actions');
 assert.match(consentManagerJs, /#manageCookies, \.manage-cookies, \[data-manage-cookies\]/, 'consent manager should delegate clicks from all manage cookies links');
 assert.match(consentManagerJs, /window\.klaro\.show\(window\.klaroConfig, true\)/, 'manage cookies should open the Klaro preference modal');
 assert.match(consentManagerJs, /netlify-drawer-active/, 'consent runtime should expose the active Netlify drawer state to responsive UI');

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -65,7 +65,7 @@ const actionBarIndex = tableV2Html.indexOf('class="poker-action-bar"');
 const actionButtonsIndex = tableV2Html.indexOf('class="poker-action-buttons"');
 assert.equal(actionBarIndex < reactionControlIndex && reactionControlIndex < actionButtonsIndex, true, 'reaction control should live above the poker action buttons');
 assert.match(tableV2Html, /id="pokerV2ReactionControl" hidden/, 'reaction control should stay hidden until a seated player can use it');
-assert.match(tableV2Css, /\.poker-seat-reaction-bubble\{[^}]*animation:poker-reaction-bubble-flyout/, 'reaction bubbles should have a flyout animation');
+assert.match(tableV2Css, /\.poker-seat-reaction-bubble--enter\{[^}]*animation:poker-reaction-bubble-flyout/, 'reaction bubble entry should have a flyout animation');
 assert.match(tableV2Css, /\.poker-action-reaction \.poker-reaction-menu\{[^}]*bottom:calc\(100% \+ 8px\)/, 'reaction menu should fly out above the poker actions');
 assert.match(consentManagerJs, /#manageCookies, \.manage-cookies, \[data-manage-cookies\]/, 'consent manager should delegate clicks from all manage cookies links');
 assert.match(consentManagerJs, /window\.klaro\.show\(window\.klaroConfig, true\)/, 'manage cookies should open the Klaro preference modal');

--- a/tests/static-html.behavior.test.mjs
+++ b/tests/static-html.behavior.test.mjs
@@ -50,12 +50,14 @@ assert.doesNotMatch(tableV2Html, /pokerV2Link/, 'poker table v2 should not expos
 assert.doesNotMatch(tableV2Html, /pokerV2DemoPill/, 'poker table v2 should not render the legacy demo pill');
 assert.match(tableV2Html, /src="\/poker\/poker-ws-client\.js" defer/, 'poker table v2 should bootstrap WS client for live runtime');
 assert.equal(tableV2Html.indexOf('id="pokerSeatLayer"') < tableV2Html.indexOf('id="pokerDealerChip"'), true, 'dealer chip should be positioned in the full scene after the seat layer');
+assert.match(tableV2Html, /id="pokerReactionLayer"/, 'poker table v2 should render a top reaction layer above seat chips');
 assert.equal(tableV2Html.indexOf('id="pokerDealerChip"') < tableV2Html.indexOf('class="poker-center-layer"'), true, 'dealer chip should not live inside the center layer');
 assert.match(tableV2Css, /\.poker-menu-panel\[hidden\]\{display:none;\}/, 'poker table v2 menu should hard-hide when hidden attribute is present');
 assert.match(tableV2Css, /\.poker-closed-table-modal\{z-index:65;\}/, 'poker table v2 should style the closed-table redirect notice');
 assert.match(tableV2Css, /\.poker-guest-panel\{margin-top:12px; padding:14px 14px 12px; border-radius:18px; border:1px solid rgba\(255,223,180,0\.2\); background:rgba\(8,13,22,0\.72\);\}/, 'poker table v2 should style the guest restrictions panel');
 assert.match(tableV2Css, /\.poker-guest-panel__item--blocked::before\{content:"✕"; color:#ffb5b5;\}/, 'guest restrictions panel should visibly mark blocked items');
 assert.match(tableV2Css, /\.poker-action-bar\{position:fixed; right:max\(10px, env\(safe-area-inset-right\)\); bottom:max\(10px, env\(safe-area-inset-bottom\)\); width:min\(33vw, 196px\); display:grid; grid-template-columns:40px minmax\(0, 1fr\);/, 'poker table v2 action rail should dock to the bottom-right with a left-side vertical amount slider');
+assert.match(tableV2Css, /\.poker-reaction-layer\{position:absolute; inset:0; z-index:14; pointer-events:none;\}/, 'reaction bubbles should render in a non-interactive layer above chips');
 assert.doesNotMatch(tableV2Css, /\.poker-seat--hero \.poker-seat-avatar\{[^}]*border-color:/, 'hero avatar should not keep an always-on active ring');
 assert.match(tableV2Css, /\.poker-seat--hero\.poker-seat--active \.poker-seat-avatar\{border-color:rgba\(84,245,152,0\.88\);/, 'hero avatar should turn green only on the active turn');
 assert.match(tableV2Html, /id="pokerBootSplash"/, 'poker table v2 should render a boot splash to avoid raw HTML flash');

--- a/ws-server/poker/handlers/reaction.behavior.test.mjs
+++ b/ws-server/poker/handlers/reaction.behavior.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  REACTION_KEYS,
+  clearTable,
+  evaluateHumanReactionCommand,
+  tryCreateBotReaction
+} from './reaction.mjs';
+
+test('human reactions use the closed allowlist and atomically reserve the sender cooldown', () => {
+  const tableId = 'reaction-human-contract';
+  clearTable(tableId);
+
+  assert.deepEqual(REACTION_KEYS, [
+    'hello',
+    'nice_hand',
+    'well_played',
+    'thinking',
+    'haha',
+    'wow',
+    'bad_beat',
+    'nice_bluff',
+    'good_luck',
+    'thanks'
+  ]);
+
+  const first = evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: ' wow ',
+    nowMs: 1_000
+  });
+  const second = evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'hello',
+    nowMs: 1_000
+  });
+
+  assert.deepEqual(first, { ok: true, seatNo: 2, reactionKey: 'wow' });
+  assert.deepEqual(second, { ok: false, reason: 'reaction_rate_limited' });
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-2',
+    senderSeatNo: 1,
+    reactionKey: 'not_allowed',
+    nowMs: 1_000
+  }), { ok: false, reason: 'invalid_reaction' });
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-3',
+    senderSeatNo: null,
+    reactionKey: 'hello',
+    nowMs: 1_000
+  }), { ok: false, reason: 'invalid_sender' });
+
+  clearTable(tableId);
+});
+
+test('bot reactions use the real bot action object and table-level throttle', () => {
+  const tableId = 'reaction-bot-contract';
+  clearTable(tableId);
+
+  const accepted = tryCreateBotReaction({
+    tableId,
+    botUserId: 'bot-1',
+    botSeatNo: 3,
+    botAction: { type: ' raise ', amount: 40 },
+    nowMs: 2_000,
+    random: (() => {
+      const values = [0.01, 0.9];
+      return () => values.shift();
+    })()
+  });
+  const throttledForAnotherBot = tryCreateBotReaction({
+    tableId,
+    botUserId: 'bot-2',
+    botSeatNo: 4,
+    botAction: { type: 'BET', amount: 20 },
+    nowMs: 2_001,
+    random: () => 0.01
+  });
+
+  assert.deepEqual(accepted, { seatNo: 3, reactionKey: 'haha' });
+  assert.equal(throttledForAnotherBot, null);
+  assert.equal(tryCreateBotReaction({
+    tableId,
+    botUserId: 'bot-3',
+    botSeatNo: 5,
+    botAction: { type: 'FOLD' },
+    nowMs: 30_000,
+    random: () => 0.01
+  }), null);
+  assert.equal(tryCreateBotReaction({
+    tableId,
+    botUserId: 'bot-4',
+    botSeatNo: 6,
+    botAction: 'RAISE',
+    nowMs: 30_000,
+    random: () => 0.01
+  }), null);
+
+  clearTable(tableId);
+  const afterClear = tryCreateBotReaction({
+    tableId,
+    botUserId: 'bot-1',
+    botSeatNo: 3,
+    botAction: { type: 'ALL_IN' },
+    nowMs: 40_000,
+    random: () => 0.01
+  });
+  assert.deepEqual(afterClear, { seatNo: 3, reactionKey: 'wow' });
+  clearTable(tableId);
+});

--- a/ws-server/poker/handlers/reaction.mjs
+++ b/ws-server/poker/handlers/reaction.mjs
@@ -1,0 +1,151 @@
+const HUMAN_REACTION_COOLDOWN_MS = 4_000;
+const BOT_TABLE_THROTTLE_MS = 20_000;
+const BOT_REACTION_PROBABILITY = 0.02;
+
+export const REACTION_KEYS = Object.freeze([
+  "hello",
+  "nice_hand",
+  "well_played",
+  "thinking",
+  "haha",
+  "wow",
+  "bad_beat",
+  "nice_bluff",
+  "good_luck",
+  "thanks"
+]);
+
+const REACTION_KEY_SET = new Set(REACTION_KEYS);
+const BOT_REACTION_KEYS_BY_ACTION = Object.freeze({
+  BET: Object.freeze(["wow", "haha"]),
+  RAISE: Object.freeze(["wow", "haha"]),
+  ALL_IN: Object.freeze(["wow", "haha"])
+});
+
+const senderCooldownUntilByTableUser = new Map();
+const botReactionUntilByTable = new Map();
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeNowMs(value) {
+  return Number.isFinite(value) ? Math.trunc(value) : Date.now();
+}
+
+function isPositiveSeatNo(value) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function hasActiveCooldown(map, key, nowMs) {
+  const expiresAt = Number(map.get(key));
+  if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+    if (map.has(key)) map.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function normalizeBotActionType(botAction) {
+  if (!botAction || typeof botAction !== "object" || Array.isArray(botAction)) {
+    return "";
+  }
+  const value = typeof botAction.type === "string" ? botAction.type.trim().toUpperCase() : "";
+  return value;
+}
+
+export function evaluateHumanReactionCommand({
+  tableId,
+  senderUserId,
+  senderSeatNo,
+  reactionKey,
+  tableClosed = false,
+  nowMs
+} = {}) {
+  const normalizedTableId = normalizeString(tableId);
+  const normalizedUserId = normalizeString(senderUserId);
+  const normalizedReactionKey = normalizeString(reactionKey);
+  const resolvedNowMs = normalizeNowMs(nowMs);
+
+  if (!normalizedTableId || !normalizedUserId || !isPositiveSeatNo(senderSeatNo)) {
+    return { ok: false, reason: "invalid_sender" };
+  }
+  if (!REACTION_KEY_SET.has(normalizedReactionKey)) {
+    return { ok: false, reason: "invalid_reaction" };
+  }
+  if (tableClosed === true) {
+    return { ok: false, reason: "table_closed" };
+  }
+
+  const cooldownKey = `${normalizedTableId}:${normalizedUserId}`;
+  if (hasActiveCooldown(senderCooldownUntilByTableUser, cooldownKey, resolvedNowMs)) {
+    return { ok: false, reason: "reaction_rate_limited" };
+  }
+
+  senderCooldownUntilByTableUser.set(cooldownKey, resolvedNowMs + HUMAN_REACTION_COOLDOWN_MS);
+  return {
+    ok: true,
+    seatNo: senderSeatNo,
+    reactionKey: normalizedReactionKey
+  };
+}
+
+export function tryCreateBotReaction({
+  tableId,
+  botUserId,
+  botSeatNo,
+  botAction,
+  tableClosed = false,
+  nowMs,
+  random = Math.random
+} = {}) {
+  const normalizedTableId = normalizeString(tableId);
+  const normalizedBotUserId = normalizeString(botUserId);
+  const actionType = normalizeBotActionType(botAction);
+  const availableReactionKeys = BOT_REACTION_KEYS_BY_ACTION[actionType];
+  const resolvedNowMs = normalizeNowMs(nowMs);
+
+  if (tableClosed === true || !normalizedTableId || !normalizedBotUserId || !isPositiveSeatNo(botSeatNo)) {
+    return null;
+  }
+  if (!availableReactionKeys || availableReactionKeys.length === 0) {
+    return null;
+  }
+
+  const sample = Number(random());
+  if (!Number.isFinite(sample) || sample < 0 || sample >= BOT_REACTION_PROBABILITY) {
+    return null;
+  }
+
+  const senderKey = `${normalizedTableId}:${normalizedBotUserId}`;
+  if (hasActiveCooldown(senderCooldownUntilByTableUser, senderKey, resolvedNowMs)) {
+    return null;
+  }
+  if (hasActiveCooldown(botReactionUntilByTable, normalizedTableId, resolvedNowMs)) {
+    return null;
+  }
+
+  const selection = Number(random());
+  const selectionIndex = Number.isFinite(selection) && selection >= 0 && selection < 1
+    ? Math.floor(selection * availableReactionKeys.length)
+    : 0;
+
+  senderCooldownUntilByTableUser.set(senderKey, resolvedNowMs + HUMAN_REACTION_COOLDOWN_MS);
+  botReactionUntilByTable.set(normalizedTableId, resolvedNowMs + BOT_TABLE_THROTTLE_MS);
+
+  return {
+    seatNo: botSeatNo,
+    reactionKey: availableReactionKeys[selectionIndex] || availableReactionKeys[0]
+  };
+}
+
+export function clearTable(tableId) {
+  const normalizedTableId = normalizeString(tableId);
+  if (!normalizedTableId) return;
+
+  const prefix = `${normalizedTableId}:`;
+  for (const key of [...senderCooldownUntilByTableUser.keys()]) {
+    if (key.startsWith(prefix)) senderCooldownUntilByTableUser.delete(key);
+  }
+  botReactionUntilByTable.delete(normalizedTableId);
+}

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -254,6 +254,7 @@ register("ERROR", "runtime", [
   "ws_continuous_bot_table_profile_update_failed",
   "ws_continuous_bot_table_status_failed",
   "ws_continuous_bot_table_supervisor_failed",
+  "ws_table_reaction_broadcast_failed",
   "ws_error",
   "ws_message_processing_error",
   "ws_table_command_failed",

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -1481,6 +1481,7 @@ function createServer({ env = {} } = {}) {
     const child = spawn(process.execPath, ["ws-server/server.mjs"], {
       env: {
         ...process.env,
+        WS_POKER_LOG_LEVEL: "INFO",
         PORT: String(port),
         WS_BOT_REACTION_MIN_MS: "0",
         WS_BOT_REACTION_MAX_MS: "0",

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -36,6 +36,7 @@ import { createTableSnapshotLoader } from "./poker/table/table-snapshot.mjs";
 import { handleJoinCommand } from "./poker/handlers/join.mjs";
 import { handleActCommand } from "./poker/handlers/act.mjs";
 import { handleStartHandCommand } from "./poker/handlers/start-hand.mjs";
+import { evaluateHumanReactionCommand, tryCreateBotReaction, clearTable as clearReactionTable } from "./poker/handlers/reaction.mjs";
 import { handleTurnTimeoutCommand } from "./poker/handlers/turn-timeout.mjs";
 import {
   createBotAutoplayCascadeScheduler,
@@ -79,13 +80,14 @@ const PROTECTED_MESSAGE_TYPES = new Set([
   "lobby_subscribe",
   "table_state_sub",
   "table_snapshot",
+  "reaction_send",
   "act",
   "start_hand",
   "resync",
   "resume",
   "ack"
 ]);
-const REQUEST_ID_REQUIRED_TYPES = new Set(["join", "leave", "table_join", "table_leave", "rebuy", "table_rebuy", "lobby_subscribe", "table_state_sub", "table_snapshot", "act", "start_hand", "resync", "resume"]);
+const REQUEST_ID_REQUIRED_TYPES = new Set(["join", "leave", "table_join", "table_leave", "rebuy", "table_rebuy", "lobby_subscribe", "table_state_sub", "table_snapshot", "reaction_send", "act", "start_hand", "resync", "resume"]);
 const TABLE_SNAPSHOT_KNOWN_FAILURE_CODES = new Set([
   "invalid_table_id",
   "table_not_found",
@@ -442,8 +444,21 @@ async function loadAcceptedBotAutoplayExecutor() {
           persistMutatedState,
           restoreTableFromPersisted,
           broadcastResyncRequired,
-          onBotStepPersisted: ({ tableId }) => {
+          onBotStepPersisted: async ({ tableId, botTurnUserId, botAction }) => {
             broadcastStateSnapshots(tableId);
+            if (tableManager.isBotUser(tableId, botTurnUserId) !== true) return;
+            const botSnapshot = tableManager.tableSnapshot(tableId, botTurnUserId);
+            const reaction = tryCreateBotReaction({
+              tableId,
+              botUserId: botTurnUserId,
+              botSeatNo: botSnapshot?.youSeat,
+              botAction,
+              tableClosed: tableManager.isTableClosed(tableId),
+              nowMs: Date.now()
+            });
+            if (reaction) {
+              broadcastTableReaction(tableId, reaction);
+            }
           },
           getBotReactionOverride: () => botReactionOverrideStore.getOverrideRange(),
           env: process.env,
@@ -1563,6 +1578,7 @@ function releaseTableRuntimeResources(tableId) {
   pendingTableJanitorEvaluationByTableId.delete(tableId);
   suppressedNonRetryableTerminalJanitorFailuresByTableId.delete(tableId);
   guestDisconnectCleanupRuntime?.forgetTable(tableId);
+  clearReactionTable(tableId);
   streamLog.forgetTable(tableId);
   continuousBotRetirementRequested.delete(tableId);
 }
@@ -2141,6 +2157,50 @@ function broadcastStateSnapshots(tableId) {
     const tableSnapshot = tableManager.tableSnapshot(tableId, recipientConnState.session.userId);
     sendStateSnapshot(recipient, recipientConnState, { tableSnapshot });
   }
+}
+
+function broadcastTableReaction(tableId, { seatNo, reactionKey } = {}) {
+  const recipients = tableManager.orderedConnectionsForTable(tableId, (socket) => socket.__connState?.sessionId ?? "");
+  let sentCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+
+  for (const recipient of recipients) {
+    const recipientConnState = recipient?.__connState;
+    if (!recipientConnState || recipient.readyState !== WebSocket.OPEN) {
+      skippedCount += 1;
+      continue;
+    }
+
+    try {
+      sendFrame(recipient, {
+        version: "1.0",
+        type: "table_reaction",
+        ts: nowTs(),
+        roomId: tableId,
+        sessionId: recipientConnState.sessionId,
+        payload: {
+          seatNo,
+          reactionKey
+        }
+      });
+      sentCount += 1;
+    } catch {
+      failedCount += 1;
+    }
+  }
+
+  if (failedCount > 0) {
+    klogSafe("ws_table_reaction_broadcast_failed", {
+      tableId,
+      recipientCount: recipients.length,
+      sentCount,
+      skippedCount,
+      failedCount
+    });
+  }
+
+  return { sentCount, skippedCount, failedCount };
 }
 
 function sweepExpiredSessionsOnly() {
@@ -3766,6 +3826,81 @@ wss.on("connection", (ws) => {
     if (frame.type === "protected_echo") {
       const response = handleProtectedEcho({ frame, connState, nowTs });
       sendFrame(ws, response.frame);
+      return;
+    }
+
+    if (frame.type === "reaction_send") {
+      const resolvedRoomId = resolveRoomId(frame);
+      if (!resolvedRoomId.ok) {
+        sendError(ws, connState, {
+          code: resolvedRoomId.code,
+          message: resolvedRoomId.message,
+          requestId: frame.requestId ?? null
+        });
+        return;
+      }
+
+      const tableId = resolvedRoomId.roomId;
+      const association = tableManager.connectionTableAssociation(ws);
+      const connectedToTable = association?.joinedTableId === tableId || association?.subscribedTableId === tableId;
+      if (!connectedToTable) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: "not_seated"
+        });
+        return;
+      }
+
+      const senderUserId = connState.session.userId;
+      if (tableManager.isBotUser(tableId, senderUserId) === true) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: "invalid_sender"
+        });
+        return;
+      }
+
+      const senderSnapshot = tableManager.tableSnapshot(tableId, senderUserId);
+      const senderSeatNo = Number.isInteger(senderSnapshot?.youSeat) ? senderSnapshot.youSeat : null;
+      if (!Number.isInteger(senderSeatNo)) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: "not_seated"
+        });
+        return;
+      }
+
+      const result = evaluateHumanReactionCommand({
+        tableId,
+        senderUserId,
+        senderSeatNo,
+        reactionKey: frame.payload?.reactionKey,
+        tableClosed: tableManager.isTableClosed(tableId),
+        nowMs: Date.now()
+      });
+      if (!result.ok) {
+        sendCommandResult(ws, connState, {
+          requestId: frame.requestId ?? null,
+          tableId,
+          status: "rejected",
+          reason: result.reason
+        });
+        return;
+      }
+
+      sendCommandResult(ws, connState, {
+        requestId: frame.requestId ?? null,
+        tableId,
+        status: "accepted",
+        reason: null
+      });
+      broadcastTableReaction(tableId, result);
       return;
     }
 

--- a/ws-tests/ws-poker-protocol-compliance.test.mjs
+++ b/ws-tests/ws-poker-protocol-compliance.test.mjs
@@ -270,7 +270,7 @@ function waitForExit(proc, timeoutMs = 5000) {
 function createServer({ env = {} } = {}) {
   return getFreePort().then((port) => {
     const child = spawn(process.execPath, ["ws-server/server.mjs"], {
-      env: { ...process.env, PORT: String(port), ...env },
+      env: { ...process.env, WS_POKER_LOG_LEVEL: "INFO", PORT: String(port), ...env },
       stdio: ["ignore", "pipe", "pipe"]
     });
     return { port, child };
@@ -617,6 +617,88 @@ test("default runtime join is command-first and still mutates membership", async
 
     subscriber.close();
     actor.close();
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+  }
+}));
+
+test("reaction_send broadcasts an ephemeral table event without stream replay", async () => runSerial(async () => {
+  const secret = "test-secret";
+  const tableId = "table_reaction_contract";
+  const fixtures = {
+    [tableId]: {
+      tableRow: { id: tableId, max_players: 6, status: "active" },
+      seatRows: [{ user_id: "reaction_human", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 100 }],
+      stateRow: { version: 1, state: { handId: null, phase: "LOBBY", stacks: { reaction_human: 100 } } }
+    }
+  };
+  const { port, child } = await createServer({
+    env: {
+      WS_AUTH_REQUIRED: "1",
+      WS_AUTH_TEST_SECRET: secret,
+      ...observeOnlyJoinEnv(),
+      WS_PRESENCE_TTL_MS: "0",
+      ...persistedBootstrapFixturesEnv(fixtures)
+    }
+  });
+
+  try {
+    await waitForListening(child, 5000);
+    const sender = await connectClient(port);
+    const observer = await connectClient(port);
+    await hello(sender, "req-hello-reaction-sender");
+    await hello(observer, "req-hello-reaction-observer");
+    assert.equal((await auth(sender, secret, "reaction_human", "req-auth-reaction-sender")).type, "authOk");
+    assert.equal((await auth(observer, secret, "reaction_observer", "req-auth-reaction-observer")).type, "authOk");
+
+    for (const [socket, suffix] of [[sender, "sender"], [observer, "observer"]]) {
+      sendFrame(socket, {
+        version: "1.0",
+        type: "table_state_sub",
+        requestId: `req-sub-reaction-${suffix}`,
+        ts: "2026-08-03T00:00:00Z",
+        payload: { tableId }
+      });
+      assert.equal((await nextMessageOfType(socket, "table_state", 5000, `reactionInitial-${suffix}`)).type, "table_state");
+    }
+
+    const senderResultPromise = nextMessageOfType(sender, "commandResult", 5000, "reactionCommandResult");
+    const senderReactionPromise = nextMessageOfType(sender, "table_reaction", 5000, "reactionSenderEvent");
+    const observerReactionPromise = nextMessageOfType(observer, "table_reaction", 5000, "reactionObserverEvent");
+    sendFrame(sender, {
+      version: "1.0",
+      type: "reaction_send",
+      requestId: "req-reaction-send",
+      ts: "2026-08-03T00:00:01Z",
+      payload: { tableId, reactionKey: "wow" }
+    });
+
+    const commandResult = await senderResultPromise;
+    assert.equal(commandResult.payload.status, "accepted");
+    assert.equal(commandResult.payload.reason, null);
+    for (const reaction of await Promise.all([senderReactionPromise, observerReactionPromise])) {
+      assert.equal(reaction.type, "table_reaction");
+      assert.equal(reaction.roomId, tableId);
+      assert.deepEqual(reaction.payload, { seatNo: 1, reactionKey: "wow" });
+    }
+
+    observer.close();
+    const reconnectedObserver = await connectClient(port);
+    await hello(reconnectedObserver, "req-hello-reaction-reconnect");
+    assert.equal((await auth(reconnectedObserver, secret, "reaction_observer", "req-auth-reaction-reconnect")).type, "authOk");
+    sendFrame(reconnectedObserver, {
+      version: "1.0",
+      type: "table_state_sub",
+      requestId: "req-sub-reaction-reconnect",
+      ts: "2026-08-03T00:00:02Z",
+      payload: { tableId }
+    });
+    assert.equal((await nextMessageOfType(reconnectedObserver, "table_state", 5000, "reactionReconnectState")).type, "table_state");
+    await expectNoFrameOfType(reconnectedObserver, ["table_reaction"], 400);
+
+    sender.close();
+    reconnectedObserver.close();
   } finally {
     child.kill("SIGTERM");
     await waitForExit(child);


### PR DESCRIPTION
## Summary\n\nImplements Issue #785 with predefined ephemeral poker reactions and emotes.\n\n- Adds authenticated seated-human reaction_send with a server-authoritative 4-second cooldown.\n- Adds ephemeral table_reaction delivery to current table connections; reactions are not persisted, replayed, or added to snapshots.\n- Adds low-frequency bot reactions for existing BET/RAISE/ALL_IN bot actions with deterministic throttle/probability boundaries.\n- Adds the JSP-compatible reaction menu, accessible cooldown hint, and short-lived seat bubbles.\n- Keeps future contextual reactions (large win, bad beat, bluff, join, waiting) owned by #838 and does not reconstruct poker outcomes.\n- Documents the protocol and classifies only broadcast failures as ERROR; routine accepted/cooldown/invalid reactions are not logged.\n\n## Validation\n\n- npm test\n- node --test ws-server/server.behavior.test.mjs\n- node --test ws-tests/ws-poker-protocol-compliance.test.mjs\n- node --test ws-server/poker/handlers/reaction.behavior.test.mjs tests/poker-ws-client.test.mjs tests/poker-v2-live.behavior.test.mjs\n- syntax, CSP, lifecycle, and XP guards\n\nCloses #785