### PR TITLE
Fix split-pot winner congratulations

### DIFF
--- a/docs/ws-poker-protocol.md
+++ b/docs/ws-poker-protocol.md
@@ -59,7 +59,7 @@ Example envelope:
 | `leave` | `{ "reason": string }` | Requests leave/cashout workflow. |
 | `ack` | `{ "seq": integer }` | Acknowledges latest processed server sequence (flow-control aid). |
 | `table_snapshot` | `{ "tableId": string }` (or envelope `roomId`) | Protected read-only gameplay snapshot command. **Requires `requestId`** like other stateful protected commands. Returns viewer-scoped poker state and does not mutate presence membership. |
-| `reaction_send` | `{ "tableId": string, "reactionKey": "hello"|"nice_hand"|"well_played"|"thinking"|"haha"|"wow"|"bad_beat"|"nice_bluff"|"good_luck"|"thanks", "targetSeatNo"?: integer, "handId"?: string }` | Requests one predefined ephemeral reaction. Requires an authenticated seated human sender and `requestId`; the server enforces a four-second sender cooldown. A targeted request must contain both `targetSeatNo` and `handId`, and currently supports only `nice_hand` during the matching settlement reveal window. |
+| `reaction_send` | `{ "tableId": string, "reactionKey": "hello"|"nice_hand"|"well_played"|"thinking"|"haha"|"wow"|"bad_beat"|"nice_bluff"|"good_luck"|"thanks", "targetSeatNo"?: integer, "handId"?: string }` | Requests one predefined ephemeral reaction. Requires an authenticated seated human sender and `requestId`; ordinary reactions have a four-second sender cooldown. A targeted request must contain both `targetSeatNo` and `handId`, and supports one `nice_hand` per sender, settled hand, and winning target during the unchanged settlement reveal window. |
 
 ### Server → Client
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -221,6 +221,8 @@
   var reactionRenderNodes = [];
   var nextTargetedReactionEffectId = 1;
   var dismissedTargetedReactionOffersByKey = {};
+  var pendingTargetedReactionOfferKeys = new Set();
+  var targetedReactionOfferHandId = null;
   var targetedReactionDismissTimer = null;
   var reactionControlTimer = null;
   var reactionControlUntilMs = 0;
@@ -1942,8 +1944,17 @@
     return String(handId || '') + ':' + String(targetSeatNo);
   }
 
+  function syncTargetedReactionOfferHand(handId){
+    var normalizedHandId = handId ? String(handId) : null;
+    if (targetedReactionOfferHandId === normalizedHandId) return;
+    targetedReactionOfferHandId = normalizedHandId;
+    pendingTargetedReactionOfferKeys.clear();
+    dismissedTargetedReactionOffersByKey = {};
+  }
+
   function dismissTargetedReactionOffer(handId, targetSeatNo){
     if (!handId || !Number.isInteger(targetSeatNo)) return;
+    if (targetedReactionOfferHandId !== String(handId)) return;
     dismissedTargetedReactionOffersByKey[targetedReactionOfferKey(handId, targetSeatNo)] = true;
   }
 
@@ -1968,9 +1979,16 @@
     if (state.reconnectGate || !deriveCurrentSeat()) return [];
     var sticky = getActiveWinnerReveal();
     var presentation = sticky && sticky.settlementPresentation;
-    if (!sticky || !presentation || presentation.valid !== true || !presentation.handId) return [];
+    if (!sticky || !presentation || presentation.valid !== true || !presentation.handId){
+      syncTargetedReactionOfferHand(null);
+      return [];
+    }
     var deadlineMs = getTargetedReactionDeadlineMs(sticky);
-    if (!Number.isFinite(deadlineMs) || deadlineMs <= Date.now()) return [];
+    if (!Number.isFinite(deadlineMs) || deadlineMs <= Date.now()){
+      syncTargetedReactionOfferHand(null);
+      return [];
+    }
+    syncTargetedReactionOfferHand(presentation.handId);
     var currentSeat = deriveCurrentSeat();
     var offers = [];
     state.seats.forEach(function(seat){
@@ -2017,6 +2035,8 @@
     targetedReactionEffectNodesById = {};
     reactionRenderNodes = [];
     clearTargetedReactionDismissTimer();
+    pendingTargetedReactionOfferKeys.clear();
+    targetedReactionOfferHandId = null;
     dismissedTargetedReactionOffersByKey = {};
     if (els.reactionLayer) els.reactionLayer.innerHTML = '';
   }
@@ -2103,14 +2123,25 @@
     if (!wsClient || typeof wsClient.sendTargetedReaction !== 'function' || !isWsReady() || !deriveCurrentSeat()) {
       return Promise.resolve(null);
     }
+    var offerKey = targetedReactionOfferKey(handId, targetSeatNo);
+    if (pendingTargetedReactionOfferKeys.has(offerKey) || dismissedTargetedReactionOffersByKey[offerKey]) return Promise.resolve(null);
+    pendingTargetedReactionOfferKeys.add(offerKey);
+    renderSeats();
     return wsClient.sendTargetedReaction(targetSeatNo, handId).then(function(result){
+      pendingTargetedReactionOfferKeys.delete(offerKey);
       dismissTargetedReactionOffer(handId, targetSeatNo);
-      startReactionCooldown();
+      renderSeats();
       return result;
     }).catch(function(error){
+      pendingTargetedReactionOfferKeys.delete(offerKey);
       var code = normalizeSignalCode(error && (error.code || error.message));
+      if (code === 'reaction_already_sent'){
+        dismissTargetedReactionOffer(handId, targetSeatNo);
+        renderSeats();
+        return null;
+      }
       if (code === 'reaction_rate_limited'){
-        startReactionCooldown();
+        renderSeats();
         return null;
       }
       if (code === 'settlement_reaction_window_closed' || code === 'settlement_mismatch'){
@@ -2125,11 +2156,13 @@
         return null;
       }
       if (code === 'not_seated' || code === 'table_closed'){
+        renderSeats();
         renderControls();
         if (wsClient && typeof wsClient.requestGameplaySnapshot === 'function') wsClient.requestGameplaySnapshot();
         return null;
       }
       klog('poker_targeted_reaction_error', { code: code || 'targeted_reaction_failed' });
+      renderSeats();
       return null;
     });
   }
@@ -3136,7 +3169,7 @@
       button.textContent = '👍';
       button.setAttribute('aria-label', 'Send Nice hand');
       button.title = 'Send Nice hand';
-      button.disabled = reactionControlUntilMs > Date.now();
+      button.disabled = pendingTargetedReactionOfferKeys.has(targetedReactionOfferKey(offer.handId, offer.targetSeatNo));
       button.addEventListener('click', function(event){
         if (event && typeof event.stopPropagation === 'function') event.stopPropagation();
         sendTargetedReaction(offer.targetSeatNo, offer.handId);

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -595,8 +595,21 @@ test('poker v2 uses the WS settlement reveal deadline for targeted reactions', a
     .filter((child) => String(child.className || '').includes('poker-seat-target-reaction'));
   assert.equal(targetButtons.length, 2);
   targetButtons[0].click();
+  targetButtons[0].click();
   await harness.flush();
   assert.deepEqual(harness.targetedReactionPayloads, [{ targetSeatNo: 2, handId: 'hand-1' }]);
+
+  const remainingTargetButtons = harness.elements.pokerReactionLayer.children
+    .flatMap((anchor) => anchor.children || [])
+    .filter((child) => String(child.className || '').includes('poker-seat-target-reaction'));
+  assert.equal(remainingTargetButtons.length, 1);
+  assert.equal(remainingTargetButtons[0].disabled, false);
+  remainingTargetButtons[0].click();
+  await harness.flush();
+  assert.deepEqual(harness.targetedReactionPayloads, [
+    { targetSeatNo: 2, handId: 'hand-1' },
+    { targetSeatNo: 3, handId: 'hand-1' }
+  ]);
 
   ws.onReaction({ payload: { seatNo: 1, targetSeatNo: 2, reactionKey: 'nice_hand' } });
   await harness.flush();
@@ -618,7 +631,7 @@ test('poker v2 uses the WS settlement reveal deadline for targeted reactions', a
   const targetButtonsBeforeServerRevealDeadline = harness.elements.pokerReactionLayer.children
     .flatMap((anchor) => anchor.children || [])
     .filter((child) => String(child.className || '').includes('poker-seat-target-reaction'));
-  assert.equal(targetButtonsBeforeServerRevealDeadline.length, 1, 'the unused targeted offer should remain available for the local 3.5-second window');
+  assert.equal(targetButtonsBeforeServerRevealDeadline.length, 0, 'consumed targeted offers should stay hidden for the hand');
   harness.advanceTime(1);
   await harness.flush();
   const targetButtonsAfterServerRevealDeadline = harness.elements.pokerReactionLayer.children

--- a/ws-server/poker/handlers/reaction.behavior.test.mjs
+++ b/ws-server/poker/handlers/reaction.behavior.test.mjs
@@ -60,7 +60,7 @@ test('human reactions use the closed allowlist and atomically reserve the sender
   clearTable(tableId);
 });
 
-test('targeted human reactions require nice_hand, matching settlement facts, and share the cooldown', () => {
+test('targeted human reactions allow each winner once per authoritative settled hand', () => {
   const tableId = 'reaction-targeted-contract';
   clearTable(tableId);
 
@@ -75,9 +75,25 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: true,
     settlementMatchesHand: true,
     settlementWindowOpen: true,
+    settlementHandId: 'hand-a',
     nowMs: 1_000
   });
   assert.deepEqual(first, { ok: true, seatNo: 2, targetSeatNo: 4, reactionKey: 'nice_hand' });
+
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'nice_hand',
+    targeted: true,
+    targetSeatNo: 5,
+    targetOccupied: true,
+    targetIsWinner: true,
+    settlementMatchesHand: true,
+    settlementWindowOpen: true,
+    settlementHandId: 'hand-a',
+    nowMs: 1_000
+  }), { ok: true, seatNo: 2, targetSeatNo: 5, reactionKey: 'nice_hand' });
 
   assert.deepEqual(evaluateHumanReactionCommand({
     tableId,
@@ -90,9 +106,55 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: true,
     settlementMatchesHand: true,
     settlementWindowOpen: true,
+    settlementHandId: 'hand-a',
+    nowMs: 5_001
+  }), { ok: false, reason: 'reaction_already_sent' });
+
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'wow',
+    nowMs: 1_000
+  }), { ok: true, seatNo: 2, reactionKey: 'wow' });
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'hello',
     nowMs: 1_000
   }), { ok: false, reason: 'reaction_rate_limited' });
 
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'nice_hand',
+    targeted: true,
+    targetSeatNo: 4,
+    targetOccupied: true,
+    targetIsWinner: true,
+    settlementMatchesHand: true,
+    settlementWindowOpen: true,
+    settlementHandId: 'hand-b',
+    nowMs: 1_000
+  }), { ok: true, seatNo: 2, targetSeatNo: 4, reactionKey: 'nice_hand' });
+
+  clearTable(tableId);
+  assert.deepEqual(evaluateHumanReactionCommand({
+    tableId,
+    senderUserId: 'human-1',
+    senderSeatNo: 2,
+    reactionKey: 'nice_hand',
+    targeted: true,
+    targetSeatNo: 4,
+    targetOccupied: true,
+    targetIsWinner: true,
+    settlementMatchesHand: true,
+    settlementWindowOpen: true,
+    settlementHandId: 'hand-b',
+    nowMs: 1_000
+  }), { ok: true, seatNo: 2, targetSeatNo: 4, reactionKey: 'nice_hand' });
   clearTable(tableId);
   assert.deepEqual(evaluateHumanReactionCommand({
     tableId,
@@ -105,6 +167,7 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: true,
     settlementMatchesHand: true,
     settlementWindowOpen: true,
+    settlementHandId: 'hand-validation',
     nowMs: 2_000
   }), { ok: false, reason: 'invalid_reaction' });
   assert.deepEqual(evaluateHumanReactionCommand({
@@ -118,6 +181,7 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: true,
     settlementMatchesHand: false,
     settlementWindowOpen: true,
+    settlementHandId: 'hand-validation',
     nowMs: 2_000
   }), { ok: false, reason: 'settlement_mismatch' });
   assert.deepEqual(evaluateHumanReactionCommand({
@@ -131,6 +195,7 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: false,
     settlementMatchesHand: true,
     settlementWindowOpen: true,
+    settlementHandId: 'hand-validation',
     nowMs: 2_000
   }), { ok: false, reason: 'target_not_available' });
   assert.deepEqual(evaluateHumanReactionCommand({
@@ -144,6 +209,7 @@ test('targeted human reactions require nice_hand, matching settlement facts, and
     targetIsWinner: true,
     settlementMatchesHand: true,
     settlementWindowOpen: false,
+    settlementHandId: 'hand-validation',
     nowMs: 2_000
   }), { ok: false, reason: 'settlement_reaction_window_closed' });
 

--- a/ws-server/poker/handlers/reaction.mjs
+++ b/ws-server/poker/handlers/reaction.mjs
@@ -24,6 +24,7 @@ const BOT_REACTION_KEYS_BY_ACTION = Object.freeze({
 
 const senderCooldownUntilByTableUser = new Map();
 const botReactionUntilByTable = new Map();
+const targetedNiceHandByTableUser = new Map();
 
 function normalizeString(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -65,12 +66,14 @@ export function evaluateHumanReactionCommand({
   targetIsWinner = false,
   settlementMatchesHand = false,
   settlementWindowOpen = false,
+  settlementHandId,
   tableClosed = false,
   nowMs
 } = {}) {
   const normalizedTableId = normalizeString(tableId);
   const normalizedUserId = normalizeString(senderUserId);
   const normalizedReactionKey = normalizeString(reactionKey);
+  const normalizedSettlementHandId = normalizeString(settlementHandId);
   const resolvedNowMs = normalizeNowMs(nowMs);
 
   if (!normalizedTableId || !normalizedUserId || !isPositiveSeatNo(senderSeatNo)) {
@@ -95,9 +98,31 @@ export function evaluateHumanReactionCommand({
     if (settlementWindowOpen !== true) {
       return { ok: false, reason: "settlement_reaction_window_closed" };
     }
+    if (!normalizedSettlementHandId) {
+      return { ok: false, reason: "settlement_mismatch" };
+    }
   }
   if (tableClosed === true) {
     return { ok: false, reason: "table_closed" };
+  }
+
+  if (targeted === true) {
+    const dedupeKey = `${normalizedTableId}:${normalizedUserId}`;
+    let dedupe = targetedNiceHandByTableUser.get(dedupeKey);
+    if (!dedupe || dedupe.settlementHandId !== normalizedSettlementHandId) {
+      dedupe = { settlementHandId: normalizedSettlementHandId, targetSeatNos: new Set() };
+      targetedNiceHandByTableUser.set(dedupeKey, dedupe);
+    }
+    if (dedupe.targetSeatNos.has(targetSeatNo)) {
+      return { ok: false, reason: "reaction_already_sent" };
+    }
+    dedupe.targetSeatNos.add(targetSeatNo);
+    return {
+      ok: true,
+      seatNo: senderSeatNo,
+      targetSeatNo,
+      reactionKey: normalizedReactionKey
+    };
   }
 
   const cooldownKey = `${normalizedTableId}:${normalizedUserId}`;
@@ -170,6 +195,9 @@ export function clearTable(tableId) {
   const prefix = `${normalizedTableId}:`;
   for (const key of [...senderCooldownUntilByTableUser.keys()]) {
     if (key.startsWith(prefix)) senderCooldownUntilByTableUser.delete(key);
+  }
+  for (const key of [...targetedNiceHandByTableUser.keys()]) {
+    if (key.startsWith(prefix)) targetedNiceHandByTableUser.delete(key);
   }
   botReactionUntilByTable.delete(normalizedTableId);
 }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -4048,12 +4048,13 @@ wss.on("connection", (ws) => {
       let targetIsWinner = false;
       let settlementMatchesHand = false;
       let settlementWindowOpen = false;
+      let settlementHandId = null;
       if (targeted) {
         const pokerState = tableManager.persistedPokerState(tableId);
         const requestedHandId = typeof reactionPayload.handId === "string" ? reactionPayload.handId.trim() : "";
         const currentHandId = typeof pokerState?.handId === "string" ? pokerState.handId.trim() : "";
         const showdownHandId = typeof pokerState?.showdown?.handId === "string" ? pokerState.showdown.handId.trim() : "";
-        const settlementHandId = typeof pokerState?.handSettlement?.handId === "string" ? pokerState.handSettlement.handId.trim() : "";
+        settlementHandId = typeof pokerState?.handSettlement?.handId === "string" ? pokerState.handSettlement.handId.trim() : "";
         settlementMatchesHand = !!requestedHandId
           && requestedHandId === currentHandId
           && requestedHandId === showdownHandId
@@ -4084,6 +4085,7 @@ wss.on("connection", (ws) => {
         targetIsWinner,
         settlementMatchesHand,
         settlementWindowOpen,
+        settlementHandId,
         tableClosed: tableManager.isTableClosed(tableId),
         nowMs: Date.now()
       });


### PR DESCRIPTION
## Summary

- let a player congratulate every split-pot winner independently
- deduplicate targeted `nice_hand` reactions once per sender, authoritative settled hand, and target seat
- keep ordinary reaction cooldowns and settlement timing windows unchanged

## Root cause

The client disabled every winner button through the shared reaction cooldown, while the server applied the same sender-level cooldown to targeted reactions. The first congratulations therefore blocked all remaining winners.

## Validation

- `node --test tests/poker-v2-live.behavior.test.mjs ws-server/poker/handlers/reaction.behavior.test.mjs`
- targeted `ws-poker-protocol-compliance` integration test
- `npm test`
- syntax checks and `git diff --check`

Fixes #847