### PR TITLE
chips: clean redundant ledger indexes

### DIFF
--- a/docs/issue-874-stage-2a-audit.md
+++ b/docs/issue-874-stage-2a-audit.md
@@ -1,14 +1,40 @@
 # Issue #874 — Stage 2A audit
 
-Audit date: 2026-08-10 UTC. Target: Production Supabase project
-`otbqfijerkieoxwpxjnm`. The catalog queries were read-only; no Production
-schema or ledger data was changed during the audit.
+Original audit date: 2026-08-10 UTC. Corrective snapshot: 2026-08-11 UTC.
+Target: Production Supabase project `otbqfijerkieoxwpxjnm`. The catalog
+queries were read-only; no Production schema or ledger data was changed.
+
+The 3,506,176-byte Production baseline in this document is real, but it is a
+small Production database: the corrective snapshot identified database
+`postgres` with 102 `chips_transactions` rows and 204 `chips_entries` rows.
+It must not be conflated with the approximately 59 MB / 31,878-transaction
+stress figures quoted in Issue #874. Those figures are not supported by the
+current Production catalog and are now treated as historical Stage/stress
+evidence pending independent source verification. The 63,553,536-byte
+before-snapshot below is explicitly Stage data, not Production data.
 
 The byte values below use the same functions as the existing #860 metrics:
 `pg_table_size`, `pg_indexes_size`, and `pg_total_relation_size`. Per-index
 sizes use `pg_relation_size`. `idx_scan` is supporting evidence only. The
 database reported `stats_reset = NULL`, so the scan counters are not treated
 as proof of non-use.
+
+## Corrected target snapshot before Production rollout
+
+This single read-only snapshot includes target identity, row counts, and all
+relation-size metrics. It was collected before any Production rollout.
+
+| Target | Project ref | Database | `chips_transactions` rows | `chips_entries` rows | Transactions table | Transactions indexes | Transactions total | Entries table | Entries indexes | Entries total | Combined total |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Production | `otbqfijerkieoxwpxjnm` | `postgres` | 102 | 204 | 737280 | 1425408 | 2162688 | 368640 | 974848 | 1343488 | 3506176 |
+| Stage, current post-migration snapshot | `krydukthwdvccggbyjfw` | `postgres` | 33908 | 67816 | 23330816 | 7938048 | 31268864 | 9084928 | 14188544 | 23273472 | 54542336 |
+
+The Production row counts and relation sizes above are the authoritative
+before values for a future Production rollout. If the same three confirmed
+redundant index relations are removed there, the directly observed
+per-index-sized overhead is 802816 bytes (about 0.8 MB / 0.77 MiB), subject to
+normal catalog-size variation. The larger 10,608,640-byte recovery belongs
+only to the historical Stage snapshot below.
 
 ## Production before
 
@@ -57,7 +83,7 @@ No `chips_entries` index was removed. `chips_entries_account_seq_idx` has
 not a redundant lookup index. The remaining indexes have query consumers and
 were left unchanged.
 
-### #860 before metrics
+### #860 Production before metrics
 
 | Relation | Table bytes | Index bytes | Total bytes |
 | --- | ---: | ---: | ---: |
@@ -98,13 +124,14 @@ all ledger rows and columns, all `chips_entries` indexes, append-only
 triggers, payload hashing, and accounting behavior. No archive/cold-storage
 work is included.
 
-## Safe-environment after verification
+## Safe-environment after verification (Stage, not Production)
 
 The migration was applied on the deploy-preview Stage project
 `krydukthwdvccggbyjfw` on 2026-08-10 UTC. Stage had the same ledger index
 layout as the Production audit before the migration. The migration history
-recorded version `20260810120000` and the existing stage migration smoke
-checks passed.
+recorded version `20260810120000` and the existing Stage migration smoke
+checks passed. These Stage values must not be reported as Production
+before/after metrics.
 
 ### #860 before/after comparison on Stage
 

--- a/docs/issue-874-stage-2a-audit.md
+++ b/docs/issue-874-stage-2a-audit.md
@@ -1,0 +1,158 @@
+# Issue #874 — Stage 2A audit
+
+Audit date: 2026-08-10 UTC. Target: Production Supabase project
+`otbqfijerkieoxwpxjnm`. The catalog queries were read-only; no Production
+schema or ledger data was changed during the audit.
+
+The byte values below use the same functions as the existing #860 metrics:
+`pg_table_size`, `pg_indexes_size`, and `pg_total_relation_size`. Per-index
+sizes use `pg_relation_size`. `idx_scan` is supporting evidence only. The
+database reported `stats_reset = NULL`, so the scan counters are not treated
+as proof of non-use.
+
+## Production before
+
+### Constraints
+
+| Table | Constraint | Type | Definition | Backing index |
+| --- | --- | --- | --- | --- |
+| `chips_entries` | `chips_entries_account_id_fkey` | FOREIGN KEY | `FOREIGN KEY (account_id) REFERENCES chips_accounts(id)` | `chips_accounts_pkey` |
+| `chips_entries` | `chips_entries_balanced_transaction` | constraint trigger | `TRIGGER DEFERRABLE INITIALLY DEFERRED` | — |
+| `chips_entries` | `chips_entries_entry_seq_positive` | CHECK | `CHECK (entry_seq > 0)` | — |
+| `chips_entries` | `chips_entries_non_zero_amount` | CHECK | `CHECK (amount <> 0)` | — |
+| `chips_entries` | `chips_entries_pkey` | PRIMARY KEY | `PRIMARY KEY (id)` | `chips_entries_pkey` |
+| `chips_entries` | `chips_entries_transaction_id_fkey` | FOREIGN KEY | `FOREIGN KEY (transaction_id) REFERENCES chips_transactions(id) ON DELETE CASCADE` | `chips_transactions_pkey` |
+| `chips_transactions` | `chips_transactions_idempotency_key_present` | CHECK | `CHECK (length(idempotency_key) > 0)` | — |
+| `chips_transactions` | `chips_transactions_idempotency_key_unique` | UNIQUE | `UNIQUE (idempotency_key)` | `chips_transactions_idempotency_key_unique` |
+| `chips_transactions` | `chips_transactions_payload_hash_present` | CHECK | `CHECK (length(payload_hash) > 0)` | — |
+| `chips_transactions` | `chips_transactions_pkey` | PRIMARY KEY | `PRIMARY KEY (id)` | `chips_transactions_pkey` |
+| `chips_transactions` | `chips_transactions_sequence_key` | UNIQUE | `UNIQUE (sequence)` | `chips_transactions_sequence_key` |
+| `chips_transactions` | `chips_transactions_sequence_positive` | CHECK | `CHECK (sequence > 0)` | — |
+
+### Indexes and usage
+
+| Table | Index | Definition | Bytes | `idx_scan` |
+| --- | --- | --- | ---: | ---: |
+| `chips_entries` | `chips_entries_account_created_seq_idx` | `btree (account_id, created_at DESC, entry_seq DESC)` | 344064 | 1763 |
+| `chips_entries` | `chips_entries_account_idx` | `btree (account_id)` | 73728 | 776 |
+| `chips_entries` | `chips_entries_account_seq_idx` | `UNIQUE btree (account_id, entry_seq) WHERE (entry_seq IS NOT NULL)` | 262144 | 0 |
+| `chips_entries` | `chips_entries_pkey` | `UNIQUE btree (id)` | 122880 | 41 |
+| `chips_entries` | `chips_entries_transaction_idx` | `btree (transaction_id)` | 172032 | 12560 |
+| `chips_transactions` | `chips_transactions_idempotency_idx` | `btree (idempotency_key)` | 352256 | 0 |
+| `chips_transactions` | `chips_transactions_idempotency_key_uidx` | `UNIQUE btree (idempotency_key)` | 352256 | 42 |
+| `chips_transactions` | `chips_transactions_idempotency_key_unique` | `UNIQUE btree (idempotency_key)` | 352256 | 9 |
+| `chips_transactions` | `chips_transactions_pkey` | `UNIQUE btree (id)` | 106496 | 205757 |
+| `chips_transactions` | `chips_transactions_sequence_key` | `UNIQUE btree (sequence)` | 98304 | 0 |
+| `chips_transactions` | `chips_transactions_tx_type_created_idx` | `btree (tx_type, created_at)` | 98304 | 61 |
+| `chips_transactions` | `chips_transactions_user_id_idx` | `btree (user_id)` | 40960 | 25 |
+
+The three `idempotency_key` indexes are equivalent for lookup, while the
+named UNIQUE constraint is the intended enforcement path. The two standalone
+indexes are therefore the Stage 2A cleanup targets. Production also has a
+legacy UNIQUE constraint/index on `chips_transactions.sequence`; no current
+`origin/main` consumer uses that column for lookup, ordering, or identity.
+
+No `chips_entries` index was removed. `chips_entries_account_seq_idx` has
+`idx_scan = 0`, but it is a UNIQUE invariant for `(account_id, entry_seq)`,
+not a redundant lookup index. The remaining indexes have query consumers and
+were left unchanged.
+
+### #860 before metrics
+
+| Relation | Table bytes | Index bytes | Total bytes |
+| --- | ---: | ---: | ---: |
+| `chips_transactions` | 737280 | 1425408 | 2162688 |
+| `chips_entries` | 368640 | 974848 | 1343488 |
+| **Combined ledger** | **1105920** | **2400256** | **3506176** |
+
+For reference, the raw heap-only sizes were 696320 bytes for
+`chips_transactions` and 327680 bytes for `chips_entries`. `pg_table_size`
+includes the table storage used by the #860 metric.
+
+## Consumer review
+
+- `idempotency_key`: `postTransaction()` performs the lookup, inserts the
+  transaction inside the accounting transaction, catches the unique race,
+  and compares `payload_hash`/`tx_type` for replay versus conflict behavior.
+  The WS ledger path, terminal close, admin adjustment, bonus, welcome-bonus,
+  admin ledger, and recovery/provenance paths use the same transaction
+  identity contract. None requires more than one unique structure.
+- `chips_transactions.sequence`: current `origin/main` contains no runtime,
+  admin, ledger API, reconciliation, recovery, or tooling consumer of this
+  column. The only non-migration sequence references are the separate
+  per-account `chips_entries.entry_seq` contract.
+- `chips_entries`: account history/cursor queries, transaction joins,
+  terminal close, recovery evidence, and admin ledger paths were inspected.
+  There was no sufficiently strong evidence to remove any of its indexes.
+
+## Stage 2A scope
+
+The accompanying migration drops only:
+
+- `chips_transactions_idempotency_idx`;
+- `chips_transactions_idempotency_key_uidx`;
+- the legacy `chips_transactions_sequence_key` UNIQUE constraint/index.
+
+It retains the named `chips_transactions_idempotency_key_unique` constraint,
+all ledger rows and columns, all `chips_entries` indexes, append-only
+triggers, payload hashing, and accounting behavior. No archive/cold-storage
+work is included.
+
+## Safe-environment after verification
+
+The migration was applied on the deploy-preview Stage project
+`krydukthwdvccggbyjfw` on 2026-08-10 UTC. Stage had the same ledger index
+layout as the Production audit before the migration. The migration history
+recorded version `20260810120000` and the existing stage migration smoke
+checks passed.
+
+### #860 before/after comparison on Stage
+
+| Relation | Metric | Before bytes | After bytes | Delta |
+| --- | --- | ---: | ---: | ---: |
+| `chips_transactions` | Table | 22609920 | 22609920 | 0 |
+| `chips_transactions` | Index | 18309120 | 7700480 | -10608640 |
+| `chips_transactions` | Total | 40919040 | 30310400 | -10608640 |
+| `chips_entries` | Table | 8839168 | 8839168 | 0 |
+| `chips_entries` | Index | 13795328 | 13795328 | 0 |
+| `chips_entries` | Total | 22634496 | 22634496 | 0 |
+| **Combined ledger** | **Table** | **31449088** | **31449088** | **0** |
+| **Combined ledger** | **Index** | **32104448** | **21495808** | **-10608640** |
+| **Combined ledger** | **Total** | **63553536** | **52944896** | **-10608640** |
+
+The observed relation-level recovery was 10,608,640 bytes (10.61 MB / 10.12
+MiB) from `chips_transactions` and the combined ledger. The three dropped
+index relations accounted for 10,534,912 bytes in the before per-index
+snapshot; `pg_indexes_size` also includes associated TOAST index storage and
+can vary between live catalog snapshots.
+
+### Stage after per-index snapshot
+
+| Table | Index | Bytes | `idx_scan` |
+| --- | --- | ---: | ---: |
+| `chips_entries` | `chips_entries_account_created_seq_idx` | 5062656 | 8504 |
+| `chips_entries` | `chips_entries_account_idx` | 909312 | 21382 |
+| `chips_entries` | `chips_entries_account_seq_idx` | 4096000 | 0 |
+| `chips_entries` | `chips_entries_pkey` | 1490944 | 3 |
+| `chips_entries` | `chips_entries_transaction_idx` | 2138112 | 391928 |
+| `chips_transactions` | `chips_transactions_idempotency_key_unique` | 4874240 | 2 |
+| `chips_transactions` | `chips_transactions_pkey` | 1236992 | 358583 |
+| `chips_transactions` | `chips_transactions_tx_type_created_idx` | 1171456 | 142 |
+| `chips_transactions` | `chips_transactions_user_id_idx` | 368640 | 510 |
+
+The after catalog has exactly one effective UNIQUE index for
+`chips_transactions.idempotency_key`, backed by the retained named UNIQUE
+constraint. The two standalone idempotency indexes and the
+`chips_transactions.sequence` UNIQUE index are absent. The `sequence` column
+still exists as an identity column, and all six non-internal ledger triggers
+remain enabled, including the deferred balancing trigger and append-only
+guards.
+
+A duplicate probe attempted to insert an existing idempotency key inside a
+PL/pgSQL subtransaction and was rejected by `unique_violation`; the stage
+transaction row count stayed at `32799`. Existing migration/accounting tests
+cover same-payload replay and payload-hash conflict behavior. An after-
+migration `EXPLAIN` for `where idempotency_key = $1` selected
+`chips_transactions_idempotency_key_unique`. Production rollout is a separate
+step; the existing #860 `transactionIndexBytes` and combined ledger metrics
+are the post-rollout measurement source.

--- a/supabase/migrations/20260810120000_chips_ledger_schema_cleanup.sql
+++ b/supabase/migrations/20260810120000_chips_ledger_schema_cleanup.sql
@@ -1,0 +1,12 @@
+-- Stage 2A: remove confirmed redundant ledger indexes.
+-- Keep the named UNIQUE constraint as the sole idempotency enforcement.
+drop index if exists public.chips_transactions_idempotency_idx;
+drop index if exists public.chips_transactions_idempotency_key_uidx;
+
+-- chips_transactions.sequence is retained for compatibility, but its legacy
+-- UNIQUE constraint has no runtime/query consumer.
+alter table if exists public.chips_transactions
+  drop constraint if exists chips_transactions_sequence_key;
+
+-- Covers a standalone index with the legacy name if a deployed schema has one.
+drop index if exists public.chips_transactions_sequence_key;

--- a/tests/chips-ledger.test.mjs
+++ b/tests/chips-ledger.test.mjs
@@ -86,7 +86,7 @@ function normalizeTimestampLabel(label) {
 function handleLedgerQuery(query, params = []) {
   const text = normalizeSql(normalizeQueryText(query));
 
-  if (text.includes("from public.chips_accounts") && text.includes("account_type = 'user'") && text.includes("user_id")) {
+  if (text.includes("from public.chips_accounts") && text.includes("account_type = 'user'") && text.includes("user_id") && text.includes("with existing as")) {
     const userId = params[0];
     const account = ensureUserAccount(userId);
     return [{ account }];
@@ -97,7 +97,7 @@ function handleLedgerQuery(query, params = []) {
     return [...mockDb.accounts.values()].filter(acc => keys.includes(acc.system_key));
   }
 
-  if (text.includes("from public.chips_transactions") && text.includes("idempotency_key")) {
+  if (text.includes("from public.chips_transactions") && text.includes("where idempotency_key")) {
     const key = params[0];
     const existing = [...mockDb.transactions.values()].find(tx => tx.idempotency_key === key);
     return existing ? [existing] : [];
@@ -321,7 +321,7 @@ function makeTxRunner() {
       if (existing) {
         const duplicate = new Error("duplicate key value violates unique constraint\n");
         duplicate.code = "23505";
-        duplicate.constraint = "chips_transactions_idempotency_key_uidx";
+        duplicate.constraint = "chips_transactions_idempotency_key_unique";
         throw duplicate;
       }
       const txRow = {
@@ -353,7 +353,7 @@ function makeTxRunner() {
     return handleLedgerQuery(text, params);
   };
 
-  const tx = (...args) => runQuery(...args);
+  const tx = (query, ...params) => runQuery(query, params);
   tx.unsafe = runQuery;
   return tx;
 }


### PR DESCRIPTION
## Summary

Addresses the Stage 2A review findings for issue #874 without changing the migration or accounting runtime.

- Keeps `chips_transactions_idempotency_key_unique` as the sole UNIQUE enforcement for `idempotency_key`.
- Drops the redundant standalone `chips_transactions_idempotency_idx` and `chips_transactions_idempotency_key_uidx`.
- Drops the legacy UNIQUE constraint/index for `chips_transactions.sequence`, while retaining the column.
- Leaves all `chips_entries` indexes unchanged.
- Corrects the audit and Issue #874 evidence labels.
- Updates the existing replay fixture to use `chips_transactions_idempotency_key_unique`; no new test was added.

## Evidence correction

A new read-only snapshot identified the configured Production target as Supabase project `otbqfijerkieoxwpxjnm`, database `postgres`, with 102 transactions and 204 entries:

- `chips_transactions`: table 737,280 B; indexes 1,425,408 B; total 2,162,688 B.
- `chips_entries`: table 368,640 B; indexes 974,848 B; total 1,343,488 B.
- Combined ledger: 3,506,176 B.

The approximately 59 MB / 31,878-transaction figures in Issue #874 were not consistent with that Production catalog and are now labeled historical Stage/stress evidence. Issue #874 and `docs/issue-874-stage-2a-audit.md` now explicitly separate the targets.

## Stage verification

The migration was applied to Stage project `krydukthwdvccggbyjfw`:

- Before: 63,553,536 B combined ledger.
- After: 52,944,896 B combined ledger.
- Observed recovery: 10,608,640 B (10.61 MB / 10.12 MiB).
- Production has not been modified. Based on the verified Production snapshot, the three removed index relations represent approximately 802,816 B (about 0.8 MB / 0.77 MiB), subject to catalog variation.

## Validation

Passed:

- migration validation;
- syntax validation;
- existing `postTransaction()` replay/payload-conflict tests (4 tests);
- chips escrow-only unit test;
- poker settlement idempotency test.

The branch is synchronized with current `origin/main`, so the DB Stage Apply PR merge-base gate can run with the complete base history.

No ledger rows, balances, transaction/entry creation, append-only triggers, provenance fields, WS, UI, archive, or cold-storage behavior are changed.