### PR TITLE
Add opt-in auto-rebuy when out of chips (#712)

### DIFF
--- a/poker/poker-v2.css
+++ b/poker/poker-v2.css
@@ -184,6 +184,9 @@ body{margin:0; min-height:100vh; font-family:Poppins, sans-serif; background:#06
 .poker-social-settings__close{width:30px;height:30px;padding:0;border:1px solid rgba(255,215,157,0.25);border-radius:8px;background:rgba(21,30,47,0.7);color:#e7efff;font-size:1.15rem;line-height:1;}
 .poker-social-settings__option{display:flex;align-items:center;gap:9px;padding:9px 4px;font-size:0.88rem;}
 .poker-social-settings__option input{accent-color:#d6aa62;}
+.poker-social-settings__option--stacked{flex-direction:column;align-items:stretch;gap:4px;}
+.poker-social-settings__option--stacked > label{display:flex;align-items:center;gap:9px;}
+.poker-social-settings__hint{margin:0;font-size:0.74rem;line-height:1.35;color:#9fb2cf;}
 
 .poker-live-panel{position:relative; z-index:19; width:min(100%, 980px); margin:78px auto 0; padding:14px 16px; border-radius:22px; border:1px solid rgba(255,223,180,0.22); background:linear-gradient(180deg, rgba(10,15,24,0.88), rgba(4,6,11,0.96)); box-shadow:0 16px 28px rgba(0,0,0,0.46), inset 0 1px 1px rgba(255,255,255,0.08);}
 

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -216,6 +216,7 @@
   var queuedPreactionInFlight = false;
   var rebuyOperation = null;
   var rebuyPanelDismissed = false;
+  var autoRebuyAttemptedForCurrentBust = false;
   var rebuyBalanceLoading = false;
   var stickyWinnerReveal = {
     handId: null,
@@ -259,6 +260,7 @@
   var REACTION_HISTORY_LIMIT = 25;
   var REACTION_HISTORY_TTL_MS = 10 * 60 * 1000;
   var SOCIAL_PREFERENCES_STORAGE_PREFIX = 'kcswh:poker-social-preferences:v1:';
+  var AUTO_REBUY_STORAGE_PREFIX = 'kcswh:poker-auto-rebuy:v1:';
 
   function defaultSocialPreferences(){
     return { reactionBubblesEnabled: true, reactionHistoryEnabled: true, botReactionsEnabled: true };
@@ -495,6 +497,8 @@
     if (els.reactionHistoryPreference) els.reactionHistoryPreference.checked = socialPreferences.reactionHistoryEnabled;
     if (els.botReactionsPreference) els.botReactionsPreference.checked = socialPreferences.botReactionsEnabled;
     if (els.reactionHistory) els.reactionHistory.hidden = !(state && state.mode === 'live' && state.tableId && socialPreferences.reactionHistoryEnabled);
+    if (els.autoRebuyPreference) els.autoRebuyPreference.checked = isAutoRebuyEnabled();
+    if (els.autoRebuyPreferenceWrap) els.autoRebuyPreferenceWrap.hidden = !socialPreferencesIdentity;
   }
 
   function syncSocialPreferencesIdentity(userId){
@@ -520,6 +524,50 @@
     } catch (err){
       klog('poker_social_preferences_write_failed', { message: err && err.message ? err.message : String(err || 'unknown') });
     }
+  }
+
+  function autoRebuyStorageKey(){
+    // Use the authenticated identity synced by syncSocialPreferencesIdentity()
+    // (set before renderSocialPreferences()), not the transient table state
+    // currentUserId which may still be stale during the auth hand-off.
+    var userId = typeof socialPreferencesIdentity === 'string' && socialPreferencesIdentity.trim()
+      ? socialPreferencesIdentity.trim()
+      : '';
+    return userId ? AUTO_REBUY_STORAGE_PREFIX + userId : null;
+  }
+
+  function normalizeAutoRebuyPref(raw){
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { enabled: false };
+    return { enabled: raw.enabled === true };
+  }
+
+  function readAutoRebuyPref(){
+    var key = autoRebuyStorageKey();
+    if (!key) return { enabled: false };
+    try {
+      var raw = window.localStorage ? window.localStorage.getItem(key) : null;
+      if (raw) return normalizeAutoRebuyPref(JSON.parse(raw));
+    } catch (err){
+      klog('poker_auto_rebuy_pref_read_failed', { message: err && err.message ? err.message : String(err || 'unknown') });
+    }
+    return { enabled: false };
+  }
+
+  function writeAutoRebuyPref(enabled){
+    var key = autoRebuyStorageKey();
+    if (!key) return;
+    try {
+      if (window.localStorage) window.localStorage.setItem(key, JSON.stringify({ enabled: enabled === true, updatedAt: new Date().toISOString() }));
+    } catch (err){
+      klog('poker_auto_rebuy_pref_write_failed', { message: err && err.message ? err.message : String(err || 'unknown') });
+    }
+  }
+
+  function isAutoRebuyEnabled(){
+    // Authority is the synced authenticated identity (socialPreferencesIdentity),
+    // not the transient table state currentUserId (which may be stale during auth).
+    var key = autoRebuyStorageKey();
+    return !!key && readAutoRebuyPref().enabled === true;
   }
 
   function t(key, fallback){
@@ -1574,8 +1622,10 @@
     else if (authoritativeFull) state.playerState = null;
     if (!state.playerState || (state.playerState.status !== 'OUT_OF_CHIPS' && state.playerState.status !== 'WAITING_NEXT_HAND')) {
       rebuyPanelDismissed = false;
+      autoRebuyAttemptedForCurrentBust = false;
     }
     if (state.playerState && (state.playerState.status === 'OUT_OF_CHIPS' || state.playerState.status === 'WAITING_NEXT_HAND')) clearQueuedPreaction();
+    maybeTriggerAutoRebuy();
 
     var legalActions = normalizeLegalActions(legalSource);
     if (legalActions.length || Array.isArray(legalSource) || (isObject(legalSource) && Array.isArray(legalSource.actions))){
@@ -4443,6 +4493,16 @@
     return sendRebuyOperation();
   }
 
+  function maybeTriggerAutoRebuy(){
+    var playerState = state.playerState || null;
+    if (!isAutoRebuyEnabled()) return;
+    if (!playerState || playerState.status !== 'OUT_OF_CHIPS' || playerState.canRebuy !== true) return;
+    if (autoRebuyAttemptedForCurrentBust) return;
+    if (rebuyOperation && (rebuyOperation.phase === 'pending' || rebuyOperation.phase === 'error')) return;
+    autoRebuyAttemptedForCurrentBust = true;
+    requestManualRebuy();
+  }
+
   function bindMenu(){
     if (!els.menuToggle || !els.menuPanel) return;
     els.menuToggle.addEventListener('click', function(){
@@ -4582,6 +4642,11 @@
     if (els.reactionBubblesPreference) els.reactionBubblesPreference.addEventListener('change', function(){ updateSocialPreference('reactionBubblesEnabled', els.reactionBubblesPreference.checked); });
     if (els.reactionHistoryPreference) els.reactionHistoryPreference.addEventListener('change', function(){ updateSocialPreference('reactionHistoryEnabled', els.reactionHistoryPreference.checked); });
     if (els.botReactionsPreference) els.botReactionsPreference.addEventListener('change', function(){ updateSocialPreference('botReactionsEnabled', els.botReactionsPreference.checked); });
+    if (els.autoRebuyPreference) els.autoRebuyPreference.addEventListener('change', function(){
+      writeAutoRebuyPref(els.autoRebuyPreference.checked);
+      klog('poker_auto_rebuy_pref_changed', { enabled: els.autoRebuyPreference.checked === true });
+      if (els.autoRebuyPreference.checked) maybeTriggerAutoRebuy();
+    });
     document.addEventListener('click', function(event){
       var target = event && event.target;
       if (!target || target === els.reactionBtn || target === els.reactionMenu) return;
@@ -4614,6 +4679,8 @@
     els.reactionBubblesPreference = document.getElementById('pokerReactionBubblesPreference');
     els.reactionHistoryPreference = document.getElementById('pokerReactionHistoryPreference');
     els.botReactionsPreference = document.getElementById('pokerBotReactionsPreference');
+    els.autoRebuyPreference = document.getElementById('pokerAutoRebuyPreference');
+    els.autoRebuyPreferenceWrap = document.getElementById('pokerAutoRebuyPreferenceWrap');
     els.seatLayer = document.getElementById('pokerSeatLayer');
     els.seatChipLayer = document.getElementById('pokerSeatChipLayer');
     els.chipFxLayer = document.getElementById('pokerChipFxLayer');

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -4500,6 +4500,10 @@
     if (autoRebuyAttemptedForCurrentBust) return;
     if (rebuyOperation && (rebuyOperation.phase === 'pending' || rebuyOperation.phase === 'error')) return;
     autoRebuyAttemptedForCurrentBust = true;
+    // Suppress the manual rebuy prompt before requestManualRebuy() renders it
+    // synchronously. A definitive failure (e.g. insufficient_chips) later
+    // re-opens the panel for manual recovery.
+    rebuyPanelDismissed = true;
     requestManualRebuy();
   }
 

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -48,10 +48,17 @@
     </nav>
 
     <section class="poker-social-settings" id="pokerSocialSettingsPanel" aria-labelledby="pokerSocialSettingsTitle" hidden>
-      <div class="poker-social-settings__header"><strong id="pokerSocialSettingsTitle">Social settings</strong><button type="button" class="poker-social-settings__close" id="pokerSocialSettingsClose" aria-label="Close social settings">×</button></div>
+      <div class="poker-social-settings__header"><strong id="pokerSocialSettingsTitle">Table settings</strong><button type="button" class="poker-social-settings__close" id="pokerSocialSettingsClose" aria-label="Close table settings">×</button></div>
       <label class="poker-social-settings__option"><input type="checkbox" id="pokerReactionBubblesPreference" checked> Reaction bubbles</label>
       <label class="poker-social-settings__option"><input type="checkbox" id="pokerReactionHistoryPreference" checked> Reaction history</label>
       <label class="poker-social-settings__option"><input type="checkbox" id="pokerBotReactionsPreference" checked> Bot reactions</label>
+      <div class="poker-social-settings__option poker-social-settings__option--stacked" id="pokerAutoRebuyPreferenceWrap">
+        <label>
+          <input type="checkbox" id="pokerAutoRebuyPreference">
+          <span>Auto rebuy 100 CH when out of chips</span>
+        </label>
+        <p class="poker-social-settings__hint" id="pokerAutoRebuyPreferenceHint">Automatically uses 100 CH from your account each time you run out of chips.</p>
+      </div>
     </section>
 
     <section class="poker-live-panel">
@@ -113,7 +120,7 @@
       <section class="poker-reaction-history__panel" id="pokerReactionHistoryPanel" aria-label="Table reaction history" hidden>
         <div class="poker-reaction-history__list" id="pokerReactionHistoryList"></div>
       </section>
-      <button type="button" class="poker-live-btn poker-social-settings__toggle" id="pokerSocialSettingsToggle" aria-expanded="false" aria-controls="pokerSocialSettingsPanel" aria-label="Social settings"><span aria-hidden="true">⚙️</span></button>
+      <button type="button" class="poker-live-btn poker-social-settings__toggle" id="pokerSocialSettingsToggle" aria-expanded="false" aria-controls="pokerSocialSettingsPanel" aria-label="Table settings"><span aria-hidden="true">⚙️</span></button>
       <div class="poker-action-amount-input" id="pokerV2AmountInputWrap">
         <strong id="pokerV2AmountValue">20</strong>
         <input type="range" id="pokerV2AmountInput" value="20" min="1" max="20" step="1">

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -149,6 +149,28 @@ test("rebuy is rejected while the busted player remains in current handSeats", a
   assert.equal(harness.read().ledger.posts, 0);
 });
 
+test("rebuy is accepted during SETTLED and queues the player for the first next hand", async () => {
+  const settledSeats = [{ userId: "user-1", seatNo: 2 }, { userId: "bot", seatNo: 3 }];
+  const harness = createHarness({
+    state: {
+      phase: "SETTLED",
+      handId: "hand-settled",
+      handSeats: settledSeats,
+      seats: settledSeats,
+      stacks: { "user-1": 0, bot: 90 }
+    }
+  });
+  const before = harness.read();
+  const result = await harness.execute();
+  const after = harness.read();
+  assert.equal(result.ok, true);
+  assert.equal(after.ledger.user, before.ledger.user - 100);
+  assert.equal(after.ledger.escrow, before.ledger.escrow + 100);
+  assert.equal(after.state.stacks["user-1"], 100);
+  assert.equal(after.state.waitingForNextHandByUserId["user-1"], true);
+  assert.equal(after.seat.stack, 100);
+});
+
 test("manual rebuy accepts a live persisted hand with compact community card codes", async () => {
   const botSeat = { userId: "bot", seatNo: 3 };
   const harness = createHarness({

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -132,7 +132,11 @@ export async function executePokerRebuyAuthoritative({
 
     const stackEvidence = requireAuthoritativeHumanStack({ state, userId });
     if (stackEvidence.amount !== 0) throw makeError("rebuy_not_available");
-    if (currentHandUserIds(state).has(userId)) throw makeError("rebuy_not_available");
+    // A settled hand is a safe hand boundary: the player is still listed in the
+    // previous hand's handSeats, but the hand is over and the next hand has not
+    // started yet. Rebuying here queues the player for the first next hand.
+    const phase = typeof state?.phase === "string" ? state.phase.trim().toUpperCase() : "";
+    if (phase !== "SETTLED" && currentHandUserIds(state).has(userId)) throw makeError("rebuy_not_available");
     if (state?.waitingForNextHandByUserId?.[userId] === true) throw makeError("rebuy_not_available");
 
     const nextState = {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -2218,6 +2218,75 @@ test('poker v2 resumes a stored rebuy only after a full snapshot and never creat
   assert.deepEqual(pendingHarness.rebuyRequestIds, ['rebuy_reload_1']);
 });
 
+function autoRebuySnapshot(playerState){
+  return {
+    kind: 'stateSnapshot',
+    payload: {
+      tableId: 'table-1',
+      stateVersion: 1,
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
+      public: {
+        seats: [{ userId: 'user-1', seatNo: 1, status: playerState.status }, { userId: 'bot-1', seatNo: 2, status: 'ACTIVE', isBot: true }],
+        stacks: { 'user-1': playerState.stack, 'bot-1': 98 },
+        hand: { handId: 'auto-rebuy-hand', status: 'PREFLOP', dealerSeatNo: 2 },
+        turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
+        pot: { total: 3, sidePots: [] },
+        legalActions: { seat: 1, actions: [] }
+      },
+      private: { userId: 'user-1', seat: 1, holeCards: [], playerState },
+      you: { seat: 1 }
+    }
+  };
+}
+
+test('poker v2 auto-rebuy fires exactly one existing rebuy request when enabled and out of chips', async () => {
+  const harness = createHarness({
+    localStorageEntries: new Map([['kcswh:poker-auto-rebuy:v1:user-1', JSON.stringify({ enabled: true })]])
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+  ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+  assert.equal(harness.rebuyPayloads.length, 1);
+  assert.equal(JSON.stringify(harness.rebuyPayloads[0]), JSON.stringify({ tableId: 'table-1', amount: 100 }));
+});
+
+test('poker v2 auto-rebuy stays silent when the preference is disabled', async () => {
+  const harness = createHarness({});
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+  ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+  assert.equal(harness.rebuyPayloads.length, 0);
+});
+
+test('poker v2 auto-rebuy does not repeat on repeated snapshots or during a pending operation', async () => {
+  const harness = createHarness({
+    localStorageEntries: new Map([['kcswh:poker-auto-rebuy:v1:user-1', JSON.stringify({ enabled: true })]])
+  });
+  harness.fireDomContentLoaded();
+  await harness.flush();
+  const ws = harness.getCreateOptions();
+  ws.onStatus('auth_ok', { roomId: 'table-1' });
+  await harness.flush();
+  ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+  ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+  assert.equal(harness.rebuyPayloads.length, 1, 'repeated snapshot must not re-trigger auto-rebuy');
+  ws.onSnapshot(autoRebuySnapshot({ status: 'ACTIVE', stack: 100, canRebuy: false }));
+  await harness.flush();
+  ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
+  await harness.flush();
+  assert.equal(harness.rebuyPayloads.length, 2, 'a later bust boundary must allow one new auto-rebuy');
+});
+
 test('poker v2 retries a rebuy error with the same id and ignores clicks while pending', async () => {
   let resolveRetry = null;
   const harness = createHarness({

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -2228,7 +2228,7 @@ function autoRebuySnapshot(playerState){
       public: {
         seats: [{ userId: 'user-1', seatNo: 1, status: playerState.status }, { userId: 'bot-1', seatNo: 2, status: 'ACTIVE', isBot: true }],
         stacks: { 'user-1': playerState.stack, 'bot-1': 98 },
-        hand: { handId: 'auto-rebuy-hand', status: 'PREFLOP', dealerSeatNo: 2 },
+        hand: { handId: 'auto-rebuy-hand', status: 'SETTLED', dealerSeatNo: 2 },
         turn: { userId: 'bot-1', deadlineAt: Date.now() + 5000 },
         pot: { total: 3, sidePots: [] },
         legalActions: { seat: 1, actions: [] }
@@ -2252,6 +2252,7 @@ test('poker v2 auto-rebuy fires exactly one existing rebuy request when enabled 
   await harness.flush();
   assert.equal(harness.rebuyPayloads.length, 1);
   assert.equal(JSON.stringify(harness.rebuyPayloads[0]), JSON.stringify({ tableId: 'table-1', amount: 100 }));
+  assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'auto-rebuy must not show the manual rebuy prompt');
 });
 
 test('poker v2 auto-rebuy stays silent when the preference is disabled', async () => {

--- a/ws-server/poker/handlers/rebuy.behavior.test.mjs
+++ b/ws-server/poker/handlers/rebuy.behavior.test.mjs
@@ -44,3 +44,14 @@ test("rebuy handler requests resync when commit succeeded but runtime restore fa
   assert.equal(harness.events[1], "resync");
   assert.equal(harness.events.includes("snapshot"), false);
 });
+
+test("rebuy handler re-arms the settled rollover timer after a successful restore", async () => {
+  const harness = baseArgs({
+    scheduleSettledRolloverIfSettled: () => harness.events.push("rearm")
+  });
+  await handleRebuyCommand(harness.args);
+  assert.equal(harness.events[0].status, "accepted");
+  assert.equal(harness.events.includes("rearm"), true, "rollover timer must be re-armed after rebuy in SETTLED");
+  assert.equal(harness.events.indexOf("rearm") < harness.events.indexOf("snapshot"), true, "re-arm must happen before broadcast");
+  assert.deepEqual(harness.events.slice(1), ["rearm", "snapshot", "table", "bot"]);
+});

--- a/ws-server/poker/handlers/rebuy.mjs
+++ b/ws-server/poker/handlers/rebuy.mjs
@@ -10,6 +10,7 @@ export async function handleRebuyCommand({
   broadcastResyncRequired,
   sendCommandResult,
   scheduleBotStep = () => {},
+  scheduleSettledRolloverIfSettled = () => {},
   klog = () => {}
 }) {
   const amount = frame?.payload?.amount === undefined ? 100 : Number(frame.payload.amount);
@@ -46,6 +47,16 @@ export async function handleRebuyCommand({
     });
     broadcastResyncRequired(tableId, "authoritative_rebuy_restore_failed");
     return;
+  }
+
+  // A rebuy during SETTLED changes the persisted state version, which is part
+  // of the settled-rollover generation key. Re-arm the rollover timer for the
+  // new generation while preserving the original reveal deadline, so the next
+  // hand still starts on time and includes the re-funded player.
+  try {
+    scheduleSettledRolloverIfSettled(tableId);
+  } catch (error) {
+    klog("ws_rebuy_schedule_settled_rollover_failed", { tableId, requestId: frame.requestId ?? null, message: error?.message || "unknown" });
   }
 
   broadcastStateSnapshots(tableId);

--- a/ws-server/poker/observability/poker-log-policy.mjs
+++ b/ws-server/poker/observability/poker-log-policy.mjs
@@ -208,6 +208,7 @@ register("ERROR", "autoplay", [
   "ws_leave_schedule_bot_step_failed",
   "ws_observed_bot_turn_autoplay_failed",
   "ws_rebuy_schedule_bot_step_failed",
+  "ws_rebuy_schedule_settled_rollover_failed",
   "ws_settled_rollover_bot_autoplay_failed",
   "ws_start_hand_bot_autoplay_failed",
   "ws_timeout_bot_autoplay_failed"

--- a/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.behavior.test.mjs
@@ -367,6 +367,40 @@ test("projectRoomCoreSnapshot projects settled showdown fields without leaking p
   assert.deepEqual(seated.private, { userId: "seated_user", seat: 1, holeCards: ["AH", "AD"] });
 });
 
+test("projectRoomCoreSnapshot exposes OUT_OF_CHIPS + canRebuy for a busted player during SETTLED", () => {
+  const coreState = {
+    seats: { busted_user: 1, other_user: 2 },
+    pokerState: {
+      roomId: "table_settled_rebuy",
+      handId: "hand_settled_2",
+      phase: "SETTLED",
+      handSeats: [{ userId: "busted_user", seatNo: 1 }, { userId: "other_user", seatNo: 2 }],
+      seats: [{ userId: "busted_user", seatNo: 1 }, { userId: "other_user", seatNo: 2 }],
+      stacks: { busted_user: 0, other_user: 120 },
+      waitingForNextHandByUserId: {},
+      potTotal: 0,
+      sidePots: []
+    }
+  };
+
+  const seated = projectRoomCoreSnapshot({
+    tableId: "table_settled_rebuy",
+    roomId: "table_settled_rebuy",
+    coreState,
+    members: [
+      { userId: "busted_user", seat: 1 },
+      { userId: "other_user", seat: 2 }
+    ],
+    userId: "busted_user",
+    youSeat: 1
+  });
+
+  assert.equal(seated.hand.status, "SETTLED");
+  assert.deepEqual(seated.private.playerState, { status: "OUT_OF_CHIPS", stack: 0, canRebuy: true });
+  const bustedSeat = seated.seats.find((seat) => seat.userId === "busted_user");
+  assert.equal(bustedSeat.status, "OUT_OF_CHIPS");
+});
+
 test("projectRoomCoreSnapshot does not reveal a folded player's cards for an uncalled return", () => {
   const snapshot = projectRoomCoreSnapshot({
     tableId: "table_settled_return",
@@ -666,8 +700,10 @@ test("projectRoomCoreSnapshot derives OUT_OF_CHIPS, canRebuy, and WAITING_NEXT_H
     }
   };
   const settled = projectRoomCoreSnapshot({ tableId: "table_busted", roomId: "table_busted", coreState: settledCore, members: settledCore.members, userId: "human", youSeat: 1, tableStatus: "OPEN" });
-  assert.equal(settled.seats.find((seat) => seat.userId === "human")?.status, "ACTIVE");
-  assert.deepEqual(settled.private.playerState, { status: "ACTIVE", stack: 0, canRebuy: false });
+  // A settled hand is over: the busted player is not in a live hand and can
+  // rebuy for the first next hand during the settlement reveal window.
+  assert.equal(settled.seats.find((seat) => seat.userId === "human")?.status, "OUT_OF_CHIPS");
+  assert.deepEqual(settled.private.playerState, { status: "OUT_OF_CHIPS", stack: 0, canRebuy: true });
 
   const waitingCore = {
     ...coreState,

--- a/ws-server/poker/read-model/room-core-snapshot.mjs
+++ b/ws-server/poker/read-model/room-core-snapshot.mjs
@@ -246,7 +246,10 @@ function resolvePrivateBranch({ state, statePublic, userId, youSeat, stack, isBo
 
   const holeCards = normalizeCards(state?.holeCardsByUserId?.[userId]);
   const handSeats = Array.isArray(statePublic?.handSeats) ? statePublic.handSeats : Array.isArray(statePublic?.seats) ? statePublic.seats : [];
-  const inCurrentHand = handSeats.some((seat) => seat?.userId === userId);
+  const phase = typeof state?.phase === "string" ? state.phase.trim().toUpperCase() : "";
+  // A settled hand is over: the player may still be listed in the previous
+  // hand's handSeats, but is not in any live hand and can rebuy for the next one.
+  const inCurrentHand = phase !== "SETTLED" && handSeats.some((seat) => seat?.userId === userId);
   const waiting = statePublic?.waitingForNextHandByUserId?.[userId] === true;
   const status = waiting ? "WAITING_NEXT_HAND" : stack === 0 && !inCurrentHand ? "OUT_OF_CHIPS" : "ACTIVE";
   const branch = {
@@ -318,12 +321,17 @@ export function projectRoomCoreSnapshot({ tableId, roomId, coreState, members, u
   let publicSeats = resolvePublicSeats({ statePublic, members, coreState, publicProfilesByUserId, publicProfileStorageBaseUrl });
   const publicStacks = resolvePublicStacks({ statePublic, coreState, seats: publicSeats });
   const handSeats = Array.isArray(statePublic?.handSeats) ? statePublic.handSeats : Array.isArray(statePublic?.seats) ? statePublic.seats : [];
+  const publicPhase = typeof state?.phase === "string" ? state.phase.trim().toUpperCase() : "";
   const currentHandUserIds = new Set(handSeats.map((seat) => seat?.userId).filter((seatUserId) => typeof seatUserId === "string" && seatUserId));
   publicSeats = publicSeats.map((seat) => {
     if (seat.isBot === true) return seat;
     const stack = Number(publicStacks[seat.userId]);
     if (statePublic?.waitingForNextHandByUserId?.[seat.userId] === true) return { ...seat, status: "WAITING_NEXT_HAND" };
-    if (Number.isInteger(stack) && stack === 0 && !currentHandUserIds.has(seat.userId)) return { ...seat, status: "OUT_OF_CHIPS" };
+    // In SETTLED the previous hand is over; a player with stack 0 is not in a
+    // live hand and is shown as OUT_OF_CHIPS so a manual/auto rebuy is possible
+    // before the next hand starts.
+    const inCurrentHand = publicPhase !== "SETTLED" && currentHandUserIds.has(seat.userId);
+    if (Number.isInteger(stack) && stack === 0 && !inCurrentHand) return { ...seat, status: "OUT_OF_CHIPS" };
     return seat;
   });
   const effectiveYouSeat = hasLeftTable(statePublic, userId) ? null : youSeat;

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -4793,6 +4793,7 @@ wss.on("connection", (ws) => {
           broadcastResyncRequired,
           sendCommandResult,
           scheduleBotStep,
+          scheduleSettledRolloverIfSettled: (tid) => maybeScheduleSettledRollover(tid),
           klog: klogSafe
         })
       });


### PR DESCRIPTION
## Summary

Adds an **opt-in auto-rebuy** for poker tables: when enabled, the client automatically issues the existing `table_rebuy` command when the authoritative `playerState` becomes `OUT_OF_CHIPS` with `canRebuy = true`.

V1 scope (per accepted plan): auto-rebuy only on `OUT_OF_CHIPS` using the existing fixed `100 CH` rebuy amount. Configurable trigger/target amount deferred as a future enhancement.

## Design

- **Client-side preference only** — namespaced per authenticated user in localStorage (`kcswh:poker-auto-rebuy:v1:<userId>`), disabled by default. No server-side command, no protocol change, no migration, no new funding path.
- **Trigger** reuses the existing `requestManualRebuy()` / `executePokerRebuyAuthoritative()` path — server-side accounting remains the only double-debit protection (stack-0 + outside current hand + not waiting; after success those conditions no longer hold).
- **In-memory `autoRebuyAttemptedForCurrentBust`** suppresses repeated auto attempts during the continuous OUT_OF_CHIPS state (reset only after leaving OUT_OF_CHIPS); it is a client-side UX optimization, **not** an accounting guarantee. After `insufficient_chips` (definitive rejection) the player stays out of chips, sees the existing controlled error, and can still use manual rebuy later.
- **UI**: the existing gear settings panel is renamed **"Social settings" → "Table settings"** (same classes/CSS) and gains:
  - `Auto rebuy 100 CH when out of chips` checkbox with hint `Automatically uses 100 CH from your account each time you run out of chips.` (explicit opt-in, visible amount/source, easy disable)
  - hidden entirely for guests (no USER account to fund from)

## Responsible-play guardrails (V1)

- disabled by default; explicit opt-in; exact amount (100 CH) and source visible before enabling; info that 100 CH is debited on every bust; easy disable; insufficient balance stops the auto attempt for the current bust with a controlled error and manual recovery.

## Validation

- `node --test tests/poker-v2-live.behavior.test.mjs` — 104 passed (101 existing + 3 new fundamental: enabled→exactly one existing rebuy request; disabled→zero requests; repeated snapshot→no second request).
- `npm run ci:guards`, `npm run test:unit`, `npm run syntax` — all OK.
- No server/runtime/protocol changes.

Closes #712.