### PR TITLE
Keep rebuy requests resumable across reconnects

### DIFF
--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -193,7 +193,8 @@
   var bootReady = false;
   var queuedPreaction = null;
   var queuedPreactionInFlight = false;
-  var rebuyInFlight = false;
+  var rebuyOperation = null;
+  var pendingRebuyResumeAttempted = false;
   var rebuyPanelDismissed = false;
   var rebuyBalanceLoading = false;
   var stickyWinnerReveal = {
@@ -1597,6 +1598,128 @@
   function pendingJoinStorageKey(){
     if (!state.currentUserId || !state.tableId) return null;
     return 'poker:pendingJoin:' + String(state.currentUserId) + ':' + String(state.tableId);
+  }
+
+  function buildRebuyRequestId(){
+    return 'rebuy_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function pendingRebuyStorageKey(){
+    if (!state.currentUserId || !state.tableId) return null;
+    return 'poker:pendingRebuy:' + String(state.currentUserId) + ':' + String(state.tableId);
+  }
+
+  function persistPendingRebuy(){
+    var key = pendingRebuyStorageKey();
+    if (!key || !rebuyOperation || !rebuyOperation.requestId || !rebuyOperation.payload) return;
+    try {
+      if (window.sessionStorage){
+        window.sessionStorage.setItem(key, JSON.stringify({
+          requestId: rebuyOperation.requestId,
+          tableId: rebuyOperation.tableId,
+          userId: rebuyOperation.userId,
+          payload: rebuyOperation.payload,
+          phase: rebuyOperation.phase
+        }));
+      }
+    } catch (_err){}
+  }
+
+  function clearPendingRebuyStorage(){
+    var key = pendingRebuyStorageKey();
+    if (!key) return;
+    try { if (window.sessionStorage) window.sessionStorage.removeItem(key); } catch (_err){}
+  }
+
+  function clearRebuyOperation(){
+    rebuyOperation = null;
+    pendingRebuyResumeAttempted = false;
+    clearPendingRebuyStorage();
+  }
+
+  function loadPendingRebuy(){
+    var key = pendingRebuyStorageKey();
+    if (!key) return null;
+    try {
+      var raw = window.sessionStorage ? window.sessionStorage.getItem(key) : null;
+      var parsed = raw ? JSON.parse(raw) : null;
+      if (!parsed || parsed.tableId !== state.tableId || parsed.userId !== state.currentUserId
+        || typeof parsed.requestId !== 'string' || !parsed.requestId || !isObject(parsed.payload)){
+        if (raw && window.sessionStorage) window.sessionStorage.removeItem(key);
+        return null;
+      }
+      return {
+        phase: parsed.phase === 'error' ? 'error' : 'pending',
+        requestId: parsed.requestId,
+        tableId: parsed.tableId,
+        userId: parsed.userId,
+        payload: parsed.payload
+      };
+    } catch (_err){
+      return null;
+    }
+  }
+
+  function rebuyErrorCode(error){
+    return error && (error.code || error.message) ? String(error.code || error.message) : 'rebuy_failed';
+  }
+
+  function isDefinitiveRebuyRejection(code){
+    return ['insufficient_chips', 'invalid_rebuy_amount', 'table_not_found', 'table_not_open',
+      'seat_not_active', 'rebuy_not_allowed', 'rebuy_not_available'].indexOf(code) >= 0;
+  }
+
+  function sendRebuyOperation(){
+    if (!rebuyOperation || rebuyOperation.phase !== 'pending') return Promise.resolve({ ok: true, pending: true });
+    var operation = rebuyOperation;
+    return sendCommand('sendRebuy', operation.payload, operation.requestId).then(function(result){
+      if (rebuyOperation !== operation) return result;
+      clearRebuyOperation();
+      rebuyPanelDismissed = true;
+      state.statusText = 'Buy-in accepted';
+      render();
+      return result;
+    }).catch(function(error){
+      if (rebuyOperation !== operation) return null;
+      var code = rebuyErrorCode(error);
+      if (isDefinitiveRebuyRejection(code)){
+        clearRebuyOperation();
+        rebuyPanelDismissed = false;
+      } else {
+        operation.phase = 'error';
+        persistPendingRebuy();
+      }
+      if (els.rebuyAccountLink) els.rebuyAccountLink.hidden = code !== 'insufficient_chips';
+      setError(code === 'insufficient_chips' ? 'Not enough CH for a 100 CH buy-in' : code);
+      render();
+      return null;
+    });
+  }
+
+  function reconcileRebuyOperationFromSnapshot(authoritativeSnapshot){
+    if (!authoritativeSnapshot || !state.currentUserId || !state.tableId || !Number.isInteger(state.youSeat) || !state.playerState) return false;
+    if (!rebuyOperation) rebuyOperation = loadPendingRebuy();
+    if (!rebuyOperation) return false;
+    if (rebuyOperation.tableId !== state.tableId || rebuyOperation.userId !== state.currentUserId){
+      clearRebuyOperation();
+      return false;
+    }
+    var stack = Number(state.playerState.stack);
+    var status = state.playerState.status;
+    var funded = Number.isFinite(stack) && stack > 0 && state.playerState.canRebuy !== true
+      && (status === 'WAITING_NEXT_HAND' || status === 'ACTIVE');
+    if (funded){
+      clearRebuyOperation();
+      rebuyPanelDismissed = true;
+      return true;
+    }
+    if (rebuyOperation.phase === 'pending' && !pendingRebuyResumeAttempted
+      && status === 'OUT_OF_CHIPS' && stack === 0 && state.playerState.canRebuy === true){
+      pendingRebuyResumeAttempted = true;
+      persistPendingRebuy();
+      void sendRebuyOperation();
+    }
+    return true;
   }
 
   function persistPendingJoin(){
@@ -3215,10 +3338,11 @@
     if (els.rebuyTitle) els.rebuyTitle.textContent = waiting ? 'Buy-in confirmed' : 'Out of chips';
     if (els.rebuyCopy) els.rebuyCopy.textContent = waiting ? 'Funded · Joining next hand' : 'The table will keep playing. Buy in to join the next hand.';
     if (els.rebuyBtn) {
-      els.rebuyBtn.disabled = rebuyInFlight || !isWsReady() || playerState.canRebuy !== true;
-      els.rebuyBtn.textContent = rebuyInFlight ? 'Buying in…' : 'Buy in 100 CH';
+      var rebuyPending = !!rebuyOperation && rebuyOperation.phase === 'pending';
+      els.rebuyBtn.disabled = rebuyPending || !isWsReady() || playerState.canRebuy !== true;
+      els.rebuyBtn.textContent = rebuyPending ? 'Buying in…' : (rebuyOperation && rebuyOperation.phase === 'error' ? 'Retry buy-in' : 'Buy in 100 CH');
     }
-    if (els.rebuyLobbyBtn) els.rebuyLobbyBtn.disabled = rebuyInFlight || !isWsReady();
+    if (els.rebuyLobbyBtn) els.rebuyLobbyBtn.disabled = (!!rebuyOperation && rebuyOperation.phase === 'pending') || !isWsReady();
     if (outOfChips) refreshRebuyBalance();
   }
 
@@ -3765,6 +3889,7 @@
 
   function queueLeaveAndNavigateImmediately(){
     if (!wsClient || typeof wsClient.sendLeaveQueued !== 'function' || !isWsReady()) return false;
+    clearRebuyOperation();
     wsClient.sendLeaveQueued({ tableId: state.tableId });
     pendingLeaveRetryAfterReconnect = false;
     pendingLeaveNavigation = false;
@@ -3973,6 +4098,7 @@
   }
 
   function leaveAndReturnToLobby(){
+    clearRebuyOperation();
     pendingLeaveNavigation = true;
     try {
       if (queueLeaveAndNavigateImmediately()) return Promise.resolve({ ok: true, queued: true });
@@ -3998,21 +4124,29 @@
   }
 
   function requestManualRebuy(){
-    if (rebuyInFlight || !state.playerState || state.playerState.canRebuy !== true) return Promise.resolve();
-    rebuyInFlight = true;
+    if (!state.playerState || state.playerState.canRebuy !== true) return Promise.resolve();
+    if (rebuyOperation && rebuyOperation.phase === 'pending') return Promise.resolve({ ok: true, pending: true });
+    if (rebuyOperation && rebuyOperation.phase === 'error'){
+      rebuyOperation.phase = 'pending';
+      pendingRebuyResumeAttempted = true;
+      persistPendingRebuy();
+      setError('');
+      renderRebuyPanel();
+      return sendRebuyOperation();
+    }
+    var requestId = buildRebuyRequestId();
+    rebuyOperation = {
+      phase: 'pending',
+      requestId: requestId,
+      tableId: state.tableId,
+      userId: state.currentUserId,
+      payload: { tableId: state.tableId, amount: 100 }
+    };
+    pendingRebuyResumeAttempted = true;
+    persistPendingRebuy();
     setError('');
     renderRebuyPanel();
-    return sendCommand('sendRebuy', { tableId: state.tableId, amount: 100 }).then(function(){
-      state.statusText = 'Buy-in accepted';
-      rebuyPanelDismissed = true;
-    }).catch(function(error){
-      var reason = error && (error.code || error.message) ? String(error.code || error.message) : 'rebuy_failed';
-      if (els.rebuyAccountLink) els.rebuyAccountLink.hidden = reason !== 'insufficient_chips';
-      setError(reason === 'insufficient_chips' ? 'Not enough CH for a 100 CH buy-in' : reason);
-    }).then(function(){
-      rebuyInFlight = false;
-      render();
-    });
+    return sendRebuyOperation();
   }
 
   function bindMenu(){
@@ -4300,6 +4434,7 @@
   }
 
   function applySignedOutState(){
+    clearRebuyOperation();
     stopLiveMode();
     resetQueuedPreactionState();
     state = createEmptyLiveState(tableId, null);
@@ -4308,6 +4443,7 @@
   }
 
   function applyAuthenticatedPendingState(user){
+    if (!user || !state.currentUserId || String(user.id || '') !== String(state.currentUserId)) clearRebuyOperation();
     stopLiveMode();
     resetQueuedPreactionState();
     isGuestMode = false;
@@ -4326,6 +4462,8 @@
 
   function restartAuthenticatedLiveMode(token){
     if (!tableId || !token) return;
+    var nextUserId = getUserIdFromToken(token);
+    if (nextUserId && state.currentUserId && nextUserId !== state.currentUserId) clearRebuyOperation();
     isGuestMode = false;
     currentGuestSession = null;
     clearGuestSession();
@@ -4463,6 +4601,7 @@
         }
         var previousVisual = captureVisualSnapshot();
         mergeSnapshot(payload, frame);
+        reconcileRebuyOperationFromSnapshot(authoritativeSnapshot);
         if (authoritativeSnapshot) state.hasAppliedAuthoritativeSnapshot = true;
         // Open the reconnect gate only after a full authoritative snapshot is merged.
         var openedRecoveryGate = false;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -194,7 +194,6 @@
   var queuedPreaction = null;
   var queuedPreactionInFlight = false;
   var rebuyOperation = null;
-  var pendingRebuyResumeAttempted = false;
   var rebuyPanelDismissed = false;
   var rebuyBalanceLoading = false;
   var stickyWinnerReveal = {
@@ -1633,7 +1632,6 @@
 
   function clearRebuyOperation(){
     rebuyOperation = null;
-    pendingRebuyResumeAttempted = false;
     clearPendingRebuyStorage();
   }
 
@@ -1650,6 +1648,7 @@
       }
       return {
         phase: parsed.phase === 'error' ? 'error' : 'pending',
+        resumeAttempted: false,
         requestId: parsed.requestId,
         tableId: parsed.tableId,
         userId: parsed.userId,
@@ -1682,6 +1681,13 @@
     }).catch(function(error){
       if (rebuyOperation !== operation) return null;
       var code = rebuyErrorCode(error);
+      if (code === 'ws_closed' && operation.preserveOnTechnicalRestart === true){
+        operation.preserveOnTechnicalRestart = false;
+        operation.phase = 'pending';
+        persistPendingRebuy();
+        renderRebuyPanel();
+        return null;
+      }
       if (isDefinitiveRebuyRejection(code)){
         clearRebuyOperation();
         rebuyPanelDismissed = false;
@@ -1713,9 +1719,9 @@
       rebuyPanelDismissed = true;
       return true;
     }
-    if (rebuyOperation.phase === 'pending' && !pendingRebuyResumeAttempted
+    if (rebuyOperation.phase === 'pending' && rebuyOperation.resumeAttempted !== true
       && status === 'OUT_OF_CHIPS' && stack === 0 && state.playerState.canRebuy === true){
-      pendingRebuyResumeAttempted = true;
+      rebuyOperation.resumeAttempted = true;
       persistPendingRebuy();
       void sendRebuyOperation();
     }
@@ -4128,7 +4134,7 @@
     if (rebuyOperation && rebuyOperation.phase === 'pending') return Promise.resolve({ ok: true, pending: true });
     if (rebuyOperation && rebuyOperation.phase === 'error'){
       rebuyOperation.phase = 'pending';
-      pendingRebuyResumeAttempted = true;
+      rebuyOperation.resumeAttempted = true;
       persistPendingRebuy();
       setError('');
       renderRebuyPanel();
@@ -4137,12 +4143,12 @@
     var requestId = buildRebuyRequestId();
     rebuyOperation = {
       phase: 'pending',
+      resumeAttempted: true,
       requestId: requestId,
       tableId: state.tableId,
       userId: state.currentUserId,
       payload: { tableId: state.tableId, amount: 100 }
     };
-    pendingRebuyResumeAttempted = true;
     persistPendingRebuy();
     setError('');
     renderRebuyPanel();
@@ -4482,6 +4488,11 @@
     var preservingState = !!(state && state.mode === 'live'
       && state.hasAppliedAuthoritativeSnapshot
       && state.tableId && state.tableId === tableId);
+    if (preservingState && rebuyOperation && rebuyOperation.phase === 'pending'){
+      rebuyOperation.preserveOnTechnicalRestart = true;
+      rebuyOperation.resumeAttempted = false;
+      persistPendingRebuy();
+    }
     stopLiveMode();
     startTurnClock();
     // 2. THEN capture the new generation (old = N, stop => N+1 stale, this => N+2 active).

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -125,12 +125,16 @@
       return rid;
     }
 
-    function markJoinPending(entry, reason){
-      if (!entry || entry.type !== 'join') return;
+    function isResumableCommand(entry){
+      return !!entry && (entry.type === 'join' || entry.type === 'rebuy');
+    }
+
+    function markResumablePending(entry, reason){
+      if (!isResumableCommand(entry)) return;
       if (entry.timer) clearTimeout(entry.timer);
       entry.timer = null;
       entry.softPending = true;
-      emitStatus('join_pending', {
+      emitStatus(entry.type === 'join' ? 'join_pending' : 'rebuy_pending', {
         requestId: entry.requestId,
         reason: reason || 'pending'
       });
@@ -141,8 +145,8 @@
       if (entry.timer) clearTimeout(entry.timer);
       entry.timer = setTimeout(function(){
         if (!pending.has(entry.requestId)) return;
-        if (entry.type === 'join'){
-          markJoinPending(entry, 'soft_timeout');
+        if (isResumableCommand(entry)){
+          markResumablePending(entry, 'soft_timeout');
           requestGameplaySnapshot();
           return;
         }
@@ -152,21 +156,21 @@
     }
 
     function rejectAllPending(code, options){
-      var preserveJoins = !!(options && options.preserveJoins);
+      var preserveResumable = !!(options && (options.preserveResumable || options.preserveJoins));
       pending.forEach(function(entry){
-        if (preserveJoins && entry.type === 'join'){
-          markJoinPending(entry, code || 'ws_closed');
+        if (preserveResumable && isResumableCommand(entry)){
+          markResumablePending(entry, code || 'ws_closed');
           return;
         }
         if (entry.timer) clearTimeout(entry.timer);
         entry.reject(createError(code || 'ws_closed'));
       });
-      if (!preserveJoins) {
+      if (!preserveResumable) {
         pending.clear();
         return;
       }
       pending.forEach(function(entry, requestId){
-        if (entry.type !== 'join') pending.delete(requestId);
+        if (!isResumableCommand(entry)) pending.delete(requestId);
       });
     }
 
@@ -189,15 +193,15 @@
       });
     }
 
-    function retryPendingJoins(){
+    function retryPendingResumableCommands(){
       if (!authOk || !ws || ws.readyState !== 1) return;
       pending.forEach(function(entry){
-        if (entry.type !== 'join' || !entry.softPending) return;
-        var retriedRequestId = send('join', entry.payload || {}, entry.requestId);
+        if (!isResumableCommand(entry) || !entry.softPending) return;
+        var retriedRequestId = send(entry.type, entry.payload || {}, entry.requestId);
         if (!retriedRequestId) return;
         entry.softPending = false;
         armCommandTimer(entry);
-        emitStatus('join_retry', { requestId: entry.requestId });
+        emitStatus(entry.type === 'join' ? 'join_retry' : 'rebuy_retry', { requestId: entry.requestId });
       });
     }
 
@@ -316,8 +320,9 @@
       var rid = payload.requestId || frame.requestId || null;
       if (!rid || !pending.has(rid)) return;
       var entry = pending.get(rid);
-      if (entry.type === 'join' && payload.status === 'pending') {
-        markJoinPending(entry, payload.reason || 'server_recovery_pending');
+      var requestPending = payload.reason === 'request_pending' || payload.code === 'request_pending';
+      if (isResumableCommand(entry) && (payload.status === 'pending' || requestPending)) {
+        markResumablePending(entry, payload.reason || 'server_recovery_pending');
         requestGameplaySnapshot();
         return;
       }
@@ -344,7 +349,7 @@
         mintAndAuth().catch(function(err){ var code = safeErrorCode(err); log('poker_ws_auth_error', { tableId: tableId, code: code }); emitStatus('failed', { stage: 'auth', code: code }); emitProtocolError(code, 'auth_failed'); destroy(); });
         return;
       }
-      if (frame.type === 'authOk') { authOk = true; reconnectAttempt = 0; emitStatus('auth_ok', { roomId: frame.payload && frame.payload.roomId ? frame.payload.roomId : null }); requestLiveState(); retryPendingJoins(); return; }
+      if (frame.type === 'authOk') { authOk = true; reconnectAttempt = 0; emitStatus('auth_ok', { roomId: frame.payload && frame.payload.roomId ? frame.payload.roomId : null }); requestLiveState(); retryPendingResumableCommands(); return; }
       if (frame.type === 'lobby_snapshot') {
         var initialLobby = !initialLobbySnapshotDelivered;
         initialLobbySnapshotDelivered = true;
@@ -383,18 +388,22 @@
       }
       if (frame.type === 'error') {
         var rid = frame.requestId || (frame.payload && frame.payload.requestId) || null;
+        var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error';
         var commandErrorHandled = false;
         if (rid && pending.has(rid)) {
           var entry = pending.get(rid);
           if (entry.type === 'join') {
-            markJoinPending(entry, frame.payload && frame.payload.code ? frame.payload.code : 'ws_error');
+            markResumablePending(entry, code);
+            commandErrorHandled = true;
+          } else if (entry.type === 'rebuy' && code === 'request_pending') {
+            markResumablePending(entry, code);
+            requestGameplaySnapshot();
             commandErrorHandled = true;
           } else {
-            pending.delete(rid); clearTimeout(entry.timer); entry.reject(createError(frame.payload && frame.payload.code ? frame.payload.code : 'ws_error'));
+            pending.delete(rid); clearTimeout(entry.timer); entry.reject(createError(code));
             commandErrorHandled = true;
           }
         }
-        var code = frame.payload && frame.payload.code ? frame.payload.code : 'ws_error';
         if (commandErrorHandled) {
           emitStatus('command_error', { code: code, requestId: rid });
           return;
@@ -435,11 +444,12 @@
         authOk = false;
         connecting = false;
         clearHeartbeat();
-        rejectAllPending('ws_closed', { preserveJoins: true });
+        var willReconnect = shouldAutoReconnect(code);
+        rejectAllPending('ws_closed', { preserveResumable: willReconnect });
         log('poker_ws_close', { tableId: tableId, readyState: safeReadyState(ws), code: code, reason: sanitizeText(evt && evt.reason), wasClean: !!(evt && evt.wasClean) });
         emitStatus('closed', { code: code });
         ws = null;
-        if (shouldAutoReconnect(code)) {
+        if (willReconnect) {
           scheduleReconnect(code);
           return;
         }
@@ -462,7 +472,7 @@
       authOk = false;
       clearHeartbeat();
       clearReconnect();
-      rejectAllPending('ws_closed', { preserveJoins: true });
+      rejectAllPending('ws_closed', { preserveResumable: false });
       if (ws && ws.readyState <= 1){ try { ws.close(1000, 'client_shutdown'); } catch (_err){} }
       ws = null;
     }

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -151,6 +151,7 @@ function createHarness(options = {}){
   const startPayloads = [];
   const leavePayloads = [];
   const rebuyPayloads = [];
+  const rebuyRequestIds = [];
   const reactionPayloads = [];
   const targetedReactionPayloads = [];
   let createOptions = null;
@@ -178,9 +179,10 @@ function createHarness(options = {}){
     },
     sendAct(payload){ actPayloads.push(payload); return Promise.resolve({ ok: true }); },
     sendStartHand(payload){ startPayloads.push(payload); return Promise.resolve({ ok: true }); },
-    sendRebuy(payload){
+    sendRebuy(payload, requestId){
       rebuyPayloads.push(payload);
-      if (typeof options.sendRebuy === 'function') return options.sendRebuy(payload, { attempt: rebuyPayloads.length });
+      rebuyRequestIds.push(requestId || null);
+      if (typeof options.sendRebuy === 'function') return options.sendRebuy(payload, { attempt: rebuyPayloads.length, requestId: requestId || null });
       return Promise.resolve({ ok: true });
     },
     sendLeave(payload){
@@ -295,6 +297,9 @@ function createHarness(options = {}){
   if (options.guestSession) {
     sandbox.sessionStorage.setItem('poker:guestSession', JSON.stringify(options.guestSession));
   }
+  Object.keys(options.sessionStorageEntries || {}).forEach((key) => {
+    sandbox.sessionStorage.setItem(key, options.sessionStorageEntries[key]);
+  });
 
   vm.createContext(sandbox);
   vm.runInContext(source, sandbox, { filename: 'poker/poker-v2.js' });
@@ -337,6 +342,7 @@ async function flush(){
     startPayloads,
     leavePayloads,
     rebuyPayloads,
+    rebuyRequestIds,
     reactionPayloads,
     targetedReactionPayloads,
     getSnapshotRequestCount(){ return snapshotRequestCount; },
@@ -1757,6 +1763,92 @@ test('poker v2 renders authoritative out-of-chips state with stable disabled act
   assert.equal(harness.elements.pokerV2TurnText.textContent, 'Funded · Joining next hand');
   assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'waiting snapshot must not reopen an accepted rebuy prompt');
   assert.equal(harness.elements.pokerV2RebuyBtn.hidden, true);
+});
+
+test('poker v2 resumes a stored rebuy only after a full snapshot and never creates a new request id', async () => {
+  const stored = JSON.stringify({
+    phase: 'pending',
+    requestId: 'rebuy_reload_1',
+    tableId: 'table-1',
+    userId: 'user-1',
+    payload: { tableId: 'table-1', amount: 100 }
+  });
+  const buildSnapshot = (playerState) => ({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', members: [{ userId: 'user-1', seat: 1 }] },
+      public: { hand: { handId: 'hand-rebuy-reload', status: 'TURN' }, turn: { userId: 'bot-1' }, pot: { total: 0, sidePots: [] }, legalActions: { seat: null, actions: [] } },
+      private: { userId: 'user-1', seat: 1, playerState },
+      you: { seat: 1 }
+    }
+  });
+
+  const fundedHarness = createHarness({
+    sessionStorageEntries: { 'poker:pendingRebuy:user-1:table-1': stored }
+  });
+  fundedHarness.fireDomContentLoaded();
+  await fundedHarness.flush();
+  assert.equal(fundedHarness.rebuyRequestIds.length, 0);
+  fundedHarness.getCreateOptions().onStatus('auth_ok', { roomId: 'table-1' });
+  await fundedHarness.flush();
+  fundedHarness.getCreateOptions().onSnapshot(buildSnapshot({ status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false }));
+  await fundedHarness.flush();
+  assert.equal(fundedHarness.rebuyRequestIds.length, 0);
+  assert.equal(fundedHarness.getSessionStorage('poker:pendingRebuy:user-1:table-1'), null);
+
+  const pendingHarness = createHarness({
+    sessionStorageEntries: { 'poker:pendingRebuy:user-1:table-1': stored }
+  });
+  pendingHarness.fireDomContentLoaded();
+  await pendingHarness.flush();
+  assert.equal(pendingHarness.rebuyRequestIds.length, 0);
+  pendingHarness.getCreateOptions().onStatus('auth_ok', { roomId: 'table-1' });
+  await pendingHarness.flush();
+  pendingHarness.getCreateOptions().onSnapshot(buildSnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await pendingHarness.flush();
+  assert.deepEqual(pendingHarness.rebuyRequestIds, ['rebuy_reload_1']);
+  pendingHarness.getCreateOptions().onSnapshot(buildSnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await pendingHarness.flush();
+  assert.deepEqual(pendingHarness.rebuyRequestIds, ['rebuy_reload_1']);
+});
+
+test('poker v2 retries a rebuy error with the same id and ignores clicks while pending', async () => {
+  let resolveRetry = null;
+  const harness = createHarness({
+    sendRebuy(_payload, meta){
+      if (meta.attempt === 1) return Promise.reject(Object.assign(new Error('temporarily_unavailable'), { code: 'temporarily_unavailable' }));
+      return new Promise((resolve) => { resolveRetry = resolve; });
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onSnapshot({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      table: { tableId: 'table-1', status: 'OPEN', members: [{ userId: 'user-1', seat: 1 }] },
+      public: { hand: { handId: 'hand-rebuy-error', status: 'TURN' }, turn: { userId: 'bot-1' }, pot: { total: 0, sidePots: [] }, legalActions: { seat: null, actions: [] } },
+      private: { userId: 'user-1', seat: 1, playerState: { status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true } },
+      you: { seat: 1 }
+    }
+  });
+  await harness.flush();
+  harness.elements.pokerV2RebuyBtn.click();
+  await harness.flush();
+  assert.equal(harness.rebuyRequestIds.length, 1);
+  assert.ok(harness.rebuyRequestIds[0]);
+  harness.elements.pokerV2RebuyBtn.click();
+  await harness.flush();
+  assert.deepEqual(harness.rebuyRequestIds, [harness.rebuyRequestIds[0], harness.rebuyRequestIds[0]]);
+  harness.elements.pokerV2RebuyBtn.click();
+  await harness.flush();
+  assert.equal(harness.rebuyRequestIds.length, 2);
+  resolveRetry({ ok: true, requestId: harness.rebuyRequestIds[0] });
+  await harness.flush();
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true);
 });
 
 test('poker v2 keeps action buttons stable while exposing single-select preactions off-turn', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -159,6 +159,8 @@ function createHarness(options = {}){
   const token = Object.prototype.hasOwnProperty.call(options, 'token')
     ? options.token
     : ('aaa.' + Buffer.from(JSON.stringify({ sub: 'user-1' })).toString('base64') + '.zzz');
+  let activeToken = token;
+  let authChangeHandler = null;
   const wsClient = {
     _ready: false,
     start(){
@@ -169,7 +171,10 @@ function createHarness(options = {}){
         }
       });
     },
-    destroy(){ this._ready = false; },
+    destroy(){
+      this._ready = false;
+      if (typeof options.onDestroy === 'function') options.onDestroy();
+    },
     isReady(){ return this._ready; },
     sendJoin(payload, requestId){
       joinPayloads.push(payload);
@@ -238,7 +243,7 @@ function createHarness(options = {}){
       },
       KLog: { log(kind, data){ logs.push({ kind, data }); } },
       SupabaseAuthBridge: {
-        getAccessToken: async () => token
+        getAccessToken: async () => activeToken
       },
       PokerWsClient: {
         create(opts){
@@ -290,7 +295,7 @@ function createHarness(options = {}){
   if (Object.prototype.hasOwnProperty.call(options, 'authUser')) {
     sandbox.window.SupabaseAuth = {
       getCurrentUser: async () => options.authUser,
-      onAuthChange(){ return function(){}; }
+      onAuthChange(handler){ authChangeHandler = handler; return function(){}; }
     };
   }
 
@@ -351,6 +356,8 @@ async function flush(){
     flush,
     advanceTime,
     getCreateOptions(){ return createOptions; },
+    setAuthToken(nextToken){ activeToken = nextToken; },
+    triggerAuthChange(user){ return authChangeHandler ? authChangeHandler('TOKEN_REFRESHED', user) : null; },
     getIntervalCount(){ return intervalTimers.length; },
     getSessionStorage(key){ return sandbox.sessionStorage.getItem(key); }
   };
@@ -1849,6 +1856,59 @@ test('poker v2 retries a rebuy error with the same id and ignores clicks while p
   resolveRetry({ ok: true, requestId: harness.rebuyRequestIds[0] });
   await harness.flush();
   assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true);
+});
+
+test('poker v2 keeps a rebuy pending across a technical live restart and resumes it once', async () => {
+  let rejectRebuy = null;
+  const tokenOne = 'aaa.' + Buffer.from(JSON.stringify({ sub: 'user-1' })).toString('base64') + '.one';
+  const tokenTwo = 'aaa.' + Buffer.from(JSON.stringify({ sub: 'user-1' })).toString('base64') + '.two';
+  const buildSnapshot = () => ({
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 2,
+      table: { tableId: 'table-1', status: 'OPEN', members: [{ userId: 'user-1', seat: 1 }] },
+      public: { hand: { handId: 'hand-rebuy-restart', status: 'TURN' }, turn: { userId: 'bot-1' }, pot: { total: 0, sidePots: [] }, legalActions: { seat: null, actions: [] } },
+      private: { userId: 'user-1', seat: 1, playerState: { status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true } },
+      you: { seat: 1 }
+    }
+  });
+
+  const harness = createHarness({
+    token: tokenOne,
+    authUser: { id: 'user-1' },
+    sendRebuy(){
+      return new Promise((_resolve, reject) => { rejectRebuy = reject; });
+    },
+    onDestroy(){
+      if (rejectRebuy) {
+        const reject = rejectRebuy;
+        rejectRebuy = null;
+        reject(Object.assign(new Error('ws_closed'), { code: 'ws_closed' }));
+      }
+    }
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  await harness.flush();
+  const firstWs = harness.getCreateOptions();
+  firstWs.onSnapshot(buildSnapshot());
+  await harness.flush();
+  harness.elements.pokerV2RebuyBtn.click();
+  await harness.flush();
+  assert.equal(harness.rebuyRequestIds.length, 1);
+  const requestId = harness.rebuyRequestIds[0];
+
+  harness.setAuthToken(tokenTwo);
+  await harness.triggerAuthChange({ id: 'user-1' });
+  await harness.flush();
+  harness.getCreateOptions().onSnapshot(buildSnapshot());
+  await harness.flush();
+
+  assert.deepEqual(harness.rebuyRequestIds, [requestId, requestId]);
+  harness.getCreateOptions().onSnapshot(buildSnapshot());
+  await harness.flush();
+  assert.deepEqual(harness.rebuyRequestIds, [requestId, requestId]);
 });
 
 test('poker v2 keeps action buttons stable while exposing single-select preactions off-turn', async () => {

--- a/tests/poker-ws-client.test.mjs
+++ b/tests/poker-ws-client.test.mjs
@@ -354,6 +354,95 @@ test('poker ws client treats the join timeout as soft and accepts a late result'
   assert.equal((await joinPromise).seatNo, 4);
 });
 
+test('poker ws client treats rebuy timeout and request_pending as resumable', async () => {
+  let commandTimeout = null;
+  const h = loadClientHarness({
+    setTimeout(fn, delay){
+      if (delay === 12_000) commandTimeout = fn;
+      return 1;
+    },
+    clearTimeout(){}
+  });
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await Promise.resolve();
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const rebuyPromise = h.client.sendRebuy({ tableId: 'table_test_1', amount: 100 }, 'rebuy_soft_timeout');
+  commandTimeout();
+  let settled = false;
+  rebuyPromise.then(() => { settled = true; }, () => { settled = true; });
+  await Promise.resolve();
+  assert.equal(settled, false);
+  assert.equal(h.sentFrames.some((frame) => frame.type === 'table_state_sub' && frame.payload.view === 'snapshot'), true);
+
+  ws.message({
+    type: 'commandResult',
+    requestId: 'rebuy_soft_timeout',
+    payload: { requestId: 'rebuy_soft_timeout', status: 'accepted' }
+  });
+  assert.equal((await rebuyPromise).requestId, 'rebuy_soft_timeout');
+
+  const pendingVariants = [
+    { type: 'commandResult', requestId: 'rebuy_pending_result', payload: { requestId: 'rebuy_pending_result', status: 'pending', reason: 'request_pending' } },
+    { type: 'commandResult', requestId: 'rebuy_pending_rejected', payload: { requestId: 'rebuy_pending_rejected', status: 'rejected', reason: 'request_pending' } },
+    { type: 'error', requestId: 'rebuy_pending_error', payload: { requestId: 'rebuy_pending_error', code: 'request_pending' } }
+  ];
+  for (const frame of pendingVariants){
+    const requestId = frame.requestId;
+    const promise = h.client.sendRebuy({ tableId: 'table_test_1', amount: 100 }, requestId);
+    let variantSettled = false;
+    promise.then(() => { variantSettled = true; }, () => { variantSettled = true; });
+    ws.message(frame);
+    await Promise.resolve();
+    assert.equal(variantSettled, false, requestId);
+    ws.message({ type: 'commandResult', requestId, payload: { requestId, status: 'accepted' } });
+    assert.equal((await promise).requestId, requestId);
+  }
+});
+
+test('poker ws client retries the same rebuy request id once after reconnect', async () => {
+  const h = loadClientHarness({
+    clientOptions: { reconnectBaseMs: 5, reconnectMaxMs: 5 }
+  });
+  h.client.start();
+  const ws1 = h.FakeWebSocket.instances[0];
+  ws1.open();
+  ws1.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await Promise.resolve();
+  ws1.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const rebuyPromise = h.client.sendRebuy({ tableId: 'table_test_1', amount: 100 }, 'rebuy_reconnect_1');
+  ws1.close(1006, 'abnormal_close');
+  await new Promise((resolve) => setTimeout(resolve, 12));
+  const ws2 = h.FakeWebSocket.instances[1];
+  ws2.open();
+  ws2.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await Promise.resolve();
+  ws2.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+
+  const rebuyFrames = h.sentFrames.filter((frame) => frame.type === 'rebuy');
+  assert.equal(rebuyFrames.length, 2);
+  assert.deepEqual(rebuyFrames.map((frame) => frame.requestId), ['rebuy_reconnect_1', 'rebuy_reconnect_1']);
+  ws2.message({ type: 'commandResult', requestId: 'rebuy_reconnect_1', payload: { requestId: 'rebuy_reconnect_1', status: 'accepted' } });
+  assert.equal((await rebuyPromise).requestId, 'rebuy_reconnect_1');
+});
+
+test('poker ws client rejects an in-memory rebuy when reconnect is not possible', async () => {
+  const h = loadClientHarness({ clientOptions: { autoReconnect: false } });
+  h.client.start();
+  const ws = h.FakeWebSocket.instances[0];
+  ws.open();
+  ws.message({ type: 'helloAck', payload: { version: '1.0' } });
+  await Promise.resolve();
+  ws.message({ type: 'authOk', payload: { roomId: 'table_test_1' } });
+  const rebuyPromise = h.client.sendRebuy({ tableId: 'table_test_1', amount: 100 }, 'rebuy_close_1');
+  ws.close(1000, 'client_shutdown');
+  await assert.rejects(rebuyPromise, (err) => err && err.code === 'ws_closed');
+});
+
 test('poker ws client can queue leave without waiting for commandResult', async () => {
   const h = loadClientHarness();
   h.client.start();


### PR DESCRIPTION
## Summary

Fixes #842.

- Keeps rebuy commands pending across transport timeouts and reconnects.
- Reuses the same requestId for retries and late command results.
- Persists unresolved rebuy operations in sessionStorage and reconciles them only after an authoritative snapshot.
- Avoids a second rebuy when the snapshot already proves a positive stack.
- Preserves existing join resumability and adds regression coverage for timeout, reconnect, reload, snapshot reconciliation, and join behavior.

## Root cause

Rebuy had only a local in-flight flag and no stable requestId. A transport timeout or page reload could discard the client-side operation even though the server-side idempotent request was still pending or had already succeeded.

## Validation

- `npm run syntax`
- `node --test tests/poker-ws-client.test.mjs tests/poker-v2-live.behavior.test.mjs`
- Focused rebuy/backend/client regression suite: 126 passing tests
- `git diff --check`

No backend, SQL, ledger, protocol schema, environment variable, or migration changes are included.