### PR TITLE
[P0] Add poker hole-card retention cleanup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Native JSONB integration test
         run: node --test ws-server/poker/persistence/native-jsonb.integration.test.mjs
 
+      - name: Action-history cleanup PostgreSQL integration test
+        run: node --test ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+
       - name: Validate games catalog
         run: npm run lint:games
 

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -303,9 +303,9 @@ The order in every round is hole cards, Phase 1, then Phase 2. A hole-card failu
 | Variable | Unit | Default | Range | Disabled | Meaning |
 |----------|------|---------|-------|----------|---------|
 | `WS_POKER_BOT_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete ordinary actions and eligible hole cards for bot-only tables after this many ms since the hand's `HAND_SETTLED` marker |
-| `WS_POKER_BOT_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for bot-only tables after this many ms, and only when ordinary actions are already gone |
+| `WS_POKER_BOT_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for bot-only tables after this many ms, only when ordinary actions and hole cards are gone |
 | `WS_POKER_HUMAN_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-action but for tables where a human ever played |
-| `WS_POKER_HUMAN_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-settled but for human-participated tables |
+| `WS_POKER_HUMAN_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for human-participated tables after this many ms, only when ordinary actions and hole cards are gone |
 | `WS_POKER_ACTION_HISTORY_SWEEP_MS` | ms | `300000` (5 min) | `30_000`–`3_600_000` | N/A | Interval between cleanup sweep invocations |
 | `WS_POKER_ACTION_HISTORY_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate hands/settlements per phase per sweep. `lockLimit` is derived as `batchSize * 2` |
 

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -279,23 +279,30 @@ Once set to `true` the flag never returns to `false`. Existing tables are backfi
 
 This classification affects retention only. It does not make the database authoritative for active gameplay, does not replace `poker_seats` or `poker_state`, and is not consulted by bot claims recovery, terminal accounting, or any gameplay decision.
 
-### Two-phase deletion semantics
+### Three-phase deletion semantics
 
-Cleanup runs in two sequential phases inside a single database transaction:
+Cleanup runs in bounded rounds. Each phase has its own database transaction, so
+a successful phase is not rolled back when a later phase fails:
+
+**Hole cards phase.** Deletes `poker_hole_cards` for unique `(table_id, hand_id)`
+hands whose `HAND_SETTLED` marker is older than the applicable action-retention
+cutoff. `batchSize` limits candidate hands; `holeCardsDeleted` counts physical
+hole-card rows. A failed hole-card phase is not retried in later rounds of the
+same sweep, but is retried by the next sweep.
 
 **Phase 1 — ordinary actions.** Deletes all action rows except `HAND_SETTLED` for completed hands whose `HAND_SETTLED` audit row is older than the applicable action-retention cutoff. Only hands that still have ordinary action rows are selected (correlated `EXISTS`). A table's retention classification is read while holding a row lock (`FOR UPDATE OF t SKIP LOCKED`) and locked tables are bounded by `lockLimit = batchSize * 2`.
 
-**Phase 2 — settlement markers.** Deletes old `HAND_SETTLED` rows only when no ordinary actions remain for the same hand (correlated `NOT EXISTS`). This guarantees Phase 1 processes a hand before Phase 2 removes its marker, even if a sweep backlog builds up.
+**Phase 2 — settlement markers.** Deletes old `HAND_SETTLED` rows only when no ordinary actions and no `poker_hole_cards` remain for the same hand (two correlated `NOT EXISTS` checks). This guarantees that a marker remains available for a later hole-card retry if that phase previously failed.
 
-Phase 1 always runs before Phase 2 in the same transaction. Both phases use bounded `locked_tables` and candidate CTEs followed by `DELETE … RETURNING id`. Bot and human cutoffs are selected through classification predicates (`has_human_participant`) inside each CTE.
+The order in every round is hole cards, Phase 1, then Phase 2. A hole-card failure does not block the action phases. A Phase 1 or Phase 2 failure stops later rounds. All phases use bounded `locked_tables` and candidate CTEs followed by `DELETE … RETURNING id`. Bot and human cutoffs are selected through classification predicates (`has_human_participant`) inside each CTE.
 
-`batchSize` limits the number of candidate hands (Phase 1) or settlement rows (Phase 2) selected per sweep, not the number of ordinary action rows deleted. A single Phase 1 candidate hand may contain dozens of ordinary action rows, so `phase1Deleted` in the log may be much larger than `batchSize`.
+`batchSize` limits the number of candidate hands (hole cards and Phase 1) or settlement rows (Phase 2) selected per sweep, not the number of physical rows deleted. A single candidate hand may contain multiple hole-card or ordinary-action rows, so the corresponding deleted counters may be much larger than `batchSize`.
 
 ### Environment variables
 
 | Variable | Unit | Default | Range | Disabled | Meaning |
 |----------|------|---------|-------|----------|---------|
-| `WS_POKER_BOT_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete ordinary actions for bot-only tables after this many ms since the hand's `HAND_SETTLED` marker |
+| `WS_POKER_BOT_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete ordinary actions and eligible hole cards for bot-only tables after this many ms since the hand's `HAND_SETTLED` marker |
 | `WS_POKER_BOT_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for bot-only tables after this many ms, and only when ordinary actions are already gone |
 | `WS_POKER_HUMAN_ACTION_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-action but for tables where a human ever played |
 | `WS_POKER_HUMAN_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Same as bot-settled but for human-participated tables |
@@ -359,10 +366,10 @@ Editing an already-applied migration is not allowed. Use a new timestamped migra
 
 | Event | Severity | Fields |
 |-------|----------|--------|
-| `ws_action_history_cleanup_complete` | INFO | `phase1Deleted`, `phase2Deleted`, `batchSize`, `lockLimit` |
-| `ws_action_history_cleanup_failed` | ERROR | `reason` (error code or message) |
+| `ws_action_history_cleanup_complete` | INFO | `holeCardsDeleted`, `phase1Deleted`, `phase2Deleted`, `batchSize`, `lockLimit` |
+| `ws_action_history_cleanup_failed` | ERROR | stable `errorCode`, ordered `failedPhases`, completed phase counters |
 
-The `complete` event is emitted only when at least one row was deleted. The `failed` event is emitted on any unexpected error.
+The `complete` event is emitted only when at least one row was deleted. A no-op with enabled retention remains a successful, quiet sweep. The `failed` event is emitted after a sweep with one or more failed phases. Because transactions are separate, `failed` does not mean that successful phase counters were rolled back; the panel may show positive deletion counts together with `failed`.
 
 **Preview verification commands:**
 
@@ -434,6 +441,6 @@ A shared stage database may contain a historical backlog. A recently active cont
 - Deployed SHA: `a9eacc3f6ac37d9dab473e6f12febf417b4f06d1`
 - Local health (`http://127.0.0.1:3001/healthz`) returned `200`; public health passed.
 - Both phases deleted rows against real PostgreSQL on the stage database.
-- Bounded `phase1Deleted` and `phase2Deleted` values were observed in `ws_action_history_cleanup_complete` logs.
+- Bounded `holeCardsDeleted`, `phase1Deleted`, and `phase2Deleted` values were observed in `ws_action_history_cleanup_complete` logs.
 - No `ws_action_history_cleanup_failed` events were observed.
 - Preview was then configured for continuous retention with the policy documented above.

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1322,6 +1322,7 @@
       renderKvRow("Last cleanup", lastRun ? formatTimestamp(lastRun.finishedAt) : "No run recorded"),
       renderKvRow("Last cleanup deleted", deletedRows),
       renderKvRow("Last cleanup result", lastRun ? lastRun.result : "No run recorded"),
+      renderKvRow("Failed phases", lastRun && Array.isArray(lastRun.failedPhases) && lastRun.failedPhases.length ? lastRun.failedPhases.join(", ") : "—"),
       "</div>",
       "</div>"
     ].join("");
@@ -1736,7 +1737,10 @@
         renderKvRow("Next cleanup batch · HAND_SETTLED", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.handSettledRows : "unavailable"),
         renderKvRow("Last cleanup", formatTimestamp(lastRun.finishedAt)),
         renderKvRow("Last cleanup result", lastRun.result || "—"),
+        renderKvRow("Last hole-card deletes", lastRun.holeCardsDeleted == null ? "—" : String(lastRun.holeCardsDeleted)),
         renderKvRow("Last phase deletes", lastRun.phase1Deleted == null ? "—" : String(lastRun.phase1Deleted) + "/" + String(lastRun.phase2Deleted || 0)),
+        renderKvRow("Failed phases", Array.isArray(lastRun.failedPhases) && lastRun.failedPhases.length ? lastRun.failedPhases.join(", ") : "—"),
+        renderKvRow("Last error code", lastRun.errorCode || "—"),
         renderKvRow("Last duration", lastRun.durationMs == null ? "—" : String(lastRun.durationMs) + " ms"),
         '</div>'
       ].join("");
@@ -2599,6 +2603,10 @@
       if (state.ops.pokerMaintenanceError === "ws_maintenance_timeout"){
         await loadOps();
         state.ops.pokerMaintenanceError = "Request timed out; refreshing status to show the current result.";
+      } else if (operation === "cleanup" && err && err.payload && Array.isArray(err.payload.failedPhases)) {
+        try { await loadOps(); } catch (_refreshError) {}
+        state.ops.pokerMaintenanceError = "cleanup_failed";
+        setStatus("Cleanup failed in one or more phases; completed phase counts were preserved.", "error");
       } else {
         handleApiError(err, "Could not update poker maintenance.");
       }

--- a/netlify/functions/admin-poker-maintenance.mjs
+++ b/netlify/functions/admin-poker-maintenance.mjs
@@ -20,6 +20,7 @@ const EXPOSED_ERRORS = new Set([
   "already_closed",
   "already_due",
   "retirement_request_failed",
+  "cleanup_failed",
 ]);
 
 function jsonResponse(statusCode, headers, body) {
@@ -30,11 +31,35 @@ function jsonResponse(statusCode, headers, body) {
   };
 }
 
-function controlError(code, status = 400) {
+function controlError(code, status = 400, details = null) {
   const error = new Error(code);
   error.code = code;
   error.status = status;
+  if (details && typeof details === "object") error.details = details;
   return error;
+}
+
+function projectMaintenanceFailure(value) {
+  if (!value || typeof value !== "object") return {};
+  const allowedPhases = ["hole_cards", "ordinary_actions", "hand_settled"];
+  const failedPhases = Array.isArray(value.failedPhases)
+    ? allowedPhases.filter((phase) => value.failedPhases.includes(phase))
+    : [];
+  const result = {};
+  if (typeof value.operation === "string") result.operation = value.operation;
+  if (typeof value.result === "string") result.result = value.result;
+  if (Number.isSafeInteger(value.holeCardsDeleted) && value.holeCardsDeleted >= 0) {
+    result.holeCardsDeleted = value.holeCardsDeleted;
+  }
+  if (Number.isSafeInteger(value.phase1Deleted) && value.phase1Deleted >= 0) {
+    result.phase1Deleted = value.phase1Deleted;
+  }
+  if (Number.isSafeInteger(value.phase2Deleted) && value.phase2Deleted >= 0) {
+    result.phase2Deleted = value.phase2Deleted;
+  }
+  if (typeof value.errorCode === "string") result.errorCode = value.errorCode;
+  if (failedPhases.length > 0) result.failedPhases = failedPhases;
+  return result;
 }
 
 function parseJsonObject(body) {
@@ -141,10 +166,21 @@ async function proxyMaintenance({ method, payload, adminUserId, target, env, fet
     try {
       body = await response.json();
     } catch {}
+    if (body && body.environment != null && body.environment !== target) {
+      throw controlError("ws_maintenance_environment_mismatch", 502);
+    }
     if (!response.ok) {
-      const upstream = typeof body?.error === "string" ? body.error : "ws_maintenance_unavailable";
+      const upstream = typeof body?.error === "string"
+        ? body.error
+        : body?.operation === "cleanup" && body?.ok === false
+          ? "cleanup_failed"
+          : "ws_maintenance_unavailable";
       const exposed = EXPOSED_ERRORS.has(upstream);
-      throw controlError(exposed ? upstream : "ws_maintenance_unavailable", exposed ? response.status : 502);
+      throw controlError(
+        exposed ? upstream : "ws_maintenance_unavailable",
+        exposed ? response.status : 502,
+        exposed ? projectMaintenanceFailure(body) : null
+      );
     }
     if (!body || body.environment !== target) {
       throw controlError("ws_maintenance_environment_mismatch", 502);
@@ -203,7 +239,7 @@ function createAdminPokerMaintenanceHandler(deps = {}) {
       const status = Number(error?.status) || 500;
       const code = error?.code || "server_error";
       klog("admin_poker_maintenance_failed", { status, code });
-      return jsonResponse(status, cors, { error: code });
+      return jsonResponse(status, cors, { ...(error?.details || {}), error: code });
     }
   };
 }

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -121,7 +121,8 @@ function normalizeMetricsSnapshot(value, target) {
       "ordinaryActionRows", "handSettledRows", "cappedAtBatchSize", "measuredAt"
     ]);
     cleanup.lastRun = projectFields(value.cleanup.lastRun, [
-      "finishedAt", "durationMs", "deletedRows", "result"
+      "finishedAt", "durationMs", "holeCardsDeleted", "phase1Deleted", "phase2Deleted",
+      "deletedRows", "result", "errorCode", "failedPhases"
     ]);
   }
   return {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -307,6 +307,14 @@ function createAdminDom() {
     "adminOpsRuntime",
     "adminOpsVpsMetrics",
     "adminOpsPokerEscrow",
+    "adminOpsMaintenance",
+    "adminOpsMaintenanceEnabled",
+    "adminOpsMaintenanceCount",
+    "adminOpsMaintenanceApply",
+    "adminOpsMaintenanceStop",
+    "adminOpsMaintenanceReconcile",
+    "adminOpsMaintenanceCleanup",
+    "adminOpsMaintenanceStatus",
     "adminOpsBotReactionSummary",
     "adminOpsBotReactionDelay",
     "adminOpsBotReactionApply",
@@ -406,7 +414,7 @@ function buildContext(options = {}) {
   const { document, tabs, panels } = createAdminDom();
   const fetchCalls = [];
   var vpsMetricsCalls = 0;
-  const fetch = async (url) => {
+  const fetch = async (url, options) => {
     fetchCalls.push(String(url || ""));
     const text = String(url || "");
     if (text.includes("/.netlify/functions/admin-me")) {
@@ -558,6 +566,40 @@ function buildContext(options = {}) {
           backlog: { ordinaryActionRows: 0, handSettledRows: 0, cappedAtBatchSize: true, measuredAt: "2026-08-02T18:59:58.000Z" },
           lastRun: { finishedAt: "2026-08-02T18:55:00.000Z", durationMs: 184, deletedRows: 37, result: "success" },
         },
+      }) };
+    }
+    if (text.includes("/.netlify/functions/admin-poker-maintenance")) {
+      if (opts.cleanupFails && options && options.method === "POST") {
+        return { ok: false, status: 409, json: async () => ({
+          error: "cleanup_failed",
+          operation: "cleanup",
+          result: "failed",
+          holeCardsDeleted: 4,
+          phase1Deleted: 9,
+          phase2Deleted: 2,
+          errorCode: "hole_cards_cleanup_failed",
+          failedPhases: ["hole_cards"]
+        }) };
+      }
+      return { ok: true, json: async () => ({
+        ok: true,
+        environment: "preview",
+        continuous: {
+          maintenanceEnabled: true,
+          desiredTableCount: 2,
+          maxDesiredTableCount: 2,
+          creationLimitPerReconcile: 2,
+          effectiveDesiredTableCount: 2,
+          tables: [],
+          supervisor: { started: true, sweepInProgress: false, lastSweepFinishedAt: null, lastSweepResult: null, lastError: null }
+        },
+        cleanup: {
+          retention: { botActionsMs: 1000, botSettledMs: 2000, humanActionsMs: 3000, humanSettledMs: 4000 },
+          batchSize: 5,
+          sweepRounds: 1,
+          backlog: { available: true, ordinaryActionRows: 0, handSettledRows: 0 },
+          lastRun: { finishedAt: null, durationMs: 1, holeCardsDeleted: 0, phase1Deleted: 0, phase2Deleted: 0, result: "success", failedPhases: [], errorCode: null }
+        }
       }) };
     }
     if (text.includes("/.netlify/functions/admin-stage-identity")) {
@@ -831,7 +873,6 @@ test("admin page marks the previous VPS metrics snapshot stale after a refresh f
   await flush();
   tabs[5].dispatchEvent({ type: "click", bubbles: true, target: tabs[5], preventDefault() {} });
   await flush();
-  await flush();
   assert.match(document.getElementById("adminOpsVpsMetrics").innerHTML, /Available/);
 
   document.getElementById("adminOpsRefresh").dispatchEvent({ type: "click", preventDefault() {} });
@@ -899,6 +940,26 @@ test("admin page keeps read-only Ops available during CH maintenance", async () 
   assert.equal(document.getElementById("adminOpsBotReactionDelay").disabled, true);
   assert.equal(document.getElementById("adminOpsBotReactionApply").disabled, true);
   assert.equal(document.getElementById("adminOpsBotReactionDefault").disabled, true);
+});
+
+test("admin cleanup failure preserves phase details and refreshes status", async () => {
+  const { context, document, tabs } = buildContext({ cleanupFails: true });
+  vm.runInContext(source, context, { filename: "js/admin-page.js" });
+
+  await flush();
+  tabs[5].dispatchEvent({ type: "click", bubbles: true, target: tabs[5], preventDefault() {} });
+  await flush();
+  await flush();
+  await flush();
+
+  const cleanupButton = document.getElementById("adminOpsMaintenanceCleanup");
+  assert.ok(cleanupButton);
+  cleanupButton.dispatchEvent({ type: "click", bubbles: true, target: cleanupButton, preventDefault() {} });
+  await flush();
+  await flush();
+
+  assert.match(document.getElementById("adminStatus").textContent, /completed phase counts were preserved/);
+  assert.match(document.getElementById("adminOpsMaintenance").innerHTML, /Failed phases/);
 });
 
 test("admin page distinguishes unavailable bootstrap from a non-admin account", async () => {

--- a/tests/admin-poker-maintenance.behavior.test.mjs
+++ b/tests/admin-poker-maintenance.behavior.test.mjs
@@ -195,8 +195,10 @@ test("maintenance proxy accepts the environment from an actual WS POST response"
     assert.deepEqual(JSON.parse(response.body), {
       ok: true,
       operation: "cleanup",
+      holeCardsDeleted: 0,
       phase1Deleted: 0,
       phase2Deleted: 0,
+      failedPhases: [],
       skipped: true,
       reason: "cleanup_disabled",
       environment: "preview"
@@ -222,6 +224,46 @@ test("maintenance proxy rejects an upstream environment mismatch", async () => {
   const response = await handler(event("GET"));
   assert.equal(response.statusCode, 502);
   assert.deepEqual(JSON.parse(response.body), { error: "ws_maintenance_environment_mismatch" });
+});
+
+test("maintenance proxy preserves cleanup failure counters and failed phases from HTTP 409", async () => {
+  const handler = createAdminPokerMaintenanceHandler({
+    env: {
+      CHIPS_ENABLED: "1",
+      POKER_WS_INTERNAL_BASE_URL: "https://ws-preview.kcswh.pl",
+      POKER_WS_INTERNAL_TOKEN: "preview-token"
+    },
+    requireAdminUser: async () => ({ userId: "00000000-0000-4000-8000-000000000010" }),
+    buildStageIdentity: previewIdentity,
+    fetchImpl: async () => ({
+      ok: false,
+      status: 409,
+      json: async () => ({
+        ok: false,
+        operation: "cleanup",
+        result: "failed",
+        holeCardsDeleted: 4,
+        phase1Deleted: 9,
+        phase2Deleted: 2,
+        errorCode: "hole_cards_cleanup_failed",
+        failedPhases: ["hole_cards"],
+        environment: "preview"
+      })
+    })
+  });
+
+  const response = await handler(event("POST", JSON.stringify({ operation: "cleanup" })));
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    operation: "cleanup",
+    result: "failed",
+    holeCardsDeleted: 4,
+    phase1Deleted: 9,
+    phase2Deleted: 2,
+    errorCode: "hole_cards_cleanup_failed",
+    failedPhases: ["hole_cards"],
+    error: "cleanup_failed"
+  });
 });
 
 test("maintenance proxy does not contact WS for non-admin or unverified environment", async () => {

--- a/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
@@ -107,7 +107,7 @@ test("phase 2 deletes HAND_SETTLED when ordinary actions already gone", async ()
 
   const result = await cleanup.sweep();
   assert.equal(result.ok, true);
-  assert.equal(phase1Called, true);  // Phase 1 always runs first
+  assert.equal(phase1Called, true);  // Phase 1 runs before Phase 2
   assert.equal(result.phase2Deleted, 2);
 });
 
@@ -395,4 +395,170 @@ test("status exposes effective cleanup configuration and phase-2-only HAND_SETTL
   const backlogQuery = queries.find((sql) => sql.includes("ordinary_action_rows"));
   assert.match(backlogQuery, /not exists[\s\S]+action_type != 'HAND_SETTLED'/);
   assert.equal(queries.some((sql) => sql.includes("statement_timeout")), true);
+});
+
+test("hole-card phase deletes unique hands and phase 2 keeps the hole-card guard", async () => {
+  const queries = [];
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: String(2 * HOUR),
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        queries.push(sql);
+        if (sql.includes("hole_card_candidates")) return [{ table_id: "t1", hand_id: "h1", user_id: "u1" }, { table_id: "t1", hand_id: "h1", user_id: "u2" }];
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, true);
+  assert.equal(result.holeCardsDeleted, 2);
+  assert.equal(result.phase1Deleted, 0);
+  assert.equal(result.phase2Deleted, 0);
+  assert.deepEqual(result.failedPhases, []);
+  const holeCardQuery = queries.find((sql) => sql.includes("hole_card_candidates"));
+  const phase2Query = queries.find((sql) => sql.includes("id in (select id from candidates)"));
+  assert.match(holeCardQuery, /group by pa\.table_id, pa\.hand_id/);
+  assert.match(phase2Query, /poker_hole_cards/);
+  assert.match(phase2Query, /not exists[\s\S]+poker_hole_cards/);
+});
+
+test("hole-card failure is not retried in later rounds and remains failed after action cleanup succeeds", async () => {
+  let holeCardCalls = 0;
+  let phase1Calls = 0;
+  let phase2Calls = 0;
+  const cleanup = createActionHistoryCleanup({
+    maxSweepRounds: 3,
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: String(2 * HOUR),
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("hole_card_candidates")) {
+          holeCardCalls += 1;
+          throw new Error("hole-card database unavailable");
+        }
+        if (sql.includes("candidate_hands")) {
+          phase1Calls += 1;
+          return phase1Calls === 1 ? [{ id: 1 }, { id: 2 }] : [];
+        }
+        if (sql.includes("id in (select id from candidates)")) {
+          phase2Calls += 1;
+          return phase2Calls === 1 ? [{ id: 3 }] : [];
+        }
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  const status = await cleanup.status();
+  assert.equal(holeCardCalls, 1);
+  assert.equal(phase1Calls, 2);
+  assert.equal(phase2Calls, 2);
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, "hole_cards_cleanup_failed");
+  assert.deepEqual(result.failedPhases, ["hole_cards"]);
+  assert.equal(result.phase1Deleted, 2);
+  assert.equal(result.phase2Deleted, 1);
+  assert.equal(status.lastRun.result, "failed");
+  assert.equal(status.lastRun.errorCode, "hole_cards_cleanup_failed");
+  assert.deepEqual(status.lastRun.failedPhases, ["hole_cards"]);
+});
+
+test("next sweep retries hole cards after a failed hole-card transaction", async () => {
+  let holeCardCalls = 0;
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: String(2 * HOUR),
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("hole_card_candidates")) {
+          holeCardCalls += 1;
+          if (holeCardCalls === 1) throw new Error("temporary hole-card failure");
+          return [{ id: 1 }, { id: 2 }];
+        }
+        return [];
+      }
+    })
+  });
+
+  const first = await cleanup.sweep();
+  const second = await cleanup.sweep();
+  assert.equal(first.ok, false);
+  assert.deepEqual(first.failedPhases, ["hole_cards"]);
+  assert.equal(second.ok, true);
+  assert.equal(second.holeCardsDeleted, 2);
+  assert.deepEqual(second.failedPhases, []);
+  assert.equal(holeCardCalls, 2);
+});
+
+test("failed phases are unique and ordered when a main phase fails after hole cards", async () => {
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: String(2 * HOUR),
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("hole_card_candidates")) throw new Error("hole-card failure");
+        if (sql.includes("candidate_hands")) throw new Error("ordinary action failure");
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, "ordinary_actions_cleanup_failed");
+  assert.deepEqual(result.failedPhases, ["hole_cards", "ordinary_actions"]);
+  assert.equal(result.holeCardsDeleted, 0);
+  assert.equal(result.phase1Deleted, 0);
+  assert.equal(result.phase2Deleted, 0);
+});
+
+test("enabled no-op sweep is success and does not emit a completion log", async () => {
+  const events = [];
+  const cleanup = createActionHistoryCleanup({
+    klog: (...args) => events.push(args),
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5",
+      SUPABASE_DB_URL: "postgres://test/db"
+    },
+    beginSql: async (fn) => fn({ unsafe: async () => [] })
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, false);
+  assert.equal(result.holeCardsDeleted, 0);
+  assert.equal(result.phase1Deleted, 0);
+  assert.equal(result.phase2Deleted, 0);
+  assert.equal(events.length, 0);
 });

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { createActionHistoryCleanup } from "./action-history-cleanup.mjs";
+
+// This test intentionally uses a disposable PostgreSQL database only. It is
+// enabled by TEST_DB_URL in CI and is never pointed at a shared Supabase DB by
+// the application itself.
+const dbUrl = process.env.TEST_DB_URL;
+const HAS_DB = Boolean(dbUrl);
+
+let sql;
+let createdMinimalSchema = false;
+
+async function connect() {
+  if (!HAS_DB) return null;
+  const postgres = (await import("postgres")).default;
+  sql = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  return sql;
+}
+
+async function ensureSchema(db) {
+  const rows = await db.unsafe(`
+    select
+      to_regclass('public.poker_tables') as tables_regclass,
+      to_regclass('public.poker_actions') as actions_regclass,
+      to_regclass('public.poker_hole_cards') as hole_cards_regclass,
+      exists (
+        select 1
+          from information_schema.columns
+         where table_schema = 'public'
+           and table_name = 'poker_tables'
+           and column_name = 'has_human_participant'
+      ) as has_human_participant
+  `);
+  const row = rows[0];
+  const present = [row.tables_regclass, row.actions_regclass, row.hole_cards_regclass]
+    .filter(Boolean).length;
+
+  if (present > 0 && (present < 3 || row.has_human_participant !== true)) {
+    throw new Error(
+      "TEST_DB_URL has an incomplete poker cleanup schema; use a disposable database with current migrations"
+    );
+  }
+  if (present === 3) return;
+
+  await db.unsafe(`
+    create table public.poker_tables (
+      id uuid primary key,
+      has_human_participant boolean not null default false
+    );
+    create table public.poker_actions (
+      id bigserial primary key,
+      table_id uuid not null,
+      hand_id text,
+      action_type text not null,
+      created_at timestamptz not null default now()
+    );
+    create index poker_actions_table_id_hand_id_created_at_idx
+      on public.poker_actions (table_id, hand_id, created_at);
+    create table public.poker_hole_cards (
+      table_id uuid not null,
+      hand_id text not null,
+      user_id uuid not null,
+      cards jsonb not null,
+      created_at timestamptz not null default now()
+    );
+    create index poker_hole_cards_table_hand_idx
+      on public.poker_hole_cards (table_id, hand_id);
+  `);
+  createdMinimalSchema = true;
+}
+
+function beginSql(db, afterTransaction) {
+  return async (fn) => {
+    const result = await db.begin(async (tx) => fn({
+      unsafe: (query, params) => tx.unsafe(query, params)
+    }));
+    await afterTransaction?.();
+    return result;
+  };
+}
+
+test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL", { skip: !HAS_DB }, async () => {
+  const db = await connect();
+  let tableId = null;
+  const regularHandId = `cleanup-regular-${randomUUID()}`;
+  const activeHandId = `cleanup-active-${randomUUID()}`;
+  const guardedHandId = `cleanup-guarded-${randomUUID()}`;
+  const userId = randomUUID();
+  const oldCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const recentCreatedAt = new Date().toISOString();
+  let phaseTransactions = 0;
+
+  try {
+    await ensureSchema(db);
+    tableId = randomUUID();
+    await db.unsafe(
+      "insert into public.poker_tables (id, has_human_participant) values ($1, false)",
+      [tableId]
+    );
+
+    await db.unsafe(
+      `insert into public.poker_actions (table_id, hand_id, action_type, created_at)
+       values
+         ($1, $2, 'CHECK', $3),
+         ($1, $2, 'HAND_SETTLED', $3),
+         ($1, $4, 'CHECK', $5),
+         ($1, $6, 'HAND_SETTLED', $3)`,
+      [tableId, regularHandId, oldCreatedAt, activeHandId, recentCreatedAt, guardedHandId]
+    );
+    await db.unsafe(
+      `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+       values ($1, $2, $3, $4::jsonb, $5)`,
+      [tableId, regularHandId, userId, JSON.stringify(["AS", "KD"]), oldCreatedAt]
+    );
+    await db.unsafe(
+      `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+       values ($1, $2, $3, $4::jsonb, $5)`,
+      [tableId, activeHandId, userId, JSON.stringify(["QH", "JC"]), recentCreatedAt]
+    );
+
+    const cleanup = createActionHistoryCleanup({
+      maxSweepRounds: 1,
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: String(60 * 60 * 1000),
+        WS_POKER_BOT_SETTLED_RETENTION_MS: String(2 * 60 * 60 * 1000),
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "100"
+      },
+      beginSql: beginSql(db, async () => {
+        phaseTransactions += 1;
+        // The first transaction is the real hole-card phase. Add a card after
+        // it commits so the real phase-2 SQL must preserve its HAND_SETTLED row.
+        if (phaseTransactions === 1) {
+          await db.unsafe(
+            `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+             values ($1, $2, $3, $4::jsonb, $5)`,
+            [tableId, guardedHandId, userId, JSON.stringify(["2C", "3C"]), oldCreatedAt]
+          );
+        }
+      })
+    });
+
+    const first = await cleanup.sweep();
+    assert.equal(first.ok, true);
+    assert.equal(first.holeCardsDeleted, 1);
+    assert.equal(first.phase1Deleted, 1);
+    assert.equal(first.phase2Deleted, 1);
+
+    const afterFirst = await db.unsafe(
+      `select
+         (select count(*) from public.poker_hole_cards where table_id = $1 and hand_id = $2) as guarded_cards,
+         (select count(*) from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = 'HAND_SETTLED') as guarded_marker,
+         (select count(*) from public.poker_hole_cards where table_id = $1 and hand_id = $3) as active_cards,
+         (select count(*) from public.poker_actions where table_id = $1 and hand_id = $3) as active_actions`,
+      [tableId, guardedHandId, activeHandId]
+    );
+    assert.equal(Number(afterFirst[0].guarded_cards), 1, "phase 2 must not delete a marker with cards");
+    assert.equal(Number(afterFirst[0].guarded_marker), 1, "HAND_SETTLED must remain for retry");
+    assert.equal(Number(afterFirst[0].active_cards), 1, "active hand cards must remain");
+    assert.equal(Number(afterFirst[0].active_actions), 1, "active hand actions must remain");
+
+    const second = await cleanup.sweep();
+    assert.equal(second.ok, true);
+    assert.equal(second.holeCardsDeleted, 1);
+    assert.equal(second.phase1Deleted, 0);
+    assert.equal(second.phase2Deleted, 1);
+
+    const afterSecond = await db.unsafe(
+      `select
+         (select count(*) from public.poker_hole_cards where table_id = $1 and hand_id = $2) as guarded_cards,
+         (select count(*) from public.poker_actions where table_id = $1 and hand_id = $2 and action_type = 'HAND_SETTLED') as guarded_marker,
+         (select count(*) from public.poker_actions where table_id = $1 and hand_id = $3) as active_actions`,
+      [tableId, guardedHandId, activeHandId]
+    );
+    assert.equal(Number(afterSecond[0].guarded_cards), 0, "next sweep should retry hole-card cleanup");
+    assert.equal(Number(afterSecond[0].guarded_marker), 0, "marker should be removable after cards are gone");
+    assert.equal(Number(afterSecond[0].active_actions), 1, "active hand must remain untouched");
+  } finally {
+    if (tableId) {
+      await db.unsafe("delete from public.poker_hole_cards where table_id = $1", [tableId]);
+      await db.unsafe("delete from public.poker_actions where table_id = $1", [tableId]);
+      await db.unsafe("delete from public.poker_tables where id = $1", [tableId]);
+    }
+    if (createdMinimalSchema) {
+      await db.unsafe("drop table if exists public.poker_hole_cards");
+      await db.unsafe("drop table if exists public.poker_actions");
+      await db.unsafe("drop table if exists public.poker_tables");
+    }
+    await db.end();
+    sql = null;
+  }
+});

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -1,10 +1,10 @@
 // Action-history retention cleanup.
 //
-// Two-phase sweep that runs on a timer (see server.mjs).
-// Phase 1 deletes ordinary actions (everything except HAND_SETTLED)
-// for completed hands older than the applicable retention cutoff.
-// Phase 2 deletes HAND_SETTLED audit rows for hands whose ordinary
-// actions have already been cleaned up.
+// Bounded three-phase sweep that runs on a timer (see server.mjs).
+// The hole-card phase deletes poker_hole_cards for completed hands older than
+// the applicable action retention cutoff. Phase 1 deletes ordinary actions
+// (everything except HAND_SETTLED). Phase 2 deletes HAND_SETTLED audit rows
+// only after both ordinary actions and hole cards are gone.
 //
 // Retention is per-table: bot-only tables (has_human_participant = false)
 // use a short window; tables with human gameplay use a long window.
@@ -16,10 +16,82 @@ const BACKLOG_CACHE_TTL_MS = 15_000;
 const DEFAULT_MAX_SWEEP_ROUNDS = 1;
 const MAX_SWEEP_ROUNDS = 20;
 // Preview uses bounded repeated batches for stress tests; Production stays at one round.
+const CLEANUP_PHASE_ORDER = Object.freeze(["hole_cards", "ordinary_actions", "hand_settled"]);
 
 function resolveCutoff(retentionMs) {
   if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
   return new Date(Date.now() - retentionMs).toISOString();
+}
+
+// Hole-card rows are deleted by unique (table_id, hand_id) candidates. The
+// batch bounds hands, while the returned row count reflects all users/cards
+// deleted for those hands.
+async function sweepHoleCards({ tx, botActionCutoff, humanActionCutoff, batchSize, lockLimit }) {
+  const result = await tx.unsafe(
+    `with locked_tables as (
+  select t.id, t.has_human_participant
+    from public.poker_tables t
+   where exists (
+           select 1
+             from public.poker_actions pa
+            where pa.table_id = t.id
+              and pa.action_type = 'HAND_SETTLED'
+              and (
+                    (t.has_human_participant = false
+                     and $1::timestamptz is not null
+                     and pa.created_at < $1::timestamptz)
+                 or (t.has_human_participant = true
+                     and $2::timestamptz is not null
+                     and pa.created_at < $2::timestamptz)
+                  )
+              and exists (
+                    select 1
+                      from public.poker_hole_cards hc
+                     where hc.table_id = pa.table_id
+                       and hc.hand_id = pa.hand_id
+                  )
+         )
+   order by (
+     select min(pa2.created_at) from public.poker_actions pa2
+      where pa2.table_id = t.id
+        and pa2.action_type = 'HAND_SETTLED'
+   )
+   limit $4
+   for update skip locked
+), hole_card_candidates as (
+  select pa.table_id, pa.hand_id, min(pa.created_at) as created_at
+    from public.poker_actions pa
+    join locked_tables t on t.id = pa.table_id
+   where pa.action_type = 'HAND_SETTLED'
+     and (
+           (t.has_human_participant = false
+            and $1::timestamptz is not null
+            and pa.created_at < $1::timestamptz)
+        or (t.has_human_participant = true
+            and $2::timestamptz is not null
+            and pa.created_at < $2::timestamptz)
+         )
+     and exists (
+           select 1
+             from public.poker_hole_cards hc
+            where hc.table_id = pa.table_id
+              and hc.hand_id = pa.hand_id
+         )
+   group by pa.table_id, pa.hand_id
+   order by created_at
+   limit $3
+)
+delete from public.poker_hole_cards hc
+ where exists (
+   select 1
+     from hole_card_candidates ch
+    where ch.table_id = hc.table_id
+      and ch.hand_id = hc.hand_id
+ )
+returning hc.table_id, hc.hand_id, hc.user_id;`,
+    [botActionCutoff, humanActionCutoff, batchSize, lockLimit]
+  );
+  return Array.isArray(result) ? result.length : 0;
 }
 
 // Phase 1 — delete ordinary actions for completed hands.
@@ -121,6 +193,12 @@ async function sweepPhase2({ tx, botSettledCutoff, humanSettledCutoff, batchSize
                        and oa.hand_id = pa.hand_id
                        and oa.action_type != 'HAND_SETTLED'
                   )
+              and not exists (
+                    select 1
+                      from public.poker_hole_cards hc
+                     where hc.table_id = pa.table_id
+                       and hc.hand_id = pa.hand_id
+                  )
          )
    order by (
      select min(pa2.created_at) from public.poker_actions pa2
@@ -149,6 +227,12 @@ candidates as (
             where oa.table_id = pa.table_id
               and oa.hand_id = pa.hand_id
               and oa.action_type != 'HAND_SETTLED'
+         )
+     and not exists (
+           select 1
+             from public.poker_hole_cards hc
+            where hc.table_id = pa.table_id
+              and hc.hand_id = pa.hand_id
          )
    order by created_at
    limit $3
@@ -237,8 +321,18 @@ export function createActionHistoryCleanup({
 
   let sweepInProgress = false;
   let lastRun = null;
-  let lastError = null;
   let backlogCache = null;
+
+  function orderedFailedPhases(failedPhases) {
+    return CLEANUP_PHASE_ORDER.filter((phase) => failedPhases.has(phase));
+  }
+
+  function primaryErrorCode(failedPhases) {
+    if (failedPhases.has("ordinary_actions")) return "ordinary_actions_cleanup_failed";
+    if (failedPhases.has("hand_settled")) return "hand_settled_cleanup_failed";
+    if (failedPhases.has("hole_cards")) return "hole_cards_cleanup_failed";
+    return null;
+  }
 
   async function readBacklog(cutoffs) {
     const nowMs = Date.now();
@@ -302,6 +396,11 @@ export function createActionHistoryCleanup({
                        and oa.hand_id = pa.hand_id
                        and oa.action_type != 'HAND_SETTLED'
                   )
+              and not exists (
+                    select 1 from public.poker_hole_cards hc
+                     where hc.table_id = pa.table_id
+                       and hc.hand_id = pa.hand_id
+                  )
          )
    order by (select min(pa2.created_at) from public.poker_actions pa2
               where pa2.table_id = t.id and pa2.action_type = 'HAND_SETTLED')
@@ -318,6 +417,10 @@ export function createActionHistoryCleanup({
      and not exists (
            select 1 from public.poker_actions oa
             where oa.table_id = pa.table_id and oa.hand_id = pa.hand_id and oa.action_type != 'HAND_SETTLED'
+         )
+     and not exists (
+           select 1 from public.poker_hole_cards hc
+            where hc.table_id = pa.table_id and hc.hand_id = pa.hand_id
          )
    order by pa.created_at
    limit $3
@@ -361,7 +464,17 @@ select
   }
 
   async function sweep() {
-    if (sweepInProgress) return { ok: true, phase1Deleted: 0, phase2Deleted: 0, skipped: true, reason: "sweep_in_progress" };
+    if (sweepInProgress) {
+      return {
+        ok: true,
+        holeCardsDeleted: 0,
+        phase1Deleted: 0,
+        phase2Deleted: 0,
+        failedPhases: [],
+        skipped: true,
+        reason: "sweep_in_progress"
+      };
+    }
     sweepInProgress = true;
     const startedAtMs = Date.now();
     const startedAt = new Date(startedAtMs).toISOString();
@@ -371,69 +484,149 @@ select
       const anyEnabled = cutoffs.botActionEnabled || cutoffs.humanActionEnabled
         || cutoffs.botSettledEnabled || cutoffs.humanSettledEnabled;
       if (!anyEnabled) {
-        result = { ok: true, phase1Deleted: 0, phase2Deleted: 0, skipped: true, reason: "cleanup_disabled" };
+        result = {
+          ok: true,
+          holeCardsDeleted: 0,
+          phase1Deleted: 0,
+          phase2Deleted: 0,
+          failedPhases: [],
+          skipped: true,
+          reason: "cleanup_disabled"
+        };
         return result;
       }
 
-      try {
-        result = await beginSql(async (tx) => {
-        let phase1Deleted = 0;
-        let phase2Deleted = 0;
-        for (let round = 0; round < sweepRounds; round += 1) {
-          const phase1RoundDeleted = await sweepPhase1({
+      let holeCardsDeleted = 0;
+      let phase1Deleted = 0;
+      let phase2Deleted = 0;
+      let holeCardsPhaseEnabledForSweep = cutoffs.botActionEnabled || cutoffs.humanActionEnabled;
+      const failedPhases = new Set();
+
+      for (let round = 0; round < sweepRounds; round += 1) {
+        let holeCardsRoundDeleted = 0;
+        if (holeCardsPhaseEnabledForSweep) {
+          try {
+            holeCardsRoundDeleted = await beginSql((tx) => sweepHoleCards({
+              tx,
+              botActionCutoff: cutoffs.botActionCutoff,
+              humanActionCutoff: cutoffs.humanActionCutoff,
+              batchSize,
+              lockLimit
+            }), { env });
+            holeCardsDeleted += holeCardsRoundDeleted;
+          } catch (_error) {
+            failedPhases.add("hole_cards");
+            holeCardsPhaseEnabledForSweep = false;
+          }
+        }
+
+        let phase1RoundDeleted = 0;
+        try {
+          phase1RoundDeleted = await beginSql((tx) => sweepPhase1({
             tx,
             botActionCutoff: cutoffs.botActionCutoff,
             humanActionCutoff: cutoffs.humanActionCutoff,
             batchSize,
             lockLimit,
             klog
-          });
-          const phase2RoundDeleted = await sweepPhase2({
+          }), { env });
+          phase1Deleted += phase1RoundDeleted;
+        } catch (_error) {
+          failedPhases.add("ordinary_actions");
+          break;
+        }
+
+        let phase2RoundDeleted = 0;
+        try {
+          phase2RoundDeleted = await beginSql((tx) => sweepPhase2({
             tx,
             botSettledCutoff: cutoffs.botSettledCutoff,
             humanSettledCutoff: cutoffs.humanSettledCutoff,
             batchSize,
             lockLimit,
             klog
-          });
-          phase1Deleted += phase1RoundDeleted;
+          }), { env });
           phase2Deleted += phase2RoundDeleted;
-          if (phase1RoundDeleted === 0 && phase2RoundDeleted === 0) break;
+        } catch (_error) {
+          failedPhases.add("hand_settled");
+          break;
         }
 
-        if (phase1Deleted > 0 || phase2Deleted > 0) {
-          klog("ws_action_history_cleanup_complete", {
-            phase1Deleted,
-            phase2Deleted,
-            batchSize,
-            lockLimit,
-            sweepRounds
-          });
-        }
+        if (holeCardsRoundDeleted === 0 && phase1RoundDeleted === 0 && phase2RoundDeleted === 0) break;
+      }
 
-        return { ok: true, phase1Deleted, phase2Deleted };
-      }, { env });
+      const orderedPhases = orderedFailedPhases(failedPhases);
+      const errorCode = primaryErrorCode(failedPhases);
+      result = {
+        ok: orderedPhases.length === 0,
+        holeCardsDeleted,
+        phase1Deleted,
+        phase2Deleted,
+        failedPhases: orderedPhases,
+        errorCode,
+        skipped: false,
+        reason: errorCode
+      };
+
+      if (result.ok && (holeCardsDeleted > 0 || phase1Deleted > 0 || phase2Deleted > 0)) {
+        klog("ws_action_history_cleanup_complete", {
+          holeCardsDeleted,
+          phase1Deleted,
+          phase2Deleted,
+          batchSize,
+          lockLimit,
+          sweepRounds
+        });
+      } else if (!result.ok) {
+        klog("ws_action_history_cleanup_failed", {
+          errorCode,
+          failedPhases: orderedPhases,
+          holeCardsDeleted,
+          phase1Deleted,
+          phase2Deleted,
+          batchSize,
+          lockLimit,
+          sweepRounds
+        });
+      }
       return result;
-    } catch (error) {
+    } catch (_error) {
+      result = {
+        ok: false,
+        holeCardsDeleted: 0,
+        phase1Deleted: 0,
+        phase2Deleted: 0,
+        failedPhases: ["ordinary_actions"],
+        errorCode: "ordinary_actions_cleanup_failed",
+        skipped: false,
+        reason: "ordinary_actions_cleanup_failed"
+      };
       klog("ws_action_history_cleanup_failed", {
-        reason: error?.code || error?.message || "unknown"
+        errorCode: result.errorCode,
+        failedPhases: result.failedPhases,
+        holeCardsDeleted: 0,
+        phase1Deleted: 0,
+        phase2Deleted: 0,
+        batchSize,
+        lockLimit,
+        sweepRounds
       });
-      result = { ok: false, phase1Deleted: 0, phase2Deleted: 0, reason: error?.code || "cleanup_failed" };
       return result;
-    }
     } finally {
       sweepInProgress = false;
       const finishedAt = new Date().toISOString();
-      lastError = result?.ok === false ? { code: String(result.reason || "cleanup_failed").slice(0, 120) } : null;
       lastRun = {
         startedAt,
         finishedAt,
         durationMs: Math.max(0, Date.now() - startedAtMs),
+        holeCardsDeleted: Number(result?.holeCardsDeleted || 0),
         phase1Deleted: Number(result?.phase1Deleted || 0),
         phase2Deleted: Number(result?.phase2Deleted || 0),
         result: result?.ok === true ? (result?.skipped ? "skipped" : "success") : "failed",
         skipped: result?.skipped === true,
-        reason: result?.reason || null
+        reason: result?.reason || null,
+        errorCode: result?.errorCode || null,
+        failedPhases: Array.isArray(result?.failedPhases) ? result.failedPhases : []
       };
     }
   }
@@ -451,7 +644,7 @@ select
       sweepRounds,
       sweepInProgress,
       lastRun,
-      lastError,
+      lastError: lastRun?.errorCode ? { code: lastRun.errorCode } : null,
       backlog: await readBacklog(cutoffs)
     };
   }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -3348,11 +3348,16 @@ function projectCleanupMetrics(cleanupResult) {
   if (!cleanupResult || typeof cleanupResult !== "object") return null;
   const backlog = cleanupResult.backlog;
   const lastRun = cleanupResult.lastRun;
+  const holeCardsDeleted = safeMetricInteger(lastRun?.holeCardsDeleted);
   const phase1Deleted = safeMetricInteger(lastRun?.phase1Deleted);
   const phase2Deleted = safeMetricInteger(lastRun?.phase2Deleted);
   const deletedRows = phase1Deleted != null && phase2Deleted != null
-    ? phase1Deleted + phase2Deleted
+    ? (holeCardsDeleted || 0) + phase1Deleted + phase2Deleted
     : null;
+  const failedPhaseOrder = ["hole_cards", "ordinary_actions", "hand_settled"];
+  const failedPhases = Array.isArray(lastRun?.failedPhases)
+    ? failedPhaseOrder.filter((phase) => lastRun.failedPhases.includes(phase))
+    : [];
   return {
     backlog: backlog && typeof backlog === "object" ? {
       ordinaryActionRows: safeMetricInteger(backlog.ordinaryActionRows),
@@ -3365,8 +3370,13 @@ function projectCleanupMetrics(cleanupResult) {
     lastRun: lastRun && typeof lastRun === "object" ? {
       finishedAt: typeof lastRun.finishedAt === "string" ? lastRun.finishedAt : null,
       durationMs: safeMetricInteger(lastRun.durationMs),
+      holeCardsDeleted,
+      phase1Deleted,
+      phase2Deleted,
       deletedRows: Number.isSafeInteger(deletedRows) ? deletedRows : null,
-      result: typeof lastRun.result === "string" ? lastRun.result : null
+      result: typeof lastRun.result === "string" ? lastRun.result : null,
+      errorCode: typeof lastRun.errorCode === "string" ? lastRun.errorCode : null,
+      failedPhases
     } : null
   };
 }


### PR DESCRIPTION
## Summary

- Add bounded retention cleanup for `public.poker_hole_cards` using existing action-retention cutoffs and `HAND_SETTLED` markers.
- Run hole-card, ordinary-action, and `HAND_SETTLED` cleanup phases in separate transactions per round.
- Keep `HAND_SETTLED` markers while ordinary actions or hole cards remain, and retry a failed hole-card phase on the next sweep.
- Preserve completed phase counters and expose deterministic `failedPhases` details through the existing admin maintenance flow.
- Extend Admin/Ops metrics and deployment documentation without adding migrations, environment variables, workers, or endpoints.

## Failure semantics

Cleanup keeps the existing `failed`/HTTP 409 contract. A hole-card failure does not prevent best-effort action cleanup, and a failed result does not imply rollback of already committed phase counters. Empty enabled sweeps remain successful no-ops without a new completion-log event.

## Validation

- `npm test`
- `npm run check:csp-inline`
- targeted cleanup, admin proxy, admin page, VPS metrics, inactive cleanup, syntax, and `git diff --check` checks

Closes #843
