### PR TITLE
Add chips ledger and database capacity monitoring to admin Ops (#860)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -700,6 +700,16 @@
                 <div id="adminOpsPokerEscrow"></div>
               </section>
 
+              <section class="xp-card admin-card" aria-labelledby="adminOpsLedgerCapacityTitle">
+                <div class="admin-card__head">
+                  <div>
+                    <h2 class="xp-card__title" id="adminOpsLedgerCapacityTitle">Ledger / Database capacity</h2>
+                    <p class="admin-card__subtitle">Read-only capacity snapshot of the chips ledger and database.</p>
+                  </div>
+                </div>
+                <div id="adminOpsLedgerCapacity"></div>
+              </section>
+
               <section class="xp-card admin-card" aria-labelledby="adminOpsBotReactionTitle">
                 <div class="admin-card__head">
                   <div>

--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -329,6 +329,7 @@ through `has_human_participant` predicates.
 | `WS_POKER_ACTION_HISTORY_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate hands/settlements per phase per sweep. `lockLimit` is derived as `batchSize * 2` |
 | `WS_POKER_CLOSED_TABLE_RETENTION_MS` | ms | `604800000` (7 days) | finite non-negative integer | `0` | Delete old `CLOSED` poker tables after this many ms since terminal close (`updated_at`). Runs after the action-history sweep on the same timer; requires terminal state (`HAND_DONE` + empty `handId`), settled escrow (`balance = 0`), zero actions/hole cards, no fresh requests, and no unfinished durable `ACT` request |
 | `WS_POKER_CLOSED_TABLE_BATCH_SIZE` | count | `20` | `1`–`100` integer | N/A | Maximum candidate tables deleted per sweep. Runtime-loaded tables are excluded via `tableManager` retirement claims; the final guarded DELETE uses `FOR UPDATE SKIP LOCKED` |
+| `ADMIN_LEDGER_DB_WARNING_MB` | MB | `800` | finite non-negative integer | `0` | Database total size warning threshold for the admin Ops "Ledger / Database capacity" section. `0` disables the warning only (measurements are still reported and `capacityStatus` stays `OK`); invalid or negative values fall back to the default. Configure per environment according to the actual database capacity and operational policy. |
 
 Validation rules (fail-fast at WS startup):
 

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -148,6 +148,7 @@
     nodes.opsIdentity = doc.getElementById("adminOpsIdentity");
     nodes.opsRuntime = doc.getElementById("adminOpsRuntime");
     nodes.opsPokerEscrow = doc.getElementById("adminOpsPokerEscrow");
+    nodes.opsLedgerCapacity = doc.getElementById("adminOpsLedgerCapacity");
     nodes.opsBotReactionSummary = doc.getElementById("adminOpsBotReactionSummary");
     nodes.opsBotReactionForm = doc.getElementById("adminOpsBotReactionForm");
     nodes.opsBotReactionDelay = doc.getElementById("adminOpsBotReactionDelay");
@@ -1349,6 +1350,7 @@
       if (nodes.opsIdentity) nodes.opsIdentity.innerHTML = "";
       if (nodes.opsRuntime) nodes.opsRuntime.innerHTML = "";
       if (nodes.opsPokerEscrow) nodes.opsPokerEscrow.innerHTML = "";
+      if (nodes.opsLedgerCapacity) nodes.opsLedgerCapacity.innerHTML = "";
       if (nodes.opsRecentActions) nodes.opsRecentActions.innerHTML = "";
       if (nodes.opsRecentCleanup) nodes.opsRecentCleanup.innerHTML = "";
       return;
@@ -1444,6 +1446,44 @@
                 meta: escapeHtml((item.status || "unknown") + " · escrow " + formatTimestamp(item.escrowUpdatedAt) + " · table " + formatTimestamp(item.tableUpdatedAt)),
               };
             })),
+            "</div>"
+          ].join("");
+        }
+      }
+    }
+    if (nodes.opsLedgerCapacity){
+      if (!summary){
+        nodes.opsLedgerCapacity.innerHTML = "";
+      } else {
+        var capacity = summary.ledgerCapacity;
+        var capacityAvailable = capacity && capacity.available === true;
+        if (!capacityAvailable){
+          nodes.opsLedgerCapacity.innerHTML = [
+            '<div class="admin-surface">',
+            '<div class="admin-list__title"><span>Ledger capacity</span>' + pill("Unavailable", "info") + "</div>",
+            '<p class="admin-empty">Capacity data could not be loaded.</p>',
+            "</div>"
+          ].join("");
+        } else {
+          var capacityTone = capacity.capacityStatus === "warning" ? "danger" : "success";
+          var capacityLabel = capacity.capacityStatus === "warning" ? "Warning" : "OK";
+          var thresholdLabel = Number(capacity.warningThresholdBytes) > 0
+            ? formatBytes(capacity.warningThresholdBytes)
+            : "disabled";
+          var shareText = Number.isFinite(Number(capacity.ledgerSharePercent))
+            ? " (" + String(capacity.ledgerSharePercent) + "% of database)"
+            : "";
+          nodes.opsLedgerCapacity.innerHTML = [
+            '<div class="admin-surface">',
+            '<div class="admin-list__title"><span>Ledger capacity</span>' + pill(capacityLabel, capacityTone) + "</div>",
+            '<div class="admin-kv">',
+            renderKvRow("Database total size", formatBytes(capacity.dbTotalBytes)),
+            renderKvRow("chips_transactions", formatAmount(capacity.transactionRowCount) + " rows · " + formatBytes(capacity.transactionTotalBytes) + " total · " + formatBytes(capacity.transactionTableBytes) + " table · " + formatBytes(capacity.transactionIndexBytes) + " indexes"),
+            renderKvRow("chips_entries", formatAmount(capacity.entryRowCount) + " rows · " + formatBytes(capacity.entryTotalBytes) + " total · " + formatBytes(capacity.entryTableBytes) + " table · " + formatBytes(capacity.entryIndexBytes) + " indexes"),
+            renderKvRow("Ledger total", formatBytes(capacity.ledgerTotalBytes) + shareText),
+            renderKvRow("Capacity status", String(capacity.capacityStatus || "—") + " · threshold " + thresholdLabel),
+            renderKvRow("Measured", formatTimestamp(capacity.measuredAt)),
+            "</div>",
             "</div>"
           ].join("");
         }

--- a/netlify/functions/admin-ops-summary.mjs
+++ b/netlify/functions/admin-ops-summary.mjs
@@ -96,6 +96,96 @@ select
   }
 }
 
+const DEFAULT_LEDGER_DB_WARNING_MB = 800;
+
+function resolveLedgerDbWarningMb(rawValue) {
+  if (rawValue === undefined || rawValue === null || String(rawValue).trim() === "") return DEFAULT_LEDGER_DB_WARNING_MB;
+  const num = Number(rawValue);
+  // The env value is documented as a finite non-negative integer; a
+  // non-integer value is treated as invalid rather than silently truncated.
+  if (!Number.isInteger(num) || num < 0) return DEFAULT_LEDGER_DB_WARNING_MB;
+  return num;
+}
+
+async function loadLedgerCapacity(env = process.env, runSql = executeSql) {
+  const warningMb = resolveLedgerDbWarningMb(env.ADMIN_LEDGER_DB_WARNING_MB);
+  const warningThresholdBytes = warningMb * 1024 * 1024;
+  const measuredAt = new Date().toISOString();
+  try {
+    const rows = await runSql(
+      `select
+  (select count(*) from public.chips_transactions) as tx_rows,
+  (select count(*) from public.chips_entries)      as entry_rows,
+  (select pg_table_size('public.chips_transactions'))        as tx_table_bytes,
+  (select pg_indexes_size('public.chips_transactions'))      as tx_index_bytes,
+  (select pg_total_relation_size('public.chips_transactions')) as tx_total_bytes,
+  (select pg_table_size('public.chips_entries'))             as entry_table_bytes,
+  (select pg_indexes_size('public.chips_entries'))           as entry_index_bytes,
+  (select pg_total_relation_size('public.chips_entries'))    as entry_total_bytes,
+  (select pg_database_size(current_database()))              as db_total_bytes;`,
+    );
+    const row = rows?.[0] || {};
+    const transactionTotalBytes = Number(row.tx_total_bytes);
+    const entryTotalBytes = Number(row.entry_total_bytes);
+    const dbTotalBytes = Number(row.db_total_bytes);
+    const ledgerTotalBytes = Number.isSafeInteger(transactionTotalBytes) && Number.isSafeInteger(entryTotalBytes)
+      ? transactionTotalBytes + entryTotalBytes
+      : null;
+    const ledgerSharePercent = Number.isSafeInteger(dbTotalBytes) && dbTotalBytes > 0 && Number.isSafeInteger(ledgerTotalBytes)
+      ? Number(((ledgerTotalBytes / dbTotalBytes) * 100).toFixed(1))
+      : null;
+    const capacityStatus = warningThresholdBytes > 0 && Number.isSafeInteger(dbTotalBytes) && dbTotalBytes >= warningThresholdBytes
+      ? "warning"
+      : "OK";
+    const result = {
+      available: true,
+      transactionRowCount: Number(row.tx_rows) || 0,
+      entryRowCount: Number(row.entry_rows) || 0,
+      transactionTableBytes: Number(row.tx_table_bytes) || 0,
+      transactionIndexBytes: Number(row.tx_index_bytes) || 0,
+      transactionTotalBytes: transactionTotalBytes || 0,
+      entryTableBytes: Number(row.entry_table_bytes) || 0,
+      entryIndexBytes: Number(row.entry_index_bytes) || 0,
+      entryTotalBytes: entryTotalBytes || 0,
+      ledgerTotalBytes: ledgerTotalBytes || 0,
+      ledgerSharePercent,
+      dbTotalBytes: dbTotalBytes || 0,
+      capacityStatus,
+      warningThresholdBytes,
+      measuredAt,
+    };
+    klog("admin_ops_ledger_capacity", {
+      databaseBytes: result.dbTotalBytes,
+      ledgerBytes: result.ledgerTotalBytes,
+      transactionRows: result.transactionRowCount,
+      entryRows: result.entryRowCount,
+      capacityStatus,
+      warningThresholdBytes,
+      measuredAt,
+    });
+    return result;
+  } catch (error) {
+    klog("admin_ops_ledger_capacity_failed", { reason: error?.code || "query_failed" });
+    return {
+      available: false,
+      transactionRowCount: null,
+      entryRowCount: null,
+      transactionTableBytes: null,
+      transactionIndexBytes: null,
+      transactionTotalBytes: null,
+      entryTableBytes: null,
+      entryIndexBytes: null,
+      entryTotalBytes: null,
+      ledgerTotalBytes: null,
+      ledgerSharePercent: null,
+      dbTotalBytes: null,
+      capacityStatus: null,
+      warningThresholdBytes,
+      measuredAt,
+    };
+  }
+}
+
 async function loadOpsSummary(env = process.env) {
   const janitorConfig = resolveJanitorConfig(env);
   const staleSeatCutoffIso = new Date(
@@ -103,7 +193,7 @@ async function loadOpsSummary(env = process.env) {
   ).toISOString();
   const idleThresholdMinutes = 15;
   const idleCutoffIso = new Date(Date.now() - idleThresholdMinutes * 60 * 1000).toISOString();
-  const [openTableRows, statsRows, recentActions, recentCleanupTransactions, wsHealth, pokerEscrowResiduals] = await Promise.all([
+  const [openTableRows, statsRows, recentActions, recentCleanupTransactions, wsHealth, pokerEscrowResiduals, ledgerCapacity] = await Promise.all([
     executeSql("select id from public.poker_tables where status = 'OPEN' order by updated_at asc, id asc;"),
     executeSql(
       `
@@ -149,6 +239,7 @@ limit 16;
     ),
     fetchWsHealth(env),
     loadPokerEscrowResidualSummary(),
+    loadLedgerCapacity(env),
   ]);
   const openTableIds = (Array.isArray(openTableRows) ? openTableRows : []).map((row) => row.id).filter(Boolean);
   const snapshots = await loadPersistedTableSnapshots(openTableIds);
@@ -206,6 +297,7 @@ limit 16;
       healthy: envVisibility.chipsEnabled && envVisibility.adminUserIdsConfigured && wsHealth.ok !== false,
     },
     pokerEscrowResiduals,
+    ledgerCapacity,
   };
 }
 
@@ -242,6 +334,8 @@ const handler = createAdminOpsSummaryHandler();
 export {
   createAdminOpsSummaryHandler,
   handler,
+  loadLedgerCapacity,
   loadPokerEscrowResidualSummary,
   loadOpsSummary,
+  resolveLedgerDbWarningMb,
 };

--- a/tests/admin-ops-summary.behavior.test.mjs
+++ b/tests/admin-ops-summary.behavior.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-const { createAdminOpsSummaryHandler, loadPokerEscrowResidualSummary } = await import("../netlify/functions/admin-ops-summary.mjs");
+const { createAdminOpsSummaryHandler, loadLedgerCapacity, loadPokerEscrowResidualSummary, resolveLedgerDbWarningMb } = await import("../netlify/functions/admin-ops-summary.mjs");
 
 function createEvent() {
   return {
@@ -95,4 +95,92 @@ test("poker escrow monitoring treats positive orphan escrow as a problem", async
   assert.equal(summary.problemChips, 500);
   assert.equal(summary.latestEscrowUpdateAt, "2026-07-16T15:00:00.000Z");
   assert.equal(summary.items[0].status, "ORPHANED");
+});
+
+function ledgerRowFixture() {
+  return [{
+    tx_rows: 19800,
+    entry_rows: 39700,
+    tx_table_bytes: 20000000,
+    tx_index_bytes: 4000000,
+    tx_total_bytes: 24000000,
+    entry_table_bytes: 10000000,
+    entry_index_bytes: 3000000,
+    entry_total_bytes: 13000000,
+    db_total_bytes: 200000000,
+  }];
+}
+
+test("ledger capacity maps SQL rows to the ops contract with table/index/total sizes", async () => {
+  const summary = await loadLedgerCapacity(
+    { ADMIN_LEDGER_DB_WARNING_MB: "800" },
+    async () => ledgerRowFixture(),
+  );
+
+  assert.equal(summary.available, true);
+  assert.equal(summary.transactionRowCount, 19800);
+  assert.equal(summary.entryRowCount, 39700);
+  assert.equal(summary.transactionTableBytes, 20000000);
+  assert.equal(summary.transactionIndexBytes, 4000000);
+  assert.equal(summary.transactionTotalBytes, 24000000);
+  assert.equal(summary.entryTableBytes, 10000000);
+  assert.equal(summary.entryIndexBytes, 3000000);
+  assert.equal(summary.entryTotalBytes, 13000000);
+  assert.equal(summary.ledgerTotalBytes, 37000000);
+  assert.equal(summary.dbTotalBytes, 200000000);
+  assert.equal(summary.ledgerSharePercent, 18.5);
+  assert.equal(summary.warningThresholdBytes, 800 * 1024 * 1024);
+  assert.equal(summary.capacityStatus, "OK");
+  assert.ok(typeof summary.measuredAt === "string" && summary.measuredAt.length > 0);
+});
+
+test("ledger capacity reports warning when database size reaches the threshold", async () => {
+  const summary = await loadLedgerCapacity(
+    { ADMIN_LEDGER_DB_WARNING_MB: "100" },
+    async () => [{
+      tx_rows: 19800, entry_rows: 39700,
+      tx_table_bytes: 20000000, tx_index_bytes: 4000000, tx_total_bytes: 24000000,
+      entry_table_bytes: 10000000, entry_index_bytes: 3000000, entry_total_bytes: 13000000,
+      db_total_bytes: 200 * 1024 * 1024,
+    }],
+  );
+
+  assert.equal(summary.available, true);
+  assert.equal(summary.warningThresholdBytes, 100 * 1024 * 1024);
+  assert.equal(summary.capacityStatus, "warning");
+});
+
+test("ledger capacity stays OK when the warning threshold is disabled", async () => {
+  const summary = await loadLedgerCapacity(
+    { ADMIN_LEDGER_DB_WARNING_MB: "0" },
+    async () => ledgerRowFixture(),
+  );
+
+  assert.equal(summary.available, true);
+  assert.equal(summary.warningThresholdBytes, 0);
+  assert.equal(summary.capacityStatus, "OK");
+  assert.ok(summary.transactionRowCount > 0, "measurements still reported when threshold disabled");
+});
+
+test("ledger capacity falls back to the default threshold for invalid env values", () => {
+  assert.equal(resolveLedgerDbWarningMb("abc"), 800);
+  assert.equal(resolveLedgerDbWarningMb("-5"), 800);
+  assert.equal(resolveLedgerDbWarningMb("1.9"), 800);
+  assert.equal(resolveLedgerDbWarningMb(undefined), 800);
+  assert.equal(resolveLedgerDbWarningMb(""), 800);
+  assert.equal(resolveLedgerDbWarningMb("120"), 120);
+});
+
+test("ledger capacity returns available:false without raw error on SQL failure", async () => {
+  const summary = await loadLedgerCapacity(
+    { ADMIN_LEDGER_DB_WARNING_MB: "800" },
+    async () => { throw Object.assign(new Error("connect timeout"), { code: "CONNECT_TIMEOUT" }); },
+  );
+
+  assert.equal(summary.available, false);
+  assert.equal(summary.transactionRowCount, null);
+  assert.equal(summary.dbTotalBytes, null);
+  assert.equal(summary.capacityStatus, null);
+  assert.equal("error" in summary, false);
+  assert.equal(summary.warningThresholdBytes, 800 * 1024 * 1024);
 });


### PR DESCRIPTION
## Summary

Adds a lightweight, read-only **Ledger / Database capacity** section to the existing admin Ops panel, exposing chips-ledger size and growth without SQL/SSH for operators.

## Design

- **`admin-ops-summary.mjs`**: new `loadLedgerCapacity(env, runSql)` — one read-only SQL returning row counts and `pg_table_size`/`pg_indexes_size`/`pg_total_relation_size` for `chips_transactions` and `chips_entries`, plus `pg_database_size(current_database())`.
- Contract: `transactionRowCount`/`entryRowCount`, table/index/total sizes per table, `ledgerTotalBytes`, informational `ledgerSharePercent`, `dbTotalBytes`, `capacityStatus` (`OK`/`warning`), `warningThresholdBytes`, `measuredAt`.
- **Warning threshold** `ADMIN_LEDGER_DB_WARNING_MB` (default `800`): `0` disables the warning only (measurements still reported, `capacityStatus` stays `OK`); invalid/negative fall back to the default.
- **Best-effort**: SQL failure → `available: false` with null measurements + `klog("admin_ops_ledger_capacity_failed")`; success → `klog("admin_ops_ledger_capacity")` with timestamped samples (growth derivable over time). No new scheduler.
- **`admin.html` + `js/admin-page.js`**: compact read-only section in the Ops tab (reuses existing `xp-card`/`admin-card`/`renderKvRow`/`formatBytes`/`formatAmount`/`formatTimestamp`); table/index/total sizes always shown, plus combined ledger size + share of database, status + threshold, measurement timestamp.

## Impact

Monitoring only. No ledger mutation, no gameplay/funding/settlement/cashout changes, no DB migration, no new dashboard or scheduler.

Closes #860.

## Validation

- `node --test tests/admin-ops-summary.behavior.test.mjs` — 5 new fundamental backend tests (SQL→contract mapping, OK below threshold, warning at/above threshold, threshold disabled, invalid env fallback, `available:false` without raw error). Note: 3 pre-existing tests in this file fail on `main` with `forbidden_origin` (CORS origin not in allowlist); they are unchanged and not executed by CI.
- `node --test tests/admin-page.behavior.test.mjs` (11 passed)
- `npm run ci:guards`, `npm run test:unit`, `npm run syntax`