### PR TITLE
security: enable RLS for managed table profiles

### DIFF
--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -62,6 +62,7 @@ run("node", ["tests/poker-eval.test.mjs"], "poker-eval");
 run("node", ["tests/poker-cards-utils.test.mjs"], "poker-cards-utils");
 run("node", ["tests/poker-hole-cards-store.test.mjs"], "poker-hole-cards-store");
 run("node", ["tests/poker-db-lockdown.contract.test.mjs"], "poker-db-lockdown");
+run("node", ["tests/poker-managed-table-profiles.rls.contract.test.mjs"], "poker-managed-table-profiles-rls");
 run("node", ["tests/poker-hole-cards.rls.test.mjs"], "poker-hole-cards-rls");
 run("node", ["tests/poker-hole-cards.allow-bots.contract.test.mjs"], "poker-hole-cards-allow-bots-contract");
 run("node", ["tests/poker-rls.read.test.mjs"], "poker-rls-read");

--- a/supabase/migrations/20260804160000_poker_managed_table_profiles_enable_rls.sql
+++ b/supabase/migrations/20260804160000_poker_managed_table_profiles_enable_rls.sql
@@ -1,0 +1,4 @@
+-- Continuous-table profile is a backend-only control record.
+-- WS accesses it through the existing direct PostgreSQL connection; no
+-- PostgREST policy is required or intended for anon/authenticated clients.
+alter table public.poker_managed_table_profiles enable row level security;

--- a/tests/poker-managed-table-profiles.rls.contract.test.mjs
+++ b/tests/poker-managed-table-profiles.rls.contract.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationsDir = path.join(process.cwd(), "supabase", "migrations");
+const migrationFiles = fs.readdirSync(migrationsDir).filter((file) => (
+  file.includes("poker_managed_table_profiles") && file.includes("enable_rls")
+));
+
+assert.equal(
+  migrationFiles.length,
+  1,
+  `expected one managed-table-profile RLS migration, got ${migrationFiles.join(", ")}`
+);
+
+const migrationSql = fs.readFileSync(path.join(migrationsDir, migrationFiles[0]), "utf8");
+assert.match(
+  migrationSql,
+  /alter\s+table\s+public\.poker_managed_table_profiles\s+enable\s+row\s+level\s+security\s*;/i
+);
+assert.doesNotMatch(migrationSql, /create\s+policy/i, "backend-only profile must not gain a client policy");
+assert.doesNotMatch(migrationSql, /grant[\s\S]+\b(anon|authenticated)\b/i);
+


### PR DESCRIPTION
## Summary

- Enable Row Level Security for `public.poker_managed_table_profiles` with one new migration.
- Keep the table backend-only: the WS runtime reads and writes it through the existing direct PostgreSQL connection.
- Add a focused migration contract test and register it in the full test runner.

## Security review

The current codebase uses this table only from `ws-server/poker/persistence/continuous-bot-table-repository.mjs`, through `beginSqlWs` and `SUPABASE_DB_URL`. No browser code, Netlify function, Supabase JS/PostgREST call, `anon` path, or `authenticated` path accesses the table.

The migration intentionally adds no client policies and no permissions for `anon` or `authenticated`. With RLS enabled and no client policy, PostgREST clients cannot read or modify rows. The existing direct WS PostgreSQL path remains compatible with the RLS model already used by the poker state and hole-card tables.

## Verification

- `node --test tests/poker-managed-table-profiles.rls.contract.test.mjs`
- `node --test tests/test-all.runner-registration.guard.test.mjs`
- `node scripts/check-db-migrations.mjs`
- `node --test ws-server/poker/persistence/continuous-bot-table-repository.behavior.test.mjs`
- `npm run syntax`
- `npm test`
- `npm run check:csp-inline`

## Rollout

1. Merge and deploy to Stage.
2. Verify WS maintenance profile reads, desired-state updates, and reconciliation on Stage.
3. Confirm the Security Advisor finding clears on Stage.
4. Apply the same migration manually to Production after Stage verification.

No WS Preview deploy, Netlify environment change, production code mutation, or additional migration is required by this PR.
