### PR TITLE
Add recurring closed-table retention cleanup (#859)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Action-history cleanup PostgreSQL integration test
         run: node --test ws-server/poker/persistence/action-history-cleanup.integration.test.mjs
 
+      - name: Closed-table cleanup PostgreSQL integration test
+        run: node --test ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs
+
       - name: Validate games catalog
         run: npm run lint:games
 

--- a/.github/workflows/ws-pr-checks.yml
+++ b/.github/workflows/ws-pr-checks.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Run ws table manager behavior test
         run: node --test ws-server/poker/table/table-manager.behavior.test.mjs
 
+      - name: Run closed-table cleanup behavior test
+        run: node --test ws-server/poker/persistence/closed-table-cleanup.behavior.test.mjs
+
       - name: Run persisted state writer behavior test
         run: node --test ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
 

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -327,6 +327,8 @@ through `has_human_participant` predicates.
 | `WS_POKER_HUMAN_SETTLED_RETENTION_MS` | ms | `0` | finite non-negative integer | `0` | Delete `HAND_SETTLED` markers for human-participated tables after this many ms, only when ordinary actions and hole cards are gone |
 | `WS_POKER_ACTION_HISTORY_SWEEP_MS` | ms | `300000` (5 min) | `30_000`–`3_600_000` | N/A | Interval between cleanup sweep invocations |
 | `WS_POKER_ACTION_HISTORY_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate hands/settlements per phase per sweep. `lockLimit` is derived as `batchSize * 2` |
+| `WS_POKER_CLOSED_TABLE_RETENTION_MS` | ms | `604800000` (7 days) | finite non-negative integer | `0` | Delete old `CLOSED` poker tables after this many ms since terminal close (`updated_at`). Runs after the action-history sweep on the same timer; requires terminal state (`HAND_DONE` + empty `handId`), settled escrow (`balance = 0`), zero actions/hole cards, no fresh requests, and no unfinished durable `ACT` request |
+| `WS_POKER_CLOSED_TABLE_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate tables deleted per sweep. Runtime-loaded tables are excluded via `tableManager` retirement claims; the final guarded DELETE uses `FOR UPDATE SKIP LOCKED` |
 
 Validation rules (fail-fast at WS startup):
 
@@ -335,7 +337,7 @@ Validation rules (fail-fast at WS startup):
 - When both `> 0`, `settled` must be `>= action`.
 - `batchSize` must be an integer from 1 through 100.
 - Bot and human retention pairs are validated independently.
-- All defaults are `0`, so cleanup is disabled until explicitly configured.
+- Action-history retention defaults are `0` (disabled until configured). Closed-table retention defaults to 7 days; `0` disables it.
 
 A sweep-in-progress guard prevents concurrent sweeps when a sweep takes longer than the sweep interval.
 
@@ -350,6 +352,9 @@ WS_POKER_HUMAN_ACTION_RETENTION_MS=604800000
 WS_POKER_HUMAN_SETTLED_RETENTION_MS=2592000000
 WS_POKER_ACTION_HISTORY_SWEEP_MS=300000
 WS_POKER_ACTION_HISTORY_BATCH_SIZE=50
+# Closed-table retention (after terminal close + settled escrow):
+WS_POKER_CLOSED_TABLE_RETENTION_MS=604800000
+WS_POKER_CLOSED_TABLE_BATCH_SIZE=50
 ```
 
 Human-readable equivalents:
@@ -359,8 +364,9 @@ Human-readable equivalents:
 - Human-table settlements: **30 days**
 - Sweep interval: **5 minutes**
 - Batch size: **50** (lock limit: **100**)
+- Closed-table retention: **7 days** after terminal close, only when escrow is settled and history is gone
 
-This Preview policy is distinct from code defaults. Production defaults remain `0` (disabled) until separately configured. The `/opt/arcade-ws-preview/.env.preview` file is **not touched** by the `ws-preview-deploy.yml` workflow — rsync syncs only `ws-server/`, `shared/`, and `netlify/functions/_shared/` directories, so Preview env configuration persists across deploys.
+This Preview policy is distinct from code defaults. Action-history retention production defaults remain `0` (disabled) until separately configured; closed-table retention defaults to 7 days but only deletes tables that satisfy every safety guard. The `/opt/arcade-ws-preview/.env.preview` file is **not touched** by the `ws-preview-deploy.yml` workflow — rsync syncs only `ws-server/`, `shared/`, and `netlify/functions/_shared/` directories, so Preview env configuration persists across deploys.
 
 ### Required migrations and deployment order
 

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -87,7 +87,8 @@ register("DEBUG", "table_lifecycle", [
 register("INFO", "accounting", [
   "poker_leave_cashout",
   "poker_terminal_accounting_closed",
-  "ws_action_history_cleanup_complete"
+  "ws_action_history_cleanup_complete",
+  "ws_closed_table_cleanup_complete"
 ]);
 
 register("INFO", "admin", [
@@ -189,7 +190,8 @@ register("WARN", "table_lifecycle", [
 
 register("ERROR", "accounting", [
   "poker_terminal_accounting_invariant_failed",
-  "ws_action_history_cleanup_failed"
+  "ws_action_history_cleanup_failed",
+  "ws_closed_table_cleanup_failed"
 ]);
 
 register("ERROR", "autoplay", [

--- a/ws-server/poker/persistence/closed-table-cleanup.behavior.test.mjs
+++ b/ws-server/poker/persistence/closed-table-cleanup.behavior.test.mjs
@@ -1,0 +1,170 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createClosedTableCleanup } from "./closed-table-cleanup.mjs";
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+function envWithRetention(retentionMs = String(7 * DAY), batchSize = "20") {
+  return {
+    WS_POKER_CLOSED_TABLE_RETENTION_MS: String(retentionMs),
+    WS_POKER_CLOSED_TABLE_BATCH_SIZE: batchSize
+  };
+}
+
+test("cleanup is disabled when retention is 0", async () => {
+  let queries = 0;
+  const cleanup = createClosedTableCleanup({
+    env: { WS_POKER_CLOSED_TABLE_RETENTION_MS: "0", WS_POKER_CLOSED_TABLE_BATCH_SIZE: "20" },
+    beginSql: async (fn) => {
+      queries += 1;
+      return fn({ unsafe: async () => [] });
+    }
+  });
+  const result = await cleanup.sweep({ claimTableIds: () => ({ claimed: [], skipped: [] }) });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "cleanup_disabled");
+  assert.equal(queries, 0);
+});
+
+test("cleanup defaults to 7-day retention when the env var is absent", async () => {
+  const cleanup = createClosedTableCleanup({
+    env: { WS_POKER_CLOSED_TABLE_BATCH_SIZE: "20" },
+    beginSql: async (fn) => fn({
+      unsafe: async () => []
+    })
+  });
+  const status = await cleanup.status();
+  assert.equal(status.retentionMs, 7 * 86_400_000);
+  assert.equal(status.skipped, undefined);
+});
+
+test("rejects NaN retention", () => {
+  assert.throws(() => createClosedTableCleanup({
+    env: { WS_POKER_CLOSED_TABLE_RETENTION_MS: "not-a-number", WS_POKER_CLOSED_TABLE_BATCH_SIZE: "20" }
+  }), /WS_POKER_CLOSED_TABLE_RETENTION_MS/);
+});
+
+test("rejects negative retention", () => {
+  assert.throws(() => createClosedTableCleanup({
+    env: { WS_POKER_CLOSED_TABLE_RETENTION_MS: "-1", WS_POKER_CLOSED_TABLE_BATCH_SIZE: "20" }
+  }), /WS_POKER_CLOSED_TABLE_RETENTION_MS/);
+});
+
+test("rejects batch size 0", () => {
+  assert.throws(() => createClosedTableCleanup({
+    env: envWithRetention(undefined, "0")
+  }), /WS_POKER_CLOSED_TABLE_BATCH_SIZE/);
+});
+
+test("rejects batch size above 100", () => {
+  assert.throws(() => createClosedTableCleanup({
+    env: envWithRetention(undefined, "101")
+  }), /WS_POKER_CLOSED_TABLE_BATCH_SIZE/);
+});
+
+test("discover -> claim -> delete only claimed; skipped ids stay untouched", async () => {
+  const discoveryResults = [
+    ["table-a", "table-b", "table-c"]
+  ];
+  let released = [];
+  const cleanup = createClosedTableCleanup({
+    env: envWithRetention(),
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("delete from public.poker_tables")) {
+          return [{ id: "table-a" }, { id: "table-c" }];
+        }
+        if (sql.includes("select t.id")) {
+          const next = discoveryResults.shift() || [];
+          return next.map((id) => ({ id }));
+        }
+        return [];
+      }
+    })
+  });
+  const result = await cleanup.sweep({
+    claimTableIds: (candidateIds) => ({
+      claimed: candidateIds.filter((id) => id !== "table-b"),
+      skipped: candidateIds.filter((id) => id === "table-b")
+    }),
+    releaseTableIds: (claimedIds) => { released = claimedIds; }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.claimed, 2);
+  assert.equal(result.skippedIds, 1);
+  assert.equal(result.deleted, 2);
+  assert.deepEqual(released.sort(), ["table-a", "table-c"]);
+});
+
+test("release runs in finally even when the delete phase fails", async () => {
+  let released = null;
+  const cleanup = createClosedTableCleanup({
+    env: envWithRetention(),
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("delete from public.poker_tables")) {
+          const error = new Error("lock timeout");
+          error.code = "55P03";
+          throw error;
+        }
+        if (sql.includes("select t.id")) return [{ id: "table-a" }];
+        return [];
+      }
+    })
+  });
+  const result = await cleanup.sweep({
+    claimTableIds: (candidateIds) => ({ claimed: candidateIds, skipped: [] }),
+    releaseTableIds: (claimedIds) => { released = claimedIds; }
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(released, ["table-a"]);
+});
+
+test("skips sweep when a previous sweep is still in progress", async () => {
+  let resolveDiscovery;
+  const gate = new Promise((resolve) => { resolveDiscovery = resolve; });
+  const cleanup = createClosedTableCleanup({
+    env: envWithRetention(),
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("select t.id")) {
+          await gate;
+          return [{ id: "table-a" }];
+        }
+        return [];
+      }
+    })
+  });
+  const firstSweep = cleanup.sweep({
+    claimTableIds: (candidateIds) => ({ claimed: candidateIds, skipped: [] }),
+    releaseTableIds: () => {}
+  });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  const second = await cleanup.sweep({
+    claimTableIds: (candidateIds) => ({ claimed: candidateIds, skipped: [] }),
+    releaseTableIds: () => {}
+  });
+  assert.equal(second.skipped, true);
+  assert.equal(second.reason, "sweep_in_progress");
+  resolveDiscovery();
+  await firstSweep;
+});
+
+test("status exposes retention, batch and last run", async () => {
+  const cleanup = createClosedTableCleanup({
+    env: envWithRetention(String(7 * DAY), "50"),
+    beginSql: async (fn) => fn({
+      unsafe: async (sql) => {
+        if (sql.includes("count(*)::bigint")) return [{ eligible: "3" }];
+        return [];
+      }
+    })
+  });
+  const status = await cleanup.status();
+  assert.equal(status.retentionMs, 7 * DAY);
+  assert.equal(status.batchSize, 50);
+  assert.equal(status.backlog.available, true);
+  assert.equal(status.backlog.eligibleTables, 3);
+});

--- a/ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs
@@ -1,0 +1,320 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { createClosedTableCleanup } from "./closed-table-cleanup.mjs";
+
+// This test intentionally uses a disposable PostgreSQL database only. It is
+// enabled by TEST_DB_URL in CI and is never pointed at a shared Supabase DB by
+// the application itself.
+const dbUrl = process.env.TEST_DB_URL;
+const HAS_DB = Boolean(dbUrl);
+
+let sql;
+
+async function connect() {
+  if (!HAS_DB) return null;
+  const postgres = (await import("postgres")).default;
+  sql = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  return sql;
+}
+
+async function ensureSchema(db) {
+  // Add-missing, idempotent schema setup: this test may share the disposable
+  // TEST_DB_URL database with the action-history cleanup integration test,
+  // which already created poker_tables/poker_state/poker_actions/
+  // poker_hole_cards in a minimal shape (without updated_at). ALTER ... ADD
+  // COLUMN IF NOT EXISTS and CREATE ... IF NOT EXISTS make the schema complete
+  // for the closed-table SQL regardless of what already exists.
+  await db.unsafe(`
+    do $$ begin
+      create type public.chips_account_type as enum ('USER', 'SYSTEM', 'ESCROW');
+    exception when duplicate_object then null;
+    end $$;
+    do $$ begin
+      create type public.chips_account_status as enum ('active', 'frozen', 'closed');
+    exception when duplicate_object then null;
+    end $$;
+    create table if not exists public.poker_tables (
+      id uuid primary key,
+      status text not null default 'OPEN',
+      updated_at timestamptz not null default now()
+    );
+    alter table public.poker_tables
+      add column if not exists updated_at timestamptz not null default now();
+    create table if not exists public.poker_state (
+      table_id uuid primary key,
+      version bigint not null default 0,
+      state jsonb not null default '{}'::jsonb
+    );
+    create table if not exists public.poker_actions (
+      id bigserial primary key,
+      table_id uuid not null,
+      hand_id text,
+      action_type text not null,
+      created_at timestamptz not null default now()
+    );
+    create index if not exists poker_actions_table_id_created_at_idx
+      on public.poker_actions (table_id, created_at);
+    create table if not exists public.poker_hole_cards (
+      table_id uuid not null,
+      hand_id text not null,
+      user_id uuid not null,
+      cards jsonb not null,
+      created_at timestamptz not null default now()
+    );
+    create index if not exists poker_hole_cards_table_hand_idx
+      on public.poker_hole_cards (table_id, hand_id);
+    create table if not exists public.poker_requests (
+      table_id uuid not null references public.poker_tables (id) on delete cascade,
+      user_id uuid not null,
+      request_id text not null,
+      kind text not null,
+      result_json jsonb,
+      created_at timestamptz not null default now(),
+      unique (table_id, request_id)
+    );
+    create table if not exists public.chips_accounts (
+      id uuid primary key default gen_random_uuid(),
+      account_type public.chips_account_type not null,
+      status public.chips_account_status not null default 'active',
+      label text,
+      system_key text,
+      balance bigint not null default 0,
+      next_entry_seq bigint not null default 1,
+      created_at timestamptz not null default timezone('utc', now()),
+      updated_at timestamptz not null default timezone('utc', now())
+    );
+  `);
+  // Ensure poker_state cascades to poker_tables. The shared TEST_DB_URL may
+  // already have a minimal poker_state created by the action-history cleanup
+  // integration test without the FK; add it idempotently (table is empty at
+  // this point because that test cleans up its fixtures in finally).
+  await db.unsafe(`
+    do $$ begin
+      alter table public.poker_state
+        add constraint poker_state_table_id_fkey
+        foreign key (table_id) references public.poker_tables (id) on delete cascade;
+    exception when duplicate_object then null;
+    end $$;
+  `);
+}
+
+function beginSql(db) {
+  return async (fn) => db.begin(async (tx) => fn({
+    unsafe: (query, params) => tx.unsafe(query, params)
+  }));
+}
+
+const DAY = 86_400_000;
+const RETENTION_MS = 7 * DAY;
+
+function oldCutoff() {
+  return new Date(Date.now() - RETENTION_MS).toISOString();
+}
+
+function oldDate() {
+  return new Date(Date.now() - (RETENTION_MS + 60_000)).toISOString();
+}
+
+test("closed-table cleanup executes guarded DELETE on PostgreSQL", { skip: !HAS_DB }, async () => {
+  const db = await connect();
+  const cleanupTableIds = [];
+
+  try {
+    await ensureSchema(db);
+    const cleanup = createClosedTableCleanup({
+      maxSweepRounds: 1,
+      env: {
+        WS_POKER_CLOSED_TABLE_RETENTION_MS: String(RETENTION_MS),
+        WS_POKER_CLOSED_TABLE_BATCH_SIZE: "100"
+      },
+      beginSql: beginSql(db)
+    });
+
+    // --- safe candidate: everything clean, escrow 0, no actions/cards/requests
+    const safeTableId = randomUUID();
+    cleanupTableIds.push(safeTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [safeTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [safeTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${safeTableId}`]
+    );
+    await db.unsafe(
+      "insert into public.poker_requests (table_id, user_id, request_id, kind, result_json, created_at) values ($1, $2, $3, 'ACT', $4::jsonb, $5)",
+      [safeTableId, randomUUID(), `req-${randomUUID()}`, JSON.stringify({ ok: true }), oldDate()]
+    );
+
+    // --- protected: OPEN table
+    const openTableId = randomUUID();
+    cleanupTableIds.push(openTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'OPEN', $2)",
+      [openTableId, oldDate()]
+    );
+
+    // --- protected: CLOSED with poker_actions
+    const actionsTableId = randomUUID();
+    cleanupTableIds.push(actionsTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [actionsTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [actionsTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${actionsTableId}`]
+    );
+    await db.unsafe(
+      "insert into public.poker_actions (table_id, action_type, created_at) values ($1, 'CHECK', $2)",
+      [actionsTableId, oldDate()]
+    );
+
+    // --- protected: CLOSED with escrow > 0
+    const escrowTableId = randomUUID();
+    cleanupTableIds.push(escrowTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [escrowTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [escrowTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 250)",
+      [`POKER_TABLE:${escrowTableId}`]
+    );
+
+    // --- protected: CLOSED with unfinished durable ACT
+    const unfinishedActTableId = randomUUID();
+    cleanupTableIds.push(unfinishedActTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [unfinishedActTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [unfinishedActTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${unfinishedActTableId}`]
+    );
+    await db.unsafe(
+      "insert into public.poker_requests (table_id, user_id, request_id, kind, result_json, created_at) values ($1, $2, $3, 'ACT', null, $4)",
+      [unfinishedActTableId, randomUUID(), `req-${randomUUID()}`, oldDate()]
+    );
+
+    // --- protected: CLOSED with fresh request (any kind, inside window)
+    const freshRequestTableId = randomUUID();
+    cleanupTableIds.push(freshRequestTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [freshRequestTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [freshRequestTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${freshRequestTableId}`]
+    );
+    await db.unsafe(
+      "insert into public.poker_requests (table_id, user_id, request_id, kind, result_json) values ($1, $2, $3, 'LEAVE', $4::jsonb)",
+      [freshRequestTableId, randomUUID(), `req-${randomUUID()}`, JSON.stringify({ ok: true })]
+    );
+
+    // --- protected: CLOSED with fresh updated_at (inside window)
+    const freshTableId = randomUUID();
+    cleanupTableIds.push(freshTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status) values ($1, 'CLOSED')",
+      [freshTableId]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [freshTableId, { phase: "HAND_DONE", handId: "" }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${freshTableId}`]
+    );
+
+    // --- protected: CLOSED with non-terminal state
+    const nonTerminalTableId = randomUUID();
+    cleanupTableIds.push(nonTerminalTableId);
+    await db.unsafe(
+      "insert into public.poker_tables (id, status, updated_at) values ($1, 'CLOSED', $2)",
+      [nonTerminalTableId, oldDate()]
+    );
+    await db.unsafe(
+      "insert into public.poker_state (table_id, state) values ($1, $2::jsonb)",
+      [nonTerminalTableId, { phase: "FLOP", handId: `hand-${randomUUID()}` }]
+    );
+    await db.unsafe(
+      "insert into public.chips_accounts (account_type, status, system_key, balance) values ('ESCROW', 'active', $1, 0)",
+      [`POKER_TABLE:${nonTerminalTableId}`]
+    );
+
+    // --- measure eligible CLOSED count before the sweep (functional proof)
+    const eligibleBefore = await cleanup.readBacklog();
+    assert.equal(eligibleBefore.available, true, JSON.stringify(eligibleBefore));
+    assert.ok(eligibleBefore.eligibleTables >= 1, `expected >=1 eligible before sweep, got ${eligibleBefore.eligibleTables}`);
+
+    const result = await cleanup.sweep({
+      claimTableIds: (candidateIds) => ({ claimed: candidateIds, skipped: [] }),
+      releaseTableIds: () => {}
+    });
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.ok(result.deleted >= 1, `expected deleted >= 1, got ${result.deleted}`);
+
+    // --- eligible count must decrease after the sweep
+    const eligibleAfter = await cleanup.readBacklog();
+    assert.equal(eligibleAfter.available, true, JSON.stringify(eligibleAfter));
+    assert.ok(eligibleAfter.eligibleTables < eligibleBefore.eligibleTables,
+      `expected eligible after < before (${eligibleBefore.eligibleTables}), got ${eligibleAfter.eligibleTables}`);
+
+    const remaining = await db.unsafe(
+      "select id from public.poker_tables where id = any($1::uuid[])",
+      [cleanupTableIds]
+    );
+    const remainingIds = remaining.map((row) => row.id);
+
+    // safe table is deleted along with cascade rows
+    assert.ok(!remainingIds.includes(safeTableId), `safe table should be deleted: ${remainingIds}`);
+    const safeState = await db.unsafe(
+      "select count(*)::bigint as rows from public.poker_state where table_id = $1",
+      [safeTableId]
+    );
+    const safeRequests = await db.unsafe(
+      "select count(*)::bigint as rows from public.poker_requests where table_id = $1",
+      [safeTableId]
+    );
+    assert.equal(Number(safeState[0].rows), 0, "poker_state should cascade");
+    assert.equal(Number(safeRequests[0].rows), 0, "poker_requests should cascade");
+
+    // all protected cases remain
+    for (const protectedId of [openTableId, actionsTableId, escrowTableId,
+      unfinishedActTableId, freshRequestTableId, freshTableId, nonTerminalTableId]) {
+      assert.ok(remainingIds.includes(protectedId), `protected table ${protectedId} should remain`);
+    }
+  } finally {
+    if (sql && cleanupTableIds.length > 0) {
+      try {
+        await sql`delete from public.poker_tables where id = any(${sql(cleanupTableIds)})`;
+      } catch { /* ignore cleanup failure */ }
+    }
+    await sql?.end();
+  }
+});

--- a/ws-server/poker/persistence/closed-table-cleanup.mjs
+++ b/ws-server/poker/persistence/closed-table-cleanup.mjs
@@ -1,0 +1,423 @@
+// Closed-table retention cleanup.
+//
+// Removes old CLOSED poker tables whose gameplay/audit data has already been
+// retained away and whose terminal accounting is fully settled. This is the
+// FINAL stage of the table lifecycle: it runs after the action-history cleanup
+// so that poker_actions and poker_hole_cards are gone first, and it requires
+// positive proof that the table is safe to delete.
+//
+// Safety (all enforced inside the same final DELETE statement):
+//   - status = 'CLOSED' and updated_at older than the retention cutoff
+//     (terminal close sets updated_at = now() in the same transaction);
+//   - terminal persisted state (phase = 'HAND_DONE', handId = ''); a missing
+//     or malformed state fails closed;
+//   - escrow accounting proof (read-only): an active ESCROW chips_account with
+//     balance = 0 for 'POKER_TABLE:<id>';
+//   - no poker_actions rows;
+//   - no poker_hole_cards rows;
+//   - no fresh poker_requests (any kind) inside the retention window;
+//   - no unfinished durable ACT request (kind = 'ACT' AND result_json IS NULL).
+//
+// Runtime safety: candidates are atomically claimed through
+// tableManager.beginTableRetirement() (synchronous, checks tables and
+// pendingBootstrapByTableId). ensureTable/ensureTableLoaded reject claimed ids
+// fail-closed, so a candidate cannot be materialized back into the runtime
+// between the final runtime check and the DELETE.
+//
+// Flow: bounded candidate discovery -> runtime claim -> final guarded
+// CTE DELETE (FOR UPDATE SKIP LOCKED) -> release in finally.
+
+import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
+
+const DEFAULT_MAX_SWEEP_ROUNDS = 1;
+const MAX_SWEEP_ROUNDS = 20;
+const DELETE_LOCK_TIMEOUT_MS = 250;
+const DELETE_STATEMENT_TIMEOUT_MS = 10_000;
+// Closed-table retention is ON by default (7 days) so unbounded CLOSED-table
+// growth is bounded without requiring new env configuration. Set
+// WS_POKER_CLOSED_TABLE_RETENTION_MS=0 to disable.
+const DEFAULT_CLOSED_TABLE_RETENTION_MS = 7 * 86_400_000;
+
+function resolveCutoff(retentionMs) {
+  if (!Number.isFinite(retentionMs) || retentionMs <= 0) return null;
+  return new Date(Date.now() - retentionMs).toISOString();
+}
+
+function postgresErrorDetails(error) {
+  const text = (value, maxLength) => typeof value === "string" && value.length > 0
+    ? value.slice(0, maxLength)
+    : null;
+  return {
+    code: text(error?.code, 40),
+    message: text(error?.message, 500),
+    detail: text(error?.detail, 1_000),
+    where: text(error?.where, 1_000)
+  };
+}
+
+// Bounded discovery of candidate CLOSED table ids that currently satisfy the
+// DB eligibility predicates. Read-only (no row locks).
+async function discoverCandidates({ tx, cutoff, batchSize, statementTimeoutMs }) {
+  await tx.unsafe("select set_config('statement_timeout', $1, true);", [`${statementTimeoutMs}ms`]);
+  const rows = await tx.unsafe(
+    `select t.id
+       from public.poker_tables t
+      where t.status = 'CLOSED'
+        and t.updated_at < $1::timestamptz
+        and exists (
+              select 1 from public.poker_state ps
+               where ps.table_id = t.id
+                 and jsonb_typeof(ps.state) = 'object'
+                 and ps.state ->> 'phase' = 'HAND_DONE'
+                 and jsonb_typeof(ps.state -> 'handId') = 'string'
+                 and ps.state ->> 'handId' = ''
+            )
+        and exists (
+              select 1 from public.chips_accounts ca
+               where ca.system_key = 'POKER_TABLE:' || t.id::text
+                 and ca.account_type = 'ESCROW'
+                 and ca.status = 'active'
+                 and ca.balance = 0
+            )
+        and not exists (select 1 from public.poker_actions pa where pa.table_id = t.id)
+        and not exists (select 1 from public.poker_hole_cards hc where hc.table_id = t.id)
+        and not exists (select 1 from public.poker_requests r
+                         where r.table_id = t.id
+                           and r.created_at >= $1::timestamptz)
+        and not exists (select 1 from public.poker_requests r
+                         where r.table_id = t.id
+                           and r.kind = 'ACT'
+                           and r.result_json is null)
+      order by t.updated_at
+      limit $2;`,
+    [cutoff, batchSize]
+  );
+  return Array.isArray(rows) ? rows.map((row) => row?.id).filter((id) => typeof id === "string") : [];
+}
+
+// Final guarded DELETE for claimed ids. Re-validates EVERY eligibility
+// predicate in the same statement that takes the row locks, so a claimed id
+// that stopped satisfying the guards between discovery and DELETE simply drops
+// out (DELETE returns nothing for it). FOR UPDATE SKIP LOCKED skips rows
+// locked by other transactions instead of waiting.
+async function deleteClaimed({ tx, cutoff, claimedIds, batchSize }) {
+  if (!Array.isArray(claimedIds) || claimedIds.length === 0) {
+    return { deleted: 0, ids: [] };
+  }
+  await tx.unsafe("select set_config('lock_timeout', $1, true);", [`${DELETE_LOCK_TIMEOUT_MS}ms`]);
+  await tx.unsafe("select set_config('statement_timeout', $1, true);", [`${DELETE_STATEMENT_TIMEOUT_MS}ms`]);
+  const rows = await tx.unsafe(
+    `with locked as (
+  select t.id
+    from public.poker_tables t
+   where t.id = any($3::uuid[])
+     and t.status = 'CLOSED'
+     and t.updated_at < $1::timestamptz
+     and exists (
+           select 1 from public.poker_state ps
+            where ps.table_id = t.id
+              and jsonb_typeof(ps.state) = 'object'
+              and ps.state ->> 'phase' = 'HAND_DONE'
+              and jsonb_typeof(ps.state -> 'handId') = 'string'
+              and ps.state ->> 'handId' = ''
+         )
+     and exists (
+           select 1 from public.chips_accounts ca
+            where ca.system_key = 'POKER_TABLE:' || t.id::text
+              and ca.account_type = 'ESCROW'
+              and ca.status = 'active'
+              and ca.balance = 0
+         )
+     and not exists (select 1 from public.poker_actions pa where pa.table_id = t.id)
+     and not exists (select 1 from public.poker_hole_cards hc where hc.table_id = t.id)
+     and not exists (select 1 from public.poker_requests r
+                      where r.table_id = t.id
+                        and r.created_at >= $1::timestamptz)
+     and not exists (select 1 from public.poker_requests r
+                      where r.table_id = t.id
+                        and r.kind = 'ACT'
+                        and r.result_json is null)
+   order by t.updated_at
+   limit $2
+   for update skip locked
+)
+delete from public.poker_tables t
+ using locked l
+ where t.id = l.id
+returning t.id;`,
+    [cutoff, batchSize, claimedIds]
+  );
+  const ids = Array.isArray(rows) ? rows.map((row) => row?.id).filter((id) => typeof id === "string") : [];
+  return { deleted: ids.length, ids };
+}
+
+export function createClosedTableCleanup({
+  env = process.env,
+  maxSweepRounds = DEFAULT_MAX_SWEEP_ROUNDS,
+  beginSql = beginSqlWs,
+  klog = () => {}
+} = {}) {
+  function resolveRetentionMs(rawValue, label) {
+    if (rawValue === undefined) return DEFAULT_CLOSED_TABLE_RETENTION_MS;
+    const num = Number(rawValue);
+    if (!Number.isFinite(num) || num < 0 || !Number.isInteger(num)) {
+      throw new Error(
+        `WS_POKER_CLOSED_TABLE_RETENTION_MS must be a finite non-negative integer, got: ${JSON.stringify(rawValue)}`
+      );
+    }
+    return num;
+  }
+
+  function resolveBatchSize(rawValue) {
+    if (rawValue === undefined) return 20;
+    const num = Number(rawValue);
+    if (!Number.isFinite(num) || num < 1 || num > 100 || !Number.isInteger(num)) {
+      throw new Error(
+        `WS_POKER_CLOSED_TABLE_BATCH_SIZE must be an integer 1-100, got: ${JSON.stringify(rawValue)}`
+      );
+    }
+    return num;
+  }
+
+  const retentionMs = resolveRetentionMs(env.WS_POKER_CLOSED_TABLE_RETENTION_MS, "CLOSED_TABLE");
+  const batchSize = resolveBatchSize(env.WS_POKER_CLOSED_TABLE_BATCH_SIZE);
+  const sweepRounds = Number.isInteger(maxSweepRounds)
+    && maxSweepRounds >= DEFAULT_MAX_SWEEP_ROUNDS
+    && maxSweepRounds <= MAX_SWEEP_ROUNDS
+    ? maxSweepRounds
+    : DEFAULT_MAX_SWEEP_ROUNDS;
+
+  let sweepInProgress = false;
+  let lastRun = null;
+
+  function buildCutoff() {
+    return resolveCutoff(retentionMs);
+  }
+
+  async function sweep({ claimTableIds = null, releaseTableIds = null } = {}) {
+    if (sweepInProgress) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: "sweep_in_progress",
+        claimed: 0,
+        skippedIds: 0,
+        deleted: 0,
+        failedPhases: []
+      };
+    }
+    sweepInProgress = true;
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    let result = null;
+    let claimedIds = [];
+    try {
+      const cutoff = buildCutoff();
+      if (!cutoff) {
+        result = {
+          ok: true,
+          skipped: true,
+          reason: "cleanup_disabled",
+          claimed: 0,
+          skippedIds: 0,
+          deleted: 0,
+          failedPhases: []
+        };
+        return result;
+      }
+
+      let claimedTotal = 0;
+      let skippedTotal = 0;
+      let deletedTotal = 0;
+      const failedPhases = new Set();
+
+      for (let round = 0; round < sweepRounds; round += 1) {
+        const candidates = await beginSql((tx) => discoverCandidates({
+          tx,
+          cutoff,
+          batchSize,
+          statementTimeoutMs: DELETE_STATEMENT_TIMEOUT_MS
+        }), { env });
+
+        if (candidates.length === 0) break;
+
+        const claimed = typeof claimTableIds === "function"
+          ? claimTableIds(candidates)
+          : { claimed: candidates, skipped: [] };
+        const safeClaimed = Array.isArray(claimed?.claimed) ? claimed.claimed : [];
+        const safeSkipped = Array.isArray(claimed?.skipped) ? claimed.skipped : [];
+        claimedIds.push(...safeClaimed);
+        claimedTotal += safeClaimed.length;
+        skippedTotal += safeSkipped.length;
+
+        if (safeClaimed.length > 0) {
+          try {
+            const outcome = await beginSql((tx) => deleteClaimed({
+              tx,
+              cutoff,
+              claimedIds: safeClaimed,
+              batchSize
+            }), { env });
+            deletedTotal += outcome.deleted;
+          } catch (error) {
+            failedPhases.add("closed_table_delete");
+            klog("ws_closed_table_cleanup_failed", {
+              errorCode: "closed_table_cleanup_failed",
+              failedPhases: ["closed_table_delete"],
+              claimed: safeClaimed.length,
+              skippedIds: safeSkipped.length,
+              deleted: deletedTotal,
+              batchSize,
+              sweepRounds,
+              reason: postgresErrorDetails(error)
+            });
+            break;
+          }
+        }
+      }
+
+      result = {
+        ok: failedPhases.size === 0,
+        claimed: claimedTotal,
+        skippedIds: skippedTotal,
+        deleted: deletedTotal,
+        failedPhases: [...failedPhases],
+        errorCode: failedPhases.size > 0 ? "closed_table_cleanup_failed" : null,
+        skipped: false,
+        reason: failedPhases.size > 0 ? "closed_table_cleanup_failed" : null
+      };
+
+      if (result.ok && (claimedTotal > 0 || deletedTotal > 0)) {
+        klog("ws_closed_table_cleanup_complete", {
+          claimed: claimedTotal,
+          skippedIds: skippedTotal,
+          deleted: deletedTotal,
+          batchSize,
+          sweepRounds
+        });
+      } else if (!result.ok) {
+        klog("ws_closed_table_cleanup_failed", {
+          errorCode: result.errorCode,
+          failedPhases: result.failedPhases,
+          claimed: claimedTotal,
+          skippedIds: skippedTotal,
+          deleted: deletedTotal,
+          batchSize,
+          sweepRounds
+        });
+      }
+      return result;
+    } catch (error) {
+      result = {
+        ok: false,
+        claimed: 0,
+        skippedIds: 0,
+        deleted: 0,
+        failedPhases: ["closed_table_cleanup"],
+        errorCode: "closed_table_cleanup_failed",
+        skipped: false,
+        reason: "closed_table_cleanup_failed"
+      };
+      klog("ws_closed_table_cleanup_failed", {
+        errorCode: result.errorCode,
+        failedPhases: result.failedPhases,
+        claimed: 0,
+        skippedIds: 0,
+        deleted: 0,
+        batchSize,
+        sweepRounds,
+        reason: postgresErrorDetails(error)
+      });
+      return result;
+    } finally {
+      if (typeof releaseTableIds === "function" && claimedIds.length > 0) {
+        releaseTableIds(claimedIds);
+      }
+      sweepInProgress = false;
+      lastRun = {
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        durationMs: Math.max(0, Date.now() - startedAtMs),
+        claimed: Number(result?.claimed || 0),
+        skippedIds: Number(result?.skippedIds || 0),
+        deleted: Number(result?.deleted || 0),
+        result: result?.ok === true ? (result?.skipped ? "skipped" : "success") : "failed",
+        skipped: result?.skipped === true,
+        reason: result?.reason || null,
+        errorCode: result?.errorCode || null,
+        failedPhases: Array.isArray(result?.failedPhases) ? result.failedPhases : []
+      };
+    }
+  }
+
+  async function readBacklog() {
+    const cutoff = buildCutoff();
+    if (!cutoff) {
+      return { available: false, eligibleTables: null, measuredAt: new Date().toISOString() };
+    }
+    try {
+      const rows = await beginSql(async (tx) => {
+        await tx.unsafe("select set_config('statement_timeout', '2000ms', true);");
+        return tx.unsafe(
+          `select count(*)::bigint as eligible
+             from public.poker_tables t
+            where t.status = 'CLOSED'
+              and t.updated_at < $1::timestamptz
+              and exists (
+                    select 1 from public.poker_state ps
+                     where ps.table_id = t.id
+                       and jsonb_typeof(ps.state) = 'object'
+                       and ps.state ->> 'phase' = 'HAND_DONE'
+                       and jsonb_typeof(ps.state -> 'handId') = 'string'
+                       and ps.state ->> 'handId' = ''
+                  )
+              and exists (
+                    select 1 from public.chips_accounts ca
+                     where ca.system_key = 'POKER_TABLE:' || t.id::text
+                       and ca.account_type = 'ESCROW'
+                       and ca.status = 'active'
+                       and ca.balance = 0
+                  )
+              and not exists (select 1 from public.poker_actions pa where pa.table_id = t.id)
+              and not exists (select 1 from public.poker_hole_cards hc where hc.table_id = t.id)
+              and not exists (select 1 from public.poker_requests r
+                               where r.table_id = t.id
+                                 and r.created_at >= $1::timestamptz)
+              and not exists (select 1 from public.poker_requests r
+                               where r.table_id = t.id
+                                 and r.kind = 'ACT'
+                                 and r.result_json is null);`,
+          [cutoff]
+        );
+      }, { env });
+      return {
+        available: true,
+        eligibleTables: Number(rows?.[0]?.eligible || 0),
+        measuredAt: new Date().toISOString(),
+        cached: false
+      };
+    } catch (error) {
+      return {
+        available: false,
+        eligibleTables: null,
+        measuredAt: new Date().toISOString(),
+        cached: false,
+        error: String(error?.code || "backlog_query_failed").slice(0, 120)
+      };
+    }
+  }
+
+  async function status() {
+    return {
+      retentionMs,
+      batchSize,
+      sweepRounds,
+      sweepInProgress,
+      lastRun,
+      lastError: lastRun?.errorCode ? { code: lastRun.errorCode } : null,
+      backlog: await readBacklog()
+    };
+  }
+
+  return { sweep, status, readBacklog };
+}

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -3244,3 +3244,57 @@ test("public profile failure and timeout return initials fallback without reject
   assert.equal("profile" in snapshot.seats[0], false);
   assert.equal(snapshot.members.length, 1);
 });
+
+test("beginTableRetirement claims only unloaded ids and rejects materialization fail-closed", async () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+
+  // Load one table so it is resident in the runtime.
+  tableManager.materializeLobbyTable({ tableId: "loaded-table" });
+
+  const retirement = tableManager.beginTableRetirement(["loaded-table", "candidate-table"]);
+  assert.deepEqual(retirement.skipped, ["loaded-table"]);
+  assert.deepEqual(retirement.claimed, ["candidate-table"]);
+
+  assert.equal(tableManager.isTableRetiring("candidate-table"), true);
+  assert.equal(tableManager.isTableRetiring("loaded-table"), false);
+
+  // Materializing a retiring id must fail closed through the public path that
+  // reaches the central ensureTable choke-point.
+  assert.throws(() => tableManager.materializeLobbyTable({ tableId: "candidate-table" }), (error) => {
+    assert.equal(error.code, "table_retiring");
+    return true;
+  });
+
+  // ensureTableLoaded must fail closed as well.
+  const loaded = await tableManager.ensureTableLoaded("candidate-table");
+  assert.equal(loaded.ok, false);
+  assert.equal(loaded.code, "table_retiring");
+
+  // Release clears the claim so the id can be materialized again.
+  tableManager.endTableRetirement(["candidate-table"]);
+  assert.equal(tableManager.isTableRetiring("candidate-table"), false);
+  const materialized = tableManager.materializeLobbyTable({ tableId: "candidate-table" });
+  assert.equal(materialized.ok, true);
+});
+
+test("beginTableRetirement skips ids with an in-flight persisted bootstrap", async () => {
+  let releaseBootstrap;
+  const bootstrapGate = new Promise((resolve) => { releaseBootstrap = resolve; });
+  const tableManager = createTableManager({
+    maxSeats: 6,
+    tableBootstrapLoader: async () => {
+      await bootstrapGate;
+      return { ok: true, table: { coreState: { version: 0, roomId: "bootstrap-table", maxSeats: 6, members: [] } } };
+    }
+  });
+
+  const bootstrapPromise = tableManager.ensureTableLoaded("bootstrap-table");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const retirement = tableManager.beginTableRetirement(["bootstrap-table"]);
+  assert.deepEqual(retirement.claimed, []);
+  assert.deepEqual(retirement.skipped, ["bootstrap-table"]);
+
+  releaseBootstrap();
+  await bootstrapPromise;
+});

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -318,6 +318,7 @@ export function createTableManager({
     : DEFAULT_PUBLIC_PROFILE_TIMEOUT_MS;
   const tables = new Map();
   const pendingBootstrapByTableId = new Map();
+  const retiringTableIds = new Set();
   const connStateBySocket = new Map();
 
   function ensurePublicProfileState(table) {
@@ -538,6 +539,15 @@ export function createTableManager({
 
   function ensureTable(tableId) {
     if (!tables.has(tableId)) {
+      if (retiringTableIds.has(tableId)) {
+        // A retiring table (closed-table retention) must never be
+        // materialized again while its DB row is being deleted. Callers run
+        // inside enqueueTableCommand / handler error handling, so the coded
+        // throw propagates fail-closed without spreading branches to callers.
+        const error = new Error("table_retiring");
+        error.code = "table_retiring";
+        throw error;
+      }
       const initialCoreState = createInitialCoreState({ roomId: tableId, maxSeats });
       const nowMs = Date.now();
       tables.set(tableId, {
@@ -656,6 +666,12 @@ export function createTableManager({
   }
 
   async function ensureTableLoaded(tableId, { allowCreate = false } = {}) {
+    if (retiringTableIds.has(tableId)) {
+      // Retiring tables are fail-closed: they may only be read from
+      // persistence, never materialized back into the runtime while the
+      // closed-table retention cleanup is deleting their DB row.
+      return { ok: false, code: "table_retiring", message: "table_retiring" };
+    }
     const existingTable = tables.get(tableId);
     if (existingTable && !needsPersistedBootstrap(existingTable)) {
       return { ok: true, table: existingTable, cached: true };
@@ -2235,6 +2251,38 @@ export function createTableManager({
     return [...tables.keys()].sort((left, right) => left.localeCompare(right));
   }
 
+  // Closed-table retention coordination. beginTableRetirement atomically claims
+  // candidate table ids that are NOT currently materialized in the runtime
+  // (tables) and NOT mid-bootstrap (pendingBootstrapByTableId). Claimed ids
+  // are fail-closed in ensureTable/ensureTableLoaded until release.
+  function beginTableRetirement(tableIds) {
+    const claimed = [];
+    const skipped = [];
+    if (!Array.isArray(tableIds)) return { claimed, skipped };
+    for (const rawId of tableIds) {
+      const tableId = typeof rawId === "string" ? rawId.trim() : "";
+      if (!tableId || tables.has(tableId) || pendingBootstrapByTableId.has(tableId)) {
+        skipped.push(tableId || rawId);
+        continue;
+      }
+      retiringTableIds.add(tableId);
+      claimed.push(tableId);
+    }
+    return { claimed, skipped };
+  }
+
+  function endTableRetirement(tableIds) {
+    if (!Array.isArray(tableIds)) return;
+    for (const rawId of tableIds) {
+      const tableId = typeof rawId === "string" ? rawId.trim() : "";
+      if (tableId) retiringTableIds.delete(tableId);
+    }
+  }
+
+  function isTableRetiring(tableId) {
+    return typeof tableId === "string" && retiringTableIds.has(tableId.trim());
+  }
+
   function tableMeta(tableId) {
     const table = tables.get(tableId);
     if (!table) {
@@ -2328,6 +2376,9 @@ export function createTableManager({
     orderedSubscribers,
     orderedConnectionsForTable,
     listTableIds,
+    beginTableRetirement,
+    endTableRetirement,
+    isTableRetiring,
     tableMeta,
     markTableRotationDue,
     setTableRotationDueAt,

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -76,6 +76,7 @@ import { createContinuousBotTableRepository } from "./poker/persistence/continuo
 import { createContinuousBotTableSupervisor } from "./poker/runtime/continuous-bot-table-supervisor.mjs";
 import { handleContinuousBotRotationAtSettled } from "./poker/runtime/continuous-bot-table-rotation.mjs";
 import { createActionHistoryCleanup } from "./poker/persistence/action-history-cleanup.mjs";
+import { createClosedTableCleanup } from "./poker/persistence/closed-table-cleanup.mjs";
 import { createVpsMetricsCollector } from "./observability/vps-metrics.mjs";
 import {
   isManagedReplacementSeatProjectionConflict,
@@ -3570,6 +3571,9 @@ async function buildInternalPokerMaintenanceStatus(environment) {
   const cleanup = actionHistoryCleanup
     ? await actionHistoryCleanup.status()
     : null;
+  const closedTableCleanupStatus = closedTableCleanup
+    ? await closedTableCleanup.status()
+    : null;
   return {
     ok: true,
     environment,
@@ -3592,7 +3596,8 @@ async function buildInternalPokerMaintenanceStatus(environment) {
         lastError: null
       }
     },
-    cleanup
+    cleanup,
+    closedTableCleanup: closedTableCleanupStatus
   };
 }
 
@@ -5392,9 +5397,27 @@ const actionHistoryCleanup = hasSupabaseDbUrl
     })
   : null;
 
-if (actionHistoryCleanup) {
+// Closed-table retention cleanup runs AFTER the action-history sweep on the
+// same timer, so table rows are only deleted once their action/hole-card
+// history has been retained away. Runtime-loaded tables are excluded through
+// tableManager.beginTableRetirement/endTableRetirement.
+const closedTableCleanup = hasSupabaseDbUrl
+  ? createClosedTableCleanup({
+      env: process.env,
+      maxSweepRounds: loadReleaseMetadata().environment === "preview" ? 10 : 1,
+      klog: klogSafe
+    })
+  : null;
+
+if (actionHistoryCleanup || closedTableCleanup) {
   const actionHistoryCleanupTimer = setInterval(() => {
-    void actionHistoryCleanup.sweep();
+    void actionHistoryCleanup.sweep().finally(() => {
+      if (!closedTableCleanup) return;
+      void closedTableCleanup.sweep({
+        claimTableIds: (candidateIds) => tableManager.beginTableRetirement(candidateIds),
+        releaseTableIds: (claimedIds) => tableManager.endTableRetirement(claimedIds)
+      });
+    });
   }, actionHistoryCleanupSweepMs);
   actionHistoryCleanupTimer.unref();
 }


### PR DESCRIPTION
## Summary

Adds a recurring, bounded retention cleanup for old `CLOSED` poker tables so continuous-table rotation reaches a bounded plateau instead of growing `poker_tables`/`poker_state`/`poker_seats`/`poker_requests` indefinitely.

## Design

Runs as the **final stage of the table lifecycle** on the existing action-history timer (no new scheduler): `actionHistoryCleanup.sweep()` → `closedTableCleanup.sweep()`.

**Eligibility (all enforced inside the same final guarded DELETE):**
- `status = 'CLOSED'` and `updated_at < cutoff` (retention measured from terminal close, which sets `updated_at = now()`)
- Positive terminal state proof: `phase = 'HAND_DONE'` and `handId = ''` (string); missing/malformed state fails closed
- Escrow accounting proof (read-only): active `ESCROW` chips_account with `balance = 0` for `POKER_TABLE:<id>`
- No `poker_actions`, no `poker_hole_cards` (history retention ran first)
- No fresh `poker_requests` (any kind) inside the window
- No unfinished durable `ACT` request (`kind = 'ACT' AND result_json IS NULL`, any age)

**Runtime safety:** candidates are atomically claimed via `tableManager.beginTableRetirement()` (checks `tables` and `pendingBootstrapByTableId`); `ensureTable()`/`ensureTableLoaded()` reject claimed ids fail-closed, closing the materialization race between the final runtime check and the DELETE.

**DB safety:** final DELETE is a CTE `SELECT ... FOR UPDATE SKIP LOCKED` with full re-validation of every predicate; a claimed id that stops satisfying the guards between discovery and DELETE simply drops out. The chips ledger is read-only (escrow balance check) and never modified or deleted.

## Impact

Persistence lifecycle only. No gameplay, protocol, settlement, or accounting behavior changes. Ledger rows are never touched by this cleanup.

Closes #859.

## Validation

- `node --test ws-server/poker/persistence/closed-table-cleanup.behavior.test.mjs` (9 passed)
- `node --test ws-server/poker/table/table-manager.behavior.test.mjs` (88 passed)
- `node --test ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs` (PostgreSQL, TEST_DB_URL in CI)
- `npm run ci:guards`, `npm run test:unit`, `npm run syntax`
- Existing ws-server suites unchanged (124 passed, 3 integration skipped without TEST_DB_URL)