### PR TITLE
feat(poker): make table buy-in authoritative

### DIFF
--- a/docs/poker-deployment.md
+++ b/docs/poker-deployment.md
@@ -52,7 +52,7 @@ Set these as Netlify environment variables (Site settings -> Environment variabl
 
 Operational notes:
 - Bot runtime is guarded by `POKER_BOTS_ENABLED`.
-- Initial humans, initial bots, manual rebuys, and replacement bots use the current fixed `100 CH` starting stack. The retired `POKER_BOT_BUYIN_BB` setting is ignored so table stakes or bot-only configuration cannot make the initial bot stack diverge from the human and replacement stack.
+- Initial humans, initial bots, manual rebuys, and replacement bots use the table's persisted `buy_in` value. The retired `POKER_BOT_BUYIN_BB` setting is ignored so table stakes or bot-only configuration cannot make stacks diverge from the table buy-in.
 - Values above are Netlify runtime config env vars (not secrets unless explicitly sensitive).
 - Bot/gameplay orchestration runs server-side in WS runtime (no client-side bot scripts).
 - Bot replacement funding continues to use the existing configured source (default `TREASURY`); it adds no account, migration, environment variable, balance move, or manual replenishment step.

--- a/docs/ws-poker-protocol.md
+++ b/docs/ws-poker-protocol.md
@@ -53,8 +53,8 @@ Example envelope:
 | `resume` | `{ "sessionId": string, "lastSeq": integer }` | Requests stream resume from last acknowledged sequence. |
 | `ping` | `{ "clientTime": string }` | Keepalive/latency probe. No state mutation. |
 | `join` | `{ "tableId": string }` | Legacy alias of `table_join`; default runtime behavior is authoritative seat/join mutation (idempotent). Optional observe-only runtime mode can make it transport-only. Requires auth. |
-| `table_rebuy` | `{ "tableId": string, "amount": 100 }` | Canonical explicit manual rebuy for an eligible out-of-chips seat. Requires auth and `requestId`; funding and authoritative state commit atomically. |
-| `rebuy` | `{ "tableId": string, "amount": 100 }` | Legacy client alias of `table_rebuy`. Atomically debits 100 CH from the authenticated USER account, credits table ESCROW, and queues the out-of-chips seat for the next hand. Requires auth and `requestId`. |
+| `table_rebuy` | `{ "tableId": string, "amount"?: integer }` | Canonical explicit manual rebuy for an eligible out-of-chips seat. The server uses the table's authoritative fixed buy-in; an optional amount is only a matching declaration. Requires auth and `requestId`; funding and authoritative state commit atomically. |
+| `rebuy` | `{ "tableId": string, "amount"?: integer }` | Legacy client alias of `table_rebuy`. Atomically debits the authenticated USER by the table's fixed buy-in, credits table ESCROW by the same amount, and queues the out-of-chips seat for the next hand. Requires auth and `requestId`. |
 | `act` | `{ "handId": string, "action": "fold"|"check"|"call"|"bet"|"raise", "amount": integer }` | Requests poker action mutation. Requires auth and turn validity. |
 | `leave` | `{ "reason": string }` | Requests leave/cashout workflow. |
 | `ack` | `{ "seq": integer }` | Acknowledges latest processed server sequence (flow-control aid). |
@@ -218,8 +218,8 @@ Out-of-chips lifecycle contract delta:
 
 - `payload.private.playerState` is additive and has `{ status: "ACTIVE"|"OUT_OF_CHIPS"|"WAITING_NEXT_HAND", stack: integer, canRebuy: boolean }`;
 - `canRebuy` is true only for the authenticated active non-bot seat owner at an open table, with authoritative stack `0`, after the player is absent from current `handSeats` and before a rebuy is committed;
-- canonical `table_rebuy` and alias `rebuy` accept only `{ tableId, amount: 100 }` and require a unique request ID;
-- successful rebuy is one atomic `TABLE_BUY_IN` (`USER -100`, table `ESCROW +100`) plus state/seat projection and sets `WAITING_NEXT_HAND` without adding the player to a hand already in progress;
+- canonical `table_rebuy` and alias `rebuy` use the table's fixed configured buy-in (and require a unique request ID); a supplied amount must match that configuration;
+- successful rebuy is one atomic `TABLE_BUY_IN` (`USER -<table buy-in>`, table `ESCROW +<table buy-in>`) plus state/seat projection and sets `WAITING_NEXT_HAND` without adding the player to a hand already in progress;
 - repeated delivery of the same successful request ID returns its stored result and does not debit again;
 - insufficient balance, a nonzero/ambiguous stack, current-hand membership, a closed table, or a non-active/bot seat rejects without visible runtime mutation.
 
@@ -364,10 +364,10 @@ Durability note: replay buffer is process-local and bounded; server restarts or 
 
 Gameplay write commands are authoritative over WS. `start_hand` and `act` use `commandResult` as the primary command ack. `join` / `table_join` preserves legacy actor-visible `table_state` first-frame behavior and may additionally emit `commandResult` for deterministic client ack.
 
-- `join` / `table_join` payload: `{ tableId, seatNo?, autoSeat?, preferredSeatNo?, buyIn }` (`buyIn` required for gameplay-equivalent authoritative joins)
+- `join` / `table_join` payload: `{ tableId, seatNo?, autoSeat?, preferredSeatNo?, buyIn? }`; the server derives the fixed table buy-in and validates an optional declaration.
 - `start_hand` payload: `{ tableId }`
 - `act` payload: `{ handId, action, amount? }`
-- `table_rebuy` / `rebuy` payload: `{ tableId, amount: 100 }`
+- `table_rebuy` / `rebuy` payload: `{ tableId, amount? }`; the authoritative server derives the amount from the fixed table buy-in and validates an optional declaration.
 
 Success contract:
 

--- a/infra/vps/Caddyfile
+++ b/infra/vps/Caddyfile
@@ -24,6 +24,11 @@ ws.kcswh.pl {
     reverse_proxy 127.0.0.1:3000
   }
 
+  @lobbyMaterialize path /internal/lobby/materialize-table
+  handle @lobbyMaterialize {
+    reverse_proxy 127.0.0.1:3000
+  }
+
   handle {
     respond "OK" 200
   }
@@ -57,6 +62,11 @@ ws-preview.kcswh.pl {
 
   @vpsMetricsAdmin path /internal/admin/vps-metrics
   handle @vpsMetricsAdmin {
+    reverse_proxy 127.0.0.1:3001
+  }
+
+  @lobbyMaterialize path /internal/lobby/materialize-table
+  handle @lobbyMaterialize {
     reverse_proxy 127.0.0.1:3001
   }
 

--- a/netlify/functions/_shared/poker-bots.mjs
+++ b/netlify/functions/_shared/poker-bots.mjs
@@ -21,7 +21,6 @@ const parseIntClamped = (value, fallback, min, max) => {
 };
 
 const BOT_PROFILES = ["TIGHT", "NORMAL", "LOOSE"];
-const BOT_STARTING_STACK_CHIPS = 100;
 
 const parseProfile = (value, fallback = "RANDOM") => {
   const normalized = normalizeString(value).toUpperCase();
@@ -69,7 +68,6 @@ function getBotConfig(env = process.env) {
     minPerTable: parseIntClamped(source.POKER_BOTS_MIN_PER_TABLE, 2, 0, 9),
     maxPerTable: parseIntClamped(source.POKER_BOTS_MAX_PER_TABLE, 5, 0, 9),
     defaultProfile: parseProfile(source.POKER_BOT_PROFILE_DEFAULT, "RANDOM"),
-    buyInChips: BOT_STARTING_STACK_CHIPS,
     bankrollSystemKey: normalizeString(source.POKER_BOT_BANKROLL_SYSTEM_KEY) || "TREASURY",
     maxActionsPerPoll: parseIntClamped(source.POKER_BOTS_MAX_ACTIONS_PER_POLL, 2, 0, 10),
   };

--- a/netlify/functions/_shared/poker-table-init.mjs
+++ b/netlify/functions/_shared/poker-table-init.mjs
@@ -2,20 +2,25 @@ export const createPokerTableWithState = async (tx, {
   userId,
   maxPlayers,
   stakesJson,
+  buyIn,
   lifecycleKind = "STANDARD",
   managedProfileKey = null,
   rotationDueAt = null
 }) => {
+  const normalizedBuyIn = Number(buyIn);
+  if (!Number.isSafeInteger(normalizedBuyIn) || normalizedBuyIn <= 0) {
+    throw new Error("poker_table_buy_in_invalid");
+  }
   const tableRows = await tx.unsafe(
     `
 insert into public.poker_tables (
-  stakes, max_players, status, created_by, updated_at, last_activity_at,
+  stakes, buy_in, max_players, status, created_by, updated_at, last_activity_at,
   lifecycle_kind, managed_profile_key, rotation_due_at
 )
-values ($1::jsonb, $2, 'OPEN', $3, now(), now(), $4, $5, $6)
+values ($1::jsonb, $2, $3, 'OPEN', $4, now(), now(), $5, $6, $7)
 returning id;
     `,
-    [stakesJson, maxPlayers, userId, lifecycleKind, managedProfileKey, rotationDueAt]
+    [stakesJson, normalizedBuyIn, maxPlayers, userId, lifecycleKind, managedProfileKey, rotationDueAt]
   );
   const tableId = tableRows?.[0]?.id || null;
   if (!tableId) {

--- a/netlify/functions/_shared/poker-ws-runtime-notify.mjs
+++ b/netlify/functions/_shared/poker-ws-runtime-notify.mjs
@@ -24,6 +24,7 @@ export async function notifyWsLobbyMaterialize({
   tableId,
   maxPlayers,
   stakes,
+  buyIn,
   env = process.env,
   fetchImpl = globalThis.fetch,
   klog = () => {}
@@ -62,7 +63,7 @@ export async function notifyWsLobbyMaterialize({
     const response = await fetchImpl(`${baseUrl.replace(/\/$/, "")}/internal/lobby/materialize-table`, {
       method: "POST",
       headers,
-      body: JSON.stringify({ tableId: normalizedTableId, maxPlayers, stakes }),
+      body: JSON.stringify({ tableId: normalizedTableId, maxPlayers, stakes, buyIn }),
       signal: controller.signal
     });
     if (!response.ok) {

--- a/netlify/functions/_shared/poker-ws-runtime-notify.mjs
+++ b/netlify/functions/_shared/poker-ws-runtime-notify.mjs
@@ -1,4 +1,5 @@
 const DEFAULT_NOTIFY_TIMEOUT_MS = 4_000;
+const BUY_IN_CAPABILITY_HEADER = "x-poker-buy-in-materialization";
 
 function normalizeText(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "";
@@ -18,6 +19,68 @@ function resolveTimeoutMs(env) {
     return DEFAULT_NOTIFY_TIMEOUT_MS;
   }
   return Math.trunc(parsed);
+}
+
+function readHeader(response, name) {
+  if (typeof response?.headers?.get === "function") {
+    return response.headers.get(name);
+  }
+  if (response?.headers && typeof response.headers === "object") {
+    return response.headers[name] ?? response.headers[name.toLowerCase()] ?? null;
+  }
+  return null;
+}
+
+export async function checkWsBuyInCapability({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  klog = () => {}
+} = {}) {
+  const baseUrl = resolveBaseUrl(env);
+  if (!baseUrl) {
+    return { ok: false, skipped: true, reason: "ws_internal_base_url_missing" };
+  }
+
+  if (typeof fetchImpl !== "function") {
+    klog("poker_ws_buy_in_capability_unavailable", { reason: "fetch_unavailable" });
+    return { ok: false, skipped: false, reason: "fetch_unavailable" };
+  }
+
+  const timeoutMs = resolveTimeoutMs(env);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  if (typeof timer?.unref === "function") {
+    timer.unref();
+  }
+  const headers = {};
+  const token = resolveToken(env);
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetchImpl(`${baseUrl.replace(/\/$/, "")}/healthz`, {
+      method: "GET",
+      headers,
+      signal: controller.signal
+    });
+    const supported = response.ok && readHeader(response, BUY_IN_CAPABILITY_HEADER) === "1";
+    if (!supported) {
+      klog("poker_ws_buy_in_capability_unavailable", {
+        status: response.status,
+        advertised: readHeader(response, BUY_IN_CAPABILITY_HEADER)
+      });
+      return { ok: false, skipped: false, reason: "buy_in_capability_unavailable", status: response.status };
+    }
+    return { ok: true, skipped: false };
+  } catch (error) {
+    klog("poker_ws_buy_in_capability_error", {
+      message: error?.message || "unknown_error"
+    });
+    return { ok: false, skipped: false, reason: error?.name === "AbortError" ? "timeout" : "request_failed" };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function notifyWsLobbyMaterialize({

--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -16,9 +16,9 @@ const parseBody = (body) => {
   }
 };
 
-const triggerWsLobbyMaterialize = ({ tableId, maxPlayers, stakes, klog }) => {
+const triggerWsLobbyMaterialize = ({ tableId, maxPlayers, stakes, buyIn, klog }) => {
   if (typeof tableId !== "string" || !tableId) return;
-  void notifyWsLobbyMaterialize({ tableId, maxPlayers, stakes, klog });
+  void notifyWsLobbyMaterialize({ tableId, maxPlayers, stakes, buyIn, klog });
 };
 
 const isPlainObject = (value) =>
@@ -79,18 +79,19 @@ export async function handler(event) {
     return { statusCode: 400, headers: mergeHeaders(cors), body: JSON.stringify({ error: "invalid_stakes" }) };
   }
   const stakesJson = formatStakes(stakesParsed.value);
+  const buyIn = DEFAULT_CASH_TABLE_BUY_IN_CHIPS;
 
   let transactionResult = null;
   try {
     transactionResult = await beginSql(async (tx) => {
       const eligibility = await readPokerBuyInEligibility(tx, {
         userId: auth.userId,
-        requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+        requiredBuyIn: buyIn,
       });
       if (!eligibility.eligible) {
         return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
       }
-      const created = await createPokerTableWithState(tx, { userId: auth.userId, maxPlayers, stakesJson });
+      const created = await createPokerTableWithState(tx, { userId: auth.userId, maxPlayers, stakesJson, buyIn });
       return { kind: "created", tableId: created.tableId };
     });
   } catch (error) {
@@ -116,7 +117,7 @@ export async function handler(event) {
   }
 
   const escrowSystemKey = `POKER_TABLE:${tableId}`;
-  triggerWsLobbyMaterialize({ tableId, maxPlayers, stakes: stakesParsed.value, klog });
+  triggerWsLobbyMaterialize({ tableId, maxPlayers, stakes: stakesParsed.value, buyIn, klog });
   return {
     statusCode: 200,
     headers: mergeHeaders(cors),

--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -2,7 +2,7 @@ import { baseHeaders, beginSql, corsHeaders, extractBearerToken, klog, verifySup
 import { formatStakes, parseStakes } from "./_shared/poker-stakes.mjs";
 import { createPokerTableWithState } from "./_shared/poker-table-init.mjs";
 import { readPokerBuyInEligibility } from "./_shared/poker-buy-in-eligibility.mjs";
-import { notifyWsLobbyMaterialize } from "./_shared/poker-ws-runtime-notify.mjs";
+import { checkWsBuyInCapability, notifyWsLobbyMaterialize } from "./_shared/poker-ws-runtime-notify.mjs";
 import { DEFAULT_CASH_TABLE_BUY_IN_CHIPS } from "../../shared/poker-domain/table-economy.mjs";
 
 const mergeHeaders = (next) => ({ ...baseHeaders(), ...(next || {}) });
@@ -91,6 +91,21 @@ export async function handler(event) {
     return { statusCode: 400, headers: mergeHeaders(cors), body: JSON.stringify({ error: "invalid_stakes" }) };
   }
   const stakesJson = formatStakes(stakesParsed.value);
+
+  if (buyIn !== DEFAULT_CASH_TABLE_BUY_IN_CHIPS) {
+    const capability = await checkWsBuyInCapability({ klog });
+    if (!capability?.ok) {
+      klog("poker_create_table_buy_in_capability_unavailable", {
+        buyIn,
+        reason: capability?.reason || "unknown"
+      });
+      return {
+        statusCode: 503,
+        headers: mergeHeaders(cors),
+        body: JSON.stringify({ error: "ws_buy_in_capability_unavailable" })
+      };
+    }
+  }
 
   let transactionResult = null;
   try {

--- a/netlify/functions/poker-create-table.mjs
+++ b/netlify/functions/poker-create-table.mjs
@@ -32,6 +32,13 @@ const parseMaxPlayers = (value) => {
   return num;
 };
 
+const parseBuyIn = (value) => {
+  if (value == null) return DEFAULT_CASH_TABLE_BUY_IN_CHIPS;
+  const num = Number(value);
+  if (!Number.isSafeInteger(num) || num <= 0) return null;
+  return num;
+};
+
 export async function handler(event) {
   if (process.env.CHIPS_ENABLED !== "1") {
     return { statusCode: 404, headers: baseHeaders(), body: JSON.stringify({ error: "not_found" }) };
@@ -67,6 +74,11 @@ export async function handler(event) {
     return { statusCode: 400, headers: mergeHeaders(cors), body: JSON.stringify({ error: "invalid_max_players" }) };
   }
 
+  const buyIn = parseBuyIn(payload?.buyIn);
+  if (buyIn == null) {
+    return { statusCode: 400, headers: mergeHeaders(cors), body: JSON.stringify({ error: "invalid_buy_in" }) };
+  }
+
   const token = extractBearerToken(event.headers);
   const auth = await verifySupabaseJwt(token);
   if (!auth.valid || !auth.userId) {
@@ -79,7 +91,6 @@ export async function handler(event) {
     return { statusCode: 400, headers: mergeHeaders(cors), body: JSON.stringify({ error: "invalid_stakes" }) };
   }
   const stakesJson = formatStakes(stakesParsed.value);
-  const buyIn = DEFAULT_CASH_TABLE_BUY_IN_CHIPS;
 
   let transactionResult = null;
   try {

--- a/netlify/functions/poker-quick-seat.mjs
+++ b/netlify/functions/poker-quick-seat.mjs
@@ -57,29 +57,30 @@ const toUiSeatNo = (seatNoDb, maxPlayers) => {
 };
 
 const createAndRecommend = async (tx, { userId, maxPlayers, stakesJson }) => {
+  const buyIn = DEFAULT_CASH_TABLE_BUY_IN_CHIPS;
   const eligibility = await readPokerBuyInEligibility(tx, {
     userId,
-    requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+    requiredBuyIn: buyIn,
   });
   if (!eligibility.eligible) {
     return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
   }
-  const created = await createPokerTableWithState(tx, { userId, maxPlayers, stakesJson });
+  const created = await createPokerTableWithState(tx, { userId, maxPlayers, stakesJson, buyIn });
   const tableId = created.tableId;
   await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
   const seatNoUi = 1;
-  return { kind: "recommended", tableId, seatNo: seatNoUi, strategy: "create" };
+  return { kind: "recommended", tableId, seatNo: seatNoUi, strategy: "create", buyIn };
 };
 
-const triggerWsLobbyMaterialize = ({ tableId, maxPlayers, stakes, klog }) => {
+const triggerWsLobbyMaterialize = ({ tableId, maxPlayers, stakes, buyIn, klog }) => {
   if (typeof tableId !== "string" || !tableId) return;
-  void notifyWsLobbyMaterialize({ tableId, maxPlayers, stakes, klog });
+  void notifyWsLobbyMaterialize({ tableId, maxPlayers, stakes, buyIn, klog });
 };
 
 const selectCandidate = async (tx, { stakesJson, maxPlayers, requireHuman, humanSeatFreshCutoffIso }) => {
   return tx.unsafe(
     `
-select t.id, t.max_players
+select t.id, t.max_players, t.buy_in
 from public.poker_tables t
 where t.status = 'OPEN'
   and t.max_players = $1
@@ -130,7 +131,7 @@ limit 1;
   );
 };
 
-const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, allowCreateFallback, createPayload }) => {
+const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, buyIn, allowCreateFallback, createPayload }) => {
   const existingSeatRows = await tx.unsafe(
     "select seat_no from public.poker_seats where table_id = $1 and user_id = $2 limit 1;",
     [tableId, userId]
@@ -141,9 +142,13 @@ const recommendSeatAtTable = async (tx, { tableId, userId, maxPlayers, allowCrea
     return { kind: "recommended", tableId, seatNo: toUiSeatNo(existingSeatNoDb, maxPlayers) };
   }
 
+  const normalizedBuyIn = Number(buyIn);
+  if (!Number.isSafeInteger(normalizedBuyIn) || normalizedBuyIn <= 0) {
+    return { kind: "unavailable" };
+  }
   const eligibility = await readPokerBuyInEligibility(tx, {
     userId,
-    requiredBuyIn: DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
+    requiredBuyIn: normalizedBuyIn,
   });
   if (!eligibility.eligible) {
     return { kind: "insufficient_chips", balance: eligibility.balance, requiredBuyIn: eligibility.requiredBuyIn };
@@ -223,6 +228,7 @@ export async function handler(event) {
           tableId: preferredRows[0].id,
           userId: auth.userId,
           maxPlayers,
+          buyIn: preferredRows[0].buy_in,
           allowCreateFallback: true,
           createPayload,
         });
@@ -238,6 +244,7 @@ export async function handler(event) {
           tableId: anyRows[0].id,
           userId: auth.userId,
           maxPlayers,
+          buyIn: anyRows[0].buy_in,
           allowCreateFallback: true,
           createPayload,
         });
@@ -264,7 +271,7 @@ export async function handler(event) {
     }
 
     if (result.strategy === "create") {
-      triggerWsLobbyMaterialize({ tableId: result.tableId, maxPlayers, stakes: stakesParsed.value, klog });
+      triggerWsLobbyMaterialize({ tableId: result.tableId, maxPlayers, stakes: stakesParsed.value, buyIn: result.buyIn, klog });
     }
 
     return {

--- a/poker/index.html
+++ b/poker/index.html
@@ -120,6 +120,8 @@
           <input type="number" id="pokerSb" class="poker-input" value="1" min="1">
           <label class="poker-label"><span data-i18n="bb">BB</span>:</label>
           <input type="number" id="pokerBb" class="poker-input" value="2" min="1">
+          <label class="poker-label"><span data-i18n="buyIn">Buy-in</span>:</label>
+          <input type="number" id="pokerBuyIn" class="poker-input" value="100" min="1" step="1">
           <label class="poker-label"><span data-i18n="maxPlayers">Max Players</span>:</label>
           <input type="number" id="pokerMaxPlayers" class="poker-input" value="6" min="2" max="10">
         </div>

--- a/poker/poker-v2.js
+++ b/poker/poker-v2.js
@@ -205,6 +205,10 @@
   var SNAPSHOT_RECOVERY_TIMEOUT_MS = 5000;
   var SNAPSHOT_RECOVERY_MAX_ATTEMPTS = 3;
   var SNAPSHOT_RECOVERY_TIMEOUT_COPY = 'Snapshot recovery timed out';
+  // Legacy declaration for an older WS deployment. The server remains the
+  // source of truth; this value is only sent when that WS cannot yet expose
+  // the table buy-in in snapshots.
+  var LEGACY_WS_BUY_IN = 100;
   var joinOperation = {
     phase: 'idle',
     requestId: null,
@@ -391,6 +395,7 @@
       tableId: nextTableId || null,
       tableStatus: 'OPEN',
       maxSeats: 6,
+      buyIn: null,
       stateVersion: null,
       hasAppliedAuthoritativeSnapshot: false,
       reconnectGate: false,
@@ -499,6 +504,30 @@
     if (els.reactionHistory) els.reactionHistory.hidden = !(state && state.mode === 'live' && state.tableId && socialPreferences.reactionHistoryEnabled);
     if (els.autoRebuyPreference) els.autoRebuyPreference.checked = isAutoRebuyEnabled();
     if (els.autoRebuyPreferenceWrap) els.autoRebuyPreferenceWrap.hidden = !socialPreferencesIdentity;
+    renderAutoRebuyCopy();
+  }
+
+  function currentTableBuyIn(){
+    var buyIn = Number(state && state.buyIn);
+    return Number.isSafeInteger(buyIn) && buyIn > 0 ? buyIn : null;
+  }
+
+  function clientBuyInDeclaration(){
+    return currentTableBuyIn() || LEGACY_WS_BUY_IN;
+  }
+
+  function renderAutoRebuyCopy(){
+    var buyIn = currentTableBuyIn();
+    if (els.autoRebuyPreferenceLabel){
+      els.autoRebuyPreferenceLabel.textContent = buyIn == null
+        ? 'Auto rebuy at the table buy-in when out of chips'
+        : 'Auto rebuy ' + formatNumber(buyIn) + ' CH when out of chips';
+    }
+    if (els.autoRebuyPreferenceHint){
+      els.autoRebuyPreferenceHint.textContent = buyIn == null
+        ? 'Automatically uses the current table buy-in from your account each time you run out of chips.'
+        : 'Automatically uses ' + formatNumber(buyIn) + ' CH from your account each time you run out of chips.';
+    }
   }
 
   function syncSocialPreferencesIdentity(userId){
@@ -1528,6 +1557,8 @@
 
     if (typeof tableObj.status === 'string' && tableObj.status) state.tableStatus = tableObj.status.toUpperCase();
     if (typeof payload.status === 'string' && payload.status) state.tableStatus = payload.status.toUpperCase();
+    var snapshotBuyIn = hasOwn(tableObj, 'buyIn') ? tableObj.buyIn : payload.buyIn;
+    if (Number.isSafeInteger(Number(snapshotBuyIn)) && Number(snapshotBuyIn) > 0) state.buyIn = Number(snapshotBuyIn);
     syncClosedTableRedirectFromSnapshot(payload);
 
     var resolvedMaxSeats = null;
@@ -1824,7 +1855,11 @@
         persistPendingRebuy();
       }
       if (els.rebuyAccountLink) els.rebuyAccountLink.hidden = code !== 'insufficient_chips';
-      setError(code === 'insufficient_chips' ? 'Not enough CH for a 100 CH buy-in' : code);
+      setError(code === 'insufficient_chips'
+        ? (currentTableBuyIn() == null
+          ? 'Not enough CH for this table buy-in'
+          : 'Not enough CH for a ' + formatNumber(currentTableBuyIn()) + ' CH buy-in')
+        : code);
       render();
       return null;
     });
@@ -3638,11 +3673,12 @@
   function refreshRebuyBalance(){
     if (rebuyBalanceLoading || !els.rebuyBalance || !window.ChipsClient || typeof window.ChipsClient.fetchBalance !== 'function') return;
     rebuyBalanceLoading = true;
+    var buyInLabel = currentTableBuyIn() == null ? 'table buy-in unavailable' : 'Buy-in: ' + formatNumber(currentTableBuyIn()) + ' CH';
     Promise.resolve(window.ChipsClient.fetchBalance()).then(function(balance){
       var amount = balance && Number.isFinite(Number(balance.balance)) ? Number(balance.balance) : Number(balance);
-      if (Number.isFinite(amount)) els.rebuyBalance.textContent = 'Balance: ' + formatNumber(amount) + ' CH · Buy-in: 100 CH';
+      if (Number.isFinite(amount)) els.rebuyBalance.textContent = 'Balance: ' + formatNumber(amount) + ' CH · ' + buyInLabel;
     }).catch(function(){
-      els.rebuyBalance.textContent = 'Buy-in: 100 CH';
+      els.rebuyBalance.textContent = buyInLabel;
     }).then(function(){
       rebuyBalanceLoading = false;
     });
@@ -3650,6 +3686,7 @@
 
   function renderRebuyPanel(){
     if (!els.rebuyPanel) return;
+    renderAutoRebuyCopy();
     var playerState = state.playerState || null;
     var outOfChips = !!playerState && playerState.status === 'OUT_OF_CHIPS';
     var waiting = !!playerState && playerState.status === 'WAITING_NEXT_HAND';
@@ -3662,7 +3699,10 @@
     if (els.rebuyBtn) {
       var rebuyPending = !!rebuyOperation && rebuyOperation.phase === 'pending';
       els.rebuyBtn.disabled = rebuyPending || !isWsReady() || playerState.canRebuy !== true;
-      els.rebuyBtn.textContent = rebuyPending ? 'Buying in…' : (rebuyOperation && rebuyOperation.phase === 'error' ? 'Retry buy-in' : 'Buy in 100 CH');
+      var buyIn = currentTableBuyIn();
+      els.rebuyBtn.textContent = rebuyPending ? 'Buying in…' : (rebuyOperation && rebuyOperation.phase === 'error'
+        ? 'Retry buy-in'
+        : (buyIn == null ? 'Buy in' : 'Buy in ' + formatNumber(buyIn) + ' CH'));
     }
     if (els.rebuyLobbyBtn) els.rebuyLobbyBtn.disabled = (!!rebuyOperation && rebuyOperation.phase === 'pending') || !isWsReady();
     if (outOfChips) refreshRebuyBalance();
@@ -3913,7 +3953,7 @@
     var showLiveActionButtons = showActionButtons && !preactionMode;
     var actionControlsLocked = !liveReady || !usersTurn || controlsLocked || playerSittingOut;
     var joinPending = isJoinOperationPending();
-    var joinDisabled = !signedIn || seated || !state.tableId || !liveReady || joinPending;
+    var joinDisabled = !signedIn || seated || !state.tableId || !liveReady || !state.hasAppliedAuthoritativeSnapshot || joinPending;
     if (!seated || !activeHand || isCurrentUserFolded() || playerSittingOut) clearQueuedPreaction();
     if (preactionMode) {
       syncQueuedPreactionWithPreactionState({
@@ -4136,8 +4176,7 @@
   function buildJoinPayloadWithOptions(options){
     var opts = options || {};
     var payload = { tableId: state.tableId };
-    var buyIn = els.joinBuyIn ? parseInt(els.joinBuyIn.value, 10) : 100;
-    if (Number.isFinite(buyIn) && buyIn > 0) payload.buyIn = buyIn;
+    payload.buyIn = clientBuyInDeclaration();
     var preferredSeatNo = resolvePreferredSeatNo();
     if (opts.autoSeat === true) {
       payload.autoSeat = true;
@@ -4194,6 +4233,7 @@
 
   function resumePendingJoinOperation(){
     if (state.reconnectGate) return false;
+    if (!state.hasAppliedAuthoritativeSnapshot) return false;
     if (deriveCurrentSeat()){
       reconcileJoinOperationFromSnapshot();
       return false;
@@ -4284,9 +4324,9 @@
     if (code !== 'insufficient_funds' && code !== 'insufficient_chips') {
       return error && error.message ? error.message : 'Failed to join';
     }
-    var buyIn = els.joinBuyIn ? parseInt(els.joinBuyIn.value, 10) : NaN;
-    var amount = Number.isFinite(buyIn) && buyIn > 0 ? Math.trunc(buyIn) : 100;
-    return t('pokerErrInsufficientChips', 'You need at least {amount} CH to join a table.').replace('{amount}', String(amount));
+    var buyIn = currentTableBuyIn();
+    if (buyIn == null) return 'Not enough CH to join this table.';
+    return t('pokerErrInsufficientChips', 'You need at least {amount} CH to join a table.').replace('{amount}', String(buyIn));
   }
 
   function isRetryableAutoJoinError(error){
@@ -4326,6 +4366,7 @@
   }
 
   function autoJoinSeat(){
+    if (!state.hasAppliedAuthoritativeSnapshot) return;
     if (state.reconnectGate) return;
     if (!shouldAutoJoin) return;
     if (deriveCurrentSeat()){
@@ -4376,6 +4417,7 @@
     setError('');
     var reconnectPayload = {
       tableId: state.tableId,
+      buyIn: clientBuyInDeclaration(),
       autoSeat: true,
       preferredSeatNo: preferredSeatNo
     };
@@ -4485,8 +4527,9 @@
       requestId: requestId,
       tableId: state.tableId,
       userId: state.currentUserId,
-      payload: { tableId: state.tableId, amount: 100 }
+      payload: { tableId: state.tableId }
     };
+    rebuyOperation.payload.amount = clientBuyInDeclaration();
     persistPendingRebuy();
     setError('');
     renderRebuyPanel();
@@ -4537,7 +4580,10 @@
       closeMenu();
     });
     document.addEventListener('keydown', function(event){
-      if (event && event.key === 'Escape') { closeMenu(); closeSocialSettings(true); }
+      if (event && event.key === 'Escape') {
+        closeMenu();
+        closeSocialSettings(true);
+      }
     });
   }
 
@@ -4685,6 +4731,8 @@
     els.botReactionsPreference = document.getElementById('pokerBotReactionsPreference');
     els.autoRebuyPreference = document.getElementById('pokerAutoRebuyPreference');
     els.autoRebuyPreferenceWrap = document.getElementById('pokerAutoRebuyPreferenceWrap');
+    els.autoRebuyPreferenceLabel = document.querySelector ? document.querySelector('#pokerAutoRebuyPreferenceWrap label span') : null;
+    els.autoRebuyPreferenceHint = document.getElementById('pokerAutoRebuyPreferenceHint');
     els.seatLayer = document.getElementById('pokerSeatLayer');
     els.seatChipLayer = document.getElementById('pokerSeatChipLayer');
     els.chipFxLayer = document.getElementById('pokerChipFxLayer');

--- a/poker/poker-ws-client.js
+++ b/poker/poker-ws-client.js
@@ -486,7 +486,7 @@
       requestResync: requestResync,
       sendAct: function(payload, requestId){ return sendCommand('act', payload || {}, requestId); },
       sendJoin: function(payload, requestId){ return sendCommand('join', payload || { tableId: tableId }, requestId); },
-      sendRebuy: function(payload, requestId){ return sendCommand('rebuy', payload || { tableId: tableId, amount: 100 }, requestId); },
+      sendRebuy: function(payload, requestId){ return sendCommand('rebuy', payload || { tableId: tableId }, requestId); },
       sendLeave: function(payload, requestId){ return sendCommand('leave', payload || { tableId: tableId }, requestId); },
       sendLeaveQueued: function(payload, requestId){ return queueCommand('leave', payload || { tableId: tableId }, requestId); },
       sendStartHand: function(payload, requestId){ return sendCommand('start_hand', payload || { tableId: tableId }, requestId); },

--- a/poker/poker.js
+++ b/poker/poker.js
@@ -1465,6 +1465,7 @@
     var createBtn = document.getElementById('pokerCreate');
     var sbInput = document.getElementById('pokerSb');
     var bbInput = document.getElementById('pokerBb');
+    var buyInInput = document.getElementById('pokerBuyIn');
     var maxPlayersInput = document.getElementById('pokerMaxPlayers');
     var signInBtn = document.getElementById('pokerSignIn');
     var guestPlayBtn = document.getElementById('pokerGuestPlay');
@@ -1489,8 +1490,10 @@
       return t('pokerErrInsufficientChips', 'You need at least {amount} CH to join a table.').replace('{amount}', formatChips(amount));
     }
 
-    async function hasFreshCashBuyInBalance(){
-      var requiredBuyIn = requiredCashBuyIn();
+    async function hasFreshCashBuyInBalance(requiredBuyInOverride){
+      var requiredBuyIn = Number.isSafeInteger(requiredBuyInOverride) && requiredBuyInOverride > 0
+        ? requiredBuyInOverride
+        : requiredCashBuyIn();
       if (!requiredBuyIn || !window.ChipsClient || typeof window.ChipsClient.fetchBalance !== 'function') return true;
       try {
         var result = await window.ChipsClient.fetchBalance();
@@ -1886,17 +1889,23 @@
       setError(errorEl, null);
       var sbRaw = sbInput ? sbInput.value : 1;
       var bbRaw = bbInput ? bbInput.value : 2;
+      var buyInRaw = buyInInput ? buyInInput.value : 100;
       var sb = parseInt(sbRaw, 10);
       var bb = parseInt(bbRaw, 10);
+      var buyIn = Number(buyInRaw);
       if (!isFinite(sb) || !isFinite(bb) || Math.floor(sb) !== sb || Math.floor(bb) !== bb || sb < 0 || bb <= 0 || sb >= bb){
         setError(errorEl, t('pokerErrInvalidStakes', 'Invalid stakes'));
+        return;
+      }
+      if (!Number.isSafeInteger(buyIn) || buyIn <= 0){
+        setError(errorEl, t('pokerErrInvalidBuyIn', 'Invalid buy-in'));
         return;
       }
       var maxPlayers = parseInt(maxPlayersInput ? maxPlayersInput.value : 6, 10) || 6;
       setLoading(createBtn, true);
       try {
-        if (!(await hasFreshCashBuyInBalance())) return;
-        var data = await apiPost(CREATE_URL, { stakes: { sb: sb, bb: bb }, maxPlayers: maxPlayers });
+        if (!(await hasFreshCashBuyInBalance(buyIn))) return;
+        var data = await apiPost(CREATE_URL, { stakes: { sb: sb, bb: bb }, maxPlayers: maxPlayers, buyIn: buyIn });
         if (data.tableId){
           navigateToPokerTable(data.tableId);
         } else {

--- a/poker/table-v2.html
+++ b/poker/table-v2.html
@@ -55,9 +55,9 @@
       <div class="poker-social-settings__option poker-social-settings__option--stacked" id="pokerAutoRebuyPreferenceWrap">
         <label>
           <input type="checkbox" id="pokerAutoRebuyPreference">
-          <span>Auto rebuy 100 CH when out of chips</span>
+          <span>Auto rebuy at the table buy-in when out of chips</span>
         </label>
-        <p class="poker-social-settings__hint" id="pokerAutoRebuyPreferenceHint">Automatically uses 100 CH from your account each time you run out of chips.</p>
+        <p class="poker-social-settings__hint" id="pokerAutoRebuyPreferenceHint">Automatically uses the current table buy-in from your account each time you run out of chips.</p>
       </div>
     </section>
 
@@ -169,9 +169,9 @@
         <div class="poker-rebuy-panel__eyebrow">Sitting out</div>
         <div class="poker-rebuy-panel__title" id="pokerV2RebuyTitle">Out of chips</div>
         <p class="poker-rebuy-panel__copy" id="pokerV2RebuyCopy">The table will keep playing. Buy in to join the next hand.</p>
-        <div class="poker-rebuy-panel__balance" id="pokerV2RebuyBalance">Buy-in: 100 CH</div>
+        <div class="poker-rebuy-panel__balance" id="pokerV2RebuyBalance">Buy-in: Loading…</div>
         <div class="poker-rebuy-panel__actions">
-          <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2RebuyBtn">Buy in 100 CH</button>
+          <button type="button" class="poker-live-btn poker-live-btn--accent" id="pokerV2RebuyBtn">Buy in</button>
           <button type="button" class="poker-live-btn" id="pokerV2RebuyLobbyBtn">Return to lobby</button>
           <button type="button" class="poker-live-btn poker-rebuy-panel__watch" id="pokerV2RebuyWatchBtn">Keep watching</button>
         </div>

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -24,7 +24,6 @@ function parseIntClamped(value, fallback, min, max) {
 }
 
 const BOT_PROFILES = ["TIGHT", "NORMAL", "LOOSE"];
-const BOT_STARTING_STACK_CHIPS = 100;
 
 function parseProfile(value, fallback = "RANDOM") {
   const normalized = normalizeString(value).toUpperCase();
@@ -88,7 +87,6 @@ function getBotConfig(env = process.env) {
     minPerTable: parseIntClamped(env?.POKER_BOTS_MIN_PER_TABLE, 2, 0, 9),
     maxPerTable: parseIntClamped(env?.POKER_BOTS_MAX_PER_TABLE, 5, 0, 9),
     defaultProfile: parseProfile(env?.POKER_BOT_PROFILE_DEFAULT, "RANDOM"),
-    buyInChips: BOT_STARTING_STACK_CHIPS,
     bankrollSystemKey: normalizeString(env?.POKER_BOT_BANKROLL_SYSTEM_KEY) || "TREASURY"
   };
 }
@@ -211,6 +209,7 @@ async function seedBotsForJoin({
   tableId,
   maxPlayers,
   tableStakes,
+  buyInChips,
   cfg,
   humanUserId,
   postTransaction,
@@ -223,6 +222,10 @@ async function seedBotsForJoin({
   random = Math.random
 }) {
   if (!cfg?.enabled || typeof postTransaction !== "function") return [];
+  const normalizedBuyIn = Number(buyInChips);
+  if (!Number.isSafeInteger(normalizedBuyIn) || normalizedBuyIn <= 0) {
+    throw new Error("invalid_bot_buy_in");
+  }
   const stakesParsed = parseStakes(tableStakes);
   if (!stakesParsed.ok) {
     klog("poker_join_bot_seed_skip_invalid_stakes", { tableId, stakes: tableStakes ?? null });
@@ -247,7 +250,6 @@ async function seedBotsForJoin({
   if (toSeed <= 0) return [];
 
   const occupied = new Set(activeSeats.map((row) => normalizeSeatNo(row?.seat_no)).filter(Boolean));
-  const buyInChips = Math.max(1, Math.trunc(Number(cfg.buyInChips)));
   const escrowSystemKey = `POKER_TABLE:${tableId}`;
   const seededBots = [];
 
@@ -263,7 +265,7 @@ values ($1, $2, $3, 'ACTIVE', true, $4, false, $5, now(), now())
 on conflict do nothing
 returning seat_no;
       `,
-      [tableId, botUserId, seatNo, botProfile, buyInChips]
+      [tableId, botUserId, seatNo, botProfile, normalizedBuyIn]
     );
     if (!insertRows?.length) continue;
 
@@ -282,8 +284,8 @@ returning seat_no;
           reason: fundingReason
         },
         entries: [
-          { accountType: "SYSTEM", systemKey: cfg.bankrollSystemKey, amount: -buyInChips },
-          { accountType: "ESCROW", systemKey: escrowSystemKey, amount: buyInChips }
+          { accountType: "SYSTEM", systemKey: cfg.bankrollSystemKey, amount: -normalizedBuyIn },
+          { accountType: "ESCROW", systemKey: escrowSystemKey, amount: normalizedBuyIn }
         ],
         createdBy: allowBotsOnly ? null : humanUserId,
         tx
@@ -295,7 +297,7 @@ returning seat_no;
         isBot: true,
         botProfile: botProfile,
         leaveAfterHand: false,
-        stack: buyInChips
+        stack: normalizedBuyIn
       });
       occupied.add(seatNo);
     } catch (error) {

--- a/shared/poker-domain/join.behavior.test.mjs
+++ b/shared/poker-domain/join.behavior.test.mjs
@@ -50,8 +50,26 @@ function withBotsDisabled(fn) {
 }
 
 function withLockedState(args, { validateStateForStorage = () => true } = {}) {
+  const configuredBuyIn = Number.isSafeInteger(Number(args?.buyIn)) && Number(args.buyIn) > 0
+    ? Number(args.buyIn)
+    : 100;
+  const originalBeginSql = args?.beginSql;
+  const beginSql = typeof originalBeginSql === "function"
+    ? (fn) => originalBeginSql(async (tx) => {
+        const wrappedTx = Object.create(tx || null);
+        wrappedTx.unsafe = async (sql, params = []) => {
+          const rows = await tx.unsafe(sql, params);
+          if (String(sql).includes("from public.poker_tables") && Array.isArray(rows)) {
+            return rows.map((row) => row && row.buy_in == null ? { ...row, buy_in: configuredBuyIn } : row);
+          }
+          return rows;
+        };
+        return fn(wrappedTx);
+      })
+    : originalBeginSql;
   return {
     ...args,
+    beginSql,
     loadStateForUpdate: async (tx, tableId) => {
       const rows = await tx.unsafe("select version, state from public.poker_state where table_id = $1 for update;", [tableId]);
       const row = rows?.[0] || null;
@@ -1020,7 +1038,7 @@ test("first human authoritative join validates the same randomized bot target th
     return randomCalls === 1 ? 0 : 0.999999;
   };
   const store = {
-    table: { id: "t-bots", status: "OPEN", max_players: 6, stakes: '{"sb":1,"bb":2}' },
+    table: { id: "t-bots", status: "OPEN", max_players: 6, buy_in: 500, stakes: '{"sb":1,"bb":2}' },
     seatRows: [],
     stateRow: { version: 3, state: { tableId: "t-bots", seats: [], stacks: {} } },
     ledgerCalls: []
@@ -1077,7 +1095,7 @@ test("first human authoritative join validates the same randomized bot target th
     userId: "human_1",
     requestId: "join-bots-1",
     seatNo: 1,
-    buyIn: 100,
+    buyIn: 500,
     postTransactionFn: async (payload) => {
       store.ledgerCalls.push(payload);
       return { ok: true };
@@ -1092,12 +1110,15 @@ test("first human authoritative join validates the same randomized bot target th
       { seatNo: 2, botProfile: "NORMAL", leaveAfterHand: false },
       { seatNo: 3, botProfile: "NORMAL", leaveAfterHand: false }
     ]);
-    assert.equal(result.snapshot.stacks.human_1, 100);
-    assert.deepEqual(Object.values(result.snapshot.stacks), [100, 100, 100]);
+    assert.equal(result.snapshot.stacks.human_1, 500);
+    assert.deepEqual(Object.values(result.snapshot.stacks), [500, 500, 500]);
     assert.equal(result.snapshot.stateVersion, 4);
     assert.equal(store.stateRow.version, 4);
     assert.equal(store.seatRows.filter((seat) => seat.is_bot).length, 2);
     assert.equal(store.ledgerCalls.length, 3);
+    assert.equal(store.ledgerCalls.every((call) => call.entries.some((entry) => entry.accountType === "ESCROW" && entry.amount === 500)), true);
+    assert.equal(store.ledgerCalls.filter((call) => call.entries.some((entry) => entry.accountType === "USER" && entry.amount === -500)).length, 1);
+    assert.equal(store.ledgerCalls.filter((call) => call.entries.some((entry) => entry.accountType === "SYSTEM" && entry.amount === -500)).length, 2);
     assert.equal(randomCalls, 1);
   } finally {
     Math.random = originalRandom;

--- a/shared/poker-domain/join.mjs
+++ b/shared/poker-domain/join.mjs
@@ -649,15 +649,19 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
   const runPostTransaction = await resolvePostTransactionFn(postTransactionFn);
   return beginSql(async (tx) => {
     try {
-      const resolvedBuyIn = normalizePositiveInt(buyIn);
-      if (!resolvedBuyIn) throw makeError("invalid_buy_in");
-
       const tableRows = await tx.unsafe(
-        "select id, status, max_players, stakes from public.poker_tables where id = $1 limit 1 for update;",
+        "select id, status, max_players, stakes, buy_in from public.poker_tables where id = $1 limit 1 for update;",
         [tableId]
       );
       const table = tableRows?.[0] || null;
       if (!table) throw makeError("table_not_found");
+      const authoritativeBuyIn = normalizePositiveInt(table.buy_in);
+      if (!authoritativeBuyIn) throw makeError("invalid_buy_in");
+      const declaredBuyIn = buyIn == null ? null : normalizePositiveInt(buyIn);
+      if (buyIn != null && (!declaredBuyIn || declaredBuyIn !== authoritativeBuyIn)) {
+        throw makeError("invalid_buy_in");
+      }
+      const resolvedBuyIn = authoritativeBuyIn;
 
       // Lock the table row before any mutation.  Mark human participation
       // one-way (false -> true) so that action history retention uses the
@@ -701,6 +705,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
             userId,
             seatNo: persisted.seatNo,
             stack: authoritativeStack,
+            buyIn: authoritativeBuyIn,
             rejoin: true,
             requestId: requestId || null,
             me: { seated: true },
@@ -738,6 +743,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
           userId,
           seatNo: persisted.seatNo,
           stack: Number(nextStateForStorage.stacks?.[userId]),
+          buyIn: authoritativeBuyIn,
           rejoin: true,
           requestId: requestId || null,
           me: { seated: true },
@@ -872,6 +878,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
       tableId,
       maxPlayers,
       tableStakes: table.stakes,
+      buyInChips: authoritativeBuyIn,
       cfg: botCfg,
       humanUserId: userId,
       postTransaction: runPostTransaction,
@@ -900,6 +907,7 @@ export async function executePokerJoinAuthoritative({ beginSql, tableId, userId,
         userId,
         seatNo: resolvedSeatNo,
         stack: fundedStack,
+        buyIn: authoritativeBuyIn,
         rejoin: false,
         requestId: requestId || null,
         me: { seated: true },

--- a/shared/poker-domain/rebuy.behavior.test.mjs
+++ b/shared/poker-domain/rebuy.behavior.test.mjs
@@ -7,11 +7,11 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [], state = null, validateStateForStorage = () => true } = {}) {
+function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeats = [], state = null, validateStateForStorage = () => true, buyIn = 100 } = {}) {
   const lockOrder = [];
   let seatProjectionSql = "";
   let store = {
-    table: { id: "table-1", status: "OPEN" },
+    table: { id: "table-1", status: "OPEN", buy_in: buyIn },
     seat: { user_id: "user-1", seat_no: 2, stack: 0, status: "ACTIVE", is_bot: false },
     stateVersion: 7,
     state: state || { phase: "PREFLOP", handId: "hand-1", handSeats, seats: handSeats, stacks: { "user-1": 0, bot: 90 } },
@@ -85,12 +85,12 @@ function createHarness({ ledgerFails = false, stateUpdateFails = false, handSeat
     return { transaction: { id: "ledger-1" } };
   };
 
-  const execute = (requestId = "request-1") => executePokerRebuyAuthoritative({
+  const execute = (requestId = "request-1", amount = store.table.buy_in) => executePokerRebuyAuthoritative({
     beginSql,
     tableId: "table-1",
     userId: "user-1",
     requestId,
-    amount: 100,
+    amount,
     postTransactionFn,
     loadStateForUpdate,
     updateStateLocked,
@@ -126,6 +126,39 @@ test("stored rebuy result survives restart semantics and cannot fund twice", asy
   assert.equal(after.ledger.posts, 1);
   assert.equal(after.ledger.user, 400);
   assert.equal(after.ledger.escrow, 300);
+});
+
+test("authoritative rebuy uses a non-100 table buy-in for debit, stack, result, and replay", async () => {
+  const harness = createHarness({ buyIn: 500 });
+  const first = await harness.execute("non-100-request");
+  const second = await harness.execute("non-100-request");
+  const after = harness.read();
+  assert.equal(first.ok, true);
+  assert.equal(first.buyIn, 500);
+  assert.equal(first.stack, 500);
+  assert.equal(second.replayed, true);
+  assert.equal(second.buyIn, 500);
+  assert.equal(second.stack, 500);
+  assert.equal(after.ledger.user, 0);
+  assert.equal(after.ledger.escrow, 700);
+  assert.equal(after.state.stacks["user-1"], 500);
+  assert.equal(after.seat.stack, 500);
+  assert.equal(after.ledger.posts, 1);
+});
+
+test("rebuy replay validates a supplied amount against the authoritative table buy-in", async () => {
+  const harness = createHarness({ buyIn: 500 });
+  await harness.execute("replay-amount-request");
+  const before = harness.read();
+  await assert.rejects(harness.execute("replay-amount-request", 100), (error) => error?.code === "invalid_rebuy_amount");
+  assert.deepEqual(harness.read(), before);
+});
+
+test("rebuy rejects a client amount that does not match the authoritative table buy-in", async () => {
+  const harness = createHarness({ buyIn: 500 });
+  const before = harness.read();
+  await assert.rejects(harness.execute("mismatched-request", 100), (error) => error?.code === "invalid_rebuy_amount");
+  assert.deepEqual(harness.read(), before);
 });
 
 test("failed ledger funding rolls back state, seat, request, and balances", async () => {

--- a/shared/poker-domain/rebuy.mjs
+++ b/shared/poker-domain/rebuy.mjs
@@ -2,7 +2,6 @@ import { ensurePokerRequest, storePokerRequestResult } from "../../netlify/funct
 import { requireAuthoritativeHumanStack } from "./human-stack-accounting.mjs";
 import { postUserTableBuyIn } from "./table-buy-in.mjs";
 
-export const POKER_REBUY_AMOUNT = 100;
 const POKER_REQUEST_KIND = "REBUY";
 const PENDING_STALE_SEC = 30;
 
@@ -11,6 +10,14 @@ function makeError(code, status = 409) {
   error.code = code;
   error.status = status;
   return error;
+}
+
+function validateRequestedBuyIn(amount, authoritativeBuyIn) {
+  if (amount === undefined || amount === null) return;
+  const declaredAmount = Number(amount);
+  if (!Number.isSafeInteger(declaredAmount) || declaredAmount !== authoritativeBuyIn) {
+    throw makeError("invalid_rebuy_amount", 400);
+  }
 }
 
 function parseState(value) {
@@ -57,13 +64,14 @@ function normalizeStateForStorageValidation(state) {
   return { ...state, community };
 }
 
-function normalizeStoredResult(result) {
+function normalizeStoredResult(result, { allowLegacy = false } = {}) {
   if (!result || typeof result !== "object" || result.ok !== true) return null;
   const stack = Number(result.stack);
+  const buyIn = Number(result.buyIn ?? (allowLegacy ? result.stack : NaN));
   const stateVersion = Number(result.stateVersion);
-  if (!Number.isInteger(stack) || stack !== POKER_REBUY_AMOUNT) return null;
+  if (!Number.isSafeInteger(buyIn) || buyIn <= 0 || !Number.isSafeInteger(stack) || stack !== buyIn) return null;
   if (!Number.isInteger(stateVersion) || stateVersion <= 0) return null;
-  return result;
+  return { ...result, buyIn, stack };
 }
 
 export async function executePokerRebuyAuthoritative({
@@ -71,7 +79,7 @@ export async function executePokerRebuyAuthoritative({
   tableId,
   userId,
   requestId,
-  amount = POKER_REBUY_AMOUNT,
+  amount,
   postTransactionFn,
   loadStateForUpdate,
   updateStateLocked,
@@ -83,9 +91,6 @@ export async function executePokerRebuyAuthoritative({
     throw makeError("temporarily_unavailable", 503);
   }
   if (!tableId || !userId || !requestId) throw makeError("invalid_request", 400);
-  const normalizedAmount = Number(amount);
-  if (!Number.isInteger(normalizedAmount) || normalizedAmount !== POKER_REBUY_AMOUNT) throw makeError("invalid_rebuy_amount", 400);
-
   return beginSql(async (tx) => {
     const request = await ensurePokerRequest(tx, {
       tableId,
@@ -95,10 +100,19 @@ export async function executePokerRebuyAuthoritative({
       pendingStaleSec: PENDING_STALE_SEC
     });
     if (request.status === "stored") {
-      const stored = normalizeStoredResult(request.result);
-      if (!stored) throw makeError("request_result_invalid");
+      const tableRows = await tx.unsafe(
+        "select id, buy_in from public.poker_tables where id = $1 limit 1 for update;",
+        [tableId]
+      );
+      const authoritativeBuyIn = Number(tableRows?.[0]?.buy_in);
+      const stored = normalizeStoredResult(request.result, { allowLegacy: true });
+      if (!Number.isSafeInteger(authoritativeBuyIn) || authoritativeBuyIn <= 0
+        || !stored || stored.buyIn !== authoritativeBuyIn) {
+        throw makeError("request_result_invalid");
+      }
+      validateRequestedBuyIn(amount, authoritativeBuyIn);
       klog("poker_rebuy_replayed", { tableId, requestId, stateVersion: stored.stateVersion });
-      return { ...stored, replayed: true };
+      return { ...stored, buyIn: authoritativeBuyIn, stack: authoritativeBuyIn, replayed: true };
     }
     if (request.status === "pending") throw makeError("request_pending");
 
@@ -110,12 +124,15 @@ export async function executePokerRebuyAuthoritative({
     const state = parseState(locked.state);
 
     const tableRows = await tx.unsafe(
-      "select id, status from public.poker_tables where id = $1 for update;",
+      "select id, status, buy_in from public.poker_tables where id = $1 for update;",
       [tableId]
     );
     const table = tableRows?.[0] || null;
     if (!table) throw makeError("table_not_found", 404);
     if (String(table.status || "").toUpperCase() !== "OPEN") throw makeError("table_not_open");
+    const authoritativeBuyIn = Number(table.buy_in);
+    if (!Number.isSafeInteger(authoritativeBuyIn) || authoritativeBuyIn <= 0) throw makeError("invalid_rebuy_amount", 400);
+    validateRequestedBuyIn(amount, authoritativeBuyIn);
 
     const seatRows = await tx.unsafe(
       `select user_id, seat_no, stack, status, is_bot
@@ -143,7 +160,7 @@ export async function executePokerRebuyAuthoritative({
       ...state,
       stacks: {
         ...(state.stacks && typeof state.stacks === "object" && !Array.isArray(state.stacks) ? state.stacks : {}),
-        [userId]: normalizedAmount
+        [userId]: authoritativeBuyIn
       },
       waitingForNextHandByUserId: {
         ...(state.waitingForNextHandByUserId && typeof state.waitingForNextHandByUserId === "object" && !Array.isArray(state.waitingForNextHandByUserId)
@@ -163,7 +180,7 @@ export async function executePokerRebuyAuthoritative({
       tx,
       tableId,
       userId,
-      amount: normalizedAmount,
+      amount: authoritativeBuyIn,
       idempotencyKey,
       reference: `poker-rebuy:${tableId}`,
       metadata: { tableId, seatNo, reason: "manual_rebuy" }
@@ -174,7 +191,7 @@ export async function executePokerRebuyAuthoritative({
        set stack = $4
        where table_id = $1 and user_id = $2 and seat_no = $3 and status = 'ACTIVE' and is_bot = false
        returning user_id;`,
-      [tableId, userId, seatNo, normalizedAmount]
+      [tableId, userId, seatNo, authoritativeBuyIn]
     );
     if (projectedRows?.length !== 1) throw makeError("seat_projection_conflict");
     await tx.unsafe("update public.poker_tables set last_activity_at = now(), updated_at = now() where id = $1;", [tableId]);
@@ -184,7 +201,8 @@ export async function executePokerRebuyAuthoritative({
       tableId,
       userId,
       seatNo,
-      stack: normalizedAmount,
+      buyIn: authoritativeBuyIn,
+      stack: authoritativeBuyIn,
       status: "WAITING_NEXT_HAND",
       stateVersion: Number(updated.newVersion),
       ledgerTransactionId: ledger?.transaction?.id || null,
@@ -197,7 +215,7 @@ export async function executePokerRebuyAuthoritative({
       kind: POKER_REQUEST_KIND,
       result
     });
-    klog("poker_rebuy_committed", { tableId, seatNo, stateVersion: result.stateVersion, amount: normalizedAmount });
+    klog("poker_rebuy_committed", { tableId, seatNo, stateVersion: result.stateVersion, amount: authoritativeBuyIn });
     return result;
   });
 }

--- a/supabase/migrations/20260808130000_poker_table_buy_in.sql
+++ b/supabase/migrations/20260808130000_poker_table_buy_in.sql
@@ -1,0 +1,26 @@
+alter table public.poker_tables
+  add column if not exists buy_in integer;
+
+update public.poker_tables
+set buy_in = 100
+where buy_in is null;
+
+alter table public.poker_tables
+  alter column buy_in set default 100,
+  alter column buy_in set not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    join pg_class t on t.oid = c.conrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = 'public'
+      and t.relname = 'poker_tables'
+      and c.conname = 'poker_tables_buy_in_positive_chk'
+  ) then
+    alter table public.poker_tables
+      add constraint poker_tables_buy_in_positive_chk check (buy_in > 0);
+  end if;
+end $$;

--- a/tests/helpers/poker-test-helpers.mjs
+++ b/tests/helpers/poker-test-helpers.mjs
@@ -8,7 +8,7 @@ import { patchSitOutByUserId } from "../../netlify/functions/_shared/poker-sitou
 import { createPokerTableWithState } from "../../netlify/functions/_shared/poker-table-init.mjs";
 import { readPokerBuyInEligibility } from "../../netlify/functions/_shared/poker-buy-in-eligibility.mjs";
 import { shouldHideSeatRowFromReadModel } from "../../netlify/functions/_shared/poker-list-seat-visibility.mjs";
-import { notifyWsLobbyMaterialize } from "../../netlify/functions/_shared/poker-ws-runtime-notify.mjs";
+import { checkWsBuyInCapability, notifyWsLobbyMaterialize } from "../../netlify/functions/_shared/poker-ws-runtime-notify.mjs";
 import {
   buildSeatBotMap,
   chooseBotActionTrivial,
@@ -136,6 +136,7 @@ export const loadPokerHandler = (filePath, mocks) => {
     "readPokerBuyInEligibility",
     "DEFAULT_CASH_TABLE_BUY_IN_CHIPS",
     "notifyWsLobbyMaterialize",
+    "checkWsBuyInCapability",
     "PRESENCE_TTL_SEC",
     "HEARTBEAT_INTERVAL_SEC",
     "storePokerRequestResult",
@@ -193,6 +194,7 @@ return handler;`
       readPokerBuyInEligibility,
       DEFAULT_CASH_TABLE_BUY_IN_CHIPS,
       notifyWsLobbyMaterialize,
+      checkWsBuyInCapability,
       computeTargetBotCount,
       getBotAutoplayConfig,
       chooseBotActionTrivial,

--- a/tests/poker-bots.unit.test.mjs
+++ b/tests/poker-bots.unit.test.mjs
@@ -13,7 +13,6 @@ import {
   assert.equal(cfg.minPerTable, 2);
   assert.equal(cfg.maxPerTable, 5);
   assert.equal(cfg.defaultProfile, "RANDOM");
-  assert.equal(cfg.buyInChips, 100);
   assert.equal(cfg.bankrollSystemKey, "TREASURY");
   assert.equal(cfg.maxActionsPerPoll, 2);
 }
@@ -25,7 +24,6 @@ import {
   assert.equal(getBotConfig({ POKER_BOTS_ENABLED: "false" }).enabled, false);
   assert.equal(getBotConfig({ POKER_BOTS_MIN_PER_TABLE: "1" }).minPerTable, 1);
   assert.equal(getBotConfig({ POKER_BOTS_MAX_PER_TABLE: "99" }).maxPerTable, 9);
-  assert.equal(getBotConfig({ POKER_BOT_BUYIN_BB: "250" }).buyInChips, 100);
   assert.equal(getBotConfig({ POKER_BOT_PROFILE_DEFAULT: " tight " }).defaultProfile, "TIGHT");
 }
 

--- a/tests/poker-create-table.stakes.test.mjs
+++ b/tests/poker-create-table.stakes.test.mjs
@@ -79,6 +79,19 @@ const runInvalidStakes = async () => {
   assert.equal(queries.length, 0);
 };
 
+const runInvalidBuyIn = async () => {
+  const queries = [];
+  const handler = makeHandler(queries);
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2", buyIn: 500.5 }),
+  });
+  assert.equal(response.statusCode, 400);
+  assert.equal(JSON.parse(response.body).error, "invalid_buy_in");
+  assert.equal(queries.length, 0);
+};
+
 const runSlashStakes = async () => {
   const queries = [];
   const notifications = [];
@@ -99,6 +112,7 @@ const runSlashStakes = async () => {
   const insertCall = queries.find((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables"));
   assert.ok(insertCall, "expected insert into poker_tables");
   assert.deepEqual(JSON.parse(insertCall.params?.[0]), { sb: 1, bb: 2 });
+  assert.equal(insertCall.params?.[1], 100);
   const stateInsertCall = queries.find((entry) => entry.query.toLowerCase().includes("insert into public.poker_state"));
   assert.ok(stateInsertCall, "expected insert into poker_state");
   const storedState = normalizeJsonState(stateInsertCall?.params?.[1]);
@@ -107,7 +121,31 @@ const runSlashStakes = async () => {
   assert.equal(notifications[0]?.tableId, "table-1");
   assert.equal(notifications[0]?.maxPlayers, 6);
   assert.deepEqual(notifications[0]?.stakes, { sb: 1, bb: 2 });
+  assert.equal(notifications[0]?.buyIn, 100);
   assert.equal(typeof notifications[0]?.klog, "function");
+};
+
+const runCustomBuyIn = async () => {
+  const queries = [];
+  const notifications = [];
+  const handler = makeHandler(queries, {
+    balance: 500,
+    notifyWsLobbyMaterialize: async (payload) => {
+      notifications.push(payload);
+      return { ok: true };
+    }
+  });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2", buyIn: 500 }),
+  });
+  assert.equal(response.statusCode, 200);
+  const insertCall = queries.find((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables"));
+  assert.ok(insertCall, "expected insert into poker_tables");
+  assert.equal(insertCall.params?.[1], 500);
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0]?.buyIn, 500);
 };
 
 const runSlowNotifyDoesNotDelayResponse = async () => {
@@ -195,7 +233,9 @@ const runBalanceReadFailure = async () => {
 
 await runMissingStakes();
 await runInvalidStakes();
+await runInvalidBuyIn();
 await runSlashStakes();
+await runCustomBuyIn();
 await runSlowNotifyDoesNotDelayResponse();
 await runMaintenanceGuard();
 await runInsufficientBalance();

--- a/tests/poker-create-table.stakes.test.mjs
+++ b/tests/poker-create-table.stakes.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { loadPokerHandler } from "./helpers/poker-test-helpers.mjs";
 import { isStateStorageValid, normalizeJsonState } from "../netlify/functions/_shared/poker-state-utils.mjs";
 import { readPokerBuyInEligibility } from "../netlify/functions/_shared/poker-buy-in-eligibility.mjs";
+import { checkWsBuyInCapability } from "../netlify/functions/_shared/poker-ws-runtime-notify.mjs";
 
 process.env.CHIPS_ENABLED = "1";
 
@@ -25,6 +26,7 @@ const makeHandler = (queries, options = {}) =>
     extractBearerToken: () => "token",
     verifySupabaseJwt: async () => ({ valid: true, userId: "user-1" }),
     klog: options.klog || (() => {}),
+    checkWsBuyInCapability: options.checkWsBuyInCapability || (async () => ({ ok: true })),
     notifyWsLobbyMaterialize: options.notifyWsLobbyMaterialize || (async () => ({ ok: true, skipped: true })),
     beginSql: async (fn) =>
       fn({
@@ -128,8 +130,13 @@ const runSlashStakes = async () => {
 const runCustomBuyIn = async () => {
   const queries = [];
   const notifications = [];
+  let capabilityChecks = 0;
   const handler = makeHandler(queries, {
     balance: 500,
+    checkWsBuyInCapability: async () => {
+      capabilityChecks += 1;
+      return { ok: true };
+    },
     notifyWsLobbyMaterialize: async (payload) => {
       notifications.push(payload);
       return { ok: true };
@@ -141,11 +148,51 @@ const runCustomBuyIn = async () => {
     body: JSON.stringify({ maxPlayers: 6, stakes: "1/2", buyIn: 500 }),
   });
   assert.equal(response.statusCode, 200);
+  assert.equal(capabilityChecks, 1);
   const insertCall = queries.find((entry) => entry.query.toLowerCase().includes("insert into public.poker_tables"));
   assert.ok(insertCall, "expected insert into poker_tables");
   assert.equal(insertCall.params?.[1], 500);
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0]?.buyIn, 500);
+};
+
+const runCustomBuyInRolloutGuard = async () => {
+  const queries = [];
+  const handler = makeHandler(queries, {
+    balance: 500,
+    checkWsBuyInCapability: async () => ({ ok: false, reason: "buy_in_capability_unavailable" })
+  });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { origin: "https://example.test", authorization: "Bearer token" },
+    body: JSON.stringify({ maxPlayers: 6, stakes: "1/2", buyIn: 500 }),
+  });
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(JSON.parse(response.body), { error: "ws_buy_in_capability_unavailable" });
+  assert.equal(queries.length, 0, "custom buy-in must not create a DB table while the WS is too old");
+};
+
+const runWsCapabilityHeaderCheck = async () => {
+  const supported = await checkWsBuyInCapability({
+    env: { POKER_WS_INTERNAL_BASE_URL: "https://ws.example.test" },
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: (name) => name === "x-poker-buy-in-materialization" ? "1" : null }
+    })
+  });
+  assert.equal(supported.ok, true);
+
+  const legacy = await checkWsBuyInCapability({
+    env: { POKER_WS_INTERNAL_BASE_URL: "https://ws.example.test" },
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null }
+    })
+  });
+  assert.equal(legacy.ok, false);
+  assert.equal(legacy.reason, "buy_in_capability_unavailable");
 };
 
 const runSlowNotifyDoesNotDelayResponse = async () => {
@@ -236,6 +283,8 @@ await runInvalidStakes();
 await runInvalidBuyIn();
 await runSlashStakes();
 await runCustomBuyIn();
+await runCustomBuyInRolloutGuard();
+await runWsCapabilityHeaderCheck();
 await runSlowNotifyDoesNotDelayResponse();
 await runMaintenanceGuard();
 await runInsufficientBalance();

--- a/tests/poker-quick-seat.behavior.test.mjs
+++ b/tests/poker-quick-seat.behavior.test.mjs
@@ -14,7 +14,7 @@ const callQuickSeat = async (handler, body = {}) => {
   });
 };
 
-const makeHandler = ({ mode, queries, notifications = [], logs = [], balance = 100, balanceError = false }) =>
+const makeHandler = ({ mode, queries, notifications = [], logs = [], balance = 100, balanceError = false, candidateBuyIn = 100 }) =>
   loadPokerHandler("netlify/functions/poker-quick-seat.mjs", {
     baseHeaders: () => ({}),
     corsHeaders: () => ({ "access-control-allow-origin": "https://example.test" }),
@@ -41,12 +41,12 @@ const makeHandler = ({ mode, queries, notifications = [], logs = [], balance = 1
           ) {
             const requireHuman = params?.[2] === true;
             if (mode === "prefer_humans" || mode === "already_seated") {
-              if (requireHuman) return [{ id: "table-human", max_players: 6 }];
+              if (requireHuman) return [{ id: "table-human", max_players: 6, buy_in: candidateBuyIn }];
               return [];
             }
             if (mode === "any_open") {
               if (requireHuman) return [];
-              return [{ id: "table-any", max_players: 6 }];
+              return [{ id: "table-any", max_players: 6, buy_in: candidateBuyIn }];
             }
             return [];
           }
@@ -93,7 +93,7 @@ const run = async () => {
   {
     const queries = [];
     const notifications = [];
-    const handler = makeHandler({ mode: "prefer_humans", queries, notifications });
+    const handler = makeHandler({ mode: "prefer_humans", queries, notifications, balance: 500, candidateBuyIn: 500 });
     const res = await callQuickSeat(handler, { stakes: "1/2", maxPlayers: 6 });
     assert.equal(res.statusCode, 200);
     const body = JSON.parse(res.body);
@@ -313,7 +313,7 @@ const run = async () => {
               text.includes("t.max_players = $1") &&
               text.includes("t.stakes = $2::jsonb")
             ) {
-              if (state.created) return [{ id: "table-created", max_players: 6 }];
+              if (state.created) return [{ id: "table-created", max_players: 6, buy_in: 100 }];
               return [];
             }
 

--- a/tests/poker-ui.behavior.test.mjs
+++ b/tests/poker-ui.behavior.test.mjs
@@ -241,16 +241,19 @@ function loadLobbyHarness(options = {}){
     pokerCreate: makeElement('pokerCreate'),
     pokerSb: makeElement('pokerSb'),
     pokerBb: makeElement('pokerBb'),
+    pokerBuyIn: makeElement('pokerBuyIn'),
     pokerMaxPlayers: makeElement('pokerMaxPlayers'),
     pokerSignIn: makeElement('pokerSignIn'),
     pokerGuestPlay: makeElement('pokerGuestPlay'),
   };
   elements.pokerSb.value = '1';
   elements.pokerBb.value = '2';
+  elements.pokerBuyIn.value = '100';
   elements.pokerMaxPlayers.value = '6';
   elements.pokerLobbyContent.dataset.requiredBuyIn = '100';
 
   const fetchCalls = [];
+  const fetchRequests = [];
   const wsCreates = [];
   let requestLobbySnapshotCalls = 0;
   const lobbyClients = [];
@@ -345,8 +348,9 @@ function loadLobbyHarness(options = {}){
     clearInterval: () => {},
     navigator: { userAgent: 'node' },
     localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
-    fetch: async (url) => {
+    fetch: async (url, requestOptions) => {
       fetchCalls.push(String(url));
+      fetchRequests.push({ url: String(url), options: requestOptions || {} });
       if (typeof options.fetchResponse === 'function') return options.fetchResponse(String(url));
       return { ok: true, json: async () => ({ ok: true }) };
     },
@@ -367,6 +371,7 @@ function loadLobbyHarness(options = {}){
   return {
     elements,
     fetchCalls,
+    fetchRequests,
     wsCreates,
     getLobbyOptions: () => lobbyClients.length ? lobbyClients[lobbyClients.length - 1].options : null,
     getLobbyClient: (index) => lobbyClients[index == null ? lobbyClients.length - 1 : index] || null,
@@ -471,6 +476,24 @@ assert.equal(lobbyHarness.getRequestLobbySnapshotCalls(), 1, 'lobby refresh shou
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(fallbackHarness.fetchCalls.some((url) => url.includes('poker-create-table')), true, 'balance lookup failure should fall through to guarded create endpoint');
+}
+
+{
+  const customBuyInHarness = loadLobbyHarness({
+    balanceResult: { balance: 500 },
+    fetchResponse: async () => ({ ok: true, status: 200, json: async () => ({ tableId: 'table-custom-buy-in' }) }),
+  });
+  customBuyInHarness.elements.pokerBuyIn.value = '500';
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  customBuyInHarness.elements.pokerCreate.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const createRequest = customBuyInHarness.fetchRequests.find((entry) => entry.url.includes('poker-create-table'));
+  assert.ok(createRequest, 'custom buy-in should call create-table API');
+  assert.deepEqual(JSON.parse(createRequest.options.body), {
+    stakes: { sb: 1, bb: 2 },
+    maxPlayers: 6,
+    buyIn: 500,
+  });
 }
 
 {

--- a/tests/poker-ui.behavior.test.mjs
+++ b/tests/poker-ui.behavior.test.mjs
@@ -253,7 +253,6 @@ function loadLobbyHarness(options = {}){
   elements.pokerLobbyContent.dataset.requiredBuyIn = '100';
 
   const fetchCalls = [];
-  const fetchRequests = [];
   const wsCreates = [];
   let requestLobbySnapshotCalls = 0;
   const lobbyClients = [];
@@ -350,7 +349,6 @@ function loadLobbyHarness(options = {}){
     localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
     fetch: async (url, requestOptions) => {
       fetchCalls.push(String(url));
-      fetchRequests.push({ url: String(url), options: requestOptions || {} });
       if (typeof options.fetchResponse === 'function') return options.fetchResponse(String(url));
       return { ok: true, json: async () => ({ ok: true }) };
     },
@@ -371,7 +369,6 @@ function loadLobbyHarness(options = {}){
   return {
     elements,
     fetchCalls,
-    fetchRequests,
     wsCreates,
     getLobbyOptions: () => lobbyClients.length ? lobbyClients[lobbyClients.length - 1].options : null,
     getLobbyClient: (index) => lobbyClients[index == null ? lobbyClients.length - 1 : index] || null,
@@ -476,24 +473,6 @@ assert.equal(lobbyHarness.getRequestLobbySnapshotCalls(), 1, 'lobby refresh shou
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(fallbackHarness.fetchCalls.some((url) => url.includes('poker-create-table')), true, 'balance lookup failure should fall through to guarded create endpoint');
-}
-
-{
-  const customBuyInHarness = loadLobbyHarness({
-    balanceResult: { balance: 500 },
-    fetchResponse: async () => ({ ok: true, status: 200, json: async () => ({ tableId: 'table-custom-buy-in' }) }),
-  });
-  customBuyInHarness.elements.pokerBuyIn.value = '500';
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  customBuyInHarness.elements.pokerCreate.click();
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  const createRequest = customBuyInHarness.fetchRequests.find((entry) => entry.url.includes('poker-create-table'));
-  assert.ok(createRequest, 'custom buy-in should call create-table API');
-  assert.deepEqual(JSON.parse(createRequest.options.body), {
-    stakes: { sb: 1, bb: 2 },
-    maxPlayers: 6,
-    buyIn: 500,
-  });
 }
 
 {

--- a/tests/poker-v2-live.behavior.test.mjs
+++ b/tests/poker-v2-live.behavior.test.mjs
@@ -399,6 +399,26 @@ async function waitFor(predicate, attempts = 6){
   }
 }
 
+function sendInitialTableSnapshot(harness, options = {}){
+  const tableId = options.tableId || 'table-1';
+  const payload = {
+    tableId,
+    stateVersion: 1,
+    table: { tableId, status: 'OPEN', maxSeats: 6, members: [] },
+    public: {
+      hand: { handId: null, status: 'INIT', dealerSeatNo: null },
+      turn: { userId: null, deadlineAt: null },
+      pot: { total: 0, sidePots: [] },
+      legalActions: { seat: null, actions: [] },
+      actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
+      stacks: {}
+    },
+    you: { seat: null }
+  };
+  if (options.buyIn != null) payload.table.buyIn = options.buyIn;
+  harness.getCreateOptions().onSnapshot({ kind: 'stateSnapshot', payload });
+}
+
 function findSeatByLabel(harness, label){
   return harness.elements.pokerSeatLayer.children.find((node) => (
     node.children || []
@@ -458,6 +478,9 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
 
   const ws = harness.getCreateOptions();
   assert.ok(ws, 'v2 should bootstrap a WS client when tableId is present');
+  assert.equal(harness.elements.pokerV2JoinBtn.disabled, true, 'join must wait for the authoritative table snapshot');
+  sendInitialTableSnapshot(harness, { buyIn: 500 });
+  await harness.flush();
   await waitFor(() => harness.elements.pokerV2JoinBtn.disabled === false);
   assert.equal(harness.elements.pokerV2JoinBtn.textContent, 'Join', 'v2 should not mark the user as seated before a live snapshot confirms it');
   assert.equal(harness.elements.pokerV2StartBtn.hidden, true, 'start hand should stay hidden until a live seat is confirmed');
@@ -471,7 +494,7 @@ test('poker v2 boots live mode, preserves table links, and sends WS commands', a
   await harness.flush();
 
   assert.equal(harness.joinPayloads.length, 1);
-  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 240, autoSeat: true, preferredSeatNo: 3 }));
+  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 500, autoSeat: true, preferredSeatNo: 3 }));
   assert.equal(harness.elements.pokerTableScreen.attributes['data-boot-ready'], '1');
   assert.equal(harness.elements.pokerBootSplash.hidden, true);
 
@@ -1461,6 +1484,8 @@ test('poker v2 shows one reserved next-hand join without cards, actions, or fold
   harness.fireDomContentLoaded();
   await harness.flush();
   const ws = harness.getCreateOptions();
+  sendInitialTableSnapshot(harness);
+  await harness.flush();
   await waitFor(() => harness.elements.pokerV2JoinBtn.disabled === false);
 
   harness.elements.pokerV2JoinBtn.click();
@@ -1541,6 +1566,8 @@ test('poker v2 guest mode shows restrictions panel, hides XP badge, and still au
   assert.equal(harness.elements.pokerV2GuestBadge.hidden, false, 'guest mode should show the guest badge');
   assert.equal(harness.elements.pokerV2GuestPanel.hidden, false, 'guest mode should show the restrictions panel');
 
+  sendInitialTableSnapshot(harness, { tableId: 'guest_table_1' });
+  await harness.flush();
   await waitFor(() => harness.joinPayloads.length === 1);
   assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({
     tableId: 'guest_table_1',
@@ -1570,6 +1597,8 @@ test('poker v2 treats a historical guest session as resume-only and redirects on
   harness.fireDomContentLoaded();
   await harness.flush();
 
+  sendInitialTableSnapshot(harness, { tableId: 'guest_table_resume' });
+  await harness.flush();
   await waitFor(() => harness.joinPayloads.length === 1);
   assert.equal(harness.joinPayloads[0].guestJoinIntent, 'resume');
 
@@ -2130,7 +2159,7 @@ test('poker v2 renders authoritative out-of-chips state with stable disabled act
     payload: {
       tableId: 'table-1',
       stateVersion: 40,
-      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, buyIn: 500, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
       public: {
         seats: [{ userId: 'user-1', seatNo: 1, status: playerState.status }, { userId: 'bot-1', seatNo: 2, status: 'ACTIVE', isBot: true }],
         stacks: { 'user-1': playerState.stack, 'bot-1': 98 },
@@ -2159,10 +2188,10 @@ test('poker v2 renders authoritative out-of-chips state with stable disabled act
   }
   harness.elements.pokerV2RebuyBtn.click();
   await harness.flush();
-  assert.equal(JSON.stringify(harness.rebuyPayloads), JSON.stringify([{ tableId: 'table-1', amount: 100 }]));
+  assert.equal(JSON.stringify(harness.rebuyPayloads), JSON.stringify([{ tableId: 'table-1', amount: 500 }]));
   assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'accepted rebuy must close the prompt immediately');
 
-  ws.onSnapshot(snapshot({ status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false }));
+  ws.onSnapshot(snapshot({ status: 'WAITING_NEXT_HAND', stack: 500, canRebuy: false }));
   await harness.flush();
   assert.equal(harness.elements.pokerV2TurnText.textContent, 'Funded · Joining next hand');
   assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'waiting snapshot must not reopen an accepted rebuy prompt');
@@ -2175,14 +2204,14 @@ test('poker v2 resumes a stored rebuy only after a full snapshot and never creat
     requestId: 'rebuy_reload_1',
     tableId: 'table-1',
     userId: 'user-1',
-    payload: { tableId: 'table-1', amount: 100 }
+    payload: { tableId: 'table-1', amount: 500 }
   });
   const buildSnapshot = (playerState) => ({
     kind: 'stateSnapshot',
     payload: {
       tableId: 'table-1',
       stateVersion: 1,
-      table: { tableId: 'table-1', status: 'OPEN', members: [{ userId: 'user-1', seat: 1 }] },
+      table: { tableId: 'table-1', status: 'OPEN', buyIn: 500, members: [{ userId: 'user-1', seat: 1 }] },
       public: { hand: { handId: 'hand-rebuy-reload', status: 'TURN' }, turn: { userId: 'bot-1' }, pot: { total: 0, sidePots: [] }, legalActions: { seat: null, actions: [] } },
       private: { userId: 'user-1', seat: 1, playerState },
       you: { seat: 1 }
@@ -2197,7 +2226,7 @@ test('poker v2 resumes a stored rebuy only after a full snapshot and never creat
   assert.equal(fundedHarness.rebuyRequestIds.length, 0);
   fundedHarness.getCreateOptions().onStatus('auth_ok', { roomId: 'table-1' });
   await fundedHarness.flush();
-  fundedHarness.getCreateOptions().onSnapshot(buildSnapshot({ status: 'WAITING_NEXT_HAND', stack: 100, canRebuy: false }));
+  fundedHarness.getCreateOptions().onSnapshot(buildSnapshot({ status: 'WAITING_NEXT_HAND', stack: 500, canRebuy: false }));
   await fundedHarness.flush();
   assert.equal(fundedHarness.rebuyRequestIds.length, 0);
   assert.equal(fundedHarness.getSessionStorage('poker:pendingRebuy:user-1:table-1'), null);
@@ -2224,7 +2253,7 @@ function autoRebuySnapshot(playerState){
     payload: {
       tableId: 'table-1',
       stateVersion: 1,
-      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
+      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, buyIn: 500, members: [{ userId: 'user-1', seat: 1 }, { userId: 'bot-1', seat: 2 }] },
       public: {
         seats: [{ userId: 'user-1', seatNo: 1, status: playerState.status }, { userId: 'bot-1', seatNo: 2, status: 'ACTIVE', isBot: true }],
         stacks: { 'user-1': playerState.stack, 'bot-1': 98 },
@@ -2251,7 +2280,7 @@ test('poker v2 auto-rebuy fires exactly one existing rebuy request when enabled 
   ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
   await harness.flush();
   assert.equal(harness.rebuyPayloads.length, 1);
-  assert.equal(JSON.stringify(harness.rebuyPayloads[0]), JSON.stringify({ tableId: 'table-1', amount: 100 }));
+  assert.equal(JSON.stringify(harness.rebuyPayloads[0]), JSON.stringify({ tableId: 'table-1', amount: 500 }));
   assert.equal(harness.elements.pokerV2RebuyPanel.hidden, true, 'auto-rebuy must not show the manual rebuy prompt');
 });
 
@@ -2281,7 +2310,7 @@ test('poker v2 auto-rebuy does not repeat on repeated snapshots or during a pend
   ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
   await harness.flush();
   assert.equal(harness.rebuyPayloads.length, 1, 'repeated snapshot must not re-trigger auto-rebuy');
-  ws.onSnapshot(autoRebuySnapshot({ status: 'ACTIVE', stack: 100, canRebuy: false }));
+  ws.onSnapshot(autoRebuySnapshot({ status: 'ACTIVE', stack: 500, canRebuy: false }));
   await harness.flush();
   ws.onSnapshot(autoRebuySnapshot({ status: 'OUT_OF_CHIPS', stack: 0, canRebuy: true }));
   await harness.flush();
@@ -2803,9 +2832,12 @@ test('poker v2 auto-joins from query params after live auth', async () => {
   const harness = createHarness({ search: '?tableId=table-1&seatNo=4&autoJoin=1' });
   harness.fireDomContentLoaded();
   await harness.flush();
+  assert.equal(harness.joinPayloads.length, 0, 'auto-join must wait for the authoritative table snapshot');
+  sendInitialTableSnapshot(harness, { buyIn: 500 });
+  await harness.flush();
   await waitFor(() => harness.joinPayloads.length === 1);
 
-  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 100, autoSeat: true, preferredSeatNo: 4 }));
+  assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({ tableId: 'table-1', buyIn: 500, autoSeat: true, preferredSeatNo: 4 }));
 });
 
 test('poker v2 retries Play now auto-join after a transient authoritative join failure', async () => {
@@ -2822,27 +2854,9 @@ test('poker v2 retries Play now auto-join after a transient authoritative join f
   });
   harness.fireDomContentLoaded();
   await harness.flush();
-  await waitFor(() => harness.joinPayloads.length === 1);
-
-  const ws = harness.getCreateOptions();
-  ws.onSnapshot({
-    kind: 'stateSnapshot',
-    payload: {
-      tableId: 'table-1',
-      stateVersion: 0,
-      table: { tableId: 'table-1', status: 'OPEN', maxSeats: 6, members: [] },
-      public: {
-        hand: { handId: null, status: 'INIT', dealerSeatNo: null },
-        turn: { userId: null, deadlineAt: null },
-        pot: { total: 0, sidePots: [] },
-        legalActions: { seat: null, actions: [] },
-        actionConstraints: { toCall: null, minRaiseTo: null, maxRaiseTo: null, maxBetAmount: null },
-        stacks: {}
-      },
-      you: { seat: null }
-    }
-  });
+  sendInitialTableSnapshot(harness, { buyIn: 500 });
   await harness.flush();
+  await waitFor(() => harness.joinPayloads.length === 1);
 
   assert.equal(harness.joinPayloads.length, 1);
   assert.equal(harness.elements.pokerV2ErrorText.textContent, 'authoritative_join_rehydrate_failed');
@@ -2852,7 +2866,7 @@ test('poker v2 retries Play now auto-join after a transient authoritative join f
   await harness.flush();
 
   assert.equal(harness.joinPayloads.length, 2);
-  assert.equal(JSON.stringify(harness.joinPayloads[1]), JSON.stringify({ tableId: 'table-1', buyIn: 100, autoSeat: true, preferredSeatNo: 4 }));
+  assert.equal(JSON.stringify(harness.joinPayloads[1]), JSON.stringify({ tableId: 'table-1', buyIn: 500, autoSeat: true, preferredSeatNo: 4 }));
   assert.equal(harness.logs.some((entry) => entry.kind === 'poker_auto_join_failed' && entry.data.retryScheduled === true), true);
 });
 
@@ -2867,9 +2881,11 @@ test('poker v2 renders insufficient funds as controlled non-retryable buy-in cop
   });
   harness.fireDomContentLoaded();
   await harness.flush();
+  sendInitialTableSnapshot(harness);
+  await harness.flush();
   await waitFor(() => harness.joinPayloads.length === 1);
 
-  assert.equal(harness.elements.pokerV2ErrorText.textContent, 'You need at least 100 CH to join a table.');
+  assert.equal(harness.elements.pokerV2ErrorText.textContent, 'Not enough CH to join this table.');
   assert.equal(harness.elements.pokerV2ErrorText.hidden, false);
   harness.advanceTime(5000);
   await harness.flush();
@@ -2947,10 +2963,11 @@ test('poker v2 safely rejoins the same authoritative seat after a socket reconne
   assert.equal(harness.joinPayloads.length, 1);
   assert.equal(JSON.stringify(harness.joinPayloads[0]), JSON.stringify({
     tableId: 'table-1',
+    buyIn: 100,
     autoSeat: true,
     preferredSeatNo: 4
   }));
-  assert.equal(Object.prototype.hasOwnProperty.call(harness.joinPayloads[0], 'buyIn'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(harness.joinPayloads[0], 'buyIn'), true);
 });
 
 test('poker v2 retries the same reconnect seat after a transient join failure', async () => {
@@ -3033,6 +3050,7 @@ test('poker v2 retries the same reconnect seat after a transient join failure', 
   harness.joinPayloads.forEach((payload) => {
     assert.equal(JSON.stringify(payload), JSON.stringify({
       tableId: 'table-1',
+      buyIn: 100,
       autoSeat: true,
       preferredSeatNo: 4
     }));

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.behavior.test.mjs
@@ -334,11 +334,12 @@ test("adapter restores settled replacement identity from the current persisted s
       id: "table_replacement_bot_restore_settled",
       max_players: 6,
       status: "OPEN",
+      buy_in: 500,
       lifecycle_kind: "CONTINUOUS_BOT",
       managed_profile_key: "CONTINUOUS_BOT_DEFAULT"
     },
     seatRows: [
-      { user_id: "bot_current_2", seat_no: 2, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 100 },
+      { user_id: "bot_current_2", seat_no: 2, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 500 },
       { user_id: "bot_keep_3", seat_no: 3, status: "ACTIVE", is_bot: true, bot_profile: "TRIVIAL", stack: 87 }
     ],
     stateRow: {
@@ -377,7 +378,7 @@ test("adapter restores settled replacement identity from the current persisted s
     bot_keep_3: 3
   });
   assert.deepEqual(result.table.coreState.pokerState.stacks, {
-    bot_current_2: 100,
+    bot_current_2: 500,
     bot_keep_3: 87
   });
   assert.equal(result.table.coreState.pokerState.seats[0].userId, "bot_current_2");

--- a/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-adapter.mjs
@@ -126,6 +126,11 @@ function normalizeMaxSeats(rawMaxSeats) {
   return parsed;
 }
 
+function normalizeBuyIn(rawBuyIn) {
+  const parsed = Number(rawBuyIn);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 function normalizeStateVersion(rawVersion) {
   const parsed = Number(rawVersion);
   if (!Number.isInteger(parsed) || parsed < 0) {
@@ -177,6 +182,7 @@ function normalizeTableMeta(tableRow, maxSeats) {
     : "STANDARD";
   return {
     maxPlayers,
+    buyIn: normalizeBuyIn(tableRow?.buy_in ?? tableRow?.buyIn),
     stakes: stakesParsed.ok ? stakesParsed.value : null,
     createdAtMs,
     lastActivityAtMs,

--- a/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-db.mjs
@@ -79,6 +79,7 @@ async function beginSqlFileStore(fn, { env = process.env } = {}) {
           status: row.status || "OPEN",
           max_players: row.max_players || row.maxPlayers || 6,
           stakes: row.stakes ?? '{"sb":1,"bb":2}',
+          buy_in: row.buy_in ?? row.buyIn ?? null,
           created_at: row.created_at ?? null,
           updated_at: row.updated_at ?? null,
           last_activity_at: row.last_activity_at ?? null,

--- a/ws-server/poker/bootstrap/persisted-bootstrap-repository.mjs
+++ b/ws-server/poker/bootstrap/persisted-bootstrap-repository.mjs
@@ -31,7 +31,7 @@ export function createPersistedBootstrapRepository({ env = process.env } = {}) {
     const beginSql = await loadBeginSql();
     return beginSql(async (tx) => {
       const tableRows = await tx.unsafe(
-        "select id, status, max_players, stakes, created_at, updated_at, last_activity_at, lifecycle_kind, managed_profile_key, rotation_due_at from public.poker_tables where id = $1 limit 1;",
+        "select id, status, max_players, stakes, buy_in, created_at, updated_at, last_activity_at, lifecycle_kind, managed_profile_key, rotation_due_at from public.poker_tables where id = $1 limit 1;",
         [tableId]
       );
       const tableRow = tableRows?.[0] || null;

--- a/ws-server/poker/core/state.mjs
+++ b/ws-server/poker/core/state.mjs
@@ -30,7 +30,8 @@ export function cloneCoreState(state) {
     version: state.version,
     members: state.members.map((member) => ({ userId: member.userId, seat: member.seat })),
     seats: { ...state.seats },
-    appliedRequestIds: [...state.appliedRequestIds]
+    appliedRequestIds: [...state.appliedRequestIds],
+    ...(isPlainObject(state.publicStacks) ? { publicStacks: { ...state.publicStacks } } : {})
   };
 }
 

--- a/ws-server/poker/engine/engine-act.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-act.behavior.test.mjs
@@ -11,6 +11,7 @@ function initialCore() {
       { userId: "user_a", seat: 1 },
       { userId: "user_b", seat: 2 }
     ],
+    publicStacks: { user_a: 100, user_b: 100 },
     pokerState: null
   };
 }

--- a/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-bootstrap.behavior.test.mjs
@@ -12,6 +12,7 @@ function coreStateBase() {
       { userId: "user_b", seat: 2 },
       { userId: "user_c", seat: 3 }
     ],
+    publicStacks: { user_a: 500, user_b: 500, user_c: 500 },
     pokerState: null
   };
 }
@@ -39,7 +40,7 @@ test("engine bootstrap creates deterministic preflop hand with expected invarian
   assert.ok(pokerState.turnDeadlineAt > nowMs);
   assert.equal(Array.isArray(pokerState.seats), true);
   assert.deepEqual(pokerState.handSeats, pokerState.seats);
-  assert.deepEqual(pokerState.handStartStacksByUserId, { user_a: 100, user_b: 100, user_c: 100 });
+  assert.deepEqual(pokerState.handStartStacksByUserId, { user_a: 500, user_b: 500, user_c: 500 });
   assert.equal(typeof pokerState.roomId, "string");
 });
 
@@ -77,6 +78,7 @@ test("bootstrap maps dealer/SB/BB/UTG deterministically for 2-player and 3-playe
       { userId: "user_a", seat: 1 },
       { userId: "user_b", seat: 2 }
     ],
+    publicStacks: { user_a: 500, user_b: 500 },
     pokerState: null
   };
 

--- a/ws-server/poker/engine/engine-rollover.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-rollover.behavior.test.mjs
@@ -14,14 +14,14 @@ import { dealHoleCards, deriveDeck, toCardCodes } from "../shared/poker-primitiv
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 test("replacement funding delta preserves residual bot stack", () => {
-  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 0 }), { ok: true, oldStack: 0, targetStack: 100, fundingDelta: 100 });
-  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 1 }), { ok: true, oldStack: 1, targetStack: 100, fundingDelta: 99 });
-  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 99 }), { ok: true, oldStack: 99, targetStack: 100, fundingDelta: 1 });
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 0, targetStack: 500 }), { ok: true, oldStack: 0, targetStack: 500, fundingDelta: 500 });
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 1, targetStack: 500 }), { ok: true, oldStack: 1, targetStack: 500, fundingDelta: 499 });
+  assert.deepEqual(calculateReplacementFundingDelta({ oldStack: 499, targetStack: 500 }), { ok: true, oldStack: 499, targetStack: 500, fundingDelta: 1 });
 });
 
 test("replacement funding delta rejects invalid accounting inputs", () => {
-  for (const oldStack of [-1, Number.NaN, Number.POSITIVE_INFINITY, 100, 101, 1.5]) {
-    assert.equal(calculateReplacementFundingDelta({ oldStack }).ok, false);
+  for (const oldStack of [-1, Number.NaN, Number.POSITIVE_INFINITY, 500, 501, 1.5]) {
+    assert.equal(calculateReplacementFundingDelta({ oldStack, targetStack: 500 }).ok, false);
   }
   assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: 0 }).ok, false);
   assert.equal(calculateReplacementFundingDelta({ oldStack: 1, targetStack: Number.NaN }).ok, false);
@@ -53,6 +53,7 @@ test("managed settled top-up fills vacant bot seats deterministically without ch
     coreState,
     settledState,
     nextVersion: 8,
+    buyIn: 500,
     minBotCount: 2,
     targetBotCount: 3,
     maxBotCount: 3
@@ -64,7 +65,7 @@ test("managed settled top-up fills vacant bot seats deterministically without ch
   assert.equal(result.settledState.stacks.human_a, 250);
   assert.equal(result.coreState.publicStacks.human_a, 250);
   assert.equal(result.coreState.members.length, 4);
-  assert.equal(result.topUpFundings.every((entry) => entry.fundingDelta === 100), true);
+  assert.equal(result.topUpFundings.every((entry) => entry.targetStack === 500 && entry.fundingDelta === 500), true);
 });
 
 test("managed settled top-up never displaces humans when capacity cannot reach target", () => {
@@ -89,6 +90,7 @@ test("managed settled top-up never displaces humans when capacity cannot reach t
     },
     settledState: { handId: "hand_capacity", phase: "SETTLED", stacks },
     nextVersion: 3,
+    buyIn: 500,
     minBotCount: 2,
     targetBotCount: 3,
     maxBotCount: 3
@@ -109,6 +111,7 @@ function initialCore() {
       { userId: "user_a", seat: 1 },
       { userId: "user_b", seat: 2 }
     ],
+    publicStacks: { user_a: 500, user_b: 500 },
     pokerState: null
   };
 }
@@ -366,7 +369,8 @@ test("replaceBrokeBotsForNextHand swaps too-short bot only after settlement", ()
   const recycled = replaceBrokeBotsForNextHand({
     coreState,
     settledState,
-    nextVersion: 31
+    nextVersion: 31,
+    buyIn: 500
   });
 
   assert.notEqual(recycled.coreState, coreState);
@@ -377,15 +381,15 @@ test("replaceBrokeBotsForNextHand swaps too-short bot only after settlement", ()
   assert.notEqual(replacementBot.userId, "bot_old");
   assert.match(replacementBot.userId, UUID_RE);
   assert.equal(recycled.coreState.seatDetailsByUserId[replacementBot.userId].isBot, true);
-  assert.equal(recycled.settledState.stacks[replacementBot.userId], 100);
+  assert.equal(recycled.settledState.stacks[replacementBot.userId], 500);
   assert.equal("bot_old" in recycled.settledState.stacks, false);
   assert.deepEqual(recycled.replacementFundings, [{
     seatNo: 2,
     oldBotUserId: "bot_old",
     replacementBotUserId: replacementBot.userId,
     oldStack: 1,
-    targetStack: 100,
-    fundingDelta: 99,
+    targetStack: 500,
+    fundingDelta: 499,
     settledHandId: "settled_bot_replace",
     fromStateVersion: 30,
     toStateVersion: 31

--- a/ws-server/poker/engine/engine-timeout.behavior.test.mjs
+++ b/ws-server/poker/engine/engine-timeout.behavior.test.mjs
@@ -16,6 +16,7 @@ function initialCore() {
       { userId: "user_a", seat: 1 },
       { userId: "user_b", seat: 2 }
     ],
+    publicStacks: { user_a: 100, user_b: 100 },
     pokerState: null
   };
 }

--- a/ws-server/poker/engine/poker-engine.mjs
+++ b/ws-server/poker/engine/poker-engine.mjs
@@ -12,9 +12,8 @@ import { decideTurnTimeout, stampTurnDeadline } from "../shared/poker-turn-timeo
 const MIN_PLAYERS_TO_BOOTSTRAP = 2;
 const ENGINE_ACTIONS = new Set(["FOLD", "CHECK", "CALL", "BET", "RAISE"]);
 const MIN_STACK_TO_JOIN_HAND = 2;
-const BOT_REPLACEMENT_STACK = 100;
 
-export function calculateReplacementFundingDelta({ oldStack, targetStack = BOT_REPLACEMENT_STACK } = {}) {
+export function calculateReplacementFundingDelta({ oldStack, targetStack } = {}) {
   if (!Number.isInteger(targetStack) || targetStack <= 0) {
     return { ok: false, reason: "invalid_target_stack" };
   }
@@ -140,8 +139,9 @@ export function buildBootstrappedPokerState({
   const dealt = dealHoleCards(initialDeck, userIds);
   const stacks = Object.fromEntries(userIds.map((userId) => {
     const stack = Number(startingStacks?.[userId]);
-    return [userId, Number.isFinite(stack) && stack >= 0 ? Math.trunc(stack) : 100];
+    return [userId, Number.isSafeInteger(stack) && stack >= 0 ? stack : null];
   }));
+  if (Object.values(stacks).some((stack) => stack === null)) return null;
   const handStartStacksByUserId = { ...stacks };
   const betThisRoundByUserId = Object.fromEntries(userIds.map((userId) => [userId, 0]));
   const toCallByUserId = Object.fromEntries(userIds.map((userId) => [userId, 0]));
@@ -270,6 +270,7 @@ export function topUpManagedBotsForNextHand({
   coreState,
   settledState,
   nextVersion,
+  buyIn,
   minBotCount,
   targetBotCount,
   maxBotCount
@@ -283,6 +284,10 @@ export function topUpManagedBotsForNextHand({
   const minimum = Number(minBotCount);
   const target = Number(targetBotCount);
   const maximum = Number(maxBotCount);
+  const normalizedBuyIn = Number(buyIn);
+  if (!Number.isSafeInteger(normalizedBuyIn) || normalizedBuyIn <= 0) {
+    return { ok: false, reason: "invalid_managed_top_up_buy_in", coreState, settledState, topUpFundings: [] };
+  }
   if (!Number.isInteger(minimum) || !Number.isInteger(target) || !Number.isInteger(maximum)
     || minimum < 0 || minimum > target || target > maximum) {
     return { ok: false, reason: "invalid_managed_top_up_config", coreState, settledState, topUpFundings: [] };
@@ -328,14 +333,14 @@ export function topUpManagedBotsForNextHand({
       status: "ACTIVE",
       leaveAfterHand: false
     };
-    nextStacks[botUserId] = BOT_REPLACEMENT_STACK;
-    nextPublicStacks[botUserId] = BOT_REPLACEMENT_STACK;
+    nextStacks[botUserId] = normalizedBuyIn;
+    nextPublicStacks[botUserId] = normalizedBuyIn;
     topUpFundings.push({
       seatNo,
       botUserId,
       botProfile: "NORMAL",
-      targetStack: BOT_REPLACEMENT_STACK,
-      fundingDelta: BOT_REPLACEMENT_STACK,
+      targetStack: normalizedBuyIn,
+      fundingDelta: normalizedBuyIn,
       settledHandId: settledState.handId,
       fromStateVersion: Number(coreState.version),
       toStateVersion: nextVersion
@@ -356,7 +361,7 @@ export function topUpManagedBotsForNextHand({
   };
 }
 
-export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersion }) {
+export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersion, buyIn }) {
   if (!coreState || typeof coreState !== "object" || Array.isArray(coreState)) {
     return { ok: false, reason: "invalid_core_state", coreState, settledState, replacementFundings: [] };
   }
@@ -367,6 +372,10 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
   const fromStateVersion = Number(coreState.version);
   if (!Number.isInteger(fromStateVersion) || !Number.isInteger(nextVersion) || nextVersion !== fromStateVersion + 1) {
     return { ok: false, reason: "invalid_replacement_version", coreState, settledState, replacementFundings: [] };
+  }
+  const normalizedBuyIn = Number(buyIn);
+  if (!Number.isSafeInteger(normalizedBuyIn) || normalizedBuyIn <= 0) {
+    return { ok: false, reason: "invalid_replacement_buy_in", coreState, settledState, replacementFundings: [] };
   }
 
   const currentMembers = orderedSeatMembers(coreState);
@@ -405,7 +414,7 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
 
     const funding = calculateReplacementFundingDelta({
       oldStack: stack,
-      targetStack: BOT_REPLACEMENT_STACK
+      targetStack: normalizedBuyIn
     });
     if (!funding.ok) {
       return {
@@ -441,10 +450,10 @@ export function replaceBrokeBotsForNextHand({ coreState, settledState, nextVersi
     };
 
     delete nextStacks[userId];
-    nextStacks[replacementUserId] = BOT_REPLACEMENT_STACK;
+    nextStacks[replacementUserId] = normalizedBuyIn;
     if (nextPublicStacks) {
       delete nextPublicStacks[userId];
-      nextPublicStacks[replacementUserId] = BOT_REPLACEMENT_STACK;
+      nextPublicStacks[replacementUserId] = normalizedBuyIn;
     }
 
     replacementFundings.push({

--- a/ws-server/poker/handlers/join.mjs
+++ b/ws-server/poker/handlers/join.mjs
@@ -241,7 +241,8 @@ export async function handleJoinCommand({ frame, ws, connState, sessionStore, ta
     preferredSeatNo: joinIntent.preferredSeatNo,
     buyIn: authoritativeJoinResult?.rejoin === true
       ? null
-      : (authoritativeJoinResult?.stack ?? joinIntent.buyIn),
+      : (authoritativeJoinResult?.buyIn ?? joinIntent.buyIn),
+    tableBuyIn: authoritativeJoinResult?.buyIn ?? null,
     authoritativeSeatNo: authoritativeJoinResult?.seatNo ?? null
   });
   if (!joined.ok) {

--- a/ws-server/poker/handlers/rebuy.mjs
+++ b/ws-server/poker/handlers/rebuy.mjs
@@ -13,7 +13,7 @@ export async function handleRebuyCommand({
   scheduleSettledRolloverIfSettled = () => {},
   klog = () => {}
 }) {
-  const amount = frame?.payload?.amount === undefined ? 100 : Number(frame.payload.amount);
+  const amount = frame?.payload?.amount === undefined ? undefined : Number(frame.payload.amount);
   const executeAuthoritativeRebuy = await loadAuthoritativeRebuyExecutor();
   const rebuy = await executeAuthoritativeRebuy({
     tableId,
@@ -33,11 +33,12 @@ export async function handleRebuyCommand({
 
   const restored = await restoreTableFromPersisted(tableId);
   sendCommandResult(ws, connState, {
-    requestId: frame.requestId ?? null,
-    tableId,
-    status: "accepted",
-    reason: rebuy.replayed === true ? "already_applied" : null
-  });
+      requestId: frame.requestId ?? null,
+      tableId,
+      status: "accepted",
+      reason: rebuy.replayed === true ? "already_applied" : null,
+      buyIn: rebuy.buyIn
+    });
   if (!restored?.ok) {
     klog("ws_rebuy_runtime_restore_failed", {
       tableId,

--- a/ws-server/poker/persistence/authoritative-join-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-join-adapter.mjs
@@ -100,8 +100,15 @@ function normalizeSuccess(result, { tableId, userId, requestId }) {
   }
   const stack = Number(result?.stack);
   const rejoin = result?.rejoin === true;
-  if (!Number.isInteger(stack) || stack <= 0) {
+  const buyIn = Number(result?.buyIn ?? stack);
+  if (!Number.isSafeInteger(stack) || stack <= 0) {
     return invalidAuthoritativeState("invalid_stack");
+  }
+  if (!Number.isSafeInteger(buyIn) || buyIn <= 0) {
+    return invalidAuthoritativeState("invalid_buy_in");
+  }
+  if (!rejoin && buyIn !== stack) {
+    return invalidAuthoritativeState("human_buy_in_mismatch");
   }
   const seededBots = Array.isArray(result?.seededBots) ? result.seededBots : [];
   const snapshot = result?.snapshot && typeof result.snapshot === "object" ? result.snapshot : null;
@@ -152,6 +159,7 @@ function normalizeSuccess(result, { tableId, userId, requestId }) {
     userId,
     seatNo,
     stack,
+    buyIn,
     rejoin,
     requestId: requestId || null,
     seededBots,

--- a/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
+++ b/ws-server/poker/persistence/authoritative-rebuy-adapter.mjs
@@ -80,7 +80,7 @@ export function createAuthoritativeRebuyExecutor({
   loadPostTransaction = loadPostTransactionDefault,
   loadLockedStateHelpers = loadLockedStateHelpersDefault
 } = {}) {
-  return async function executeAuthoritativeRebuy({ tableId, userId, requestId, amount = 100 }) {
+  return async function executeAuthoritativeRebuy({ tableId, userId, requestId, amount }) {
     if (fileStoreOnly(env)) return { ok: false, code: "temporarily_unavailable" };
 
     let rebuyModule;

--- a/ws-server/poker/persistence/continuous-bot-table-repository.mjs
+++ b/ws-server/poker/persistence/continuous-bot-table-repository.mjs
@@ -7,6 +7,7 @@ import {
 } from "../../shared/poker-domain/bots.mjs";
 import { beginSqlWs } from "../bootstrap/persisted-bootstrap-db.mjs";
 import { postTransaction } from "./chips-ledger.mjs";
+import { DEFAULT_CASH_TABLE_BUY_IN_CHIPS } from "../../../shared/poker-domain/table-economy.mjs";
 
 export const CONTINUOUS_BOT_PROFILE_KEY = "CONTINUOUS_BOT_DEFAULT";
 const DEFAULT_MAX_DESIRED_TABLES = 2;
@@ -97,11 +98,13 @@ export function tableMatchesContinuousBotProfile(table, profile) {
 
 async function createManagedTable(tx, { profile, botConfig, klog }) {
   const stakes = { sb: profile.smallBlind, bb: profile.bigBlind };
+  const buyIn = DEFAULT_CASH_TABLE_BUY_IN_CHIPS;
   const rotationDueAt = new Date(Date.now() + profile.rotationIntervalSeconds * 1_000).toISOString();
   const created = await createPokerTableWithState(tx, {
     userId: null,
     maxPlayers: profile.maxSeats,
     stakesJson: JSON.stringify(stakes),
+    buyIn,
     lifecycleKind: "CONTINUOUS_BOT",
     managedProfileKey: profile.profileKey,
     rotationDueAt
@@ -111,6 +114,7 @@ async function createManagedTable(tx, { profile, botConfig, klog }) {
     tableId: created.tableId,
     maxPlayers: profile.maxSeats,
     tableStakes: stakes,
+    buyInChips: buyIn,
     cfg: botConfig,
     humanUserId: null,
     postTransaction,

--- a/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
+++ b/ws-server/poker/persistence/persisted-state-writer.behavior.test.mjs
@@ -275,8 +275,8 @@ test("persisted state writer persists hole cards from real WS bootstrap private 
   const userA = "00000000-0000-4000-8000-0000000000a1";
   const userB = "00000000-0000-4000-8000-0000000000b2";
   const tableManager = createTableManager({ maxSeats: 4 });
-  assert.equal(tableManager.join({ ws: { id: "ws-a" }, userId: userA, tableId, requestId: "join-a", nowTs: 1 }).ok, true);
-  assert.equal(tableManager.join({ ws: { id: "ws-b" }, userId: userB, tableId, requestId: "join-b", nowTs: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: { id: "ws-a" }, userId: userA, tableId, requestId: "join-a", nowTs: 1, buyIn: 500, authoritativeSeatNo: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: { id: "ws-b" }, userId: userB, tableId, requestId: "join-b", nowTs: 1, buyIn: 500, authoritativeSeatNo: 2 }).ok, true);
   const bootstrapped = tableManager.bootstrapHand(tableId, { nowMs: 1_000 });
   assert.equal(bootstrapped.changed, true);
 
@@ -325,8 +325,8 @@ test("persisted state writer persists hole cards from real WS rollover private a
   const userA = "00000000-0000-4000-8000-0000000000a1";
   const userB = "00000000-0000-4000-8000-0000000000b2";
   const tableManager = createTableManager({ maxSeats: 4 });
-  assert.equal(tableManager.join({ ws: { id: "ws-roll-a" }, userId: userA, tableId, requestId: "join-a", nowTs: 1 }).ok, true);
-  assert.equal(tableManager.join({ ws: { id: "ws-roll-b" }, userId: userB, tableId, requestId: "join-b", nowTs: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: { id: "ws-roll-a" }, userId: userA, tableId, requestId: "join-a", nowTs: 1, buyIn: 500, authoritativeSeatNo: 1 }).ok, true);
+  assert.equal(tableManager.join({ ws: { id: "ws-roll-b" }, userId: userB, tableId, requestId: "join-b", nowTs: 1, buyIn: 500, authoritativeSeatNo: 2 }).ok, true);
   const bootstrapped = tableManager.bootstrapHand(tableId, { nowMs: 1_000 });
   assert.equal(bootstrapped.changed, true);
   const firstState = tableManager.persistedPokerState(tableId);

--- a/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
+++ b/ws-server/poker/read-model/state-snapshot.behavior.test.mjs
@@ -1,7 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createTableManager } from "../table/table-manager.mjs";
+import { createTableManager as createRuntimeTableManager } from "../table/table-manager.mjs";
 import { buildStateSnapshotPayload } from "./state-snapshot.mjs";
+
+function createTableManager(options = {}) {
+  const manager = createRuntimeTableManager({ defaultBuyIn: 100, ...options });
+  const originalJoin = manager.join;
+  // These fixtures predate table buy-in metadata and represent the existing
+  // 100 CH default; keep that compatibility shim in tests only.
+  manager.join = (args = {}) => originalJoin({ buyIn: args.buyIn ?? 100, ...args });
+  return manager;
+}
 
 test("buildStateSnapshotPayload returns canonical room-core payload for seated authenticated user", () => {
   const tableManager = createTableManager({ maxSeats: 6 });

--- a/ws-server/poker/read-model/state-snapshot.mjs
+++ b/ws-server/poker/read-model/state-snapshot.mjs
@@ -206,6 +206,10 @@ export function buildStateSnapshotPayload({ tableSnapshot, userId, publicProfile
   if (maxSeats !== null) {
     table.maxSeats = maxSeats;
   }
+  const buyIn = Number(tableSnapshot?.buyIn);
+  if (Number.isSafeInteger(buyIn) && buyIn > 0) {
+    table.buyIn = buyIn;
+  }
 
   const payload = {
     stateVersion,

--- a/ws-server/poker/table/table-manager.behavior.test.mjs
+++ b/ws-server/poker/table/table-manager.behavior.test.mjs
@@ -1,6 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { __testOnly, createTableManager } from "./table-manager.mjs";
+import { __testOnly, createTableManager as createRuntimeTableManager } from "./table-manager.mjs";
+
+function createTableManager(options = {}) {
+  const manager = createRuntimeTableManager({ defaultBuyIn: 100, ...options });
+  const originalJoin = manager.join;
+  const originalRestore = manager.restoreTableFromPersisted;
+
+  // Legacy fixtures represent the pre-buy-in schema, whose tables all used the
+  // standard 100 CH buy-in. Keep that fixture normalization local to this suite
+  // while production remains fail-closed when authoritative metadata is absent.
+  manager.join = (args = {}) => originalJoin({ buyIn: args.buyIn ?? 100, ...args });
+  manager.restoreTableFromPersisted = (tableId, restored = {}) => originalRestore(tableId, {
+    ...restored,
+    tableMeta: { buyIn: 100, ...(restored.tableMeta || {}) }
+  });
+  return manager;
+}
 
 function fakeWs(id) {
   return { id };
@@ -3243,6 +3259,24 @@ test("public profile failure and timeout return initials fallback without reject
   assert.equal(result.reason, "public_profile_timeout");
   assert.equal("profile" in snapshot.seats[0], false);
   assert.equal(snapshot.members.length, 1);
+});
+
+test("materialized table keeps its configured buy-in immutable", () => {
+  const tableManager = createTableManager({ maxSeats: 6 });
+  const first = tableManager.materializeLobbyTable({
+    tableId: "table-buy-in-immutable",
+    tableMeta: { maxPlayers: 6, buyIn: 500 }
+  });
+  assert.equal(first.ok, true);
+  assert.equal(tableManager.tableMeta("table-buy-in-immutable").buyIn, 500);
+
+  const changed = tableManager.materializeLobbyTable({
+    tableId: "table-buy-in-immutable",
+    tableMeta: { maxPlayers: 6, buyIn: 100 }
+  });
+  assert.equal(changed.ok, false);
+  assert.equal(changed.code, "buy_in_immutable");
+  assert.equal(tableManager.tableMeta("table-buy-in-immutable").buyIn, 500);
 });
 
 test("beginTableRetirement claims only unloaded ids and rejects materialization fail-closed", async () => {

--- a/ws-server/poker/table/table-manager.mjs
+++ b/ws-server/poker/table/table-manager.mjs
@@ -181,6 +181,8 @@ function normalizeTableMeta(value, fallbackMaxPlayers, { defaultCreatedAtMs = nu
   const maxPlayers = Number.isInteger(maxPlayersRaw) && maxPlayersRaw >= 1
     ? maxPlayersRaw
     : fallbackMaxPlayers;
+  const buyInRaw = Number(value?.buyIn ?? value?.buy_in);
+  const buyIn = Number.isSafeInteger(buyInRaw) && buyInRaw > 0 ? buyInRaw : null;
   const stakes = value?.stakes && typeof value.stakes === "object" && !Array.isArray(value.stakes)
     ? {
         sb: Number.isInteger(Number(value.stakes.sb)) ? Number(value.stakes.sb) : null,
@@ -207,6 +209,7 @@ function normalizeTableMeta(value, fallbackMaxPlayers, { defaultCreatedAtMs = nu
     : "STANDARD";
   return {
     maxPlayers,
+    buyIn,
     stakes: stakes && Number.isInteger(stakes.sb) && Number.isInteger(stakes.bb)
       ? stakes
       : null,
@@ -305,6 +308,7 @@ export function createTableManager({
   onTableEvicted = null,
   observeOnlyJoin = false,
   enableDebugCore = false,
+  defaultBuyIn = null,
   nodeEnv = process.env.NODE_ENV
 } = {}) {
   const normalizedActionResultCacheMax = Number.isInteger(actionResultCacheMax) && actionResultCacheMax > 0
@@ -316,6 +320,9 @@ export function createTableManager({
   const normalizedPublicProfileTimeoutMs = Number.isFinite(Number(publicProfileTimeoutMs)) && Number(publicProfileTimeoutMs) > 0
     ? Math.trunc(Number(publicProfileTimeoutMs))
     : DEFAULT_PUBLIC_PROFILE_TIMEOUT_MS;
+  const normalizedDefaultBuyIn = Number.isSafeInteger(Number(defaultBuyIn)) && Number(defaultBuyIn) > 0
+    ? Number(defaultBuyIn)
+    : null;
   const tables = new Map();
   const pendingBootstrapByTableId = new Map();
   const retiringTableIds = new Set();
@@ -553,7 +560,7 @@ export function createTableManager({
       tables.set(tableId, {
         tableId,
         tableStatus: "OPEN",
-        tableMeta: normalizeTableMeta(null, initialCoreState.maxSeats, {
+        tableMeta: normalizeTableMeta({ buyIn: normalizedDefaultBuyIn }, initialCoreState.maxSeats, {
           defaultCreatedAtMs: nowMs,
           defaultLastActivityAtMs: nowMs
         }),
@@ -602,7 +609,20 @@ export function createTableManager({
       };
     }
     table.tableStatus = normalizeTableStatus(table.tableStatus);
-    table.tableMeta = normalizeTableMeta({ ...table.tableMeta, ...(tableMeta || {}) }, table?.coreState?.maxSeats || maxSeats, {
+    const configuredBuyIn = Number(table.tableMeta?.buyIn);
+    const incomingBuyIn = tableMeta && Object.prototype.hasOwnProperty.call(tableMeta, "buyIn")
+      ? Number(tableMeta.buyIn)
+      : null;
+    if (existed && Number.isSafeInteger(configuredBuyIn) && configuredBuyIn > 0
+      && Number.isSafeInteger(incomingBuyIn) && incomingBuyIn > 0 && incomingBuyIn !== configuredBuyIn) {
+      return { ok: false, code: "buy_in_immutable" };
+    }
+    const nextTableMeta = { ...table.tableMeta, ...(tableMeta || {}) };
+    if (existed && Number.isSafeInteger(configuredBuyIn) && configuredBuyIn > 0
+      && (!Number.isSafeInteger(incomingBuyIn) || incomingBuyIn <= 0)) {
+      nextTableMeta.buyIn = configuredBuyIn;
+    }
+    table.tableMeta = normalizeTableMeta(nextTableMeta, table?.coreState?.maxSeats || maxSeats, {
       defaultCreatedAtMs: table?.tableMeta?.createdAtMs ?? nowMs,
       defaultLastActivityAtMs: nowMs
     });
@@ -644,7 +664,7 @@ export function createTableManager({
       publicStacks[botUserId] = resolvedStack;
     }
     table.tableStatus = "OPEN";
-    table.tableMeta = normalizeTableMeta({ maxPlayers: resolvedMaxPlayers, stakes: { sb: 1, bb: 2 }, createdAtMs: nowMs, lastActivityAtMs: nowMs }, resolvedMaxPlayers, {
+    table.tableMeta = normalizeTableMeta({ maxPlayers: resolvedMaxPlayers, buyIn: resolvedStack, stakes: { sb: 1, bb: 2 }, createdAtMs: nowMs, lastActivityAtMs: nowMs }, resolvedMaxPlayers, {
       defaultCreatedAtMs: nowMs,
       defaultLastActivityAtMs: nowMs
     });
@@ -791,6 +811,7 @@ export function createTableManager({
         memberCount: 0,
         maxSeats,
         youSeat,
+        buyIn: table?.tableMeta?.buyIn ?? null,
         ...roomCore
       };
     }
@@ -804,6 +825,7 @@ export function createTableManager({
       memberCount: members.length,
       maxSeats: table.coreState.maxSeats,
       youSeat,
+      buyIn: table.tableMeta?.buyIn ?? null,
       ...roomCore
     };
   }
@@ -1156,10 +1178,12 @@ export function createTableManager({
     }
 
     const nextVersion = Number(table.coreState.version || 0) + 1;
+    const tableBuyIn = Number(table.tableMeta?.buyIn);
     const recycled = replaceBrokeBotsForNextHand({
       coreState: table.coreState,
       settledState,
-      nextVersion
+      nextVersion,
+      buyIn: tableBuyIn
     });
     if (!recycled?.ok) {
       return {
@@ -1177,6 +1201,7 @@ export function createTableManager({
           coreState: recycled.coreState,
           settledState: recycled.settledState,
           nextVersion,
+          buyIn: tableBuyIn,
           minBotCount: managedBotProfile?.minBotCount,
           targetBotCount: managedBotProfile?.targetBotCount,
           maxBotCount: managedBotProfile?.maxBotCount
@@ -1272,7 +1297,8 @@ export function createTableManager({
     const recalculated = replaceBrokeBotsForNextHand({
       coreState: table.coreState,
       settledState: table.coreState.pokerState,
-      nextVersion
+      nextVersion,
+      buyIn: Number(table.tableMeta?.buyIn)
     });
     if (!recalculated?.ok || !replacementFundingPlansEqual(recalculated.replacementFundings, replacementFundings)) {
       return { ok: false, changed: false, reason: "replacement_funding_mismatch", stateVersion: currentVersion };
@@ -1284,6 +1310,7 @@ export function createTableManager({
           coreState: recalculated.coreState,
           settledState: recalculated.settledState,
           nextVersion,
+          buyIn: Number(table.tableMeta?.buyIn),
           minBotCount: managedBotProfile?.minBotCount,
           targetBotCount: managedBotProfile?.targetBotCount,
           maxBotCount: managedBotProfile?.maxBotCount
@@ -1418,7 +1445,7 @@ export function createTableManager({
     member.expiresAt = nowMs + presenceTtlMs;
   }
 
-  function join({ ws, userId, tableId, requestId, nowTs = Date.now(), authoritativeSeatNo = null, buyIn = null }) {
+  function join({ ws, userId, tableId, requestId, nowTs = Date.now(), authoritativeSeatNo = null, buyIn = null, tableBuyIn = null }) {
     const conn = ensureConn(ws);
     const activeTableId = conn.joinedTableId || conn.subscribedTableId;
     if (activeTableId && activeTableId !== tableId) {
@@ -1455,11 +1482,28 @@ export function createTableManager({
           ? table.coreState.publicStacks
           : {};
         const nextPublicStacks = { ...currentPublicStacks };
-        const nextBuyIn = Number.isFinite(Number(buyIn)) && Number(buyIn) > 0 ? Number(buyIn) : null;
+        const stackBuyInRaw = Number(buyIn);
+        const stackBuyIn = Number.isSafeInteger(stackBuyInRaw) && stackBuyInRaw > 0 ? stackBuyInRaw : null;
+        const configuredBuyIn = Number(table.tableMeta?.buyIn);
+        const configuredBuyInValid = Number.isSafeInteger(configuredBuyIn) && configuredBuyIn > 0;
+        const tableBuyInProvided = tableBuyIn !== null && tableBuyIn !== undefined;
+        const tableBuyInRaw = tableBuyInProvided
+          ? Number(tableBuyIn)
+          : (configuredBuyInValid ? configuredBuyIn : stackBuyInRaw);
+        const nextBuyIn = Number.isSafeInteger(tableBuyInRaw) && tableBuyInRaw > 0 ? tableBuyInRaw : null;
+        if (tableBuyInProvided && nextBuyIn === null) {
+          return { ok: false, code: "invalid_buy_in", message: "invalid_buy_in", tableState: tableState(tableId) };
+        }
+        if (nextBuyIn !== null && configuredBuyInValid && configuredBuyIn !== nextBuyIn) {
+          return { ok: false, code: "invalid_buy_in", message: "invalid_buy_in", tableState: tableState(tableId) };
+        }
+        if (nextBuyIn !== null && !configuredBuyInValid) {
+          table.tableMeta = normalizeTableMeta({ ...table.tableMeta, buyIn: nextBuyIn }, table?.coreState?.maxSeats || maxSeats);
+        }
         const membershipChanged = !existingMember || existingMember.seat !== authoritativeSeat;
-        const stackChanged = nextBuyIn !== null && currentPublicStacks[userId] !== nextBuyIn;
+        const stackChanged = stackBuyIn !== null && currentPublicStacks[userId] !== stackBuyIn;
         if (stackChanged) {
-          nextPublicStacks[userId] = nextBuyIn;
+          nextPublicStacks[userId] = stackBuyIn;
         }
         const changed = membershipChanged || stackChanged;
         table.coreState = {
@@ -1512,7 +1556,17 @@ export function createTableManager({
           return { ok: false, code: joinResult.error.code, message: joinResult.error.code, tableState: tableState(tableId) };
         }
 
-        table.coreState = joinResult.state;
+        const configuredBuyIn = Number(table.tableMeta?.buyIn);
+        const hasConfiguredBuyIn = Number.isSafeInteger(configuredBuyIn) && configuredBuyIn > 0;
+        const publicStacks = joinResult.state.publicStacks && typeof joinResult.state.publicStacks === "object" && !Array.isArray(joinResult.state.publicStacks)
+          ? joinResult.state.publicStacks
+          : {};
+        table.coreState = {
+          ...joinResult.state,
+          ...(hasConfiguredBuyIn && !Object.prototype.hasOwnProperty.call(publicStacks, userId)
+            ? { publicStacks: { ...publicStacks, [userId]: configuredBuyIn } }
+            : {})
+        };
         invalidatePublicProfilesForSeatChange(table);
       }
 

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2818,6 +2818,7 @@ test("server supports healthz and hello/helloAck smoke flow", async () => {
 
     const response = await fetch(`http://127.0.0.1:${port}/healthz`);
     assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-poker-buy-in-materialization"), "1");
     assert.equal(await response.text(), "ok");
   } finally {
     child.kill("SIGTERM");

--- a/ws-server/server.behavior.test.mjs
+++ b/ws-server/server.behavior.test.mjs
@@ -2450,7 +2450,7 @@ test("accepted action that settles a hand schedules delayed rollover", async () 
   const tableId = "table_act_settled_rollover";
   const actorUserId = "act_settled_actor";
   const otherUserId = "act_settled_other";
-  const fixtureManager = createTableManager({ maxSeats: 6 });
+  const fixtureManager = createTableManager({ maxSeats: 6, defaultBuyIn: 100 });
   const wsActor = new EventEmitter();
   const wsOther = new EventEmitter();
   wsActor.close = () => {};
@@ -2478,7 +2478,7 @@ test("accepted action that settles a hand schedules delayed rollover", async () 
   const { dir, filePath } = await writePersistedFile({
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 100 },
         seatRows: [
           { user_id: actorUserId, seat_no: 1, status: "ACTIVE", is_bot: false, stack: Number(riverState.stacks?.[actorUserId] ?? 0) },
           { user_id: otherUserId, seat_no: 2, status: "ACTIVE", is_bot: false, stack: Number(riverState.stacks?.[otherUserId] ?? 0) }
@@ -2562,7 +2562,7 @@ test("zero settled reveal delay schedules immediate rollover instead of leaving 
   const { dir, filePath } = await writePersistedFile({
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 100 },
         seatRows: [
           { user_id: "user_zero_a", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 104 },
           { user_id: "user_zero_b", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 96 }
@@ -3582,7 +3582,7 @@ test("invalid WS_PRESENCE_TTL_MS falls back safely and keeps seated resync conti
   const tableId = "table_badttl";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [{ user_id: "ttl_user", seat_no: 2, status: "ACTIVE", is_bot: false }],
       stateRow: { version: 8, state: { handId: "h8", phase: "PREFLOP", turnUserId: "ttl_user" } }
     }
@@ -3834,7 +3834,7 @@ test("resume fallback snapshot on settled table still schedules delayed rollover
   const tableId = "table_resume_settled";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [
         { user_id: "user_resume", seat_no: 1, status: "ACTIVE", is_bot: false },
         { user_id: "user_other", seat_no: 2, status: "ACTIVE", is_bot: false }
@@ -4853,7 +4853,7 @@ test("WS table_join hydrates from persisted bootstrap fixture", async () => {
   const tableId = "table_persisted_join";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [{ user_id: "user_a", seat_no: 3, status: "ACTIVE", is_bot: false }],
       stateRow: { version: 21, state: { handId: "h21", phase: "PREFLOP", turnUserId: "user_a", holeCardsByUserId: { user_a: ["As", "Kd"] } } }
     }
@@ -4904,7 +4904,7 @@ test("snapshot-only settled bootstrap schedules rollover without prior broadcast
   const tableId = "table_settled_snapshot_rollover";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [
         { user_id: "user_a", seat_no: 1, status: "ACTIVE", is_bot: false },
         { user_id: "user_b", seat_no: 2, status: "ACTIVE", is_bot: false }
@@ -5895,7 +5895,7 @@ test("timeout sweep advances seated persisted table state under observe-only run
   const tableId = "table_timeout_runtime";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [
         { user_id: "timeout_a", seat_no: 1, status: "ACTIVE", is_bot: false },
         { user_id: "timeout_b", seat_no: 2, status: "ACTIVE", is_bot: false }
@@ -5967,7 +5967,7 @@ test("timeout sweep plus queued bot step returns actionable human snapshot witho
   const tableId = "table_timeout_bot_step_runtime";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [
         { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false },
         { user_id: botUserId, seat_no: 2, status: "ACTIVE", is_bot: true }
@@ -6321,7 +6321,7 @@ test("timeout during disconnect does not close active table and reconnect snapsh
   const tableId = "table_disconnect_timeout_runtime";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "active" },
+      tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
       seatRows: [
         { user_id: humanUserId, seat_no: 1, status: "ACTIVE", is_bot: false },
         { user_id: botUserId, seat_no: 2, status: "ACTIVE", is_bot: true }
@@ -7094,7 +7094,7 @@ test("WS act persists state to file-backed optimistic store", async () => {
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [
           { user_id: "seat_actor", seat_no: 1, status: "ACTIVE", is_bot: false },
           { user_id: "seat_other", seat_no: 2, status: "ACTIVE", is_bot: false }
@@ -7152,7 +7152,7 @@ test("disconnect cleanup close rewrite restores inert state and blocks repeated 
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [{ user_id: "seat_user_closed", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 500 }],
         stateRow: {
           version: 17,
@@ -7277,7 +7277,7 @@ test("disconnect cleanup restore failure does not broadcast stale success", asyn
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [{ user_id: "seat_user_fail", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 500 }],
         stateRow: { version: 3, state: { handId: "h3", phase: "PREFLOP", turnUserId: "seat_user_fail", stacks: { seat_user_fail: 500 } } }
       }
@@ -7349,7 +7349,7 @@ test("disconnect cleanup already_closed evicts stale lobby table", async () => {
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [{ user_id: "seat_user_already_closed", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 400 }],
         stateRow: {
           version: 8,
@@ -7677,7 +7677,7 @@ test("optimistic conflict restore to settled state still schedules delayed rollo
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [
           { user_id: "seat_actor", seat_no: 1, status: "ACTIVE", is_bot: false },
           { user_id: "seat_other", seat_no: 2, status: "ACTIVE", is_bot: false }
@@ -7757,7 +7757,7 @@ test("join during SETTLED skips generic bootstrap persistence and schedules exac
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "active" },
+        tableRow: { id: tableId, max_players: 6, status: "active", buy_in: 100 },
         seatRows: [
           { user_id: "seat_actor", seat_no: 1, status: "ACTIVE", is_bot: false, stack: 102 },
           { user_id: "seat_other", seat_no: 2, status: "ACTIVE", is_bot: false, stack: 98 }
@@ -8379,7 +8379,7 @@ test("authoritative join branch rehydrates from persisted source before attach",
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
         seatRows: [
           { user_id: "branch_user", seat_no: 1, status: "ACTIVE", is_bot: false }
         ],
@@ -8426,7 +8426,7 @@ test("authoritative join missing state row returns protocol-safe state_missing",
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
         seatRows: []
       }
     }
@@ -8467,7 +8467,7 @@ test("authoritative join with historical non-ACTIVE seat retries to the next sea
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
         seatRows: [{ user_id: "historical_user", seat_no: 1, status: "INACTIVE", is_bot: false }],
         stateRow: { version: 1, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
       }
@@ -8517,7 +8517,7 @@ test("authoritative WS table_join seeds two bots once and returns authoritative 
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 100 },
         seatRows: [],
         stateRow: { version: 1, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
       }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -4033,7 +4033,10 @@ async function handleInternalLobbyMaterialize(req, res) {
 
 async function handleHttpRequest(req, res) {
   if (req.url === "/healthz") {
-    res.writeHead(200, { "content-type": "text/plain" });
+    res.writeHead(200, {
+      "content-type": "text/plain",
+      "x-poker-buy-in-materialization": "1"
+    });
     res.end("ok");
     return;
   }

--- a/ws-server/server.mjs
+++ b/ws-server/server.mjs
@@ -1332,6 +1332,7 @@ function buildLobbyTableEntry(tableId) {
     live: liveHand,
     joinable,
     stakes: tableMeta?.stakes ?? null,
+    buyIn: tableMeta?.buyIn ?? null,
     maxPlayers,
     seatCount: seats.length,
     humanCount
@@ -1421,6 +1422,7 @@ function buildTableStatePayload({ tableState, tableSnapshot, userId }) {
   if (Number.isInteger(tableSnapshot.stateVersion)) payload.stateVersion = tableSnapshot.stateVersion;
   if (Number.isInteger(tableSnapshot.memberCount)) payload.memberCount = tableSnapshot.memberCount;
   if (Number.isInteger(tableSnapshot.maxSeats)) payload.maxSeats = tableSnapshot.maxSeats;
+  if (Number.isSafeInteger(tableSnapshot.buyIn) && tableSnapshot.buyIn > 0) payload.buyIn = tableSnapshot.buyIn;
   if (Number.isInteger(tableSnapshot.youSeat)) payload.youSeat = tableSnapshot.youSeat;
   if (Number.isInteger(tableSnapshot.dealerSeatNo)) payload.dealerSeatNo = tableSnapshot.dealerSeatNo;
   if (Array.isArray(tableSnapshot.seats)) payload.seats = tableSnapshot.seats;
@@ -4003,11 +4005,18 @@ async function handleInternalLobbyMaterialize(req, res) {
     res.end(JSON.stringify({ error: "invalid_stakes" }));
     return;
   }
+  const buyIn = payload?.buyIn == null ? null : Number(payload.buyIn);
+  if (buyIn !== null && (!Number.isSafeInteger(buyIn) || buyIn <= 0)) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "invalid_buy_in" }));
+    return;
+  }
   const materialized = tableManager.materializeLobbyTable({
     tableId,
     tableMeta: {
       maxPlayers,
-      stakes: stakesParsed.value
+      stakes: stakesParsed.value,
+      ...(buyIn === null ? {} : { buyIn })
     },
     nowMs: Date.now()
   });
@@ -4488,7 +4497,7 @@ wss.on("connection", (ws) => {
               requestId: frame.requestId,
               nowTs: Date.now(),
               authoritativeSeatNo: 1,
-              buyIn: 100
+              buyIn: tableManager.tableMeta(tableId)?.buyIn ?? null
             });
             if (!joined.ok) {
               sendCommandResult(ws, connState, {

--- a/ws-tests/infra-vps-caddy.guard.test.mjs
+++ b/ws-tests/infra-vps-caddy.guard.test.mjs
@@ -31,6 +31,7 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
   assert.match(prod, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(prod, /@pokerMaintenanceAdmin path \/internal\/admin\/poker-maintenance/);
   assert.match(prod, /@vpsMetricsAdmin path \/internal\/admin\/vps-metrics/);
+  assert.match(prod, /@lobbyMaterialize path \/internal\/lobby\/materialize-table/);
   assert.match(prod, /reverse_proxy 127\.0\.0\.1:3000/);
   assert.match(prod, /respond "OK" 200/);
 
@@ -40,6 +41,7 @@ test("infra/vps/Caddyfile is the unified prod+preview WS source of truth", () =>
   assert.match(preview, /@pokerLogControlAdmin path \/internal\/admin\/poker-log-control/);
   assert.match(preview, /@pokerMaintenanceAdmin path \/internal\/admin\/poker-maintenance/);
   assert.match(preview, /@vpsMetricsAdmin path \/internal\/admin\/vps-metrics/);
+  assert.match(preview, /@lobbyMaterialize path \/internal\/lobby\/materialize-table/);
   assert.match(preview, /@ws path \/ws\*/);
   assert.match(preview, /reverse_proxy 127\.0\.0\.1:3001/);
   assert.match(preview, /respond "OK" 200/);

--- a/ws-tests/ws-join-runtime.behavior.test.mjs
+++ b/ws-tests/ws-join-runtime.behavior.test.mjs
@@ -393,7 +393,7 @@ test("authoritative WS table_join returns a fully seated stacked snapshot and ke
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 150 },
         seatRows: [],
         stateRow: { version: 0, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
       }
@@ -506,7 +506,7 @@ test("authoritative WS table_join can progress through human act and bot timeout
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 150 },
         seatRows: [],
         stateRow: { version: 1, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
       }
@@ -636,7 +636,7 @@ test("authoritative repeated and replayed table_join keep bot seating stable and
   const store = {
     tables: {
       [tableId]: {
-        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}' },
+        tableRow: { id: tableId, max_players: 6, status: "OPEN", stakes: '{"sb":1,"bb":2}', buy_in: 150 },
         seatRows: [],
         stateRow: { version: 1, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
       }

--- a/ws-tests/ws-poker-protocol-compliance.test.mjs
+++ b/ws-tests/ws-poker-protocol-compliance.test.mjs
@@ -1849,7 +1849,7 @@ test("real authoritative join path stays stable without override shortcuts", asy
   const tableId = "table_protocol_real_auth_join";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+      tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
       seatRows: [{ user_id: "seed_other", seat_no: 2, status: "ACTIVE", is_bot: false }],
       stateRow: { version: 3, state: { tableId, seats: [{ userId: "seed_other", seatNo: 2 }], stacks: { seed_other: 100 } } }
     }
@@ -1895,7 +1895,7 @@ test("real authoritative join missing state row maps to state_missing error", as
   const tableId = "table_protocol_real_auth_missing_state";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+      tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
       seatRows: []
     }
   };
@@ -1969,7 +1969,7 @@ test("real authoritative join with historical non-ACTIVE seat retries to the nex
   const tableId = "table_protocol_real_auth_historical_non_active";
   const fixtures = {
     [tableId]: {
-      tableRow: { id: tableId, max_players: 6, status: "OPEN" },
+      tableRow: { id: tableId, max_players: 6, status: "OPEN", buy_in: 100 },
       seatRows: [{ user_id: "historical_proto_user", seat_no: 1, status: "INACTIVE", is_bot: false }],
       stateRow: { version: 1, state: { tableId, seats: [], stacks: {}, phase: "INIT", pot: 0 } }
     }


### PR DESCRIPTION
## Summary
- Adds poker_tables.buy_in with a rolling-safe backfill/default of 100 CH and makes it the authoritative immutable table configuration.
- Removes fixed 100 CH assumptions from authoritative join, rebuy, bot seeding, bot replacement/top-up, rollover prepare/commit, persisted bootstrap, snapshots, and quick-seat eligibility.
- Keeps rebuy idempotency/reconnect/retry behavior and validates optional client declarations against the table buy-in; replayed results are checked against the current table value.
- Propagates table buy-in to the JSP-style poker client and lets Poker Lobby Create Table select a positive integer buy-in (default 100).
- Custom non-default table creation is gated on the WS health capability before the database write, so a new Netlify cannot expose a 500 CH table to an older WS during rolling deployment.

## Scope and impact
- Existing Create Table keeps the standard default of 100 CH while exposing the selected buy-in; Play Now and quick-seat/matchmaking remain unchanged.
- New writers always provide buy_in explicitly; the migration default exists only to keep old writers compatible during deployment.
- No new rebuy flow, ledger type, or accounting API is introduced.
- #865 UI polish remains separate: this PR does not add topbar/CH feedback, auto-rebuy confirmation, avatar indicator, source-specific feedback, or settings repositioning.

## Verification
- npm test
- node --test tests/poker-create-table.stakes.test.mjs tests/poker-ui.behavior.test.mjs ws-server/server.behavior.test.mjs
- git diff --check

Closes #866
Related: #865