### PR TITLE
Add Poker V2 social preferences

### DIFF
--- a/docs/poker-bots.md
+++ b/docs/poker-bots.md
@@ -50,6 +50,7 @@ Poker bots are implemented in the current runtime.
 - The assignment is stateless and collision-free within the supported table capacity: reconnects, late observers, and authoritative restores derive the same result, while removing another bot does not rename remaining seats.
 - Images load from `/poker/assets/avatars/bots/` under the existing same-origin CSP policy. A failed image keeps the selected bot name and falls back to initials derived from that name.
 - Human public-profile avatars, guests, snapshots, poker persistence, and server runtime remain unchanged.
+- Authenticated Poker V2 users can locally hide reaction bubbles, reaction history, or bot reactions. These browser-only preferences are best-effort, user-scoped, and do not alter server reaction generation or gameplay; guest sessions always use in-memory defaults.
 
 ## Persisted seat fields used by bot flows
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -178,6 +178,13 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-menu-panel a{display:block; padding:10px 12px; border-radius:8px; text-decoration:none; color:#e7efff; font-size:0.93rem; font-weight:500; background:rgba(21,30,47,0.6); border:1px solid rgba(111,130,170,0.22);}
 
 .poker-menu-panel a:active{background:rgba(65,91,138,0.42);}
+.poker-menu-panel__button{display:block;width:100%;padding:10px 12px;border:1px solid rgba(111,130,170,0.22);border-radius:8px;background:rgba(21,30,47,0.6);color:#e7efff;font:inherit;font-size:0.93rem;text-align:left;}
+.poker-social-settings{position:fixed;top:calc(env(safe-area-inset-top) + 66px);left:calc(env(safe-area-inset-left) + 12px);z-index:32;width:min(260px,calc(100vw - 24px));padding:12px;border:1px solid rgba(255,215,157,0.28);border-radius:13px;background:linear-gradient(180deg,rgba(8,13,22,0.97),rgba(4,7,12,0.99));box-shadow:0 14px 24px rgba(0,0,0,0.55);color:#e7efff;}
+.poker-social-settings[hidden]{display:none;}
+.poker-social-settings__header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;color:#f4d7a5;}
+.poker-social-settings__close{width:30px;height:30px;padding:0;border:1px solid rgba(255,215,157,0.25);border-radius:8px;background:rgba(21,30,47,0.7);color:#e7efff;font-size:1.15rem;line-height:1;}
+.poker-social-settings__option{display:flex;align-items:center;gap:9px;padding:9px 4px;font-size:0.88rem;}
+.poker-social-settings__option input{accent-color:#d6aa62;}
 
 .poker-live-panel{position:relative; z-index:19; width:min(100%, 980px); margin:78px auto 0; padding:14px 16px; border-radius:22px; border:1px solid rgba(255,223,180,0.22); background:linear-gradient(180deg, rgba(10,15,24,0.88), rgba(4,6,11,0.96)); box-shadow:0 16px 28px rgba(0,0,0,0.46), inset 0 1px 1px rgba(255,255,255,0.08);}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -178,7 +178,6 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-menu-panel a{display:block; padding:10px 12px; border-radius:8px; text-decoration:none; color:#e7efff; font-size:0.93rem; font-weight:500; background:rgba(21,30,47,0.6); border:1px solid rgba(111,130,170,0.22);}
 
 .poker-menu-panel a:active{background:rgba(65,91,138,0.42);}
-.poker-menu-panel__button{display:block;width:100%;padding:10px 12px;border:1px solid rgba(111,130,170,0.22);border-radius:8px;background:rgba(21,30,47,0.6);color:#e7efff;font:inherit;font-size:0.93rem;text-align:left;}
 .poker-social-settings{position:fixed;top:calc(env(safe-area-inset-top) + 66px);left:calc(env(safe-area-inset-left) + 12px);z-index:32;width:min(260px,calc(100vw - 24px));padding:12px;border:1px solid rgba(255,215,157,0.28);border-radius:13px;background:linear-gradient(180deg,rgba(8,13,22,0.97),rgba(4,7,12,0.99));box-shadow:0 14px 24px rgba(0,0,0,0.55);color:#e7efff;}
 .poker-social-settings[hidden]{display:none;}
 .poker-social-settings__header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;color:#f4d7a5;}
@@ -216,6 +215,8 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-action-reaction .poker-reaction-hint{display:block;margin-top:4px;text-align:center;}
 .poker-reaction-history{position:relative;z-index:26;width:40px;grid-column:1;grid-row:1;align-self:end;}
 .poker-reaction-history[hidden]{display:none;}
+.poker-social-settings__toggle{position:relative;width:40px;min-height:42px;padding:0;border-radius:14px;background:linear-gradient(180deg,rgba(35,48,72,0.98),rgba(14,22,37,0.98));font-size:1.05rem;grid-column:1;grid-row:2;align-self:end;}
+.poker-social-settings__toggle[hidden]{display:none;}
 .poker-reaction-history__toggle{position:relative;width:40px;min-height:42px;padding:0;border-radius:14px;background:linear-gradient(180deg,rgba(35,48,72,0.98),rgba(14,22,37,0.98));font-size:1.05rem;}
 .poker-reaction-history__count{position:absolute;top:-5px;right:-5px;display:flex;align-items:center;justify-content:center;min-width:17px;height:17px;padding:0 4px;border:2px solid #111827;border-radius:999px;background:#dc4e4e;color:#fff;font-size:0.6rem;font-weight:800;line-height:1;}
 .poker-reaction-history__panel{position:absolute;right:0;bottom:calc(100% + 8px);z-index:26;width:min(280px,calc(100vw - 32px));max-height:220px;overflow:hidden;border:1px solid rgba(255,223,180,0.24);border-radius:14px;background:linear-gradient(180deg,rgba(12,18,31,0.98),rgba(5,9,16,0.99));box-shadow:0 14px 28px rgba(0,0,0,0.48);}
@@ -307,7 +308,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-bar{position:fixed; right:max(10px, env(safe-area-inset-right)); bottom:max(10px, env(safe-area-inset-bottom)); width:min(33vw, 196px); display:grid; grid-template-columns:40px minmax(0, 1fr); align-items:end; gap:8px; padding:8px; border-radius:20px; border:1px solid rgba(255,223,180,0.24); background:linear-gradient(180deg, rgba(9,12,20,0.94), rgba(2,4,8,0.98)); box-shadow:0 12px 22px rgba(0,0,0,0.56), inset 0 1px 1px rgba(255,255,255,0.12); z-index:25;}
 
-.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px; grid-column:2; grid-row:2;}
+.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px; grid-column:2; grid-row:3;}
 
 .poker-action-btn{min-height:50px; border:none; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
 
@@ -351,7 +352,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn.is-selected{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
 
-.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86); grid-column:1; grid-row:2;}
+.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86); grid-column:1; grid-row:3;}
 
 .poker-action-amount-input strong{font-size:0.78rem; font-weight:700; color:#fff;}
 
@@ -363,7 +364,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 @media (min-width:480px){.poker-scene{height:min(76vh, 860px);} .poker-seat{width:126px;} .poker-hero-cards{bottom:136px;} .poker-card{width:50px; height:68px;}}
 
-@media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;} .poker-reaction-history{width:34px;} .poker-reaction-history__toggle{width:34px;} .poker-reaction-history__panel,.poker-reaction-history__list{max-height:180px;}}
+@media (max-width:640px){.poker-live-actions{align-items:stretch;} .poker-live-input{width:calc(50% - 5px);} .poker-live-input input{width:100%;} .poker-action-bar{width:min(33vw, 156px); right:8px; bottom:8px; gap:6px; padding:6px; grid-template-columns:34px minmax(0, 1fr);} .poker-action-buttons{min-height:170px; gap:6px;} .poker-action-amount-input{height:170px;} .poker-action-amount-input input{height:106px; min-height:106px;} .poker-reaction-history{width:34px;} .poker-reaction-history__toggle{width:34px;} .poker-social-settings__toggle{width:34px;} .poker-reaction-history__panel,.poker-reaction-history__list{max-height:180px;}}
 
 @media (max-width:479px){.poker-settlement-summary{width:min(36vw, 135px); max-height:132px; font-size:0.6rem;} .poker-settlement-summary__row{grid-template-columns:1fr; gap:2px;} .poker-settlement-summary__recipients{text-align:left;} .poker-seat-settlement-badge{max-width:112px;}}
 

--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -215,7 +215,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-action-reaction .poker-reaction-hint{display:block;margin-top:4px;text-align:center;}
 .poker-reaction-history{position:relative;z-index:26;width:40px;grid-column:1;grid-row:1;align-self:end;}
 .poker-reaction-history[hidden]{display:none;}
-.poker-social-settings__toggle{position:relative;width:40px;min-height:42px;padding:0;border-radius:14px;background:linear-gradient(180deg,rgba(35,48,72,0.98),rgba(14,22,37,0.98));font-size:1.05rem;grid-column:1;grid-row:2;align-self:end;}
+.poker-social-settings__toggle{position:relative;width:40px;min-height:42px;padding:0;border-radius:14px;background:linear-gradient(180deg,rgba(35,48,72,0.98),rgba(14,22,37,0.98));font-size:1.05rem;grid-column:1;grid-row:2;align-self:start;}
 .poker-social-settings__toggle[hidden]{display:none;}
 .poker-reaction-history__toggle{position:relative;width:40px;min-height:42px;padding:0;border-radius:14px;background:linear-gradient(180deg,rgba(35,48,72,0.98),rgba(14,22,37,0.98));font-size:1.05rem;}
 .poker-reaction-history__count{position:absolute;top:-5px;right:-5px;display:flex;align-items:center;justify-content:center;min-width:17px;height:17px;padding:0 4px;border:2px solid #111827;border-radius:999px;background:#dc4e4e;color:#fff;font-size:0.6rem;font-weight:800;line-height:1;}
@@ -308,7 +308,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-bar{position:fixed; right:max(10px, env(safe-area-inset-right)); bottom:max(10px, env(safe-area-inset-bottom)); width:min(33vw, 196px); display:grid; grid-template-columns:40px minmax(0, 1fr); align-items:end; gap:8px; padding:8px; border-radius:20px; border:1px solid rgba(255,223,180,0.24); background:linear-gradient(180deg, rgba(9,12,20,0.94), rgba(2,4,8,0.98)); box-shadow:0 12px 22px rgba(0,0,0,0.56), inset 0 1px 1px rgba(255,255,255,0.12); z-index:25;}
 
-.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px; grid-column:2; grid-row:3;}
+.poker-action-buttons{display:flex; flex-direction:column; justify-content:flex-end; gap:8px; min-height:182px; grid-column:2; grid-row:2;}
 
 .poker-action-btn{min-height:50px; border:none; border-radius:17px; color:#f7f8fd; font-size:0.98rem; font-weight:700; letter-spacing:0.01em; box-shadow:inset 0 1px 1px rgba(255,255,255,0.22), 0 8px 14px rgba(0,0,0,0.42);}
 
@@ -352,7 +352,7 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 
 .poker-action-btn.is-selected{box-shadow:0 0 0 2px rgba(255,255,255,0.66), inset 0 1px 1px rgba(255,255,255,0.26), 0 10px 16px rgba(0,0,0,0.42);}
 
-.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86); grid-column:1; grid-row:3;}
+.poker-action-amount-input{align-self:end; display:flex; flex-direction:column; align-items:center; justify-content:flex-end; gap:8px; height:182px; padding:10px 6px; border-radius:17px; border:1px solid rgba(255,223,180,0.22); background:rgba(8,12,21,0.86); grid-column:1; grid-row:2;}
 
 .poker-action-amount-input strong{font-size:0.78rem; font-weight:700; color:#fff;}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -250,10 +250,25 @@
   var reactionHistoryEntries = [];
   var reactionHistoryExpiryTimer = null;
   var reactionHistoryPanelOpen = false;
+  var socialPreferencesIdentity = null;
+  var socialPreferences = defaultSocialPreferences();
   var els = {};
 
   var REACTION_HISTORY_LIMIT = 25;
   var REACTION_HISTORY_TTL_MS = 10 * 60 * 1000;
+  var SOCIAL_PREFERENCES_STORAGE_PREFIX = 'kcswh:poker-social-preferences:v1:';
+
+  function defaultSocialPreferences(){
+    return { reactionBubblesEnabled: true, reactionHistoryEnabled: true, botReactionsEnabled: true };
+  }
+
+  function normalizeSocialPreferences(raw){
+    return {
+      reactionBubblesEnabled: raw && raw.reactionBubblesEnabled === false ? false : true,
+      reactionHistoryEnabled: raw && raw.reactionHistoryEnabled === false ? false : true,
+      botReactionsEnabled: raw && raw.botReactionsEnabled === false ? false : true
+    };
+  }
 
   function cloneState(source){
     return JSON.parse(JSON.stringify(source));
@@ -471,6 +486,38 @@
     try {
       if (window.KLog && typeof window.KLog.log === 'function') window.KLog.log(kind, data || {});
     } catch (_err){}
+  }
+
+  function renderSocialPreferences(){
+    if (els.reactionBubblesPreference) els.reactionBubblesPreference.checked = socialPreferences.reactionBubblesEnabled;
+    if (els.reactionHistoryPreference) els.reactionHistoryPreference.checked = socialPreferences.reactionHistoryEnabled;
+    if (els.botReactionsPreference) els.botReactionsPreference.checked = socialPreferences.botReactionsEnabled;
+    if (els.reactionHistory) els.reactionHistory.hidden = !(state && state.mode === 'live' && state.tableId && socialPreferences.reactionHistoryEnabled);
+  }
+
+  function syncSocialPreferencesIdentity(userId){
+    var normalizedUserId = typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+    if (socialPreferencesIdentity === normalizedUserId) return;
+    socialPreferencesIdentity = normalizedUserId;
+    socialPreferences = defaultSocialPreferences();
+    if (normalizedUserId){
+      try {
+        var raw = window.localStorage ? window.localStorage.getItem(SOCIAL_PREFERENCES_STORAGE_PREFIX + normalizedUserId) : null;
+        if (raw) socialPreferences = normalizeSocialPreferences(JSON.parse(raw));
+      } catch (err){
+        klog('poker_social_preferences_read_failed', { message: err && err.message ? err.message : String(err || 'unknown') });
+      }
+    }
+    renderSocialPreferences();
+  }
+
+  function persistSocialPreferences(){
+    if (!socialPreferencesIdentity) return;
+    try {
+      if (window.localStorage) window.localStorage.setItem(SOCIAL_PREFERENCES_STORAGE_PREFIX + socialPreferencesIdentity, JSON.stringify(socialPreferences));
+    } catch (err){
+      klog('poker_social_preferences_write_failed', { message: err && err.message ? err.message : String(err || 'unknown') });
+    }
   }
 
   function t(key, fallback){
@@ -1962,13 +2009,14 @@
 
   function renderReactionHistory(){
     var live = state && state.mode === 'live' && !!state.tableId;
-    if (els.reactionHistory) els.reactionHistory.hidden = !live;
+    var visible = live && socialPreferences.reactionHistoryEnabled;
+    if (els.reactionHistory) els.reactionHistory.hidden = !visible;
     if (els.reactionHistoryToggle){
       els.reactionHistoryToggle.setAttribute('aria-label', 'Reaction history, ' + reactionHistoryEntries.length + ' messages');
       els.reactionHistoryToggle.setAttribute('aria-expanded', live && reactionHistoryPanelOpen ? 'true' : 'false');
     }
     if (els.reactionHistoryCount) els.reactionHistoryCount.textContent = String(reactionHistoryEntries.length);
-    if (els.reactionHistoryPanel) els.reactionHistoryPanel.hidden = !live || !reactionHistoryPanelOpen;
+    if (els.reactionHistoryPanel) els.reactionHistoryPanel.hidden = !visible || !reactionHistoryPanelOpen;
     if (!els.reactionHistoryList) return;
     els.reactionHistoryList.innerHTML = '';
     if (!reactionHistoryEntries.length){
@@ -2030,13 +2078,22 @@
     }
   }
 
-  function appendReactionHistory(seatNo, senderDisplayName, reactionKey){
+  function appendReactionHistory(seatNo, senderDisplayName, reactionKey, senderUserId, senderIsBot){
     reactionHistoryEntries.push({
       senderSeatNo: seatNo,
       senderDisplayName: senderDisplayName,
       reactionKey: reactionKey,
+      senderUserId: senderUserId,
+      senderIsBot: senderIsBot === true,
       createdAt: Date.now()
     });
+    pruneReactionHistory();
+    renderReactionHistory();
+    scheduleReactionHistoryExpiry();
+  }
+
+  function removeBotReactionHistory(){
+    reactionHistoryEntries = reactionHistoryEntries.filter(function(item){ return item.senderIsBot !== true; });
     pruneReactionHistory();
     renderReactionHistory();
     scheduleReactionHistoryExpiry();
@@ -2192,6 +2249,18 @@
     delete reactionBubblesBySeatNo[seatNo];
   }
 
+  function clearReactionArtifacts(filter){
+    Object.keys(reactionBubblesBySeatNo).forEach(function(seatNo){
+      var bubble = reactionBubblesBySeatNo[seatNo];
+      if (!filter || filter(bubble)) clearReactionBubble(seatNo);
+    });
+    Object.keys(targetedReactionEffectsById).forEach(function(effectId){
+      var effect = targetedReactionEffectsById[effectId];
+      if (!filter || filter(effect)) clearTargetedReactionEffect(effectId);
+    });
+    renderSeats();
+  }
+
   function clearTargetedReactionEffect(effectId){
     var effect = targetedReactionEffectsById[effectId];
     if (effect && effect.timer) window.clearTimeout(effect.timer);
@@ -2319,13 +2388,18 @@
       if (!Number.isInteger(targetSeatNo) || targetSeatNo < 1 || targetSeatNo === seatNo || !targetOwnerUserId) return;
     }
     var senderSeat = state.seats.find(function(seat){ return seat && seat.seatNo === seatNo && seat.userId === ownerUserId; });
-    appendReactionHistory(seatNo, getPublicDisplayName(senderSeat || { userId: ownerUserId }), reactionKey);
+    var senderIsBot = !!(senderSeat && senderSeat.isBot === true);
+    if (senderIsBot && !socialPreferences.botReactionsEnabled) return;
+    appendReactionHistory(seatNo, getPublicDisplayName(senderSeat || { userId: ownerUserId }), reactionKey, ownerUserId, senderIsBot);
+    if (!socialPreferences.reactionBubblesEnabled) return;
     if (hasTargetSeatNo && reactionKey === 'nice_hand'){
       var effectId = String(nextTargetedReactionEffectId++);
       var effect = {
         senderSeatNo: seatNo,
         targetSeatNo: targetSeatNo,
         senderOwnerUserId: ownerUserId,
+        senderUserId: ownerUserId,
+        senderIsBot: senderIsBot,
         targetOwnerUserId: targetOwnerUserId,
         reactionKey: reactionKey,
         animate: true,
@@ -2342,7 +2416,7 @@
     }
     var previous = reactionBubblesBySeatNo[seatNo];
     if (previous && previous.timer) window.clearTimeout(previous.timer);
-    var bubble = { reactionKey: reactionKey, ownerUserId: ownerUserId, animate: true, timer: null };
+    var bubble = { reactionKey: reactionKey, ownerUserId: ownerUserId, senderUserId: ownerUserId, senderIsBot: senderIsBot, animate: true, timer: null };
     bubble.timer = window.setTimeout(function(){
       if (reactionBubblesBySeatNo[seatNo] !== bubble) return;
       delete reactionBubblesBySeatNo[seatNo];
@@ -4278,6 +4352,24 @@
     els.menuToggle.setAttribute('aria-expanded', 'false');
   }
 
+  function closeSocialSettings(){
+    if (els.socialSettingsPanel) els.socialSettingsPanel.hidden = true;
+    if (els.socialSettingsToggle) els.socialSettingsToggle.setAttribute('aria-expanded', 'false');
+  }
+
+  function updateSocialPreference(key, enabled){
+    socialPreferences[key] = enabled === true;
+    if (key === 'reactionBubblesEnabled' && !socialPreferences.reactionBubblesEnabled) clearReactionArtifacts();
+    if (key === 'reactionHistoryEnabled' && !socialPreferences.reactionHistoryEnabled) reactionHistoryPanelOpen = false;
+    if (key === 'botReactionsEnabled' && !socialPreferences.botReactionsEnabled){
+      clearReactionArtifacts(function(item){ return item && item.senderIsBot === true; });
+      removeBotReactionHistory();
+    }
+    persistSocialPreferences();
+    renderSocialPreferences();
+    renderReactionHistory();
+  }
+
   function navigateToLobby(){
     cancelClosedTableRedirect();
     clearReactionHistory();
@@ -4361,6 +4453,13 @@
         closeMenu();
       });
     });
+    if (els.socialSettingsToggle) els.socialSettingsToggle.addEventListener('click', function(){
+      var opening = !!(els.socialSettingsPanel && els.socialSettingsPanel.hidden);
+      closeMenu();
+      if (els.socialSettingsPanel) els.socialSettingsPanel.hidden = !opening;
+      els.socialSettingsToggle.setAttribute('aria-expanded', opening ? 'true' : 'false');
+    });
+    if (els.socialSettingsClose) els.socialSettingsClose.addEventListener('click', closeSocialSettings);
     document.addEventListener('click', function(event){
       var target = event && event.target;
       if (!target) return;
@@ -4370,7 +4469,7 @@
       closeMenu();
     });
     document.addEventListener('keydown', function(event){
-      if (event && event.key === 'Escape') closeMenu();
+      if (event && event.key === 'Escape') { closeMenu(); closeSocialSettings(); }
     });
   }
 
@@ -4476,6 +4575,9 @@
         els.reactionHistoryList.scrollTop = els.reactionHistoryList.scrollHeight;
       }
     });
+    if (els.reactionBubblesPreference) els.reactionBubblesPreference.addEventListener('change', function(){ updateSocialPreference('reactionBubblesEnabled', els.reactionBubblesPreference.checked); });
+    if (els.reactionHistoryPreference) els.reactionHistoryPreference.addEventListener('change', function(){ updateSocialPreference('reactionHistoryEnabled', els.reactionHistoryPreference.checked); });
+    if (els.botReactionsPreference) els.botReactionsPreference.addEventListener('change', function(){ updateSocialPreference('botReactionsEnabled', els.botReactionsPreference.checked); });
     document.addEventListener('click', function(event){
       var target = event && event.target;
       if (!target || target === els.reactionBtn || target === els.reactionMenu) return;
@@ -4502,6 +4604,12 @@
     els.menuToggle = document.getElementById('pokerMenuToggle');
     els.menuPanel = document.getElementById('pokerMenuPanel');
     els.lobbyLink = document.getElementById('pokerLobbyLink');
+    els.socialSettingsToggle = document.getElementById('pokerSocialSettingsToggle');
+    els.socialSettingsPanel = document.getElementById('pokerSocialSettingsPanel');
+    els.socialSettingsClose = document.getElementById('pokerSocialSettingsClose');
+    els.reactionBubblesPreference = document.getElementById('pokerReactionBubblesPreference');
+    els.reactionHistoryPreference = document.getElementById('pokerReactionHistoryPreference');
+    els.botReactionsPreference = document.getElementById('pokerBotReactionsPreference');
     els.seatLayer = document.getElementById('pokerSeatLayer');
     els.seatChipLayer = document.getElementById('pokerSeatChipLayer');
     els.chipFxLayer = document.getElementById('pokerChipFxLayer');
@@ -4644,6 +4752,7 @@
   }
 
   function applySignedOutState(){
+    syncSocialPreferencesIdentity(null);
     clearRebuyOperation();
     clearReactionHistory();
     stopLiveMode();
@@ -4656,6 +4765,7 @@
   function applyAuthenticatedPendingState(user){
     if (!user || !state.currentUserId || String(user.id || '') !== String(state.currentUserId)) clearRebuyOperation();
     syncReactionHistoryContext(tableId, user && user.id ? String(user.id) : null);
+    syncSocialPreferencesIdentity(user && user.id ? String(user.id) : null);
     stopLiveMode();
     resetQueuedPreactionState();
     isGuestMode = false;
@@ -4675,6 +4785,7 @@
   function restartAuthenticatedLiveMode(token){
     if (!tableId || !token) return;
     var nextUserId = getUserIdFromToken(token);
+    syncSocialPreferencesIdentity(nextUserId);
     if (nextUserId && state.currentUserId && nextUserId !== state.currentUserId) clearRebuyOperation();
     isGuestMode = false;
     currentGuestSession = null;
@@ -4946,6 +5057,7 @@
     isGuestMode = !!(currentGuestSession && currentGuestSession.token);
     if (isGuestMode){
       currentAccessToken = null;
+      syncSocialPreferencesIdentity(null);
       startLiveMode(currentGuestSession.token);
       startAuthWatch();
       return;

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -4352,9 +4352,11 @@
     els.menuToggle.setAttribute('aria-expanded', 'false');
   }
 
-  function closeSocialSettings(){
+  function closeSocialSettings(restoreFocus){
+    var wasOpen = !!(els.socialSettingsPanel && !els.socialSettingsPanel.hidden);
     if (els.socialSettingsPanel) els.socialSettingsPanel.hidden = true;
     if (els.socialSettingsToggle) els.socialSettingsToggle.setAttribute('aria-expanded', 'false');
+    if (restoreFocus && wasOpen && els.socialSettingsToggle && typeof els.socialSettingsToggle.focus === 'function') els.socialSettingsToggle.focus();
   }
 
   function updateSocialPreference(key, enabled){
@@ -4469,7 +4471,7 @@
       closeMenu();
     });
     document.addEventListener('keydown', function(event){
-      if (event && event.key === 'Escape') { closeMenu(); closeSocialSettings(); }
+      if (event && event.key === 'Escape') { closeMenu(); closeSocialSettings(true); }
     });
   }
 

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -45,7 +45,15 @@
 
     <nav class="poker-menu-panel" id="pokerMenuPanel" hidden>
       <a id="pokerLobbyLink" href="/poker/">Back to lobby</a>
+      <button type="button" class="poker-menu-panel__button" id="pokerSocialSettingsToggle" aria-expanded="false" aria-controls="pokerSocialSettingsPanel">Social settings</button>
     </nav>
+
+    <section class="poker-social-settings" id="pokerSocialSettingsPanel" aria-labelledby="pokerSocialSettingsTitle" hidden>
+      <div class="poker-social-settings__header"><strong id="pokerSocialSettingsTitle">Social settings</strong><button type="button" class="poker-social-settings__close" id="pokerSocialSettingsClose" aria-label="Close social settings">×</button></div>
+      <label class="poker-social-settings__option"><input type="checkbox" id="pokerReactionBubblesPreference" checked> Reaction bubbles</label>
+      <label class="poker-social-settings__option"><input type="checkbox" id="pokerReactionHistoryPreference" checked> Reaction history</label>
+      <label class="poker-social-settings__option"><input type="checkbox" id="pokerBotReactionsPreference" checked> Bot reactions</label>
+    </section>
 
     <section class="poker-live-panel">
       <div class="poker-live-meta">

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -45,7 +45,6 @@
 
     <nav class="poker-menu-panel" id="pokerMenuPanel" hidden>
       <a id="pokerLobbyLink" href="/poker/">Back to lobby</a>
-      <button type="button" class="poker-menu-panel__button" id="pokerSocialSettingsToggle" aria-expanded="false" aria-controls="pokerSocialSettingsPanel">Social settings</button>
     </nav>
 
     <section class="poker-social-settings" id="pokerSocialSettingsPanel" aria-labelledby="pokerSocialSettingsTitle" hidden>
@@ -114,6 +113,7 @@
       <section class="poker-reaction-history__panel" id="pokerReactionHistoryPanel" aria-label="Table reaction history" hidden>
         <div class="poker-reaction-history__list" id="pokerReactionHistoryList"></div>
       </section>
+      <button type="button" class="poker-live-btn poker-social-settings__toggle" id="pokerSocialSettingsToggle" aria-expanded="false" aria-controls="pokerSocialSettingsPanel" aria-label="Social settings"><span aria-hidden="true">⚙️</span></button>
       <div class="poker-action-amount-input" id="pokerV2AmountInputWrap">
         <strong id="pokerV2AmountValue">20</strong>
         <input type="range" id="pokerV2AmountInput" value="20" min="1" max="20" step="1">

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -65,8 +65,10 @@ function makeElement(id){
       return sceneRect;
     },
     setAttribute(name, value){ this.attributes[name] = String(value); },
+    getAttribute(name){ return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null; },
     removeAttribute(name){ delete this.attributes[name]; },
     hasAttribute(name){ return Object.prototype.hasOwnProperty.call(this.attributes, name); },
+    focus(){ this._focused = true; },
     click(){
       if (this.disabled) return;
       if (this.type === 'checkbox') this.checked = !this.checked;
@@ -743,6 +745,29 @@ test('bot preference suppresses and clears bot artifacts while human reactions r
   harness.advanceTime(60_000);
   await harness.flush();
   assert.equal(reactionHistoryRows(harness).length, 0);
+});
+
+test('Escape closes the social settings panel and restores focus to its toggle', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.elements.pokerSocialSettingsToggle.click();
+  assert.equal(harness.elements.pokerSocialSettingsPanel.hidden, false);
+  assert.equal(harness.elements.pokerSocialSettingsToggle.getAttribute('aria-expanded'), 'true');
+
+  harness.fireDocumentEvent('keydown', { key: 'Escape' });
+  assert.equal(harness.elements.pokerSocialSettingsPanel.hidden, true);
+  assert.equal(harness.elements.pokerSocialSettingsToggle.getAttribute('aria-expanded'), 'false');
+  assert.equal(harness.elements.pokerSocialSettingsToggle._focused, true);
+});
+
+test('Escape does not steal focus to the social settings toggle when the panel is already closed', async () => {
+  const harness = createHarness();
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  harness.fireDocumentEvent('keydown', { key: 'Escape' });
+  assert.equal(harness.elements.pokerSocialSettingsPanel.hidden, true);
+  assert.equal(harness.elements.pokerSocialSettingsToggle._focused, undefined);
 });
 
 test('poker v2 uses the WS settlement reveal deadline for targeted reactions', async () => {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -110,7 +110,8 @@ function createHarness(options = {}){
   const elements = {};
   [
     'xpBadge',
-    'pokerMenuToggle', 'pokerMenuPanel', 'pokerLobbyLink',
+    'pokerMenuToggle', 'pokerMenuPanel', 'pokerLobbyLink', 'pokerSocialSettingsToggle', 'pokerSocialSettingsPanel', 'pokerSocialSettingsClose',
+    'pokerReactionBubblesPreference', 'pokerReactionHistoryPreference', 'pokerBotReactionsPreference',
     'pokerSeatLayer', 'pokerSeatChipLayer', 'pokerChipFxLayer', 'pokerReactionLayer', 'pokerPotPill', 'pokerPotChipStack', 'pokerCommunityCards', 'pokerDealerChip',
     'pokerHeroCards', 'pokerV2LiveStatus', 'pokerV2TableMeta', 'pokerV2TurnText',
     'pokerV2StackText', 'pokerV2ErrorText', 'pokerV2GuestPanel', 'pokerV2GuestBadge', 'pokerV2SignInBtn', 'pokerV2SeatNo',
@@ -142,6 +143,10 @@ function createHarness(options = {}){
   elements.pokerV2ClosedTableModal.hidden = true;
   elements.pokerV2RebuyPanel.hidden = true;
   elements.pokerMenuPanel.setAttribute('hidden', 'hidden');
+  elements.pokerSocialSettingsPanel.hidden = true;
+  elements.pokerReactionBubblesPreference.type = 'checkbox';
+  elements.pokerReactionHistoryPreference.type = 'checkbox';
+  elements.pokerBotReactionsPreference.type = 'checkbox';
 
   const documentEvents = {};
   const logs = [];
@@ -225,6 +230,7 @@ function createHarness(options = {}){
   const intervalTimers = [];
   const timeoutTimers = [];
   const sessionStorageEntries = new Map();
+  const localStorageEntries = options.localStorageEntries instanceof Map ? options.localStorageEntries : new Map();
   let nextTimeoutId = 1;
   let nowMs = Number.isFinite(options.nowMs) ? options.nowMs : 1_700_000_000_000;
   const FakeDate = class extends Date {
@@ -274,6 +280,18 @@ function createHarness(options = {}){
       removeItem(key){ sessionStorageEntries.delete(String(key)); },
       clear(){ sessionStorageEntries.clear(); }
     },
+    localStorage: {
+      getItem(key){
+        if (options.localStorageReadError) throw new Error('local storage read failed');
+        return localStorageEntries.has(String(key)) ? localStorageEntries.get(String(key)) : null;
+      },
+      setItem(key, value){
+        if (options.localStorageWriteError) throw new Error('local storage write failed');
+        localStorageEntries.set(String(key), String(value));
+      },
+      removeItem(key){ localStorageEntries.delete(String(key)); },
+      clear(){ localStorageEntries.clear(); }
+    },
     document: {
       readyState: 'loading',
       addEventListener(type, fn){ documentEvents[type] = documentEvents[type] || []; documentEvents[type].push(fn); },
@@ -293,6 +311,7 @@ function createHarness(options = {}){
   };
   sandbox.window.document = sandbox.document;
   sandbox.window.sessionStorage = sandbox.sessionStorage;
+  sandbox.window.localStorage = sandbox.localStorage;
   if (Object.prototype.hasOwnProperty.call(options, 'authUser')) {
     sandbox.window.SupabaseAuth = {
       getCurrentUser: async () => options.authUser,
@@ -360,7 +379,8 @@ async function flush(){
     setAuthToken(nextToken){ activeToken = nextToken; },
     triggerAuthChange(user){ return authChangeHandler ? authChangeHandler('TOKEN_REFRESHED', user) : null; },
     getIntervalCount(){ return intervalTimers.length; },
-    getSessionStorage(key){ return sandbox.sessionStorage.getItem(key); }
+    getSessionStorage(key){ return sandbox.sessionStorage.getItem(key); },
+    getLocalStorage(key){ return sandbox.localStorage.getItem(key); }
   };
 }
 
@@ -411,7 +431,7 @@ async function bootReactionHistoryHarness(options = {}){
         maxSeats: 6,
         members: [
           { userId: 'user-1', seat: 1, displayName: 'Alice' },
-          { userId: 'user-2', seat: 2, displayName: options.historySenderDisplayName || 'Viktor' }
+          { userId: 'user-2', seat: 2, displayName: options.historySenderDisplayName || 'Viktor', isBot: options.historySenderIsBot === true }
         ]
       },
       public: { hand: { handId: 'hand-1', status: 'TURN' }, pot: { total: 10 } },
@@ -420,6 +440,13 @@ async function bootReactionHistoryHarness(options = {}){
   });
   await harness.flush();
   return { harness, ws };
+}
+
+function reactionBubbleTexts(harness){
+  return harness.elements.pokerReactionLayer.children
+    .flatMap((anchor) => anchor.children || [])
+    .filter((child) => String(child.className || '').startsWith('poker-seat-reaction-bubble'))
+    .map((child) => child.textContent);
 }
 
 test('poker v2 boots live mode, preserves table links, and sends WS commands', async () => {
@@ -635,6 +662,87 @@ test('reaction history survives same-table reconnect and clears on definitive le
   await harness.flush();
   assert.equal(reactionHistoryRows(harness).length, 0);
   assert.equal(harness.elements.pokerReactionHistoryCount.textContent, '0');
+});
+
+test('social preferences persist per authenticated user while guests stay in-memory and storage failures are safe', async () => {
+  const storage = new Map();
+  const first = createHarness({ localStorageEntries: storage });
+  first.fireDomContentLoaded();
+  await first.flush();
+  first.elements.pokerReactionBubblesPreference.click();
+  const userOneKey = 'kcswh:poker-social-preferences:v1:user-1';
+  assert.equal(JSON.parse(storage.get(userOneKey)).reactionBubblesEnabled, false);
+
+  const reload = createHarness({ localStorageEntries: storage });
+  reload.fireDomContentLoaded();
+  await reload.flush();
+  assert.equal(reload.elements.pokerReactionBubblesPreference.checked, false);
+
+  const userTwoToken = 'aaa.' + Buffer.from(JSON.stringify({ sub: 'user-2' })).toString('base64') + '.zzz';
+  const otherUser = createHarness({ localStorageEntries: storage, token: userTwoToken });
+  otherUser.fireDomContentLoaded();
+  await otherUser.flush();
+  assert.equal(otherUser.elements.pokerReactionBubblesPreference.checked, true);
+
+  const guest = createHarness({ localStorageEntries: storage, token: null, search: '?tableId=table-1&guest=1', guestSession: { token: 'guest-token', tableId: 'table-1', expiresAt: Date.now() + 60_000 } });
+  guest.fireDomContentLoaded();
+  await guest.flush();
+  guest.elements.pokerReactionHistoryPreference.click();
+  assert.equal([...storage.keys()].some((key) => key.includes('guest') || key.endsWith(':hero')), false);
+
+  const failing = createHarness({ localStorageEntries: storage, localStorageReadError: true, localStorageWriteError: true });
+  failing.fireDomContentLoaded();
+  await failing.flush();
+  assert.equal(failing.elements.pokerReactionBubblesPreference.checked, true);
+  failing.elements.pokerReactionBubblesPreference.click();
+  assert.equal(failing.elements.pokerReactionBubblesPreference.checked, false);
+  assert.ok(failing.logs.some((entry) => entry.kind === 'poker_social_preferences_read_failed'));
+  assert.ok(failing.logs.some((entry) => entry.kind === 'poker_social_preferences_write_failed'));
+});
+
+test('social preferences independently hide bubbles and history without dropping validated human history', async () => {
+  const { harness, ws } = await bootReactionHistoryHarness();
+  harness.elements.pokerReactionBubblesPreference.click();
+  ws.onReaction({ payload: { seatNo: 2, reactionKey: 'wow' } });
+  await harness.flush();
+  assert.deepEqual(reactionBubbleTexts(harness), []);
+  assert.equal(reactionHistoryRows(harness).length, 1);
+
+  harness.elements.pokerReactionHistoryPreference.click();
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'hello' } });
+  await harness.flush();
+  assert.equal(harness.elements.pokerReactionHistory.hidden, true);
+  assert.equal(reactionHistoryRows(harness).length, 2);
+  harness.elements.pokerReactionHistoryPreference.click();
+  assert.equal(harness.elements.pokerReactionHistory.hidden, false);
+  assert.equal(reactionHistoryRows(harness).length, 2);
+});
+
+test('bot preference suppresses and clears bot artifacts while human reactions remain', async () => {
+  const { harness, ws } = await bootReactionHistoryHarness({ historySenderIsBot: true });
+  ws.onReaction({ payload: { seatNo: 2, reactionKey: 'wow' } });
+  harness.advanceTime(60_000);
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'hello' } });
+  ws.onReaction({ payload: { seatNo: 2, reactionKey: 'wow' } });
+  await harness.flush();
+  assert.equal(reactionHistoryRows(harness).length, 3);
+  assert.deepEqual(reactionBubbleTexts(harness).sort(), ['👋 Hello', '😮 Wow!'].sort());
+
+  harness.elements.pokerBotReactionsPreference.click();
+  await harness.flush();
+  assert.equal(reactionHistoryRows(harness).length, 1);
+  assert.deepEqual(reactionBubbleTexts(harness), ['👋 Hello']);
+  ws.onReaction({ payload: { seatNo: 2, reactionKey: 'thanks' } });
+  ws.onReaction({ payload: { seatNo: 1, reactionKey: 'wow' } });
+  await harness.flush();
+  assert.equal(reactionHistoryRows(harness).length, 2);
+  assert.deepEqual(reactionBubbleTexts(harness), ['😮 Wow!']);
+  harness.advanceTime(9 * 60_000);
+  await harness.flush();
+  assert.equal(reactionHistoryRows(harness).length, 2);
+  harness.advanceTime(60_000);
+  await harness.flush();
+  assert.equal(reactionHistoryRows(harness).length, 0);
 });
 
 test('poker v2 uses the WS settlement reveal deadline for targeted reactions', async () => {


### PR DESCRIPTION
## Summary

- add local Poker V2 controls for reaction bubbles, reaction history, and bot reactions
- persist preferences best-effort only for authenticated users; guests use in-memory defaults
- snapshot sender identity/type on reaction artifacts so bot filtering is independent of later seat ownership
- preserve the existing history limit, TTL, and single expiry timer

## Impact

Client-only presentation change. No WebSocket, gameplay, settlement, persistence, migration, or CSP changes.

Closes #833.

## Validation

- `node --test tests/poker-v2-live.behavior.test.mjs tests/static-html.behavior.test.mjs` (101 passed)
- `node --check poker/poker-v2.js`
- `git diff --check`