### PR TITLE
Clean up historical orphan poker hole cards

### DIFF
--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -294,7 +294,8 @@ be an object with a string `handId`. A non-empty value protects that hand;
 Missing, null, or non-string values fail closed. Candidate age is based on
 `MAX(poker_hole_cards.created_at)`, so one fresh row protects the whole hand.
 The phase uses the existing bot/human action-retention cutoffs and sets local
-`250ms` lock and `2000ms` statement timeouts. Timeout or deadlock rolls back
+`250ms` lock and `10000ms` statement timeouts. The orphan hand batch is capped
+at 25 even when the shared cleanup batch is larger. Timeout or deadlock rolls back
 only this phase; normal cleanup continues and the orphan phase retries on the
 next sweep.
 
@@ -399,7 +400,7 @@ candidate `SELECT` through `EXPLAIN (ANALYZE, BUFFERS)`. Run the complete
 ```sql
 BEGIN;
 SET LOCAL lock_timeout = '250ms';
-SET LOCAL statement_timeout = '2000ms';
+SET LOCAL statement_timeout = '10000ms';
 EXPLAIN (ANALYZE, BUFFERS)
 WITH locked_states AS MATERIALIZED (...),
      orphan_candidates AS MATERIALIZED (...)

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -279,10 +279,24 @@ Once set to `true` the flag never returns to `false`. Existing tables are backfi
 
 This classification affects retention only. It does not make the database authoritative for active gameplay, does not replace `poker_seats` or `poker_state`, and is not consulted by bot claims recovery, terminal accounting, or any gameplay decision.
 
-### Three-phase deletion semantics
+### Four-phase deletion semantics
 
 Cleanup runs in bounded rounds. Each phase has its own database transaction, so
 a successful phase is not rolled back when a later phase fails:
+
+**Historical orphan hole cards.** Before the regular phases, cleanup removes a
+bounded set of old `poker_hole_cards` from `CLOSED` tables only when no
+`poker_actions` exist for the hand. It requires and locks the authoritative
+`poker_state` row with `FOR UPDATE OF ps SKIP LOCKED`, but never locks
+`poker_tables`, avoiding a new cross-table lock-order cycle. The JSON state must
+be an object with a string `handId`. A non-empty value protects that hand;
+`handId: ""` is the canonical terminal sentinel and means no current hand.
+Missing, null, or non-string values fail closed. Candidate age is based on
+`MAX(poker_hole_cards.created_at)`, so one fresh row protects the whole hand.
+The phase uses the existing bot/human action-retention cutoffs and sets local
+`250ms` lock and `2000ms` statement timeouts. Timeout or deadlock rolls back
+only this phase; normal cleanup continues and the orphan phase retries on the
+next sweep.
 
 **Hole cards phase.** Deletes `poker_hole_cards` for unique `(table_id, hand_id)`
 hands whose `HAND_SETTLED` marker is older than the applicable action-retention
@@ -294,7 +308,11 @@ same sweep, but is retried by the next sweep.
 
 **Phase 2 — settlement markers.** Deletes old `HAND_SETTLED` rows only when no ordinary actions and no `poker_hole_cards` remain for the same hand (two correlated `NOT EXISTS` checks). This guarantees that a marker remains available for a later hole-card retry if that phase previously failed.
 
-The order in every round is hole cards, Phase 1, then Phase 2. A hole-card failure does not block the action phases. A Phase 1 or Phase 2 failure stops later rounds. All phases use bounded `locked_tables` and candidate CTEs followed by `DELETE … RETURNING id`. Bot and human cutoffs are selected through classification predicates (`has_human_participant`) inside each CTE.
+The order in every round is orphan hole cards, regular hole cards, Phase 1,
+then Phase 2. An orphan or regular hole-card failure does not block the action
+phases. A Phase 1 or Phase 2 failure stops later rounds. Candidate CTEs are
+bounded and feed `DELETE … RETURNING`; bot and human cutoffs are selected
+through `has_human_participant` predicates.
 
 `batchSize` limits the number of candidate hands (hole cards and Phase 1) or settlement rows (Phase 2) selected per sweep, not the number of physical rows deleted. A single candidate hand may contain multiple hole-card or ordinary-action rows, so the corresponding deleted counters may be much larger than `batchSize`.
 
@@ -366,10 +384,39 @@ Editing an already-applied migration is not allowed. Use a new timestamped migra
 
 | Event | Severity | Fields |
 |-------|----------|--------|
-| `ws_action_history_cleanup_complete` | INFO | `holeCardsDeleted`, `phase1Deleted`, `phase2Deleted`, `batchSize`, `lockLimit` |
+| `ws_action_history_cleanup_complete` | INFO | `orphanHoleCardsDeleted`, `holeCardsDeleted`, `phase1Deleted`, `phase2Deleted`, `batchSize`, `lockLimit` |
 | `ws_action_history_cleanup_failed` | ERROR | stable `errorCode`, ordered `failedPhases`, completed phase counters |
 
-The `complete` event is emitted only when at least one row was deleted. A no-op with enabled retention remains a successful, quiet sweep. The `failed` event is emitted after a sweep with one or more failed phases. Because transactions are separate, `failed` does not mean that successful phase counters were rolled back; the panel may show positive deletion counts together with `failed`.
+The `complete` event is emitted only when at least one row was deleted. A no-op with enabled retention remains a successful, quiet sweep. The `failed` event is emitted after a sweep with one or more failed phases. `orphan_hole_cards_cleanup_failed` identifies the recovery phase without weakening the regular `HAND_SETTLED` path. Because transactions are separate, `failed` does not mean that successful phase counters were rolled back; the panel may show positive deletion counts together with `failed`.
+
+### Historical orphan SQL rollout gate
+
+Do not deploy a revision that introduces or changes the orphan phase before
+examining its final SQL against the target Stage backlog. First run the
+candidate `SELECT` through `EXPLAIN (ANALYZE, BUFFERS)`. Run the complete
+`DELETE` plan only inside an explicitly rolled-back transaction:
+
+```sql
+BEGIN;
+SET LOCAL lock_timeout = '250ms';
+SET LOCAL statement_timeout = '2000ms';
+EXPLAIN (ANALYZE, BUFFERS)
+WITH locked_states AS MATERIALIZED (...),
+     orphan_candidates AS MATERIALIZED (...)
+DELETE FROM public.poker_hole_cards hc
+USING orphan_candidates oc
+WHERE hc.table_id = oc.table_id AND hc.hand_id = oc.hand_id
+RETURNING hc.table_id, hc.hand_id, hc.user_id;
+ROLLBACK;
+```
+
+Record the eligible orphan count before and after and require equality after
+the rollback. If the final query exceeds the statement budget or performs an
+unacceptable scan, compare real plans before choosing an index. In particular,
+evaluate existing indexes against `(table_id, hand_id, created_at)` and
+`(created_at, table_id, hand_id)`; do not add a migration speculatively. If an
+index is required, apply it to Stage and repeat both plans before the first WS
+Preview deploy containing the active phase.
 
 **Preview verification commands:**
 

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -1257,6 +1257,8 @@
       || tables.desired == null
       || tables.enabled == null
       || !backlog
+      || backlog.orphanHoleCardHands == null
+      || backlog.orphanHoleCardRows == null
       || backlog.ordinaryActionRows == null
       || backlog.handSettledRows == null;
     var availabilityLabel = primarySources === 0 ? "Unavailable" : missingMetric ? "Partial" : "Available";
@@ -1321,6 +1323,8 @@
       '<div class="admin-surface">',
       '<div class="admin-list__title"><span>Cleanup</span></div>',
       '<div class="admin-kv">',
+      renderKvRow("Next cleanup batch · orphan hands", backlog ? backlog.orphanHoleCardHands : null),
+      renderKvRow("Next cleanup batch · orphan card rows", backlog ? backlog.orphanHoleCardRows : null),
       renderKvRow("Next cleanup batch · ordinary rows", backlog ? backlog.ordinaryActionRows : null),
       renderKvRow("Next cleanup batch · HAND_SETTLED", backlog ? backlog.handSettledRows : null),
       renderKvRow("Batch capped", backlog && backlog.cappedAtBatchSize != null ? (backlog.cappedAtBatchSize ? "yes" : "no") : null),
@@ -1752,10 +1756,13 @@
         renderKvRow("Human HAND_SETTLED retention", cleanup.retention && cleanup.retention.humanSettledMs),
         renderKvRow("Batch size", cleanup.batchSize),
         renderKvRow("Cleanup rounds per sweep", cleanup.sweepRounds),
+        renderKvRow("Next cleanup batch · orphan hands", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.orphanHoleCardHands : "unavailable"),
+        renderKvRow("Next cleanup batch · orphan card rows", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.orphanHoleCardRows : "unavailable"),
         renderKvRow("Next cleanup batch · ordinary rows", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.ordinaryActionRows : "unavailable"),
         renderKvRow("Next cleanup batch · HAND_SETTLED", cleanup.backlog && cleanup.backlog.available ? cleanup.backlog.handSettledRows : "unavailable"),
         renderKvRow("Last cleanup", formatTimestamp(lastRun.finishedAt)),
         renderKvRow("Last cleanup result", lastRun.result || "—"),
+        renderKvRow("Last orphan hole-card deletes", lastRun.orphanHoleCardsDeleted == null ? "—" : String(lastRun.orphanHoleCardsDeleted)),
         renderKvRow("Last hole-card deletes", lastRun.holeCardsDeleted == null ? "—" : String(lastRun.holeCardsDeleted)),
         renderKvRow("Last phase deletes", lastRun.phase1Deleted == null ? "—" : String(lastRun.phase1Deleted) + "/" + String(lastRun.phase2Deleted || 0)),
         renderKvRow("Failed phases", Array.isArray(lastRun.failedPhases) && lastRun.failedPhases.length ? lastRun.failedPhases.join(", ") : "—"),

--- a/netlify/functions/admin-poker-maintenance.mjs
+++ b/netlify/functions/admin-poker-maintenance.mjs
@@ -41,13 +41,16 @@ function controlError(code, status = 400, details = null) {
 
 function projectMaintenanceFailure(value) {
   if (!value || typeof value !== "object") return {};
-  const allowedPhases = ["hole_cards", "ordinary_actions", "hand_settled"];
+  const allowedPhases = ["orphan_hole_cards", "hole_cards", "ordinary_actions", "hand_settled"];
   const failedPhases = Array.isArray(value.failedPhases)
     ? allowedPhases.filter((phase) => value.failedPhases.includes(phase))
     : [];
   const result = {};
   if (typeof value.operation === "string") result.operation = value.operation;
   if (typeof value.result === "string") result.result = value.result;
+  if (Number.isSafeInteger(value.orphanHoleCardsDeleted) && value.orphanHoleCardsDeleted >= 0) {
+    result.orphanHoleCardsDeleted = value.orphanHoleCardsDeleted;
+  }
   if (Number.isSafeInteger(value.holeCardsDeleted) && value.holeCardsDeleted >= 0) {
     result.holeCardsDeleted = value.holeCardsDeleted;
   }

--- a/netlify/functions/admin-vps-metrics.mjs
+++ b/netlify/functions/admin-vps-metrics.mjs
@@ -118,10 +118,11 @@ function normalizeMetricsSnapshot(value, target) {
   const cleanup = projectFields(value.cleanup, []);
   if (cleanup) {
     cleanup.backlog = projectFields(value.cleanup.backlog, [
-      "ordinaryActionRows", "handSettledRows", "cappedAtBatchSize", "measuredAt"
+      "orphanHoleCardHands", "orphanHoleCardRows", "ordinaryActionRows", "handSettledRows",
+      "cappedAtBatchSize", "measuredAt"
     ]);
     cleanup.lastRun = projectFields(value.cleanup.lastRun, [
-      "finishedAt", "durationMs", "holeCardsDeleted", "phase1Deleted", "phase2Deleted",
+      "finishedAt", "durationMs", "orphanHoleCardsDeleted", "holeCardsDeleted", "phase1Deleted", "phase2Deleted",
       "deletedRows", "result", "errorCode", "failedPhases"
     ]);
   }

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -564,7 +564,7 @@ function buildContext(options = {}) {
         },
         continuousTables: opts.vpsMetricsHostOnly ? null : { active: 2, desired: 2, enabled: true },
         cleanup: opts.vpsMetricsHostOnly ? null : {
-          backlog: { ordinaryActionRows: 0, handSettledRows: 0, cappedAtBatchSize: true, measuredAt: "2026-08-02T18:59:58.000Z" },
+          backlog: { orphanHoleCardHands: 0, orphanHoleCardRows: 0, ordinaryActionRows: 0, handSettledRows: 0, cappedAtBatchSize: true, measuredAt: "2026-08-02T18:59:58.000Z" },
           lastRun: { finishedAt: "2026-08-02T18:55:00.000Z", durationMs: 184, deletedRows: 37, result: "success" },
         },
       }) };
@@ -575,6 +575,7 @@ function buildContext(options = {}) {
           error: "cleanup_failed",
           operation: "cleanup",
           result: "failed",
+          orphanHoleCardsDeleted: 3,
           holeCardsDeleted: 4,
           phase1Deleted: 9,
           phase2Deleted: 2,
@@ -598,8 +599,8 @@ function buildContext(options = {}) {
           retention: { botActionsMs: 1000, botSettledMs: 2000, humanActionsMs: 3000, humanSettledMs: 4000 },
           batchSize: 5,
           sweepRounds: 1,
-          backlog: { available: true, ordinaryActionRows: 0, handSettledRows: 0 },
-          lastRun: { finishedAt: null, durationMs: 1, holeCardsDeleted: 0, phase1Deleted: 0, phase2Deleted: 0, result: "success", failedPhases: [], errorCode: null }
+          backlog: { available: true, orphanHoleCardHands: 0, orphanHoleCardRows: 0, ordinaryActionRows: 0, handSettledRows: 0 },
+          lastRun: { finishedAt: null, durationMs: 1, orphanHoleCardsDeleted: 0, holeCardsDeleted: 0, phase1Deleted: 0, phase2Deleted: 0, result: "success", failedPhases: [], errorCode: null }
         }
       }) };
     }

--- a/tests/admin-poker-maintenance.behavior.test.mjs
+++ b/tests/admin-poker-maintenance.behavior.test.mjs
@@ -195,6 +195,7 @@ test("maintenance proxy accepts the environment from an actual WS POST response"
     assert.deepEqual(JSON.parse(response.body), {
       ok: true,
       operation: "cleanup",
+      orphanHoleCardsDeleted: 0,
       holeCardsDeleted: 0,
       phase1Deleted: 0,
       phase2Deleted: 0,
@@ -242,6 +243,7 @@ test("maintenance proxy preserves cleanup failure counters and failed phases fro
         ok: false,
         operation: "cleanup",
         result: "failed",
+        orphanHoleCardsDeleted: 3,
         holeCardsDeleted: 4,
         phase1Deleted: 9,
         phase2Deleted: 2,
@@ -257,6 +259,7 @@ test("maintenance proxy preserves cleanup failure counters and failed phases fro
   assert.deepEqual(JSON.parse(response.body), {
     operation: "cleanup",
     result: "failed",
+    orphanHoleCardsDeleted: 3,
     holeCardsDeleted: 4,
     phase1Deleted: 9,
     phase2Deleted: 2,

--- a/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
@@ -18,6 +18,78 @@ function mockTx(handlers) {
 const HOUR = 3_600_000;
 const DAY = 86_400_000;
 
+test("orphan phase is bounded, state-locked, type-safe, and reports separate deletes", async () => {
+  const queries = [];
+  const timeoutValues = [];
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: String(DAY),
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "7"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql, params) => {
+        queries.push(sql);
+        if (sql.includes("set_config")) {
+          timeoutValues.push(params?.[0]);
+          return [];
+        }
+        if (sql.includes("orphan_candidates") && sql.includes("delete from public.poker_hole_cards")) {
+          assert.equal(params[2], 7);
+          assert.equal(params[3], 14);
+          return [{ user_id: "u1" }, { user_id: "u2" }];
+        }
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, true);
+  assert.equal(result.orphanHoleCardsDeleted, 2);
+  assert.equal(result.holeCardsDeleted, 0);
+  const orphanSql = queries.find((sql) => sql.includes("orphan_candidates") && sql.includes("delete from public.poker_hole_cards"));
+  assert.match(orphanSql, /for update of ps skip locked/i);
+  assert.doesNotMatch(orphanSql, /for update of t/i);
+  assert.match(orphanSql, /jsonb_typeof\(ps\.state -> 'handId'\) = 'string'/i);
+  assert.match(orphanSql, /max\(hc\.created_at\)/i);
+  assert.match(orphanSql, /not exists[\s\S]+public\.poker_actions/i);
+  assert.deepEqual(timeoutValues.slice(0, 2), ["250ms", "2000ms"]);
+});
+
+test("orphan phase failure is isolated from the existing cleanup phases", async () => {
+  let ordinaryCalls = 0;
+  const cleanup = createActionHistoryCleanup({
+    env: {
+      WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
+      WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+      WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+      WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "5"
+    },
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("set_config('lock_timeout'")) throw new Error("lock timeout");
+        if (sql.includes("candidate_hands")) {
+          ordinaryCalls += 1;
+          return [{ id: 1 }];
+        }
+        return [];
+      }
+    })
+  });
+
+  const result = await cleanup.sweep();
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, "orphan_hole_cards_cleanup_failed");
+  assert.deepEqual(result.failedPhases, ["orphan_hole_cards"]);
+  assert.equal(result.orphanHoleCardsDeleted, 0);
+  assert.equal(result.phase1Deleted, 1);
+  assert.equal(ordinaryCalls, 1);
+});
+
 // ---------------------------------------------------------------------------
 // Phase 1
 // ---------------------------------------------------------------------------

--- a/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.behavior.test.mjs
@@ -18,7 +18,7 @@ function mockTx(handlers) {
 const HOUR = 3_600_000;
 const DAY = 86_400_000;
 
-test("orphan phase is bounded, state-locked, type-safe, and reports separate deletes", async () => {
+test("orphan phase applies its hand cap and timeout without changing the shared lock limit", async () => {
   const queries = [];
   const timeoutValues = [];
   const cleanup = createActionHistoryCleanup({
@@ -27,7 +27,7 @@ test("orphan phase is bounded, state-locked, type-safe, and reports separate del
       WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
       WS_POKER_HUMAN_ACTION_RETENTION_MS: String(DAY),
       WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
-      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "7"
+      WS_POKER_ACTION_HISTORY_BATCH_SIZE: "50"
     },
     beginSql: async (fn) => fn({
       unsafe: async (sql, params) => {
@@ -37,8 +37,8 @@ test("orphan phase is bounded, state-locked, type-safe, and reports separate del
           return [];
         }
         if (sql.includes("orphan_candidates") && sql.includes("delete from public.poker_hole_cards")) {
-          assert.equal(params[2], 7);
-          assert.equal(params[3], 14);
+          assert.equal(params[2], 25);
+          assert.equal(params[3], 100);
           return [{ user_id: "u1" }, { user_id: "u2" }];
         }
         return [];
@@ -56,11 +56,17 @@ test("orphan phase is bounded, state-locked, type-safe, and reports separate del
   assert.match(orphanSql, /jsonb_typeof\(ps\.state -> 'handId'\) = 'string'/i);
   assert.match(orphanSql, /max\(hc\.created_at\)/i);
   assert.match(orphanSql, /not exists[\s\S]+public\.poker_actions/i);
-  assert.deepEqual(timeoutValues.slice(0, 2), ["250ms", "2000ms"]);
+  assert.deepEqual(timeoutValues.slice(0, 2), ["250ms", "10000ms"]);
 });
 
 test("orphan phase failure is isolated from the existing cleanup phases", async () => {
   let ordinaryCalls = 0;
+  const logs = [];
+  const databaseError = Object.assign(new Error("canceling statement due to statement timeout"), {
+    code: "57014",
+    detail: "bounded orphan candidate scan exceeded its statement budget",
+    where: "SQL statement in orphan cleanup"
+  });
   const cleanup = createActionHistoryCleanup({
     env: {
       WS_POKER_BOT_ACTION_RETENTION_MS: String(HOUR),
@@ -71,14 +77,15 @@ test("orphan phase failure is isolated from the existing cleanup phases", async 
     },
     beginSql: async (fn) => fn({
       unsafe: async (sql) => {
-        if (sql.includes("set_config('lock_timeout'")) throw new Error("lock timeout");
+        if (sql.includes("set_config('lock_timeout'")) throw databaseError;
         if (sql.includes("candidate_hands")) {
           ordinaryCalls += 1;
           return [{ id: 1 }];
         }
         return [];
       }
-    })
+    }),
+    klog: (event, fields) => logs.push({ event, fields })
   });
 
   const result = await cleanup.sweep();
@@ -88,6 +95,13 @@ test("orphan phase failure is isolated from the existing cleanup phases", async 
   assert.equal(result.orphanHoleCardsDeleted, 0);
   assert.equal(result.phase1Deleted, 1);
   assert.equal(ordinaryCalls, 1);
+  const failureLog = logs.find((entry) => entry.event === "ws_action_history_cleanup_failed");
+  assert.deepEqual(failureLog?.fields?.orphanFailure, {
+    code: "57014",
+    message: "canceling statement due to statement timeout",
+    detail: "bounded orphan candidate scan exceeded its statement budget",
+    where: "SQL statement in orphan cleanup"
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -116,7 +116,7 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
     );
     await db.unsafe(
       "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
-      [tableId, JSON.stringify({ phase: "HAND_DONE", handId: "" })]
+      [tableId, { phase: "HAND_DONE", handId: "" }]
     );
 
     await db.unsafe(
@@ -165,7 +165,7 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
       if (protectedCase.state) {
         await db.unsafe(
           "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
-          [protectedTableId, JSON.stringify(protectedCase.state)]
+          [protectedTableId, protectedCase.state]
         );
       }
       for (let index = 0; index < protectedCase.dates.length; index += 1) {
@@ -308,7 +308,7 @@ test("orphan cleanup skips a locked state and protects the hand committed as cur
     );
     await cleanupDb.unsafe(
       "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
-      [tableId, JSON.stringify({ phase: "HAND_DONE", handId: "" })]
+      [tableId, { phase: "HAND_DONE", handId: "" }]
     );
     await cleanupDb.unsafe(
       `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
@@ -322,7 +322,7 @@ test("orphan cleanup skips a locked state and protects the hand committed as cur
       await writerRelease;
       await tx.unsafe(
         "update public.poker_state set state = $2::jsonb where table_id = $1",
-        [tableId, JSON.stringify({ phase: "FLOP", handId })]
+        [tableId, { phase: "FLOP", handId }]
       );
     });
     await stateLocked;

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -89,7 +89,7 @@ function beginSql(db, afterTransaction) {
 }
 
 function earlySortedTableId() {
-  return `00000000-0000-0000-0000-${randomUUID().slice(-12)}`;
+  return "00000000-0000-0000-0000-000000000000";
 }
 
 test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL", { skip: !HAS_DB }, async () => {

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -200,6 +200,26 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
       })
     });
 
+    const orphanFixture = await db.unsafe(
+      `select t.status,
+              t.has_human_participant,
+              ps.state,
+              jsonb_typeof(ps.state -> 'handId') as hand_id_type,
+              hc.created_at,
+              hc.hand_id <> ps.state ->> 'handId' as differs_from_current,
+              exists (select 1 from public.poker_actions pa where pa.table_id = hc.table_id and pa.hand_id = hc.hand_id) as has_actions
+         from public.poker_hole_cards hc
+         join public.poker_state ps on ps.table_id = hc.table_id
+         join public.poker_tables t on t.id = hc.table_id
+        where hc.table_id = $1 and hc.hand_id = $2`,
+      [tableId, orphanHandId]
+    );
+    assert.equal(orphanFixture.length, 1);
+    assert.equal(orphanFixture[0].status, "CLOSED", JSON.stringify(orphanFixture[0]));
+    assert.equal(orphanFixture[0].hand_id_type, "string", JSON.stringify(orphanFixture[0]));
+    assert.equal(orphanFixture[0].differs_from_current, true, JSON.stringify(orphanFixture[0]));
+    assert.equal(orphanFixture[0].has_actions, false, JSON.stringify(orphanFixture[0]));
+
     const first = await cleanup.sweep();
     assert.equal(first.ok, true);
     const orphanAfterFirst = await db.unsafe(

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -202,7 +202,12 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
 
     const first = await cleanup.sweep();
     assert.equal(first.ok, true);
-    assert.equal(first.orphanHoleCardsDeleted, 1);
+    const orphanAfterFirst = await db.unsafe(
+      "select count(*)::bigint as rows from public.poker_hole_cards where table_id = $1 and hand_id = $2",
+      [tableId, orphanHandId]
+    );
+    assert.equal(Number(orphanAfterFirst[0].rows), 0, `orphan cleanup result: ${JSON.stringify(first)}`);
+    assert.equal(first.orphanHoleCardsDeleted, 1, `orphan cleanup result: ${JSON.stringify(first)}`);
     assert.equal(first.holeCardsDeleted, 1);
     assert.equal(first.phase1Deleted, 1);
     assert.equal(first.phase2Deleted, 1);

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -88,6 +88,10 @@ function beginSql(db, afterTransaction) {
   };
 }
 
+function earlySortedTableId() {
+  return `00000000-0000-0000-0000-${randomUUID().slice(-12)}`;
+}
+
 test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL", { skip: !HAS_DB }, async () => {
   const db = await connect();
   let tableId = null;
@@ -104,7 +108,7 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
 
   try {
     await ensureSchema(db);
-    tableId = randomUUID();
+    tableId = earlySortedTableId();
     cleanupTableIds.push(tableId);
     await db.unsafe(
       "insert into public.poker_tables (id, status, has_human_participant) values ($1, 'CLOSED', false)",
@@ -263,7 +267,7 @@ test("orphan cleanup skips a locked state and protects the hand committed as cur
   const postgres = (await import("postgres")).default;
   const cleanupDb = postgres(dbUrl, { max: 1, idle_timeout: 5 });
   const writerDb = postgres(dbUrl, { max: 1, idle_timeout: 5 });
-  const tableId = randomUUID();
+  const tableId = earlySortedTableId();
   const handId = `cleanup-concurrent-${randomUUID()}`;
   const oldCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   let releaseWriter;

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -366,3 +366,70 @@ test("orphan cleanup skips a locked state and protects the hand committed as cur
     await Promise.all([cleanupDb.end(), writerDb.end()]);
   }
 });
+
+test("mixed-age tables cannot starve a later eligible orphan", { skip: !HAS_DB }, async () => {
+  const db = await connect();
+  const tableIds = [
+    "00000000-0000-0000-0000-000000000100",
+    "00000000-0000-0000-0000-000000000101",
+    "00000000-0000-0000-0000-000000000102"
+  ];
+  const oldCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const recentCreatedAt = new Date().toISOString();
+  const orphanHandId = `eligible-${randomUUID()}`;
+
+  try {
+    await ensureSchema(db);
+    for (const [index, tableId] of tableIds.entries()) {
+      await db.unsafe(
+        "insert into public.poker_tables (id, status, has_human_participant) values ($1, 'CLOSED', false)",
+        [tableId]
+      );
+      await db.unsafe(
+        "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+        [tableId, { phase: "HAND_DONE", handId: "" }]
+      );
+      const handId = index < 2 ? `mixed-${randomUUID()}` : orphanHandId;
+      const dates = index < 2 ? [oldCreatedAt, recentCreatedAt] : [oldCreatedAt];
+      for (const createdAt of dates) {
+        await db.unsafe(
+          `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+           values ($1, $2, $3, $4::jsonb, $5)`,
+          [tableId, handId, randomUUID(), JSON.stringify(["6H", "7H"]), createdAt]
+        );
+      }
+    }
+
+    const cleanup = createActionHistoryCleanup({
+      maxSweepRounds: 1,
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: String(60 * 60 * 1000),
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "1"
+      },
+      beginSql: beginSql(db)
+    });
+    const result = await cleanup.sweep();
+    assert.equal(result.ok, true);
+    assert.equal(result.orphanHoleCardsDeleted, 1);
+    const remaining = await db.unsafe(
+      "select count(*)::bigint as rows from public.poker_hole_cards where table_id = $1 and hand_id = $2",
+      [tableIds[2], orphanHandId]
+    );
+    assert.equal(Number(remaining[0].rows), 0);
+  } finally {
+    await db.unsafe("delete from public.poker_hole_cards where table_id = any($1::uuid[])", [tableIds]);
+    await db.unsafe("delete from public.poker_actions where table_id = any($1::uuid[])", [tableIds]);
+    await db.unsafe("delete from public.poker_state where table_id = any($1::uuid[])", [tableIds]);
+    await db.unsafe("delete from public.poker_tables where id = any($1::uuid[])", [tableIds]);
+    if (createdMinimalSchema) {
+      await db.unsafe("drop table if exists public.poker_hole_cards");
+      await db.unsafe("drop table if exists public.poker_actions");
+      await db.unsafe("drop table if exists public.poker_state");
+      await db.unsafe("drop table if exists public.poker_tables");
+    }
+    await db.end();
+  }
+});

--- a/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
@@ -23,6 +23,7 @@ async function ensureSchema(db) {
   const rows = await db.unsafe(`
     select
       to_regclass('public.poker_tables') as tables_regclass,
+      to_regclass('public.poker_state') as state_regclass,
       to_regclass('public.poker_actions') as actions_regclass,
       to_regclass('public.poker_hole_cards') as hole_cards_regclass,
       exists (
@@ -34,20 +35,26 @@ async function ensureSchema(db) {
       ) as has_human_participant
   `);
   const row = rows[0];
-  const present = [row.tables_regclass, row.actions_regclass, row.hole_cards_regclass]
+  const present = [row.tables_regclass, row.state_regclass, row.actions_regclass, row.hole_cards_regclass]
     .filter(Boolean).length;
 
-  if (present > 0 && (present < 3 || row.has_human_participant !== true)) {
+  if (present > 0 && (present < 4 || row.has_human_participant !== true)) {
     throw new Error(
       "TEST_DB_URL has an incomplete poker cleanup schema; use a disposable database with current migrations"
     );
   }
-  if (present === 3) return;
+  if (present === 4) return;
 
   await db.unsafe(`
     create table public.poker_tables (
       id uuid primary key,
+      status text not null default 'OPEN',
       has_human_participant boolean not null default false
+    );
+    create table public.poker_state (
+      table_id uuid primary key,
+      version bigint not null default 0,
+      state jsonb not null default '{}'::jsonb
     );
     create table public.poker_actions (
       id bigserial primary key,
@@ -84,9 +91,12 @@ function beginSql(db, afterTransaction) {
 test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL", { skip: !HAS_DB }, async () => {
   const db = await connect();
   let tableId = null;
+  const cleanupTableIds = [];
   const regularHandId = `cleanup-regular-${randomUUID()}`;
+  const orphanHandId = `cleanup-orphan-${randomUUID()}`;
   const activeHandId = `cleanup-active-${randomUUID()}`;
   const guardedHandId = `cleanup-guarded-${randomUUID()}`;
+  const actionGuardedHandId = `cleanup-action-guarded-${randomUUID()}`;
   const userId = randomUUID();
   const oldCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const recentCreatedAt = new Date().toISOString();
@@ -95,9 +105,14 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
   try {
     await ensureSchema(db);
     tableId = randomUUID();
+    cleanupTableIds.push(tableId);
     await db.unsafe(
-      "insert into public.poker_tables (id, has_human_participant) values ($1, false)",
+      "insert into public.poker_tables (id, status, has_human_participant) values ($1, 'CLOSED', false)",
       [tableId]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [tableId, JSON.stringify({ phase: "HAND_DONE", handId: "" })]
     );
 
     await db.unsafe(
@@ -106,8 +121,9 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
          ($1, $2, 'CHECK', $3),
          ($1, $2, 'HAND_SETTLED', $3),
          ($1, $4, 'CHECK', $5),
-         ($1, $6, 'HAND_SETTLED', $3)`,
-      [tableId, regularHandId, oldCreatedAt, activeHandId, recentCreatedAt, guardedHandId]
+         ($1, $6, 'HAND_SETTLED', $3),
+         ($1, $7, 'CHECK', $3)`,
+      [tableId, regularHandId, oldCreatedAt, activeHandId, recentCreatedAt, guardedHandId, actionGuardedHandId]
     );
     await db.unsafe(
       `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
@@ -119,6 +135,43 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
        values ($1, $2, $3, $4::jsonb, $5)`,
       [tableId, activeHandId, userId, JSON.stringify(["QH", "JC"]), recentCreatedAt]
     );
+    await db.unsafe(
+      `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+       values
+         ($1, $2, $3, $4::jsonb, $5),
+         ($1, $6, $3, $4::jsonb, $5)`,
+      [tableId, orphanHandId, userId, JSON.stringify(["9H", "9C"]), oldCreatedAt, actionGuardedHandId]
+    );
+
+    const protectedCases = [
+      { status: "OPEN", state: { phase: "HAND_DONE", handId: "" }, handId: `open-${randomUUID()}`, dates: [oldCreatedAt] },
+      { status: "CLOSED", state: { phase: "FLOP", handId: `current-${randomUUID()}` }, current: true, dates: [oldCreatedAt] },
+      { status: "CLOSED", state: null, handId: `missing-state-${randomUUID()}`, dates: [oldCreatedAt] },
+      { status: "CLOSED", state: { phase: "HAND_DONE", handId: null }, handId: `invalid-state-${randomUUID()}`, dates: [oldCreatedAt] },
+      { status: "CLOSED", state: { phase: "HAND_DONE", handId: "" }, handId: `mixed-age-${randomUUID()}`, dates: [oldCreatedAt, recentCreatedAt] }
+    ];
+    for (const protectedCase of protectedCases) {
+      const protectedTableId = randomUUID();
+      cleanupTableIds.push(protectedTableId);
+      if (protectedCase.current) protectedCase.handId = protectedCase.state.handId;
+      await db.unsafe(
+        "insert into public.poker_tables (id, status, has_human_participant) values ($1, $2, false)",
+        [protectedTableId, protectedCase.status]
+      );
+      if (protectedCase.state) {
+        await db.unsafe(
+          "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+          [protectedTableId, JSON.stringify(protectedCase.state)]
+        );
+      }
+      for (let index = 0; index < protectedCase.dates.length; index += 1) {
+        await db.unsafe(
+          `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+           values ($1, $2, $3, $4::jsonb, $5)`,
+          [protectedTableId, protectedCase.handId, randomUUID(), JSON.stringify(["4S", "5S"]), protectedCase.dates[index]]
+        );
+      }
+    }
 
     const cleanup = createActionHistoryCleanup({
       maxSweepRounds: 1,
@@ -133,7 +186,7 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
         phaseTransactions += 1;
         // The first transaction is the real hole-card phase. Add a card after
         // it commits so the real phase-2 SQL must preserve its HAND_SETTLED row.
-        if (phaseTransactions === 1) {
+        if (phaseTransactions === 2) {
           await db.unsafe(
             `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
              values ($1, $2, $3, $4::jsonb, $5)`,
@@ -145,6 +198,7 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
 
     const first = await cleanup.sweep();
     assert.equal(first.ok, true);
+    assert.equal(first.orphanHoleCardsDeleted, 1);
     assert.equal(first.holeCardsDeleted, 1);
     assert.equal(first.phase1Deleted, 1);
     assert.equal(first.phase2Deleted, 1);
@@ -161,9 +215,18 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
     assert.equal(Number(afterFirst[0].guarded_marker), 1, "HAND_SETTLED must remain for retry");
     assert.equal(Number(afterFirst[0].active_cards), 1, "active hand cards must remain");
     assert.equal(Number(afterFirst[0].active_actions), 1, "active hand actions must remain");
+    const protectedCount = await db.unsafe(
+      `select count(*)::bigint as rows
+         from public.poker_hole_cards
+        where table_id = any($1::uuid[])
+          and hand_id <> $2`,
+      [cleanupTableIds, orphanHandId]
+    );
+    assert.equal(Number(protectedCount[0].rows), 9, "open, current, malformed, fresh, mixed-age, and action-bearing hands must remain");
 
     const second = await cleanup.sweep();
     assert.equal(second.ok, true);
+    assert.equal(second.orphanHoleCardsDeleted, 0);
     assert.equal(second.holeCardsDeleted, 1);
     assert.equal(second.phase1Deleted, 0);
     assert.equal(second.phase2Deleted, 1);
@@ -179,17 +242,98 @@ test("action-history cleanup executes hole-card and settlement SQL on PostgreSQL
     assert.equal(Number(afterSecond[0].guarded_marker), 0, "marker should be removable after cards are gone");
     assert.equal(Number(afterSecond[0].active_actions), 1, "active hand must remain untouched");
   } finally {
-    if (tableId) {
-      await db.unsafe("delete from public.poker_hole_cards where table_id = $1", [tableId]);
-      await db.unsafe("delete from public.poker_actions where table_id = $1", [tableId]);
-      await db.unsafe("delete from public.poker_tables where id = $1", [tableId]);
+    if (cleanupTableIds.length > 0) {
+      await db.unsafe("delete from public.poker_hole_cards where table_id = any($1::uuid[])", [cleanupTableIds]);
+      await db.unsafe("delete from public.poker_actions where table_id = any($1::uuid[])", [cleanupTableIds]);
+      await db.unsafe("delete from public.poker_state where table_id = any($1::uuid[])", [cleanupTableIds]);
+      await db.unsafe("delete from public.poker_tables where id = any($1::uuid[])", [cleanupTableIds]);
     }
     if (createdMinimalSchema) {
       await db.unsafe("drop table if exists public.poker_hole_cards");
       await db.unsafe("drop table if exists public.poker_actions");
+      await db.unsafe("drop table if exists public.poker_state");
       await db.unsafe("drop table if exists public.poker_tables");
     }
     await db.end();
     sql = null;
+  }
+});
+
+test("orphan cleanup skips a locked state and protects the hand committed as current", { skip: !HAS_DB }, async () => {
+  const postgres = (await import("postgres")).default;
+  const cleanupDb = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  const writerDb = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  const tableId = randomUUID();
+  const handId = `cleanup-concurrent-${randomUUID()}`;
+  const oldCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  let releaseWriter;
+  let reportLocked;
+  const writerRelease = new Promise((resolve) => { releaseWriter = resolve; });
+  const stateLocked = new Promise((resolve) => { reportLocked = resolve; });
+
+  try {
+    await ensureSchema(cleanupDb);
+    await cleanupDb.unsafe(
+      "insert into public.poker_tables (id, status, has_human_participant) values ($1, 'CLOSED', false)",
+      [tableId]
+    );
+    await cleanupDb.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [tableId, JSON.stringify({ phase: "HAND_DONE", handId: "" })]
+    );
+    await cleanupDb.unsafe(
+      `insert into public.poker_hole_cards (table_id, hand_id, user_id, cards, created_at)
+       values ($1, $2, $3, $4::jsonb, $5)`,
+      [tableId, handId, randomUUID(), JSON.stringify(["7H", "8H"]), oldCreatedAt]
+    );
+
+    const writer = writerDb.begin(async (tx) => {
+      await tx.unsafe("select state from public.poker_state where table_id = $1 for update", [tableId]);
+      reportLocked();
+      await writerRelease;
+      await tx.unsafe(
+        "update public.poker_state set state = $2::jsonb where table_id = $1",
+        [tableId, JSON.stringify({ phase: "FLOP", handId })]
+      );
+    });
+    await stateLocked;
+
+    const cleanup = createActionHistoryCleanup({
+      env: {
+        WS_POKER_BOT_ACTION_RETENTION_MS: String(60 * 60 * 1000),
+        WS_POKER_BOT_SETTLED_RETENTION_MS: "0",
+        WS_POKER_HUMAN_ACTION_RETENTION_MS: "0",
+        WS_POKER_HUMAN_SETTLED_RETENTION_MS: "0",
+        WS_POKER_ACTION_HISTORY_BATCH_SIZE: "10"
+      },
+      beginSql: beginSql(cleanupDb)
+    });
+    const startedAt = Date.now();
+    const whileLocked = await cleanup.sweep();
+    assert.equal(whileLocked.orphanHoleCardsDeleted, 0);
+    assert.ok(Date.now() - startedAt < 1_500, "SKIP LOCKED must avoid waiting on the writer");
+
+    releaseWriter();
+    await writer;
+    const afterCommit = await cleanup.sweep();
+    assert.equal(afterCommit.orphanHoleCardsDeleted, 0);
+    const remaining = await cleanupDb.unsafe(
+      "select count(*)::bigint as rows from public.poker_hole_cards where table_id = $1 and hand_id = $2",
+      [tableId, handId]
+    );
+    assert.equal(Number(remaining[0].rows), 1);
+  } finally {
+    releaseWriter?.();
+    await cleanupDb.unsafe("delete from public.poker_hole_cards where table_id = $1", [tableId]);
+    await cleanupDb.unsafe("delete from public.poker_actions where table_id = $1", [tableId]);
+    await cleanupDb.unsafe("delete from public.poker_state where table_id = $1", [tableId]);
+    await cleanupDb.unsafe("delete from public.poker_tables where id = $1", [tableId]);
+    if (createdMinimalSchema) {
+      await cleanupDb.unsafe("drop table if exists public.poker_hole_cards");
+      await cleanupDb.unsafe("drop table if exists public.poker_actions");
+      await cleanupDb.unsafe("drop table if exists public.poker_state");
+      await cleanupDb.unsafe("drop table if exists public.poker_tables");
+    }
+    await Promise.all([cleanupDb.end(), writerDb.end()]);
   }
 });

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -47,19 +47,20 @@ async function sweepOrphanHoleCards({ tx, botActionCutoff, humanActionCutoff, ba
              from public.poker_hole_cards hc
             where hc.table_id = ps.table_id
               and hc.hand_id <> ps.state ->> 'handId'
-              and (
-                    (t.has_human_participant = false
-                     and $1::timestamptz is not null
-                     and hc.created_at < $1::timestamptz)
-                 or (t.has_human_participant = true
-                     and $2::timestamptz is not null
-                     and hc.created_at < $2::timestamptz)
-                  )
               and not exists (
                     select 1
                       from public.poker_actions pa
                      where pa.table_id = hc.table_id
                        and pa.hand_id = hc.hand_id
+                  )
+            group by hc.hand_id
+           having (
+                    (t.has_human_participant = false
+                     and $1::timestamptz is not null
+                     and max(hc.created_at) < $1::timestamptz)
+                 or (t.has_human_participant = true
+                     and $2::timestamptz is not null
+                     and max(hc.created_at) < $2::timestamptz)
                   )
          )
    order by ps.table_id
@@ -430,13 +431,16 @@ export function createActionHistoryCleanup({
            select 1 from public.poker_hole_cards hc
             where hc.table_id = ps.table_id
               and hc.hand_id <> ps.state ->> 'handId'
-              and (
-                    (t.has_human_participant = false and $1::timestamptz is not null and hc.created_at < $1::timestamptz)
-                 or (t.has_human_participant = true and $2::timestamptz is not null and hc.created_at < $2::timestamptz)
-                  )
               and not exists (
                     select 1 from public.poker_actions pa
                      where pa.table_id = hc.table_id and pa.hand_id = hc.hand_id
+                  )
+            group by hc.hand_id
+           having (
+                    (t.has_human_participant = false and $1::timestamptz is not null
+                     and max(hc.created_at) < $1::timestamptz)
+                 or (t.has_human_participant = true and $2::timestamptz is not null
+                     and max(hc.created_at) < $2::timestamptz)
                   )
          )
    order by ps.table_id

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -1,7 +1,9 @@
 // Action-history retention cleanup.
 //
-// Bounded three-phase sweep that runs on a timer (see server.mjs).
-// The hole-card phase deletes poker_hole_cards for completed hands older than
+// Bounded four-phase sweep that runs on a timer (see server.mjs).
+// The orphan-hole-card phase removes old cards left on safely closed tables
+// without any action history. The regular hole-card phase deletes cards for
+// completed hands older than
 // the applicable action retention cutoff. Phase 1 deletes ordinary actions
 // (everything except HAND_SETTLED). Phase 2 deletes HAND_SETTLED audit rows
 // only after both ordinary actions and hole cards are gone.
@@ -15,12 +17,85 @@ import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 const BACKLOG_CACHE_TTL_MS = 15_000;
 const DEFAULT_MAX_SWEEP_ROUNDS = 1;
 const MAX_SWEEP_ROUNDS = 20;
+const ORPHAN_CLEANUP_LOCK_TIMEOUT_MS = 250;
+const ORPHAN_CLEANUP_STATEMENT_TIMEOUT_MS = 2_000;
 // Preview uses bounded repeated batches for stress tests; Production stays at one round.
-const CLEANUP_PHASE_ORDER = Object.freeze(["hole_cards", "ordinary_actions", "hand_settled"]);
+const CLEANUP_PHASE_ORDER = Object.freeze(["orphan_hole_cards", "hole_cards", "ordinary_actions", "hand_settled"]);
 
 function resolveCutoff(retentionMs) {
   if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
   return new Date(Date.now() - retentionMs).toISOString();
+}
+
+// Historical recovery path for hands whose action history (including
+// HAND_SETTLED) was deleted before hole-card retention existed. Only the
+// authoritative poker_state row is locked; poker_tables is read through MVCC
+// so this phase cannot introduce a table->state or state->table lock cycle.
+async function sweepOrphanHoleCards({ tx, botActionCutoff, humanActionCutoff, batchSize, lockLimit }) {
+  await tx.unsafe("select set_config('lock_timeout', $1, true);", [`${ORPHAN_CLEANUP_LOCK_TIMEOUT_MS}ms`]);
+  await tx.unsafe("select set_config('statement_timeout', $1, true);", [`${ORPHAN_CLEANUP_STATEMENT_TIMEOUT_MS}ms`]);
+  const result = await tx.unsafe(
+    `with locked_states as materialized (
+  select ps.table_id, ps.state, t.has_human_participant
+    from public.poker_state ps
+    join public.poker_tables t on t.id = ps.table_id
+   where t.status = 'CLOSED'
+     and jsonb_typeof(ps.state) = 'object'
+     and jsonb_typeof(ps.state -> 'handId') = 'string'
+     and exists (
+           select 1
+             from public.poker_hole_cards hc
+            where hc.table_id = ps.table_id
+              and hc.hand_id <> ps.state ->> 'handId'
+              and (
+                    (t.has_human_participant = false
+                     and $1::timestamptz is not null
+                     and hc.created_at < $1::timestamptz)
+                 or (t.has_human_participant = true
+                     and $2::timestamptz is not null
+                     and hc.created_at < $2::timestamptz)
+                  )
+              and not exists (
+                    select 1
+                      from public.poker_actions pa
+                     where pa.table_id = hc.table_id
+                       and pa.hand_id = hc.hand_id
+                  )
+         )
+   order by ps.table_id
+   limit $4
+   for update of ps skip locked
+), orphan_candidates as materialized (
+  select hc.table_id, hc.hand_id, max(hc.created_at) as newest_card_at
+    from public.poker_hole_cards hc
+    join locked_states ls on ls.table_id = hc.table_id
+   where hc.hand_id <> ls.state ->> 'handId'
+     and not exists (
+           select 1
+             from public.poker_actions pa
+            where pa.table_id = hc.table_id
+              and pa.hand_id = hc.hand_id
+         )
+   group by hc.table_id, hc.hand_id, ls.has_human_participant
+  having (
+           (ls.has_human_participant = false
+            and $1::timestamptz is not null
+            and max(hc.created_at) < $1::timestamptz)
+        or (ls.has_human_participant = true
+            and $2::timestamptz is not null
+            and max(hc.created_at) < $2::timestamptz)
+         )
+   order by newest_card_at, hc.table_id, hc.hand_id
+   limit $3
+)
+delete from public.poker_hole_cards hc
+ using orphan_candidates oc
+ where hc.table_id = oc.table_id
+   and hc.hand_id = oc.hand_id
+returning hc.table_id, hc.hand_id, hc.user_id;`,
+    [botActionCutoff, humanActionCutoff, batchSize, lockLimit]
+  );
+  return Array.isArray(result) ? result.length : 0;
 }
 
 // Hole-card rows are deleted by unique (table_id, hand_id) candidates. The
@@ -331,6 +406,7 @@ export function createActionHistoryCleanup({
     if (failedPhases.has("ordinary_actions")) return "ordinary_actions_cleanup_failed";
     if (failedPhases.has("hand_settled")) return "hand_settled_cleanup_failed";
     if (failedPhases.has("hole_cards")) return "hole_cards_cleanup_failed";
+    if (failedPhases.has("orphan_hole_cards")) return "orphan_hole_cards_cleanup_failed";
     return null;
   }
 
@@ -342,6 +418,53 @@ export function createActionHistoryCleanup({
     try {
       const value = await beginSql(async (tx) => {
         await tx.unsafe("select set_config('statement_timeout', '2000ms', true);");
+        const orphanRows = await tx.unsafe(
+          `with eligible_states as materialized (
+  select ps.table_id, ps.state, t.has_human_participant
+    from public.poker_state ps
+    join public.poker_tables t on t.id = ps.table_id
+   where t.status = 'CLOSED'
+     and jsonb_typeof(ps.state) = 'object'
+     and jsonb_typeof(ps.state -> 'handId') = 'string'
+     and exists (
+           select 1 from public.poker_hole_cards hc
+            where hc.table_id = ps.table_id
+              and hc.hand_id <> ps.state ->> 'handId'
+              and (
+                    (t.has_human_participant = false and $1::timestamptz is not null and hc.created_at < $1::timestamptz)
+                 or (t.has_human_participant = true and $2::timestamptz is not null and hc.created_at < $2::timestamptz)
+                  )
+              and not exists (
+                    select 1 from public.poker_actions pa
+                     where pa.table_id = hc.table_id and pa.hand_id = hc.hand_id
+                  )
+         )
+   order by ps.table_id
+   limit $4
+), orphan_candidates as materialized (
+  select hc.table_id, hc.hand_id, count(*)::bigint as card_rows, max(hc.created_at) as newest_card_at
+    from public.poker_hole_cards hc
+    join eligible_states es on es.table_id = hc.table_id
+   where hc.hand_id <> es.state ->> 'handId'
+     and not exists (
+           select 1 from public.poker_actions pa
+            where pa.table_id = hc.table_id and pa.hand_id = hc.hand_id
+         )
+   group by hc.table_id, hc.hand_id, es.has_human_participant
+  having (
+           (es.has_human_participant = false and $1::timestamptz is not null
+            and max(hc.created_at) < $1::timestamptz)
+        or (es.has_human_participant = true and $2::timestamptz is not null
+            and max(hc.created_at) < $2::timestamptz)
+         )
+   order by newest_card_at, hc.table_id, hc.hand_id
+   limit $3
+)
+select count(*)::bigint as orphan_hand_rows,
+       coalesce(sum(card_rows), 0)::bigint as orphan_card_rows
+  from orphan_candidates;`,
+          [cutoffs.botActionCutoff, cutoffs.humanActionCutoff, batchSize, lockLimit]
+        );
         const rows = await tx.unsafe(
           `with phase1_locked_tables as (
   select t.id, t.has_human_participant
@@ -440,8 +563,11 @@ select
           ]
         );
         const row = rows?.[0] || {};
+        const orphanRow = orphanRows?.[0] || {};
         return {
           available: true,
+          orphanHoleCardHands: Number(orphanRow.orphan_hand_rows || 0),
+          orphanHoleCardRows: Number(orphanRow.orphan_card_rows || 0),
           ordinaryActionRows: Number(row.ordinary_action_rows || 0),
           handSettledRows: Number(row.hand_settled_rows || 0),
           measuredAt: new Date().toISOString(),
@@ -454,6 +580,8 @@ select
     } catch (error) {
       return {
         available: false,
+        orphanHoleCardHands: null,
+        orphanHoleCardRows: null,
         ordinaryActionRows: null,
         handSettledRows: null,
         measuredAt: new Date().toISOString(),
@@ -467,6 +595,7 @@ select
     if (sweepInProgress) {
       return {
         ok: true,
+        orphanHoleCardsDeleted: 0,
         holeCardsDeleted: 0,
         phase1Deleted: 0,
         phase2Deleted: 0,
@@ -486,6 +615,7 @@ select
       if (!anyEnabled) {
         result = {
           ok: true,
+          orphanHoleCardsDeleted: 0,
           holeCardsDeleted: 0,
           phase1Deleted: 0,
           phase2Deleted: 0,
@@ -496,13 +626,32 @@ select
         return result;
       }
 
+      let orphanHoleCardsDeleted = 0;
       let holeCardsDeleted = 0;
       let phase1Deleted = 0;
       let phase2Deleted = 0;
       let holeCardsPhaseEnabledForSweep = cutoffs.botActionEnabled || cutoffs.humanActionEnabled;
+      let orphanHoleCardsPhaseEnabledForSweep = holeCardsPhaseEnabledForSweep;
       const failedPhases = new Set();
 
       for (let round = 0; round < sweepRounds; round += 1) {
+        let orphanHoleCardsRoundDeleted = 0;
+        if (orphanHoleCardsPhaseEnabledForSweep) {
+          try {
+            orphanHoleCardsRoundDeleted = await beginSql((tx) => sweepOrphanHoleCards({
+              tx,
+              botActionCutoff: cutoffs.botActionCutoff,
+              humanActionCutoff: cutoffs.humanActionCutoff,
+              batchSize,
+              lockLimit
+            }), { env });
+            orphanHoleCardsDeleted += orphanHoleCardsRoundDeleted;
+          } catch (_error) {
+            failedPhases.add("orphan_hole_cards");
+            orphanHoleCardsPhaseEnabledForSweep = false;
+          }
+        }
+
         let holeCardsRoundDeleted = 0;
         if (holeCardsPhaseEnabledForSweep) {
           try {
@@ -552,13 +701,15 @@ select
           break;
         }
 
-        if (holeCardsRoundDeleted === 0 && phase1RoundDeleted === 0 && phase2RoundDeleted === 0) break;
+        if (orphanHoleCardsRoundDeleted === 0 && holeCardsRoundDeleted === 0
+          && phase1RoundDeleted === 0 && phase2RoundDeleted === 0) break;
       }
 
       const orderedPhases = orderedFailedPhases(failedPhases);
       const errorCode = primaryErrorCode(failedPhases);
       result = {
         ok: orderedPhases.length === 0,
+        orphanHoleCardsDeleted,
         holeCardsDeleted,
         phase1Deleted,
         phase2Deleted,
@@ -568,8 +719,9 @@ select
         reason: errorCode
       };
 
-      if (result.ok && (holeCardsDeleted > 0 || phase1Deleted > 0 || phase2Deleted > 0)) {
+      if (result.ok && (orphanHoleCardsDeleted > 0 || holeCardsDeleted > 0 || phase1Deleted > 0 || phase2Deleted > 0)) {
         klog("ws_action_history_cleanup_complete", {
+          orphanHoleCardsDeleted,
           holeCardsDeleted,
           phase1Deleted,
           phase2Deleted,
@@ -581,6 +733,7 @@ select
         klog("ws_action_history_cleanup_failed", {
           errorCode,
           failedPhases: orderedPhases,
+          orphanHoleCardsDeleted,
           holeCardsDeleted,
           phase1Deleted,
           phase2Deleted,
@@ -593,6 +746,7 @@ select
     } catch (_error) {
       result = {
         ok: false,
+        orphanHoleCardsDeleted: 0,
         holeCardsDeleted: 0,
         phase1Deleted: 0,
         phase2Deleted: 0,
@@ -604,6 +758,7 @@ select
       klog("ws_action_history_cleanup_failed", {
         errorCode: result.errorCode,
         failedPhases: result.failedPhases,
+        orphanHoleCardsDeleted: 0,
         holeCardsDeleted: 0,
         phase1Deleted: 0,
         phase2Deleted: 0,
@@ -619,6 +774,7 @@ select
         startedAt,
         finishedAt,
         durationMs: Math.max(0, Date.now() - startedAtMs),
+        orphanHoleCardsDeleted: Number(result?.orphanHoleCardsDeleted || 0),
         holeCardsDeleted: Number(result?.holeCardsDeleted || 0),
         phase1Deleted: Number(result?.phase1Deleted || 0),
         phase2Deleted: Number(result?.phase2Deleted || 0),

--- a/ws-server/poker/persistence/action-history-cleanup.mjs
+++ b/ws-server/poker/persistence/action-history-cleanup.mjs
@@ -18,13 +18,26 @@ const BACKLOG_CACHE_TTL_MS = 15_000;
 const DEFAULT_MAX_SWEEP_ROUNDS = 1;
 const MAX_SWEEP_ROUNDS = 20;
 const ORPHAN_CLEANUP_LOCK_TIMEOUT_MS = 250;
-const ORPHAN_CLEANUP_STATEMENT_TIMEOUT_MS = 2_000;
+const ORPHAN_CLEANUP_STATEMENT_TIMEOUT_MS = 10_000;
+const ORPHAN_CLEANUP_MAX_HAND_BATCH_SIZE = 25;
 // Preview uses bounded repeated batches for stress tests; Production stays at one round.
 const CLEANUP_PHASE_ORDER = Object.freeze(["orphan_hole_cards", "hole_cards", "ordinary_actions", "hand_settled"]);
 
 function resolveCutoff(retentionMs) {
   if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
   return new Date(Date.now() - retentionMs).toISOString();
+}
+
+function postgresErrorDetails(error) {
+  const text = (value, maxLength) => typeof value === "string" && value.length > 0
+    ? value.slice(0, maxLength)
+    : null;
+  return {
+    code: text(error?.code, 40),
+    message: text(error?.message, 500),
+    detail: text(error?.detail, 1_000),
+    where: text(error?.where, 1_000)
+  };
 }
 
 // Historical recovery path for hands whose action history (including
@@ -374,6 +387,7 @@ export function createActionHistoryCleanup({
   }
 
   const batchSize = resolveBatchSize(env.WS_POKER_ACTION_HISTORY_BATCH_SIZE);
+  const orphanBatchSize = Math.min(batchSize, ORPHAN_CLEANUP_MAX_HAND_BATCH_SIZE);
   const lockLimit = batchSize * 2;
   const sweepRounds = Number.isInteger(maxSweepRounds)
     && maxSweepRounds >= DEFAULT_MAX_SWEEP_ROUNDS
@@ -467,7 +481,7 @@ export function createActionHistoryCleanup({
 select count(*)::bigint as orphan_hand_rows,
        coalesce(sum(card_rows), 0)::bigint as orphan_card_rows
   from orphan_candidates;`,
-          [cutoffs.botActionCutoff, cutoffs.humanActionCutoff, batchSize, lockLimit]
+          [cutoffs.botActionCutoff, cutoffs.humanActionCutoff, orphanBatchSize, lockLimit]
         );
         const rows = await tx.unsafe(
           `with phase1_locked_tables as (
@@ -636,6 +650,7 @@ select
       let phase2Deleted = 0;
       let holeCardsPhaseEnabledForSweep = cutoffs.botActionEnabled || cutoffs.humanActionEnabled;
       let orphanHoleCardsPhaseEnabledForSweep = holeCardsPhaseEnabledForSweep;
+      let orphanFailure = null;
       const failedPhases = new Set();
 
       for (let round = 0; round < sweepRounds; round += 1) {
@@ -646,12 +661,13 @@ select
               tx,
               botActionCutoff: cutoffs.botActionCutoff,
               humanActionCutoff: cutoffs.humanActionCutoff,
-              batchSize,
+              batchSize: orphanBatchSize,
               lockLimit
             }), { env });
             orphanHoleCardsDeleted += orphanHoleCardsRoundDeleted;
-          } catch (_error) {
+          } catch (error) {
             failedPhases.add("orphan_hole_cards");
+            orphanFailure = postgresErrorDetails(error);
             orphanHoleCardsPhaseEnabledForSweep = false;
           }
         }
@@ -730,6 +746,7 @@ select
           phase1Deleted,
           phase2Deleted,
           batchSize,
+          orphanBatchSize,
           lockLimit,
           sweepRounds
         });
@@ -742,8 +759,10 @@ select
           phase1Deleted,
           phase2Deleted,
           batchSize,
+          orphanBatchSize,
           lockLimit,
-          sweepRounds
+          sweepRounds,
+          orphanFailure
         });
       }
       return result;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -3616,18 +3616,21 @@ function projectCleanupMetrics(cleanupResult) {
   if (!cleanupResult || typeof cleanupResult !== "object") return null;
   const backlog = cleanupResult.backlog;
   const lastRun = cleanupResult.lastRun;
+  const orphanHoleCardsDeleted = safeMetricInteger(lastRun?.orphanHoleCardsDeleted);
   const holeCardsDeleted = safeMetricInteger(lastRun?.holeCardsDeleted);
   const phase1Deleted = safeMetricInteger(lastRun?.phase1Deleted);
   const phase2Deleted = safeMetricInteger(lastRun?.phase2Deleted);
   const deletedRows = phase1Deleted != null && phase2Deleted != null
-    ? (holeCardsDeleted || 0) + phase1Deleted + phase2Deleted
+    ? (orphanHoleCardsDeleted || 0) + (holeCardsDeleted || 0) + phase1Deleted + phase2Deleted
     : null;
-  const failedPhaseOrder = ["hole_cards", "ordinary_actions", "hand_settled"];
+  const failedPhaseOrder = ["orphan_hole_cards", "hole_cards", "ordinary_actions", "hand_settled"];
   const failedPhases = Array.isArray(lastRun?.failedPhases)
     ? failedPhaseOrder.filter((phase) => lastRun.failedPhases.includes(phase))
     : [];
   return {
     backlog: backlog && typeof backlog === "object" ? {
+      orphanHoleCardHands: safeMetricInteger(backlog.orphanHoleCardHands),
+      orphanHoleCardRows: safeMetricInteger(backlog.orphanHoleCardRows),
       ordinaryActionRows: safeMetricInteger(backlog.ordinaryActionRows),
       handSettledRows: safeMetricInteger(backlog.handSettledRows),
       cappedAtBatchSize: typeof backlog.cappedAtBatchSize === "boolean"
@@ -3638,6 +3641,7 @@ function projectCleanupMetrics(cleanupResult) {
     lastRun: lastRun && typeof lastRun === "object" ? {
       finishedAt: typeof lastRun.finishedAt === "string" ? lastRun.finishedAt : null,
       durationMs: safeMetricInteger(lastRun.durationMs),
+      orphanHoleCardsDeleted,
       holeCardsDeleted,
       phase1Deleted,
       phase2Deleted,


### PR DESCRIPTION
## Summary

- add a separate bounded cleanup phase for historical orphan hole cards on `CLOSED` tables
- lock only authoritative `poker_state` rows with `SKIP LOCKED`, protect the current hand, and fail closed for malformed state
- qualify whole hands with `MAX(created_at)` so mixed-age tables cannot starve eligible backlog
- retain existing bot/human cutoffs, isolate phase failures, and expose dedicated cleanup/backlog metrics in Admin Ops

## Operational bounds and diagnostics

- `250ms` orphan lock timeout
- `10000ms` orphan statement timeout
- orphan-specific cap of 25 hands per batch; existing cleanup batch behavior is unchanged for all other phases
- orphan PostgreSQL failures preserve `code`, `message`, `detail`, and `where` in `ws_action_history_cleanup_failed`
- no new environment variables, speculative index, migration, worker, or scheduler

## Validation

- all PR checks passed, including PostgreSQL integration, WS harness, CodeQL, and UI tests
- WS Preview deployed exact SHA `8198e110a9f511137da746951351345a5b819860`
- public `/healthz`: HTTP 200 `ok`; release metadata and active service verified
- first tuned Preview cleanup: HTTP 200, `orphanHoleCardsDeleted=1005`, `failedPhases=[]`, `errorCode=null`, `durationMs=5803`
- follow-up Preview cleanup: HTTP 200, `orphanHoleCardsDeleted=1003`, `failedPhases=[]`, `errorCode=null`, `durationMs=8158`
- full managed bot hand verified from `PREFLOP` through one `HAND_SETTLED` marker and the next hand starting at `PREFLOP`
- bounded backlog remained saturated at 25 hands / 100 rows after cleanup; these are next-batch metrics, not a full backlog count

## Safety

- no poker rules, reducer, settlement, accounting, protocol, persistence schema, or gameplay timing changes
- timeout/deadlock rolls back only the orphan phase; existing cleanup phases continue independently

Closes #855
