### PR TITLE
Record Stage 2A Production after metrics

### DIFF
--- a/docs/issue-874-stage-2a-audit.md
+++ b/docs/issue-874-stage-2a-audit.md
@@ -1,139 +1,69 @@
 # Issue #874 — Stage 2A audit
 
-Original audit date: 2026-08-10 UTC. Corrective snapshot: 2026-08-11 UTC.
-Target: Production Supabase project `otbqfijerkieoxwpxjnm`. The catalog
-queries were read-only; no Production schema or ledger data was changed.
+Audit date: 2026-08-10 UTC. Production rollout and corrective snapshot:
+2026-08-11 UTC.
 
-The 3,506,176-byte Production baseline in this document is real, but it is a
-small Production database: the corrective snapshot identified database
-`postgres` with 102 `chips_transactions` rows and 204 `chips_entries` rows.
-It must not be conflated with the approximately 59 MB / 31,878-transaction
-stress figures quoted in Issue #874. Those figures are not supported by the
-current Production catalog and are now treated as historical Stage/stress
-evidence pending independent source verification. The 63,553,536-byte
-before-snapshot below is explicitly Stage data, not Production data.
+## Status
 
-The byte values below use the same functions as the existing #860 metrics:
-`pg_table_size`, `pg_indexes_size`, and `pg_total_relation_size`. Per-index
-sizes use `pg_relation_size`. `idx_scan` is supporting evidence only. The
-database reported `stats_reset = NULL`, so the scan counters are not treated
-as proof of non-use.
+Stage 2A is complete:
 
-## Corrected target snapshot before Production rollout
+- PR #876 was merged to `main`;
+- migration `20260810120000_chips_ledger_schema_cleanup.sql` was applied to
+  Production;
+- the Production smoke test passed;
+- no WS/runtime deploy was required and no accounting behavior was changed.
 
-This single read-only snapshot includes target identity, row counts, and all
-relation-size metrics. It was collected before any Production rollout.
+## Production evidence correction
 
-| Target | Project ref | Database | `chips_transactions` rows | `chips_entries` rows | Transactions table | Transactions indexes | Transactions total | Entries table | Entries indexes | Entries total | Combined total |
-| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Production | `otbqfijerkieoxwpxjnm` | `postgres` | 102 | 204 | 737280 | 1425408 | 2162688 | 368640 | 974848 | 1343488 | 3506176 |
-| Stage, current post-migration snapshot | `krydukthwdvccggbyjfw` | `postgres` | 33908 | 67816 | 23330816 | 7938048 | 31268864 | 9084928 | 14188544 | 23273472 | 54542336 |
+The earlier 3,506,176-byte snapshot with 102 `chips_transactions` rows and
+204 `chips_entries` rows was not representative of the operator-confirmed
+Production database and is withdrawn. It must not be used as a Production
+baseline or as evidence that Stage 2A would reclaim only about 0.8 MB.
 
-The Production row counts and relation sizes above are the authoritative
-before values for a future Production rollout. If the same three confirmed
-redundant index relations are removed there, the directly observed
-per-index-sized overhead is 802816 bytes (about 0.8 MB / 0.77 MiB), subject to
-normal catalog-size variation. The larger 10,608,640-byte recovery belongs
-only to the historical Stage snapshot below.
+The post-migration snapshot below was run by the operator against Production.
+It is consistent with the approximately 59 MB / 31,878-transaction
+continuous-poker measurement recorded before the cleanup, allowing for
+continued ledger growth between snapshots.
 
-## Production before
+## Production after Stage 2A
 
-### Constraints
+| Relation | Rows | Table bytes | Index bytes | Total bytes |
+| --- | ---: | ---: | ---: | ---: |
+| `chips_transactions` | 34261 | 23552000 | 7987200 | 31539200 |
+| `chips_entries` | 68522 | 9150464 | 14327808 | 23478272 |
+| **Combined ledger** | — | **32702464** | **22315008** | **55017472** |
 
-| Table | Constraint | Type | Definition | Backing index |
-| --- | --- | --- | --- | --- |
-| `chips_entries` | `chips_entries_account_id_fkey` | FOREIGN KEY | `FOREIGN KEY (account_id) REFERENCES chips_accounts(id)` | `chips_accounts_pkey` |
-| `chips_entries` | `chips_entries_balanced_transaction` | constraint trigger | `TRIGGER DEFERRABLE INITIALLY DEFERRED` | — |
-| `chips_entries` | `chips_entries_entry_seq_positive` | CHECK | `CHECK (entry_seq > 0)` | — |
-| `chips_entries` | `chips_entries_non_zero_amount` | CHECK | `CHECK (amount <> 0)` | — |
-| `chips_entries` | `chips_entries_pkey` | PRIMARY KEY | `PRIMARY KEY (id)` | `chips_entries_pkey` |
-| `chips_entries` | `chips_entries_transaction_id_fkey` | FOREIGN KEY | `FOREIGN KEY (transaction_id) REFERENCES chips_transactions(id) ON DELETE CASCADE` | `chips_transactions_pkey` |
-| `chips_transactions` | `chips_transactions_idempotency_key_present` | CHECK | `CHECK (length(idempotency_key) > 0)` | — |
-| `chips_transactions` | `chips_transactions_idempotency_key_unique` | UNIQUE | `UNIQUE (idempotency_key)` | `chips_transactions_idempotency_key_unique` |
-| `chips_transactions` | `chips_transactions_payload_hash_present` | CHECK | `CHECK (length(payload_hash) > 0)` | — |
-| `chips_transactions` | `chips_transactions_pkey` | PRIMARY KEY | `PRIMARY KEY (id)` | `chips_transactions_pkey` |
-| `chips_transactions` | `chips_transactions_sequence_key` | UNIQUE | `UNIQUE (sequence)` | `chips_transactions_sequence_key` |
-| `chips_transactions` | `chips_transactions_sequence_positive` | CHECK | `CHECK (sequence > 0)` | — |
+The combined ledger currently occupies 55.02 MB / 52.47 MiB.
 
-### Indexes and usage
+The remaining `chips_transactions` indexes are exactly the intended set:
 
-| Table | Index | Definition | Bytes | `idx_scan` |
-| --- | --- | --- | ---: | ---: |
-| `chips_entries` | `chips_entries_account_created_seq_idx` | `btree (account_id, created_at DESC, entry_seq DESC)` | 344064 | 1763 |
-| `chips_entries` | `chips_entries_account_idx` | `btree (account_id)` | 73728 | 776 |
-| `chips_entries` | `chips_entries_account_seq_idx` | `UNIQUE btree (account_id, entry_seq) WHERE (entry_seq IS NOT NULL)` | 262144 | 0 |
-| `chips_entries` | `chips_entries_pkey` | `UNIQUE btree (id)` | 122880 | 41 |
-| `chips_entries` | `chips_entries_transaction_idx` | `btree (transaction_id)` | 172032 | 12560 |
-| `chips_transactions` | `chips_transactions_idempotency_idx` | `btree (idempotency_key)` | 352256 | 0 |
-| `chips_transactions` | `chips_transactions_idempotency_key_uidx` | `UNIQUE btree (idempotency_key)` | 352256 | 42 |
-| `chips_transactions` | `chips_transactions_idempotency_key_unique` | `UNIQUE btree (idempotency_key)` | 352256 | 9 |
-| `chips_transactions` | `chips_transactions_pkey` | `UNIQUE btree (id)` | 106496 | 205757 |
-| `chips_transactions` | `chips_transactions_sequence_key` | `UNIQUE btree (sequence)` | 98304 | 0 |
-| `chips_transactions` | `chips_transactions_tx_type_created_idx` | `btree (tx_type, created_at)` | 98304 | 61 |
-| `chips_transactions` | `chips_transactions_user_id_idx` | `btree (user_id)` | 40960 | 25 |
+- `chips_transactions_idempotency_key_unique`;
+- `chips_transactions_pkey`;
+- `chips_transactions_tx_type_created_idx`;
+- `chips_transactions_user_id_idx`.
 
-The three `idempotency_key` indexes are equivalent for lookup, while the
-named UNIQUE constraint is the intended enforcement path. The two standalone
-indexes are therefore the Stage 2A cleanup targets. Production also has a
-legacy UNIQUE constraint/index on `chips_transactions.sequence`; no current
-`origin/main` consumer uses that column for lookup, ordering, or identity.
-
-No `chips_entries` index was removed. `chips_entries_account_seq_idx` has
-`idx_scan = 0`, but it is a UNIQUE invariant for `(account_id, entry_seq)`,
-not a redundant lookup index. The remaining indexes have query consumers and
-were left unchanged.
-
-### #860 Production before metrics
-
-| Relation | Table bytes | Index bytes | Total bytes |
-| --- | ---: | ---: | ---: |
-| `chips_transactions` | 737280 | 1425408 | 2162688 |
-| `chips_entries` | 368640 | 974848 | 1343488 |
-| **Combined ledger** | **1105920** | **2400256** | **3506176** |
-
-For reference, the raw heap-only sizes were 696320 bytes for
-`chips_transactions` and 327680 bytes for `chips_entries`. `pg_table_size`
-includes the table storage used by the #860 metric.
-
-## Consumer review
-
-- `idempotency_key`: `postTransaction()` performs the lookup, inserts the
-  transaction inside the accounting transaction, catches the unique race,
-  and compares `payload_hash`/`tx_type` for replay versus conflict behavior.
-  The WS ledger path, terminal close, admin adjustment, bonus, welcome-bonus,
-  admin ledger, and recovery/provenance paths use the same transaction
-  identity contract. None requires more than one unique structure.
-- `chips_transactions.sequence`: current `origin/main` contains no runtime,
-  admin, ledger API, reconciliation, recovery, or tooling consumer of this
-  column. The only non-migration sequence references are the separate
-  per-account `chips_entries.entry_seq` contract.
-- `chips_entries`: account history/cursor queries, transaction joins,
-  terminal close, recovery evidence, and admin ledger paths were inspected.
-  There was no sufficiently strong evidence to remove any of its indexes.
-
-## Stage 2A scope
-
-The accompanying migration drops only:
+The migration removed:
 
 - `chips_transactions_idempotency_idx`;
 - `chips_transactions_idempotency_key_uidx`;
 - the legacy `chips_transactions_sequence_key` UNIQUE constraint/index.
 
-It retains the named `chips_transactions_idempotency_key_unique` constraint,
-all ledger rows and columns, all `chips_entries` indexes, append-only
-triggers, payload hashing, and accounting behavior. No archive/cold-storage
-work is included.
+Therefore Production now has one authoritative UNIQUE enforcement for
+`idempotency_key`. The `sequence` column remains an identity column; only its
+unused UNIQUE constraint/index was removed. All `chips_entries` indexes were
+left unchanged.
 
-## Safe-environment after verification (Stage, not Production)
+## Storage impact
 
-The migration was applied on the deploy-preview Stage project
-`krydukthwdvccggbyjfw` on 2026-08-10 UTC. Stage had the same ledger index
-layout as the Production audit before the migration. The migration history
-recorded version `20260810120000` and the existing Stage migration smoke
-checks passed. These Stage values must not be reported as Production
-before/after metrics.
+An exact Production byte delta cannot be calculated from the available
+snapshots. The original exact "before" snapshot was invalid, while the
+approximately 59 MB historical measurement and the exact 55,017,472-byte
+after snapshot were collected at different row counts during continuous
+ledger writes. Subtracting them would mix cleanup savings with intervening
+growth and catalog variation.
 
-### #860 before/after comparison on Stage
+The controlled Stage before/after measurement remains the direct isolation of
+the migration's effect:
 
 | Relation | Metric | Before bytes | After bytes | Delta |
 | --- | --- | ---: | ---: | ---: |
@@ -147,39 +77,34 @@ before/after metrics.
 | **Combined ledger** | **Index** | **32104448** | **21495808** | **-10608640** |
 | **Combined ledger** | **Total** | **63553536** | **52944896** | **-10608640** |
 
-The observed relation-level recovery was 10,608,640 bytes (10.61 MB / 10.12
-MiB) from `chips_transactions` and the combined ledger. The three dropped
-index relations accounted for 10,534,912 bytes in the before per-index
-snapshot; `pg_indexes_size` also includes associated TOAST index storage and
-can vary between live catalog snapshots.
+Stage recovered 10,608,640 bytes (10.61 MB / 10.12 MiB), entirely from
+`chips_transactions` index storage. Production had the same redundant schema,
+but its exact reclaimed bytes were not measured against a valid same-workload
+before snapshot.
 
-### Stage after per-index snapshot
+## Contract verification
 
-| Table | Index | Bytes | `idx_scan` |
-| --- | --- | ---: | ---: |
-| `chips_entries` | `chips_entries_account_created_seq_idx` | 5062656 | 8504 |
-| `chips_entries` | `chips_entries_account_idx` | 909312 | 21382 |
-| `chips_entries` | `chips_entries_account_seq_idx` | 4096000 | 0 |
-| `chips_entries` | `chips_entries_pkey` | 1490944 | 3 |
-| `chips_entries` | `chips_entries_transaction_idx` | 2138112 | 391928 |
-| `chips_transactions` | `chips_transactions_idempotency_key_unique` | 4874240 | 2 |
-| `chips_transactions` | `chips_transactions_pkey` | 1236992 | 358583 |
-| `chips_transactions` | `chips_transactions_tx_type_created_idx` | 1171456 | 142 |
-| `chips_transactions` | `chips_transactions_user_id_idx` | 368640 | 510 |
+- `postTransaction()` still uses the retained UNIQUE constraint for atomic
+  idempotency and compares `payload_hash`/`tx_type` for replay versus conflict.
+- Existing replay/conflict tests use
+  `chips_transactions_idempotency_key_unique` and passed.
+- The Stage duplicate probe was rejected by `unique_violation` without
+  changing the transaction row count.
+- `EXPLAIN` selected `chips_transactions_idempotency_key_unique` for lookup by
+  `idempotency_key`.
+- No current runtime, admin, recovery, reconciliation, or tooling consumer
+  depends on `chips_transactions.sequence` uniqueness.
+- The Production smoke test passed after the migration.
 
-The after catalog has exactly one effective UNIQUE index for
-`chips_transactions.idempotency_key`, backed by the retained named UNIQUE
-constraint. The two standalone idempotency indexes and the
-`chips_transactions.sequence` UNIQUE index are absent. The `sequence` column
-still exists as an identity column, and all six non-internal ledger triggers
-remain enabled, including the deferred balancing trigger and append-only
-guards.
+## Scope and breaking impact
 
-A duplicate probe attempted to insert an existing idempotency key inside a
-PL/pgSQL subtransaction and was rejected by `unique_violation`; the stage
-transaction row count stayed at `32799`. Existing migration/accounting tests
-cover same-payload replay and payload-hash conflict behavior. An after-
-migration `EXPLAIN` for `where idempotency_key = $1` selected
-`chips_transactions_idempotency_key_unique`. Production rollout is a separate
-step; the existing #860 `transactionIndexBytes` and combined ledger metrics
-are the post-rollout measurement source.
+Stage 2A changed schema/index storage only. It did not change ledger rows,
+balances, double-entry accounting, append-only triggers, payload hashing,
+replay behavior, `chips_entries`, WS, or UI.
+
+The only schema-contract change is that `chips_transactions.sequence` is no
+longer guaranteed UNIQUE. No current consumer depends on that guarantee.
+
+Stage 2A does not bound future ledger growth. Stage 2B remains responsible for
+the hot/cold archival design and its accounting, idempotency, provenance, and
+history contracts.


### PR DESCRIPTION
## What changed

- replace the invalid 102/204-row Production snapshot in the Stage 2A audit with the operator-confirmed post-migration metrics;
- record the exact remaining `chips_transactions` indexes and Production smoke PASS;
- retain the controlled Stage delta as the only isolated measurement of reclaimed bytes;
- explain why an exact Production reclaimed-byte delta cannot be derived from non-simultaneous snapshots during continuous writes.

## Impact

Documentation only. No schema, runtime, WS, UI, or accounting behavior changes.

## Validation

The documented totals reconcile exactly:

- table bytes: 32,702,464;
- index bytes: 22,315,008;
- combined total: 55,017,472.

Issue #874 and its Stage 2B direction comment were updated with the same corrected Production evidence.