### PR TITLE
Harden admin mutation actions against duplicate submits

### DIFF
--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -78,6 +78,7 @@
       loaded: false,
     },
     draftIdempotencyKeys: {},
+    pendingActions: {},
   };
 
   function klog(kind, data){
@@ -283,6 +284,54 @@
 
   function resetDraftIdempotencyKey(kind){
     delete state.draftIdempotencyKeys[String(kind || "admin")];
+  }
+
+  function resolveActionButton(source, form){
+    var event = source && source.target ? source : null;
+    if (event && event.submitter) return event.submitter;
+    var target = event ? (event.target || event.currentTarget) : source;
+    if (target && target.nodeType === 1 && target.tagName === "BUTTON") return target;
+    if (target && typeof target.closest === "function"){
+      var button = target.closest("button");
+      if (button) return button;
+    }
+    if (form && typeof form.querySelector === "function"){
+      return form.querySelector('button[type="submit"]');
+    }
+    return null;
+  }
+
+  function isPendingAction(actionKey){
+    return state.pendingActions[String(actionKey || "admin")] === true;
+  }
+
+  function beginPendingAction(actionKey, button, pendingLabel){
+    var key = String(actionKey || "admin");
+    if (isPendingAction(key)) return null;
+    state.pendingActions[key] = true;
+    var original = button ? {
+      text: button.textContent,
+      disabled: button.disabled === true,
+      ariaBusy: typeof button.getAttribute === "function" ? button.getAttribute("aria-busy") : null,
+    } : null;
+    if (button){
+      button.disabled = true;
+      button.setAttribute("aria-busy", "true");
+      button.textContent = pendingLabel || "Working…";
+    }
+    return function endPendingAction(){
+      if (!isPendingAction(key)) return;
+      delete state.pendingActions[key];
+      if (!button) return;
+      button.disabled = original.disabled;
+      if (original.ariaBusy == null){
+        if (typeof button.removeAttribute === "function") button.removeAttribute("aria-busy");
+        else button.setAttribute("aria-busy", "false");
+      } else {
+        button.setAttribute("aria-busy", original.ariaBusy);
+      }
+      button.textContent = original.text;
+    };
   }
 
   function getAuthBridge(){
@@ -1563,8 +1612,17 @@
     if (nodes.opsBotReactionEnabled) nodes.opsBotReactionEnabled.disabled = pending || unavailable;
     if (nodes.opsBotReactionFrequency) nodes.opsBotReactionFrequency.disabled = pending || unavailable;
     if (nodes.opsBotReactionPolicyApply) nodes.opsBotReactionPolicyApply.disabled = pending || unavailable;
-    if (nodes.opsBotReactionApply) nodes.opsBotReactionApply.disabled = pending || unavailable;
-    if (nodes.opsBotReactionDefault) nodes.opsBotReactionDefault.disabled = pending || unavailable || !value || value.mode !== "override";
+    if (nodes.opsBotReactionApply){
+      nodes.opsBotReactionApply.disabled = pending || unavailable;
+      nodes.opsBotReactionApply.textContent = pending ? "Applying…" : "Apply delay";
+    }
+    if (nodes.opsBotReactionDefault){
+      nodes.opsBotReactionDefault.disabled = pending || unavailable || !value || value.mode !== "override";
+      nodes.opsBotReactionDefault.textContent = pending ? "Applying…" : "Set default";
+    }
+    if (nodes.opsBotReactionPolicyApply){
+      nodes.opsBotReactionPolicyApply.textContent = pending ? "Applying…" : "Apply reaction settings";
+    }
     if (nodes.opsBotReactionStatus){
       var localError = errorCode && !unavailable ? errorCode : "";
       nodes.opsBotReactionStatus.textContent = pending ? "Updating WS Preview…" : state.ops.botReactionMessage || localError;
@@ -1644,7 +1702,7 @@
       return [
         '<div class="admin-list__item">',
         '<div class="admin-list__title"><span title="' + escapeHtml(item.tableId || item.category || "global") + '">' + escapeHtml(label) + "</span>",
-        '<button class="admin-btn admin-btn--ghost" type="button" data-poker-log-disable="' + String(index) + '"' + (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex === index ? " disabled" : "") + ">Disable</button></div>",
+        '<button class="admin-btn admin-btn--ghost" type="button" data-poker-log-disable="' + String(index) + '"' + (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex === index ? " disabled" : "") + ">" + (state.ops.pokerLogDisablePendingIndex === index ? "Disabling…" : "Disable") + "</button></div>",
         '<div class="admin-list__meta">' + escapeHtml(formatRemaining(item.expiresAt)) + (state.ops.pokerLogDisableErrorIndex === index ? " · Could not disable DEBUG." : "") + "</div>",
         "</div>"
       ].join("");
@@ -1681,6 +1739,7 @@
   function renderPokerLogControl(){
     var snapshot = state.ops.pokerLogControl;
     var pending = state.ops.pokerLogControlPending === true;
+    var disablePending = state.ops.pokerLogDisablePendingIndex != null;
     var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value || "table" : "table";
     if (nodes.opsPokerLogSummary){
       nodes.opsPokerLogSummary.innerHTML = snapshot
@@ -1718,10 +1777,13 @@
         nodes.opsPokerLogTtlHint.textContent = "Allowed: " + Math.ceil(snapshot.ttl.minMs / 60000) + "–" + Math.floor(snapshot.ttl.maxMs / 60000) + " minutes.";
       }
     }
-    if (nodes.opsPokerLogEnable) nodes.opsPokerLogEnable.disabled = pending || !snapshot;
-    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.disabled = pending;
-    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.disabled = pending;
-    if (nodes.opsPokerLogStatus) nodes.opsPokerLogStatus.textContent = pending ? "Updating DEBUG control…" : state.ops.pokerLogControlMessage || state.ops.pokerLogControlError || "";
+    if (nodes.opsPokerLogEnable){
+      nodes.opsPokerLogEnable.disabled = pending || disablePending || !snapshot;
+      nodes.opsPokerLogEnable.textContent = pending ? "Applying…" : "Enable DEBUG";
+    }
+    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.disabled = pending || disablePending;
+    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.disabled = pending || disablePending;
+    if (nodes.opsPokerLogStatus) nodes.opsPokerLogStatus.textContent = pending || disablePending ? "Updating DEBUG control…" : state.ops.pokerLogControlMessage || state.ops.pokerLogControlError || "";
     renderPokerLogOverrides();
   }
 
@@ -1823,10 +1885,22 @@
     var disabled = pending || state.maintenance;
     if (nodes.opsMaintenanceEnabled) nodes.opsMaintenanceEnabled.disabled = disabled;
     if (nodes.opsMaintenanceCount) nodes.opsMaintenanceCount.disabled = disabled;
-    if (nodes.opsMaintenanceApply) nodes.opsMaintenanceApply.disabled = disabled;
-    if (nodes.opsMaintenanceStop) nodes.opsMaintenanceStop.disabled = disabled;
-    if (nodes.opsMaintenanceReconcile) nodes.opsMaintenanceReconcile.disabled = disabled;
-    if (nodes.opsMaintenanceCleanup) nodes.opsMaintenanceCleanup.disabled = disabled;
+    if (nodes.opsMaintenanceApply){
+      nodes.opsMaintenanceApply.disabled = disabled;
+      nodes.opsMaintenanceApply.textContent = pending ? "Applying…" : "Apply maintenance state";
+    }
+    if (nodes.opsMaintenanceStop){
+      nodes.opsMaintenanceStop.disabled = disabled;
+      nodes.opsMaintenanceStop.textContent = pending ? "Stopping…" : "Stop continuous tables";
+    }
+    if (nodes.opsMaintenanceReconcile){
+      nodes.opsMaintenanceReconcile.disabled = disabled;
+      nodes.opsMaintenanceReconcile.textContent = pending ? "Running…" : "Reconcile now";
+    }
+    if (nodes.opsMaintenanceCleanup){
+      nodes.opsMaintenanceCleanup.disabled = disabled;
+      nodes.opsMaintenanceCleanup.textContent = pending ? "Running…" : "Run cleanup now";
+    }
     if (nodes.opsMaintenanceStatus) nodes.opsMaintenanceStatus.textContent = pending ? "Updating poker maintenance…" : state.ops.pokerMaintenanceError || "";
   }
 
@@ -1993,6 +2067,8 @@
         maxTotalClaims: data.maxTotalClaims,
       };
       if (!isUpdate) campaign.code = data.code;
+      var pending = beginPendingAction("bonus-campaign-save", resolveActionButton(event, event && event.target), "Saving…");
+      if (!pending) return;
       await apiFetch("/.netlify/functions/admin-bonus-campaigns", {
         method: "POST",
         body: JSON.stringify({
@@ -2007,15 +2083,21 @@
       await loadBonusCampaigns(1);
     } catch (err){
       handleApiError(err, bonusCampaignValidationMessage(err && err.code));
+    } finally {
+      if (pending) pending();
     }
   }
 
-  async function setBonusCampaignStatus(campaignId, status){
+  async function setBonusCampaignStatus(campaignId, status, button){
     var campaign = findBonusCampaign(campaignId);
     var label = campaign ? (campaign.code || campaign.title || campaignId) : campaignId;
+    var actionKey = "bonus-campaign-status-" + campaignId;
+    if (isPendingAction(actionKey)) return;
     if (typeof window.confirm === "function" && !window.confirm("Set bonus campaign " + label + " to " + status + "?")){
       return;
     }
+    var pending = beginPendingAction(actionKey, button, "Updating…");
+    if (!pending) return;
     setStatus("Updating bonus campaign...", "info");
     try {
       await apiFetch("/.netlify/functions/admin-bonus-campaigns", {
@@ -2030,6 +2112,8 @@
       await loadBonusCampaigns();
     } catch (err){
       handleApiError(err, "Could not update bonus campaign status.");
+    } finally {
+      pending();
     }
   }
 
@@ -2103,7 +2187,9 @@
     }
   }
 
-  async function runTableAction(tableId, action){
+  async function runTableAction(tableId, action, button){
+    var actionKey = "table-action-" + tableId;
+    if (isPendingAction(actionKey)) return;
     var reasonNode = doc.getElementById("adminTableReason");
     var customReason = reasonNode && typeof reasonNode.value === "string" ? reasonNode.value.trim() : "";
     var reason = customReason || "manual " + action;
@@ -2123,6 +2209,8 @@
         reason = "manual force close";
       }
     }
+    var pending = beginPendingAction(actionKey, button, "Running…");
+    if (!pending) return;
     setStatus(t("loading", "Loading..."), "info");
     try {
       if (action === "force_close"){
@@ -2155,6 +2243,8 @@
       loadOps();
     } catch (err){
       handleApiError(err, "Could not run table action.");
+    } finally {
+      pending();
     }
   }
 
@@ -2174,12 +2264,14 @@
     }
   }
 
-  async function executeBotRecovery(tableId){
+  async function executeBotRecovery(tableId, button){
     var recovery = state.tables.recovery;
     if (!recovery || recovery.tableId !== tableId || recovery.eligible !== true){
       setStatus("Run bot recovery analysis first.", "error");
       return;
     }
+    var actionKey = "bot-claims-recovery-" + tableId;
+    if (isPendingAction(actionKey)) return;
     if (typeof window.confirm === "function" && !window.confirm("Repair bot claims and permanently close table " + tableId + "?")){
       return;
     }
@@ -2193,9 +2285,11 @@
     var reasonNode = doc.getElementById("adminTableReason");
     var reason = reasonNode && typeof reasonNode.value === "string" ? reasonNode.value.trim() : "";
     if (!reason) reason = "approved Preview bot claims recovery";
+    var pending = beginPendingAction(actionKey, button, "Repairing…");
+    if (!pending) return;
     setStatus(t("loading", "Loading..."), "info");
     try {
-      var keyScope = "bot-claims-recovery-" + tableId;
+      var keyScope = actionKey;
       var result = await apiFetch("/.netlify/functions/admin-table-bot-claims-recovery", {
         method: "POST",
         body: JSON.stringify({
@@ -2228,6 +2322,8 @@
         return;
       }
       handleApiError(err, "Could not repair bot claims.");
+    } finally {
+      pending();
     }
   }
 
@@ -2317,9 +2413,13 @@
       return;
     }
     var preview = "Apply " + formatSignedAmount(amount) + " to " + (state.users.detail.user.email || state.users.detail.user.userId) + "?\nReason: " + reason;
+    var actionKey = "adjust-" + state.users.detail.user.userId;
+    if (isPendingAction(actionKey)) return;
     if (amount < 0 && window.confirm && !window.confirm(preview)){
       return;
     }
+    var pending = beginPendingAction(actionKey, resolveActionButton(event, form), "Applying…");
+    if (!pending) return;
     setStatus(t("loading", "Loading..."), "info");
     try {
       await apiFetch("/.netlify/functions/admin-ledger-adjust", {
@@ -2328,10 +2428,10 @@
           userId: state.users.detail.user.userId,
           amount: amount,
           reason: reason,
-          idempotencyKey: getDraftIdempotencyKey("adjust-" + state.users.detail.user.userId),
+          idempotencyKey: getDraftIdempotencyKey(actionKey),
         }),
       });
-      resetDraftIdempotencyKey("adjust-" + state.users.detail.user.userId);
+      resetDraftIdempotencyKey(actionKey);
       if (amountInput) amountInput.value = "";
       if (reasonInput) reasonInput.value = "";
       setStatus("Adjustment saved.", "success");
@@ -2341,6 +2441,8 @@
       }
     } catch (err){
       handleApiError(err, "Could not save the adjustment.");
+    } finally {
+      pending();
     }
   }
 
@@ -2387,6 +2489,7 @@
 
   async function submitPokerLogOverride(event){
     event.preventDefault();
+    if (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex != null) return;
     var snapshot = state.ops.pokerLogControl;
     if (!snapshot) return;
     var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value : "table";
@@ -2567,6 +2670,7 @@
 
   async function submitBotReactionOverride(event){
     event.preventDefault();
+    if (state.ops.botReactionPending) return;
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
@@ -2598,6 +2702,7 @@
   }
 
   async function clearBotReactionOverride(){
+    if (state.ops.botReactionPending) return;
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
@@ -2623,6 +2728,7 @@
 
   async function submitBotReactionPolicy(event){
     event.preventDefault();
+    if (state.ops.botReactionPending) return;
     var frequencyPercent = Number(nodes.opsBotReactionFrequency && nodes.opsBotReactionFrequency.value);
     if (!Number.isInteger(frequencyPercent) || frequencyPercent < 1 || frequencyPercent > 100){
       state.ops.botReactionError = "invalid_reaction_settings";
@@ -2652,22 +2758,25 @@
     }
   }
 
-  async function runOpsAction(action){
+  async function runOpsAction(action, button){
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
     }
+    var actionKey = "ops-" + action;
+    var pending = beginPendingAction(actionKey, button, "Running…");
+    if (!pending) return;
     setStatus(t("loading", "Loading..."), "info");
     try {
       var payload = await apiFetch("/.netlify/functions/admin-ops-actions", {
         method: "POST",
         body: JSON.stringify({
           action: action,
-          idempotencyKey: getDraftIdempotencyKey("ops-" + action),
+          idempotencyKey: getDraftIdempotencyKey(actionKey),
           reason: "manual " + action,
         }),
       });
-      resetDraftIdempotencyKey("ops-" + action);
+      resetDraftIdempotencyKey(actionKey);
       if (nodes.opsActionResult){
         nodes.opsActionResult.innerHTML = '<div class="admin-surface"><div class="admin-list__title"><span>' + escapeHtml(action) + '</span>' + pill(payload.changedCount > 0 ? "changed" : "noop", payload.changedCount > 0 ? "success" : "info") + '</div><div class="admin-list__meta">Processed ' + escapeHtml(payload.processed) + " tables, changed " + escapeHtml(payload.changedCount) + ".</div></div>";
       }
@@ -2676,10 +2785,13 @@
       loadTables();
     } catch (err){
       handleApiError(err, "Could not run ops action.");
+    } finally {
+      pending();
     }
   }
 
   async function runPokerMaintenance(operation, extra){
+    if (state.ops.pokerMaintenancePending) return;
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
@@ -2715,6 +2827,7 @@
 
   function submitPokerMaintenance(event){
     event.preventDefault();
+    if (state.ops.pokerMaintenancePending) return;
     var enabled = nodes.opsMaintenanceEnabled && nodes.opsMaintenanceEnabled.value === "true";
     var desiredTableCount = Number(nodes.opsMaintenanceCount && nodes.opsMaintenanceCount.value);
     var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
@@ -2733,6 +2846,7 @@
   }
 
   function stopContinuousTables(){
+    if (state.ops.pokerMaintenancePending) return;
     var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
     var desiredTableCount = continuous && Number.isInteger(continuous.desiredTableCount)
       ? continuous.desiredTableCount
@@ -2836,7 +2950,7 @@
     }
   }
 
-  function handleTableAction(action, tableId){
+  function handleTableAction(action, tableId, button){
     if (action === "details"){
       setActiveTab("tables");
       loadTableDetail(tableId);
@@ -2854,11 +2968,11 @@
     }
     if (action === "execute_bot_recovery"){
       setActiveTab("tables");
-      executeBotRecovery(tableId);
+      executeBotRecovery(tableId, button);
       return;
     }
     setActiveTab("tables");
-    runTableAction(tableId, action);
+    runTableAction(tableId, action, button);
   }
 
   function handleAuditAction(action, tableId, handId){
@@ -2927,7 +3041,7 @@
     }
   }
 
-  function handleCampaignAction(action, campaignId, status){
+  function handleCampaignAction(action, campaignId, status, button){
     if (action === "edit" || action === "view"){
       var campaign = findBonusCampaign(campaignId);
       fillBonusCampaignForm(campaign);
@@ -2941,7 +3055,7 @@
       return;
     }
     if (action === "set_status"){
-      setBonusCampaignStatus(campaignId, status);
+      setBonusCampaignStatus(campaignId, status, button);
     }
   }
 
@@ -3026,8 +3140,8 @@
         loadLedger();
       });
     });
-    if (nodes.opsRunReconciler) nodes.opsRunReconciler.addEventListener("click", function(){ runOpsAction("open_table_reconciler"); });
-    if (nodes.opsRunStaleSweep) nodes.opsRunStaleSweep.addEventListener("click", function(){ runOpsAction("stale_seat_sweep"); });
+    if (nodes.opsRunReconciler) nodes.opsRunReconciler.addEventListener("click", function(){ runOpsAction("open_table_reconciler", nodes.opsRunReconciler); });
+    if (nodes.opsRunStaleSweep) nodes.opsRunStaleSweep.addEventListener("click", function(){ runOpsAction("stale_seat_sweep", nodes.opsRunStaleSweep); });
     doc.addEventListener("click", function(event){
       var pageButton = closestEventTarget(event.target, "[data-page-scope]");
       if (pageButton){
@@ -3046,7 +3160,7 @@
       }
       var tableButton = closestEventTarget(event.target, "[data-table-action]");
       if (tableButton){
-        handleTableAction(tableButton.getAttribute("data-table-action"), tableButton.getAttribute("data-table-id"));
+        handleTableAction(tableButton.getAttribute("data-table-action"), tableButton.getAttribute("data-table-id"), tableButton);
         return;
       }
       var maintenanceRotateButton = closestEventTarget(event.target, "[data-maintenance-rotate]");
@@ -3077,7 +3191,8 @@
         handleCampaignAction(
           campaignButton.getAttribute("data-campaign-action"),
           campaignButton.getAttribute("data-campaign-id"),
-          campaignButton.getAttribute("data-campaign-status")
+          campaignButton.getAttribute("data-campaign-status"),
+          campaignButton
         );
         return;
       }

--- a/js/admin-page.js
+++ b/js/admin-page.js
@@ -50,13 +50,10 @@
       botReaction: null,
       botReactionError: null,
       botReactionMessage: "",
-      botReactionPending: false,
       pokerLogControl: null,
       pokerLogControlError: null,
       pokerLogControlMessage: "",
-      pokerLogControlPending: false,
-      pokerLogDisablePendingIndex: null,
-      pokerLogDisableErrorIndex: null,
+      pokerLogDisableErrorKey: null,
       pokerLogTables: [],
       pokerLogTablesError: null,
       pokerLogClockBaseMs: null,
@@ -65,7 +62,6 @@
       pokerLogCountdownTimer: null,
       pokerMaintenance: null,
       pokerMaintenanceError: null,
-      pokerMaintenancePending: false,
       vpsMetrics: null,
       vpsMetricsError: null,
       vpsMetricsStale: false,
@@ -332,6 +328,22 @@
       }
       button.textContent = original.text;
     };
+  }
+
+  function getPokerMaintenanceActionKey(operation, extra){
+    var options = extra || {};
+    if (operation === "set_desired_state" || operation === "reconcile") return "poker-maintenance-supervisor";
+    if (operation === "cleanup") return "poker-maintenance-cleanup";
+    if (operation === "request_rotation"){
+      return "poker-maintenance-rotation-" + encodeURIComponent(String(options.tableId || ""));
+    }
+    return "poker-maintenance-" + String(operation || "action");
+  }
+
+  function getPokerLogDisableActionKey(item){
+    return ["poker-debug-disable", item && item.scope, item && item.category || "", item && item.tableId || ""]
+      .map(function(value){ return encodeURIComponent(String(value || "")); })
+      .join(":");
   }
 
   function getAuthBridge(){
@@ -1571,7 +1583,10 @@
   function renderBotReactionControl(){
     var value = state.ops.botReaction;
     var errorCode = state.ops.botReactionError;
-    var pending = state.ops.botReactionPending === true;
+    var overridePending = isPendingAction("bot-reaction-override");
+    var defaultPending = isPendingAction("bot-reaction-default");
+    var policyPending = isPendingAction("bot-reaction-policy");
+    var pending = overridePending || defaultPending || policyPending;
     var unavailable = state.maintenance || errorCode === "maintenance" || errorCode === "preview_only" || errorCode === "ws_preview_unavailable" || errorCode === "ws_preview_timeout";
     if (nodes.opsBotReactionSummary){
       if (value){
@@ -1602,26 +1617,26 @@
         nodes.opsBotReactionSummary.innerHTML = '<p class="admin-empty">Loading WS Preview timing…</p>';
       }
     }
-    if (nodes.opsBotReactionDelay && value && !pending){
+    if (nodes.opsBotReactionDelay && value && !overridePending){
       nodes.opsBotReactionDelay.value = String(value.active && value.active.minMs != null ? value.active.minMs : 500);
     }
-    if (nodes.opsBotReactionDelay) nodes.opsBotReactionDelay.disabled = pending || unavailable;
-    if (nodes.opsBotReactionEnabled && value && !pending) nodes.opsBotReactionEnabled.checked = value.reactionSettings?.enabled !== false;
-    if (nodes.opsBotReactionFrequency && value && !pending) nodes.opsBotReactionFrequency.value = String(value.reactionSettings?.frequencyPercent || 100);
+    if (nodes.opsBotReactionDelay) nodes.opsBotReactionDelay.disabled = overridePending || unavailable;
+    if (nodes.opsBotReactionEnabled && value && !policyPending) nodes.opsBotReactionEnabled.checked = value.reactionSettings?.enabled !== false;
+    if (nodes.opsBotReactionFrequency && value && !policyPending) nodes.opsBotReactionFrequency.value = String(value.reactionSettings?.frequencyPercent || 100);
     if (nodes.opsBotReactionFrequencyValue) nodes.opsBotReactionFrequencyValue.textContent = String(Number(nodes.opsBotReactionFrequency?.value || 100)) + "%";
-    if (nodes.opsBotReactionEnabled) nodes.opsBotReactionEnabled.disabled = pending || unavailable;
-    if (nodes.opsBotReactionFrequency) nodes.opsBotReactionFrequency.disabled = pending || unavailable;
-    if (nodes.opsBotReactionPolicyApply) nodes.opsBotReactionPolicyApply.disabled = pending || unavailable;
+    if (nodes.opsBotReactionEnabled) nodes.opsBotReactionEnabled.disabled = policyPending || unavailable;
+    if (nodes.opsBotReactionFrequency) nodes.opsBotReactionFrequency.disabled = policyPending || unavailable;
+    if (nodes.opsBotReactionPolicyApply) nodes.opsBotReactionPolicyApply.disabled = policyPending || unavailable;
     if (nodes.opsBotReactionApply){
-      nodes.opsBotReactionApply.disabled = pending || unavailable;
-      nodes.opsBotReactionApply.textContent = pending ? "Applying…" : "Apply delay";
+      nodes.opsBotReactionApply.disabled = overridePending || unavailable;
+      nodes.opsBotReactionApply.textContent = overridePending ? "Applying…" : "Apply delay";
     }
     if (nodes.opsBotReactionDefault){
-      nodes.opsBotReactionDefault.disabled = pending || unavailable || !value || value.mode !== "override";
-      nodes.opsBotReactionDefault.textContent = pending ? "Applying…" : "Set default";
+      nodes.opsBotReactionDefault.disabled = defaultPending || unavailable || !value || value.mode !== "override";
+      nodes.opsBotReactionDefault.textContent = defaultPending ? "Applying…" : "Set default";
     }
     if (nodes.opsBotReactionPolicyApply){
-      nodes.opsBotReactionPolicyApply.textContent = pending ? "Applying…" : "Apply reaction settings";
+      nodes.opsBotReactionPolicyApply.textContent = policyPending ? "Applying…" : "Apply reaction settings";
     }
     if (nodes.opsBotReactionStatus){
       var localError = errorCode && !unavailable ? errorCode : "";
@@ -1699,11 +1714,13 @@
         : item.scope === "category"
           ? "Category: " + item.category
           : "Table: " + shortTableId(item.tableId);
+      var actionKey = getPokerLogDisableActionKey(item);
+      var pending = isPendingAction(actionKey);
       return [
         '<div class="admin-list__item">',
         '<div class="admin-list__title"><span title="' + escapeHtml(item.tableId || item.category || "global") + '">' + escapeHtml(label) + "</span>",
-        '<button class="admin-btn admin-btn--ghost" type="button" data-poker-log-disable="' + String(index) + '"' + (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex === index ? " disabled" : "") + ">" + (state.ops.pokerLogDisablePendingIndex === index ? "Disabling…" : "Disable") + "</button></div>",
-        '<div class="admin-list__meta">' + escapeHtml(formatRemaining(item.expiresAt)) + (state.ops.pokerLogDisableErrorIndex === index ? " · Could not disable DEBUG." : "") + "</div>",
+        '<button class="admin-btn admin-btn--ghost" type="button" data-poker-log-disable="' + String(index) + '"' + (pending ? " disabled" : "") + ">" + (pending ? "Disabling…" : "Disable") + "</button></div>",
+        '<div class="admin-list__meta">' + escapeHtml(formatRemaining(item.expiresAt)) + (state.ops.pokerLogDisableErrorKey === actionKey ? " · Could not disable DEBUG." : "") + "</div>",
         "</div>"
       ].join("");
     }).join("") + "</div>";
@@ -1738,8 +1755,9 @@
 
   function renderPokerLogControl(){
     var snapshot = state.ops.pokerLogControl;
-    var pending = state.ops.pokerLogControlPending === true;
-    var disablePending = state.ops.pokerLogDisablePendingIndex != null;
+    var enablePending = isPendingAction("poker-debug-enable");
+    var overrides = snapshot && Array.isArray(snapshot.overrides) ? snapshot.overrides : [];
+    var disablePending = overrides.some(function(item){ return isPendingAction(getPokerLogDisableActionKey(item)); });
     var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value || "table" : "table";
     if (nodes.opsPokerLogSummary){
       nodes.opsPokerLogSummary.innerHTML = snapshot
@@ -1778,12 +1796,12 @@
       }
     }
     if (nodes.opsPokerLogEnable){
-      nodes.opsPokerLogEnable.disabled = pending || disablePending || !snapshot;
-      nodes.opsPokerLogEnable.textContent = pending ? "Applying…" : "Enable DEBUG";
+      nodes.opsPokerLogEnable.disabled = enablePending || !snapshot;
+      nodes.opsPokerLogEnable.textContent = enablePending ? "Applying…" : "Enable DEBUG";
     }
-    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.disabled = pending || disablePending;
-    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.disabled = pending || disablePending;
-    if (nodes.opsPokerLogStatus) nodes.opsPokerLogStatus.textContent = pending || disablePending ? "Updating DEBUG control…" : state.ops.pokerLogControlMessage || state.ops.pokerLogControlError || "";
+    if (nodes.opsPokerLogRefresh) nodes.opsPokerLogRefresh.disabled = false;
+    if (nodes.opsPokerLogTablesRefresh) nodes.opsPokerLogTablesRefresh.disabled = false;
+    if (nodes.opsPokerLogStatus) nodes.opsPokerLogStatus.textContent = enablePending || disablePending ? "Updating DEBUG control…" : state.ops.pokerLogControlMessage || state.ops.pokerLogControlError || "";
     renderPokerLogOverrides();
   }
 
@@ -1807,7 +1825,8 @@
   function renderPokerMaintenance(){
     if (!nodes.opsMaintenance) return;
     var snapshot = state.ops.pokerMaintenance;
-    var pending = state.ops.pokerMaintenancePending === true;
+    var supervisorPending = isPendingAction("poker-maintenance-supervisor");
+    var cleanupPending = isPendingAction("poker-maintenance-cleanup");
     if (!snapshot){
       nodes.opsMaintenance.innerHTML = '<p class="admin-empty">' + escapeHtml(state.ops.pokerMaintenanceError ? "Continuous maintenance unavailable: " + state.ops.pokerMaintenanceError : "Loading continuous maintenance…") + "</p>";
     } else {
@@ -1819,8 +1838,9 @@
       var cleanup = snapshot.cleanup || {};
       var lastRun = cleanup.lastRun || {};
       var tableItems = (Array.isArray(continuous.tables) ? continuous.tables : []).map(function(table){
+        var rotationPending = isPendingAction(getPokerMaintenanceActionKey("request_rotation", { tableId: table.tableId }));
         var rotationButton = table.status === "OPEN"
-          ? '<button class="admin-btn admin-btn--ghost" type="button" data-maintenance-rotate="' + escapeHtml(table.tableId || "") + '">Request rotation</button>'
+          ? '<button class="admin-btn admin-btn--ghost" type="button" data-maintenance-rotate="' + escapeHtml(table.tableId || "") + '"' + (rotationPending ? " disabled" : "") + ">" + (rotationPending ? "Running…" : "Request rotation") + "</button>"
           : "";
         return {
           title: '<span class="admin-mono">' + escapeHtml(shortTableId(table.tableId)) + "</span> " + pill(table.status || "unknown", table.status === "OPEN" ? "success" : "info") + rotationButton,
@@ -1882,26 +1902,31 @@
       nodes.opsMaintenanceEnabled.value = continuous.maintenanceEnabled ? "true" : "false";
       nodes.opsMaintenanceCount.value = continuous.desiredTableCount == null ? "0" : String(continuous.desiredTableCount);
     }
-    var disabled = pending || state.maintenance;
-    if (nodes.opsMaintenanceEnabled) nodes.opsMaintenanceEnabled.disabled = disabled;
-    if (nodes.opsMaintenanceCount) nodes.opsMaintenanceCount.disabled = disabled;
+    var supervisorDisabled = supervisorPending || state.maintenance;
+    var cleanupDisabled = cleanupPending || state.maintenance;
+    if (nodes.opsMaintenanceEnabled) nodes.opsMaintenanceEnabled.disabled = supervisorDisabled;
+    if (nodes.opsMaintenanceCount) nodes.opsMaintenanceCount.disabled = supervisorDisabled;
     if (nodes.opsMaintenanceApply){
-      nodes.opsMaintenanceApply.disabled = disabled;
-      nodes.opsMaintenanceApply.textContent = pending ? "Applying…" : "Apply maintenance state";
+      nodes.opsMaintenanceApply.disabled = supervisorDisabled;
+      nodes.opsMaintenanceApply.textContent = supervisorPending ? "Applying…" : "Apply maintenance state";
     }
     if (nodes.opsMaintenanceStop){
-      nodes.opsMaintenanceStop.disabled = disabled;
-      nodes.opsMaintenanceStop.textContent = pending ? "Stopping…" : "Stop continuous tables";
+      nodes.opsMaintenanceStop.disabled = supervisorDisabled;
+      nodes.opsMaintenanceStop.textContent = supervisorPending ? "Stopping…" : "Stop continuous tables";
     }
     if (nodes.opsMaintenanceReconcile){
-      nodes.opsMaintenanceReconcile.disabled = disabled;
-      nodes.opsMaintenanceReconcile.textContent = pending ? "Running…" : "Reconcile now";
+      nodes.opsMaintenanceReconcile.disabled = supervisorDisabled;
+      nodes.opsMaintenanceReconcile.textContent = supervisorPending ? "Running…" : "Reconcile now";
     }
     if (nodes.opsMaintenanceCleanup){
-      nodes.opsMaintenanceCleanup.disabled = disabled;
-      nodes.opsMaintenanceCleanup.textContent = pending ? "Running…" : "Run cleanup now";
+      nodes.opsMaintenanceCleanup.disabled = cleanupDisabled;
+      nodes.opsMaintenanceCleanup.textContent = cleanupPending ? "Running…" : "Run cleanup now";
     }
-    if (nodes.opsMaintenanceStatus) nodes.opsMaintenanceStatus.textContent = pending ? "Updating poker maintenance…" : state.ops.pokerMaintenanceError || "";
+    if (nodes.opsMaintenanceStatus) nodes.opsMaintenanceStatus.textContent = supervisorPending
+      ? "Updating poker maintenance…"
+      : cleanupPending
+        ? "Running cleanup…"
+        : state.ops.pokerMaintenanceError || "";
   }
 
   function closestEventTarget(target, selector){
@@ -2489,7 +2514,6 @@
 
   async function submitPokerLogOverride(event){
     event.preventDefault();
-    if (state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex != null) return;
     var snapshot = state.ops.pokerLogControl;
     if (!snapshot) return;
     var scope = nodes.opsPokerLogScope ? nodes.opsPokerLogScope.value : "table";
@@ -2512,7 +2536,8 @@
       && typeof window.confirm === "function"
       && !window.confirm("Enable Global DEBUG on Production for " + Math.ceil(ttlMs / 60000) + " minutes?")
     ) return;
-    state.ops.pokerLogControlPending = true;
+    var pending = beginPendingAction("poker-debug-enable", resolveActionButton(event, event && event.target), "Applying…");
+    if (!pending) return;
     state.ops.pokerLogControlMessage = "";
     renderPokerLogControl();
     try {
@@ -2527,17 +2552,19 @@
       state.ops.pokerLogControlError = err && err.code ? err.code : "request_failed";
       state.ops.pokerLogControlMessage = "Could not enable DEBUG.";
     } finally {
-      state.ops.pokerLogControlPending = false;
+      pending();
       renderPokerLogControl();
     }
   }
 
-  async function disablePokerLogOverride(index){
+  async function disablePokerLogOverride(index, button){
     var snapshot = state.ops.pokerLogControl;
     var item = snapshot && snapshot.overrides && snapshot.overrides[index];
-    if (!item || state.ops.pokerLogControlPending || state.ops.pokerLogDisablePendingIndex != null) return;
-    state.ops.pokerLogDisablePendingIndex = index;
-    state.ops.pokerLogDisableErrorIndex = null;
+    if (!item) return;
+    var actionKey = getPokerLogDisableActionKey(item);
+    var pending = beginPendingAction(actionKey, button, "Disabling…");
+    if (!pending) return;
+    state.ops.pokerLogDisableErrorKey = null;
     state.ops.pokerLogControlMessage = "";
     renderPokerLogControl();
     try {
@@ -2552,14 +2579,14 @@
       });
       setPokerLogSnapshot(result);
       state.ops.pokerLogControlError = null;
-      state.ops.pokerLogDisableErrorIndex = null;
+      state.ops.pokerLogDisableErrorKey = null;
       state.ops.pokerLogControlMessage = "DEBUG override disabled.";
     } catch (err){
       state.ops.pokerLogControlError = err && err.code ? err.code : "request_failed";
-      state.ops.pokerLogDisableErrorIndex = index;
+      state.ops.pokerLogDisableErrorKey = actionKey;
       state.ops.pokerLogControlMessage = "Could not disable DEBUG.";
     } finally {
-      state.ops.pokerLogDisablePendingIndex = null;
+      pending();
       renderPokerLogControl();
     }
   }
@@ -2665,12 +2692,11 @@
     var target = closestEventTarget(event && event.target, "[data-poker-log-disable]");
     if (!target) return;
     var index = Number(target.getAttribute("data-poker-log-disable"));
-    if (Number.isInteger(index) && index >= 0) disablePokerLogOverride(index);
+    if (Number.isInteger(index) && index >= 0) disablePokerLogOverride(index, target);
   }
 
   async function submitBotReactionOverride(event){
     event.preventDefault();
-    if (state.ops.botReactionPending) return;
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
@@ -2682,7 +2708,8 @@
       renderBotReactionControl();
       return;
     }
-    state.ops.botReactionPending = true;
+    var pending = beginPendingAction("bot-reaction-override", resolveActionButton(event, event && event.target), "Applying…");
+    if (!pending) return;
     state.ops.botReactionError = null;
     state.ops.botReactionMessage = "";
     renderBotReactionControl();
@@ -2696,18 +2723,18 @@
     } catch (err){
       handleBotReactionError(err, "Could not apply the override.");
     } finally {
-      state.ops.botReactionPending = false;
+      pending();
       renderBotReactionControl();
     }
   }
 
-  async function clearBotReactionOverride(){
-    if (state.ops.botReactionPending) return;
+  async function clearBotReactionOverride(event){
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
     }
-    state.ops.botReactionPending = true;
+    var pending = beginPendingAction("bot-reaction-default", resolveActionButton(event), "Applying…");
+    if (!pending) return;
     state.ops.botReactionError = null;
     state.ops.botReactionMessage = "";
     renderBotReactionControl();
@@ -2721,14 +2748,13 @@
     } catch (err){
       handleBotReactionError(err, "Could not restore the default range.");
     } finally {
-      state.ops.botReactionPending = false;
+      pending();
       renderBotReactionControl();
     }
   }
 
   async function submitBotReactionPolicy(event){
     event.preventDefault();
-    if (state.ops.botReactionPending) return;
     var frequencyPercent = Number(nodes.opsBotReactionFrequency && nodes.opsBotReactionFrequency.value);
     if (!Number.isInteger(frequencyPercent) || frequencyPercent < 1 || frequencyPercent > 100){
       state.ops.botReactionError = "invalid_reaction_settings";
@@ -2736,7 +2762,8 @@
       renderBotReactionControl();
       return;
     }
-    state.ops.botReactionPending = true;
+    var pending = beginPendingAction("bot-reaction-policy", resolveActionButton(event, event && event.target), "Applying…");
+    if (!pending) return;
     state.ops.botReactionError = null;
     state.ops.botReactionMessage = "";
     renderBotReactionControl();
@@ -2753,7 +2780,7 @@
     } catch (err){
       handleBotReactionError(err, "Could not apply bot reaction settings.");
     } finally {
-      state.ops.botReactionPending = false;
+      pending();
       renderBotReactionControl();
     }
   }
@@ -2790,13 +2817,20 @@
     }
   }
 
-  async function runPokerMaintenance(operation, extra){
-    if (state.ops.pokerMaintenancePending) return;
+  async function runPokerMaintenance(operation, extra, button){
     if (state.maintenance){
       setStatus("CH and poker mutations are disabled during maintenance.", "error");
       return;
     }
-    state.ops.pokerMaintenancePending = true;
+    var actionKey = getPokerMaintenanceActionKey(operation, extra);
+    var pendingLabel = operation === "set_desired_state"
+      && button
+      && typeof button.getAttribute === "function"
+      && button.getAttribute("data-maintenance-stop") != null
+      ? "Stopping…"
+      : operation === "set_desired_state" ? "Applying…" : "Running…";
+    var pending = beginPendingAction(actionKey, button, pendingLabel);
+    if (!pending) return;
     state.ops.pokerMaintenanceError = null;
     renderPokerMaintenance();
     try {
@@ -2820,14 +2854,14 @@
         handleApiError(err, "Could not update poker maintenance.");
       }
     } finally {
-      state.ops.pokerMaintenancePending = false;
+      pending();
       renderPokerMaintenance();
     }
   }
 
   function submitPokerMaintenance(event){
     event.preventDefault();
-    if (state.ops.pokerMaintenancePending) return;
+    if (isPendingAction("poker-maintenance-supervisor")) return;
     var enabled = nodes.opsMaintenanceEnabled && nodes.opsMaintenanceEnabled.value === "true";
     var desiredTableCount = Number(nodes.opsMaintenanceCount && nodes.opsMaintenanceCount.value);
     var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
@@ -2842,11 +2876,11 @@
     if (desiredTableCount > 10 && typeof window !== "undefined"
       && typeof window.confirm === "function"
       && !window.confirm("This is a high-volume Preview stress test. Continue with " + String(desiredTableCount) + " desired tables?")) return;
-    runPokerMaintenance("set_desired_state", { enabled: enabled, desiredTableCount: desiredTableCount });
+    runPokerMaintenance("set_desired_state", { enabled: enabled, desiredTableCount: desiredTableCount }, resolveActionButton(event, event && event.target));
   }
 
-  function stopContinuousTables(){
-    if (state.ops.pokerMaintenancePending) return;
+  function stopContinuousTables(button){
+    if (isPendingAction("poker-maintenance-supervisor")) return;
     var continuous = state.ops.pokerMaintenance && state.ops.pokerMaintenance.continuous;
     var desiredTableCount = continuous && Number.isInteger(continuous.desiredTableCount)
       ? continuous.desiredTableCount
@@ -2854,7 +2888,7 @@
     if (typeof window !== "undefined"
       && typeof window.confirm === "function"
       && !window.confirm("Stop continuous tables? Continuous maintenance will be disabled. No new managed tables will be created. Existing managed tables will retire gracefully after their current hand. Tables with active human presence may remain alive until they can safely retire.")) return;
-    runPokerMaintenance("set_desired_state", { enabled: false, desiredTableCount: desiredTableCount });
+    runPokerMaintenance("set_desired_state", { enabled: false, desiredTableCount: desiredTableCount }, button);
   }
 
   function handleApiError(err, fallback){
@@ -3165,20 +3199,20 @@
       }
       var maintenanceRotateButton = closestEventTarget(event.target, "[data-maintenance-rotate]");
       if (maintenanceRotateButton){
-        runPokerMaintenance("request_rotation", { tableId: maintenanceRotateButton.getAttribute("data-maintenance-rotate") });
+        runPokerMaintenance("request_rotation", { tableId: maintenanceRotateButton.getAttribute("data-maintenance-rotate") }, maintenanceRotateButton);
         return;
       }
       var maintenanceStopButton = closestEventTarget(event.target, "[data-maintenance-stop]");
       if (maintenanceStopButton){
-        stopContinuousTables();
+        stopContinuousTables(maintenanceStopButton);
         return;
       }
       if (event.target && event.target.id === "adminOpsMaintenanceReconcile"){
-        runPokerMaintenance("reconcile");
+        runPokerMaintenance("reconcile", null, event.target);
         return;
       }
       if (event.target && event.target.id === "adminOpsMaintenanceCleanup"){
-        runPokerMaintenance("cleanup");
+        runPokerMaintenance("cleanup", null, event.target);
         return;
       }
       var auditButton = closestEventTarget(event.target, "[data-audit-action]");
@@ -3224,8 +3258,8 @@
         submitPokerMaintenance(event);
       }
     });
-    if (nodes.opsMaintenanceReconcile) nodes.opsMaintenanceReconcile.addEventListener("click", function(){ runPokerMaintenance("reconcile"); });
-    if (nodes.opsMaintenanceCleanup) nodes.opsMaintenanceCleanup.addEventListener("click", function(){ runPokerMaintenance("cleanup"); });
+    if (nodes.opsMaintenanceReconcile) nodes.opsMaintenanceReconcile.addEventListener("click", function(event){ runPokerMaintenance("reconcile", null, event.currentTarget || nodes.opsMaintenanceReconcile); });
+    if (nodes.opsMaintenanceCleanup) nodes.opsMaintenanceCleanup.addEventListener("click", function(event){ runPokerMaintenance("cleanup", null, event.currentTarget || nodes.opsMaintenanceCleanup); });
     doc.addEventListener("input", function(event){
       var target = event.target;
       if (target && (target.id === "adminAdjustAmount" || target.id === "adminAdjustReason") && state.users.detail && state.users.detail.user){

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -150,6 +150,9 @@ function createElement(tagName, id = null) {
       if (attributes.has(name)) return attributes.get(name);
       return null;
     },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
     closest(selector) {
       let current = node;
       while (current) {
@@ -413,10 +416,13 @@ function buildContext(options = {}) {
   const opts = options || {};
   const { document, tabs, panels } = createAdminDom();
   const fetchCalls = [];
+  const mutationCalls = [];
   var vpsMetricsCalls = 0;
   const fetch = async (url, options) => {
     fetchCalls.push(String(url || ""));
     const text = String(url || "");
+    const method = options && options.method ? String(options.method).toUpperCase() : "GET";
+    if (method !== "GET") mutationCalls.push({ method, url: text });
     if (text.includes("/.netlify/functions/admin-me")) {
       if (opts.meUnavailable){
         return { ok: false, status: 503, json: async () => ({ error: "server_error" }) };
@@ -442,6 +448,9 @@ function buildContext(options = {}) {
       return { ok: true, json: async () => ({ items: [], pagination: null }) };
     }
     if (text.includes("/.netlify/functions/admin-bonus-campaigns")) {
+      if (method === "POST" && typeof opts.waitForBonusMutation === "function"){
+        await opts.waitForBonusMutation();
+      }
       return { ok: true, json: async () => ({
         items: [
           {
@@ -686,7 +695,7 @@ function buildContext(options = {}) {
     Math,
     Date,
   });
-  return { context, document, tabs, panels, fetchCalls };
+  return { context, document, tabs, panels, fetchCalls, mutationCalls };
 }
 
 test("admin page tabs switch panels on click and keep ARIA state in sync", async () => {
@@ -1006,6 +1015,57 @@ test("admin bonus campaign form explains invalid campaign codes before sending a
   assert.match(document.getElementById("adminStatus").textContent, /lowercase letter or digit/);
   assert.match(document.getElementById("adminStatus").textContent, /daily-active-2026/);
   assert.equal(fetchCalls.some((url) => url.includes("/.netlify/functions/admin-bonus-campaigns")), false);
+});
+
+test("admin mutation buttons ignore repeats while pending and allow a deliberate next action", async () => {
+  const mutationWaiters = [];
+  const { context, document, mutationCalls } = buildContext({
+    waitForBonusMutation: () => {
+      if (!mutationWaiters.length) return new Promise((resolve) => mutationWaiters.push(resolve));
+      return Promise.resolve();
+    },
+  });
+  vm.runInContext(source, context, { filename: "js/admin-page.js" });
+
+  await flush();
+  const form = document.getElementById("adminBonusCampaignForm");
+  const saveButton = createElement("button");
+  saveButton.textContent = "Save campaign";
+  form.appendChild(saveButton);
+  const fillValidDraft = () => {
+    formField(form, "code").value = "async-campaign";
+    formField(form, "title").value = "Async campaign";
+    formField(form, "campaignType").value = "daily";
+    formField(form, "amount").value = "20";
+    formField(form, "startsAt").value = "2026-07-10T12:00";
+    formField(form, "eligibilityType").value = "all_accounts";
+    formField(form, "claimPolicy").value = "once";
+    formField(form, "eligibilityConfig").value = "{}";
+  };
+
+  fillValidDraft();
+  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
+  assert.equal(saveButton.disabled, true);
+  assert.equal(saveButton.textContent, "Saving…");
+  assert.equal(saveButton.getAttribute("aria-busy"), "true");
+
+  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
+  await flush();
+  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-bonus-campaigns")).length, 1);
+
+  const releaseFirst = mutationWaiters.shift();
+  assert.ok(releaseFirst, "the first mutation should be waiting on the test gate");
+  releaseFirst();
+  for (let index = 0; index < 5; index += 1) await flush();
+
+  assert.equal(saveButton.disabled, false);
+  assert.equal(saveButton.textContent, "Save campaign");
+  assert.equal(saveButton.getAttribute("aria-busy"), null);
+
+  fillValidDraft();
+  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
+  for (let index = 0; index < 5; index += 1) await flush();
+  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-bonus-campaigns")).length, 2);
 });
 
 test("admin page poker audit search renders hand timeline and settlement summary", async () => {

--- a/tests/admin-page.behavior.test.mjs
+++ b/tests/admin-page.behavior.test.mjs
@@ -250,6 +250,13 @@ function createForm(document, id) {
       field.value = "";
     });
   };
+  form.querySelector = function querySelector(selector) {
+    if (selector === 'button[type="submit"]') {
+      return (form.children || []).find((child) => child.tagName === "BUTTON" && child.type === "submit") || null;
+    }
+    const nameMatch = String(selector || "").match(/^\[name="([^"]+)"\]$/);
+    return nameMatch ? formField(form, nameMatch[1]) || null : null;
+  };
   return form;
 }
 
@@ -375,6 +382,9 @@ function createAdminDom() {
   addField(bonusCampaignForm, { name: "claimPolicy", value: "once" });
   addField(bonusCampaignForm, { name: "maxTotalClaims", value: "" });
   addField(bonusCampaignForm, { name: "eligibilityConfig", value: "{}" });
+  const adminAdjustForm = createForm(document, "adminAdjustForm");
+  addField(adminAdjustForm, { name: "amount", value: "" });
+  addField(adminAdjustForm, { name: "reason", value: "" });
   const pokerAuditFilters = createForm(document, "adminPokerAuditFilters");
   addField(pokerAuditFilters, { name: "tableId", value: "" });
   addField(pokerAuditFilters, { name: "handId", value: "" });
@@ -441,16 +451,29 @@ function buildContext(options = {}) {
     if (text.includes("/.netlify/functions/admin-users-list")) {
       return { ok: true, json: async () => ({ items: [], pagination: null }) };
     }
+    if (text.includes("/.netlify/functions/admin-user-details")) {
+      return { ok: true, json: async () => ({
+        user: { userId: "user-adjust", email: "adjust@example.test", activeTableCount: 0 },
+        balance: { balance: 1000 },
+        recentLedger: { items: [] },
+        activeTables: [],
+        recentPokerActivity: [],
+        activeSeats: [],
+      }) };
+    }
     if (text.includes("/.netlify/functions/admin-tables-list")) {
       return { ok: true, json: async () => ({ items: [], pagination: null }) };
     }
     if (text.includes("/.netlify/functions/admin-ledger-list")) {
       return { ok: true, json: async () => ({ items: [], pagination: null }) };
     }
-    if (text.includes("/.netlify/functions/admin-bonus-campaigns")) {
-      if (method === "POST" && typeof opts.waitForBonusMutation === "function"){
-        await opts.waitForBonusMutation();
+    if (text.includes("/.netlify/functions/admin-ledger-adjust")) {
+      if (method === "POST" && typeof opts.waitForLedgerAdjustment === "function"){
+        await opts.waitForLedgerAdjustment();
       }
+      return { ok: true, json: async () => ({ ok: true }) };
+    }
+    if (text.includes("/.netlify/functions/admin-bonus-campaigns")) {
       return { ok: true, json: async () => ({
         items: [
           {
@@ -1017,10 +1040,10 @@ test("admin bonus campaign form explains invalid campaign codes before sending a
   assert.equal(fetchCalls.some((url) => url.includes("/.netlify/functions/admin-bonus-campaigns")), false);
 });
 
-test("admin mutation buttons ignore repeats while pending and allow a deliberate next action", async () => {
+test("ADMIN_ADJUST ignores repeats while pending and allows a deliberate next action", async () => {
   const mutationWaiters = [];
   const { context, document, mutationCalls } = buildContext({
-    waitForBonusMutation: () => {
+    waitForLedgerAdjustment: () => {
       if (!mutationWaiters.length) return new Promise((resolve) => mutationWaiters.push(resolve));
       return Promise.resolve();
     },
@@ -1028,44 +1051,47 @@ test("admin mutation buttons ignore repeats while pending and allow a deliberate
   vm.runInContext(source, context, { filename: "js/admin-page.js" });
 
   await flush();
-  const form = document.getElementById("adminBonusCampaignForm");
-  const saveButton = createElement("button");
-  saveButton.textContent = "Save campaign";
-  form.appendChild(saveButton);
-  const fillValidDraft = () => {
-    formField(form, "code").value = "async-campaign";
-    formField(form, "title").value = "Async campaign";
-    formField(form, "campaignType").value = "daily";
-    formField(form, "amount").value = "20";
-    formField(form, "startsAt").value = "2026-07-10T12:00";
-    formField(form, "eligibilityType").value = "all_accounts";
-    formField(form, "claimPolicy").value = "once";
-    formField(form, "eligibilityConfig").value = "{}";
+  const detailsButton = createElement("button");
+  detailsButton.setAttribute("data-user-action", "details");
+  detailsButton.setAttribute("data-user-id", "user-adjust");
+  document.dispatchEvent({ type: "click", target: detailsButton, preventDefault() {} });
+  for (let index = 0; index < 3; index += 1) await flush();
+
+  const form = document.getElementById("adminAdjustForm");
+  const amountInput = formField(form, "amount");
+  const reasonInput = formField(form, "reason");
+  const submitButton = createElement("button");
+  submitButton.type = "submit";
+  submitButton.textContent = "Apply adjustment";
+  form.appendChild(submitButton);
+  const fillValidAdjustment = () => {
+    amountInput.value = "100";
+    reasonInput.value = "test adjustment";
   };
 
-  fillValidDraft();
-  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
-  assert.equal(saveButton.disabled, true);
-  assert.equal(saveButton.textContent, "Saving…");
-  assert.equal(saveButton.getAttribute("aria-busy"), "true");
+  fillValidAdjustment();
+  document.dispatchEvent({ type: "submit", target: form, submitter: submitButton, preventDefault() {} });
+  assert.equal(submitButton.disabled, true);
+  assert.equal(submitButton.textContent, "Applying…");
+  assert.equal(submitButton.getAttribute("aria-busy"), "true");
 
-  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
+  document.dispatchEvent({ type: "submit", target: form, submitter: submitButton, preventDefault() {} });
   await flush();
-  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-bonus-campaigns")).length, 1);
+  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-ledger-adjust")).length, 1);
 
   const releaseFirst = mutationWaiters.shift();
   assert.ok(releaseFirst, "the first mutation should be waiting on the test gate");
   releaseFirst();
   for (let index = 0; index < 5; index += 1) await flush();
 
-  assert.equal(saveButton.disabled, false);
-  assert.equal(saveButton.textContent, "Save campaign");
-  assert.equal(saveButton.getAttribute("aria-busy"), null);
+  assert.equal(submitButton.disabled, false);
+  assert.equal(submitButton.textContent, "Apply adjustment");
+  assert.equal(submitButton.getAttribute("aria-busy"), null);
 
-  fillValidDraft();
-  form.dispatchEvent({ type: "submit", target: form, submitter: saveButton, preventDefault() {} });
+  fillValidAdjustment();
+  document.dispatchEvent({ type: "submit", target: form, submitter: submitButton, preventDefault() {} });
   for (let index = 0; index < 5; index += 1) await flush();
-  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-bonus-campaigns")).length, 2);
+  assert.equal(mutationCalls.filter(({ url }) => url.includes("/.netlify/functions/admin-ledger-adjust")).length, 2);
 });
 
 test("admin page poker audit search renders hand timeline and settlement summary", async () => {

--- a/tests/admin-page.contract.test.mjs
+++ b/tests/admin-page.contract.test.mjs
@@ -63,7 +63,7 @@ test("admin ops exposes continuous maintenance and cleanup controls", () => {
   assert.match(adminJs, /Reconcile now/);
   assert.match(adminJs, /id="adminOpsMaintenanceStop"[^>]+data-maintenance-stop[^>]*>Stop continuous tables/);
   assert.match(adminJs, /Stop continuous tables\? Continuous maintenance will be disabled\./);
-  assert.match(adminJs, /runPokerMaintenance\("set_desired_state", \{ enabled: false, desiredTableCount: desiredTableCount \}\)/);
+  assert.match(adminJs, /runPokerMaintenance\("set_desired_state", \{ enabled: false, desiredTableCount: desiredTableCount \}, button\)/);
   assert.doesNotMatch(adminJs, /requestRetirement/);
   assert.match(adminJs, /Next cleanup batch · ordinary rows/);
   assert.match(adminJs, /Next cleanup batch · HAND_SETTLED/);


### PR DESCRIPTION
## Summary

Hardens the admin-panel UX so one logical click starts one async mutation, the clicked control immediately becomes pending/disabled with progress feedback, repeats are ignored, and the control is restored after success or error.

Stage 1 production evidence did not confirm a duplicate grant or backend idempotency defect; it confirmed the UI double-submit risk. This PR keeps backend, ledger, accounting, migrations, and CSP unchanged.

## Per-action pending keys

- `adjust-${userId}` — ADMIN_ADJUST; preserves the existing draft idempotency key until confirmed success.
- `bonus-campaign-save` and `bonus-campaign-status-${campaignId}`.
- `table-action-${tableId}` and `bot-claims-recovery-${tableId}`.
- `ops-${action}` — reconciler and stale-seat sweep.
- `bot-reaction-override`, `bot-reaction-default`, and `bot-reaction-policy`.
- `poker-debug-enable` and `poker-debug-disable:${scope}:${category}:${tableId}`.
- `poker-maintenance-cleanup` and `poker-maintenance-rotation:${tableId}`.

Maintenance cleanup, table rotations, bot-reaction controls, and DEBUG override rows no longer block their whole section. Read-only refresh/search/load/preflight flows remain unblocked.

## Intentional scoped locks

- `poker-maintenance-supervisor` is shared only by Apply maintenance state, Stop continuous tables, and Reconcile. They all change or operate on the same continuous-table supervisor state, so concurrent execution could race desired state/sweeps.
- `table-action-${tableId}` scopes the existing safety lock to one table; actions for other tables remain available because force-close/cleanup/reconcile on the same table can conflict.

## Tests

- `node --check js/admin-page.js`
- `XP_CORS_ALLOW=https://arcade.test node --test tests/admin-page.behavior.test.mjs tests/admin-page.contract.test.mjs tests/admin-endpoints.behavior.test.mjs tests/admin-ledger-adjust.behavior.test.mjs tests/admin-poker-maintenance.behavior.test.mjs tests/admin-poker-audit.behavior.test.mjs tests/admin-ledger-list.behavior.test.mjs` — 56/56
- Fundamental `ADMIN_ADJUST` coverage verifies pending duplicate suppression, re-enable after completion, and a deliberate subsequent submit.

Relates to #872.