### PR TITLE
ops: add read-only chips ledger archive export

### DIFF
--- a/docs/issue-874-stage-2b1-ledger-archive-export.md
+++ b/docs/issue-874-stage-2b1-ledger-archive-export.md
@@ -49,8 +49,9 @@ run. Store the output outside the repository with restrictive permissions.
 - `--batch-size <integer>` — defaults to and is capped at `5000`.
 - `--after-created-at <timestamp>` and `--after-id <uuid>` — the pair is the
   keyset cursor for resuming a batch.
-- `--output <path>` — local `.jsonl.gz` artifact. Existing files are never
-  overwritten.
+- `--output <path>` — required local `.jsonl.gz` artifact path. Use a private
+  path outside the repository; there is no default artifact path. Existing
+  files are never overwritten.
 - `--manifest <path>` — local manifest; defaults to
   `<output>.manifest.json`. Existing files are never overwritten.
 

--- a/docs/issue-874-stage-2b1-ledger-archive-export.md
+++ b/docs/issue-874-stage-2b1-ledger-archive-export.md
@@ -1,0 +1,210 @@
+# Issue #874 — Stage 2B.1 read-only ledger archive export
+
+Status: prototype only. This document describes the exporter added by this PR.
+
+The exporter measures the size of a complete, immutable ledger batch before a
+cold-storage design is selected. It writes a local `.jsonl.gz` file and a local
+JSON manifest. It does not upload to Supabase Storage, create a bucket, delete
+rows, prune history, write a remote manifest, or modify any database row.
+
+## Running it on Stage
+
+Use a private shell and the existing target-specific PostgreSQL configuration.
+The target is deliberately explicit; there is no default target.
+
+```sh
+set +o history
+read -rsp 'Stage PostgreSQL connection string: ' SUPABASE_STAGE_DB_URL
+printf '\n'
+export SUPABASE_STAGE_DB_URL
+export EXPECTED_SUPABASE_STAGE_PROJECT_REF=krydukthwdvccggbyjfw
+export EXPECTED_SUPABASE_PROD_PROJECT_REF=otbqfijerkieoxwpxjnm
+set -o history
+
+node scripts/ops/chips-ledger-archive-export.mjs \
+  --target stage \
+  --cutoff-days 30 \
+  --batch-size 5000 \
+  --output /private/path/chips-ledger-stage-2026-08-11.jsonl.gz
+```
+
+`SUPABASE_PROD_DB_URL` is selected only when `--target prod` is explicitly
+requested. Both expected project refs are checked against the versioned
+canonical refs, and the selected URL is checked against the selected ref. Do
+not run the Production target as part of this PR validation. The Production
+path is read-only by construction and is reserved for a separately approved
+measurement.
+
+The connection string is never printed. Clear database variables after the
+run. Store the output outside the repository with restrictive permissions.
+
+## Parameters
+
+- `--target stage|prod` — required. Unknown values and omitted target fail
+  closed.
+- `--cutoff <timestamp>` — explicit timezone-aware cutoff. A transaction is
+  eligible only when `created_at < cutoff` (strict comparison).
+- `--cutoff-days <integer>` — defaults to `30`; used to calculate the cutoff
+  at process start when `--cutoff` is absent.
+- `--batch-size <integer>` — defaults to and is capped at `5000`.
+- `--after-created-at <timestamp>` and `--after-id <uuid>` — the pair is the
+  keyset cursor for resuming a batch.
+- `--output <path>` — local `.jsonl.gz` artifact. Existing files are never
+  overwritten.
+- `--manifest <path>` — local manifest; defaults to
+  `<output>.manifest.json`. Existing files are never overwritten.
+
+The target-specific variables follow the existing operations convention:
+`SUPABASE_STAGE_DB_URL` / `SUPABASE_PROD_DB_URL` and
+`EXPECTED_SUPABASE_STAGE_PROJECT_REF` /
+`EXPECTED_SUPABASE_PROD_PROJECT_REF`. The older
+`SUPABASE_STAGE_PROJECT_REF` / `SUPABASE_PROD_PROJECT_REF` names are accepted
+as compatibility aliases for the expected refs.
+
+## JSONL record contract
+
+The gzip payload is UTF-8 JSON Lines with one complete transaction per line and
+a final newline. There is no header or manifest line. Each record has this
+shape (field names are part of the prototype contract):
+
+```json
+{
+  "schema_version": 1,
+  "record_type": "chips_transaction",
+  "transaction": {
+    "id": "uuid",
+    "sequence": "bigint-as-string",
+    "tx_type": "TABLE_BUY_IN",
+    "idempotency_key": "…",
+    "payload_hash": "…",
+    "user_id": "uuid-or-null",
+    "reference": "…",
+    "description": "…",
+    "metadata": {},
+    "created_by": "uuid-or-null",
+    "created_at": "2026-01-01T00:00:00.000000Z"
+  },
+  "table_context": null,
+  "entries": [
+    {
+      "id": "bigint-as-string",
+      "transaction_id": "uuid",
+      "account_id": "uuid",
+      "entry_seq": "bigint-as-string",
+      "amount": "bigint-as-string",
+      "metadata": {},
+      "created_at": "2026-01-01T00:00:00.000000Z",
+      "account": {
+        "id": "uuid",
+        "account_type": "USER|SYSTEM|ESCROW",
+        "user_id": "uuid-or-null",
+        "system_key": "TREASURY-or-null",
+        "status": "active",
+        "label": "optional label"
+      }
+    }
+  ]
+}
+```
+
+`sequence`, entry `id`, `entry_seq`, and `amount` are always strings in the
+serialized contract. Account identity is repeated with every entry so the
+record can be interpreted without querying `chips_accounts`; in particular,
+`account_type`, `user_id`, and `system_key` are retained. Current transaction
+columns and current entry columns are exported; `table_context` is derived
+eligibility evidence, not a second accounting source of truth.
+
+## Eligibility and lifecycle safety
+
+The exporter reads all rows in one PostgreSQL `REPEATABLE READ, READ ONLY`
+transaction. Poker lifecycle association is detected from any of the current
+consumer shapes:
+
+- `metadata.tableId`;
+- `reference` beginning with `table:<tableId>` or `poker-rebuy:<tableId>`;
+- an entry whose account is an `ESCROW` account with
+  `system_key = POKER_TABLE:<tableId>`.
+
+For a transaction with no such marker, no poker-specific restriction is added.
+For a marked transaction, all of these conditions must hold:
+
+- the transaction is older than the cutoff;
+- the table is absent because retention removed it, or its current status is
+  exactly `CLOSED`;
+- the corresponding `ESCROW` account exists and its balance is exactly `0`;
+- the table ID is a valid UUID and the transaction has one unambiguous table
+  ID.
+
+An active or otherwise non-`CLOSED` table, a missing escrow, a non-zero escrow,
+an invalid marker, or multiple table IDs makes the transaction ineligible.
+This keeps terminal-close bot provenance and bot-claims recovery hot-only;
+neither runtime path reads the local archive. A deleted `poker_tables` row is
+not treated as proof by itself—the zero escrow check is still required.
+
+## Cursor and resume semantics
+
+Selection order is deterministic:
+
+```text
+transaction.created_at ASC, transaction.id ASC
+```
+
+The UUID is the stable tie-breaker. The manifest reports the input cursor, the
+first/last timestamps, and `cursor.next` containing the last exported
+`created_at` and `id`. Resume with those two values:
+
+```sh
+node scripts/ops/chips-ledger-archive-export.mjs \
+  --target stage \
+  --cutoff '2026-07-12T00:00:00.000000Z' \
+  --after-created-at '2026-01-01T00:00:00.000000Z' \
+  --after-id '00000000-0000-4000-8000-000000000001' \
+  --output /private/path/next-batch.jsonl.gz
+```
+
+The cursor is a position in the ordered eligible snapshot, not an idempotency
+registry. For a later run against a changing database, rerun with an overlap
+or from the beginning if a previously active table may have become eligible
+before the saved cursor. The manifest/checksum identifies exactly what was
+written by each batch.
+
+## Verification performed before writing
+
+The exporter does not create either output until all checks pass. It verifies:
+
+- every selected transaction has exactly the database-reported number of
+  entries;
+- every entry belongs to that transaction and entry IDs are unique in the
+  batch;
+- transaction IDs are unique and ordered by the stated cursor order;
+- every transaction is older than the cutoff and satisfies lifecycle
+  eligibility;
+- the exact `bigint` sum of entries for every transaction is zero;
+- the JSONL serializes and parses back identically;
+- gzip decompression reproduces the exact raw JSONL bytes;
+- raw/compressed byte counts and SHA-256 hashes match the manifest.
+
+The sidecar manifest reports transaction and entry counts, sorted `tx_type`
+counts, time range, cursor position, raw bytes, compressed bytes, the
+compressed-over-raw ratio, and both raw JSONL and compressed-artifact SHA-256
+hashes. The ratio is defined as `compressed_bytes / raw_bytes`; an empty batch
+reports `null` for this ratio.
+
+## Stage measurement to add to Issue #874
+
+After the Stage run, add the manifest values to Issue #874, including:
+
+- exact cutoff and cursor start/end;
+- transaction and entry counts;
+- `tx_type` distribution;
+- first/last transaction timestamps;
+- raw and compressed bytes and compressed/raw ratio;
+- compressed artifact SHA-256;
+- batch duration and whether the batch was resumed;
+- any incomplete or ineligible rows observed (the expected result is zero
+  exported failures).
+
+These measurements are the evidence needed to estimate bytes per transaction,
+bytes per day, object sizes below the future Storage limit, and the next
+Stage 2B design. This prototype intentionally makes no claim about a final
+retention, idempotency registry, upload, or deletion strategy.

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -1,0 +1,726 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+import postgres from "postgres";
+
+export const EXPORT_SCHEMA_VERSION = 1;
+export const DEFAULT_CUTOFF_DAYS = 30;
+export const DEFAULT_BATCH_SIZE = 5000;
+export const MAX_BATCH_SIZE = 5000;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const INTEGER_RE = /^-?(?:0|[1-9][0-9]*)$/;
+const PROJECT_REF_RE = /^[a-z0-9]{20}$/;
+
+// Keep these bindings in sync with scripts/ops/ch-economy-network-maintenance.sh.
+const TARGETS = Object.freeze({
+  stage: Object.freeze({
+    label: "Stage",
+    dbEnv: "SUPABASE_STAGE_DB_URL",
+    expectedRefEnv: "EXPECTED_SUPABASE_STAGE_PROJECT_REF",
+    legacyRefEnv: "SUPABASE_STAGE_PROJECT_REF",
+    canonicalRef: "krydukthwdvccggbyjfw",
+  }),
+  prod: Object.freeze({
+    label: "Production",
+    dbEnv: "SUPABASE_PROD_DB_URL",
+    expectedRefEnv: "EXPECTED_SUPABASE_PROD_PROJECT_REF",
+    legacyRefEnv: "SUPABASE_PROD_PROJECT_REF",
+    canonicalRef: "otbqfijerkieoxwpxjnm",
+  }),
+});
+
+const CANDIDATE_SQL = `
+with base as (
+  select t.*
+  from public.chips_transactions t
+  where t.created_at < $1::timestamptz
+    and (
+      $3::timestamptz is null
+      or t.created_at > $3::timestamptz
+      or (t.created_at = $3::timestamptz and t.id > $4::uuid)
+    )
+), markers as (
+  select b.id as transaction_id,
+         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id
+  from base b
+  where nullif(btrim(b.metadata->>'tableId'), '') is not null
+
+  union all
+
+  select b.id,
+         case
+           when lower(b.reference) like 'table:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           when lower(b.reference) like 'poker-rebuy:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           else null
+         end
+  from base b
+  where lower(b.reference) like 'table:%'
+     or lower(b.reference) like 'poker-rebuy:%'
+
+  union all
+
+  select b.id,
+         lower(nullif(btrim(substring(a.system_key from 13)), ''))
+  from base b
+  join public.chips_entries e on e.transaction_id = b.id
+  join public.chips_accounts a on a.id = e.account_id
+  where a.account_type = 'ESCROW'
+    and upper(a.system_key) like 'POKER_TABLE:%'
+), marker_summary as (
+  select transaction_id,
+         array_agg(distinct table_id) filter (where table_id is not null) as table_ids,
+         bool_or(table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
+  from markers
+  group by transaction_id
+), classified as (
+  select b.*,
+         coalesce(ms.table_ids, array[]::text[]) as table_ids,
+         coalesce(ms.invalid_table_marker, false) as invalid_table_marker
+  from base b
+  left join marker_summary ms on ms.transaction_id = b.id
+)
+select
+  c.id::text as id,
+  c.sequence::text as sequence,
+  c.tx_type::text as tx_type,
+  c.idempotency_key,
+  c.payload_hash,
+  c.user_id::text as user_id,
+  c.reference,
+  c.description,
+  c.metadata,
+  c.created_by::text as created_by,
+  c.created_at::text as created_at,
+  (cardinality(c.table_ids) > 0) as table_related,
+  c.table_ids[1] as table_id,
+  c.invalid_table_marker,
+  (p.id is not null) as table_exists,
+  p.status::text as table_status,
+  ea.id::text as escrow_account_id,
+  ea.status::text as escrow_status,
+  ea.balance::text as escrow_balance,
+  (select count(*)::text from public.chips_entries e where e.transaction_id = c.id) as entry_count
+from classified c
+left join public.poker_tables p on p.id::text = c.table_ids[1]
+left join public.chips_accounts ea
+  on ea.account_type = 'ESCROW'
+ and ea.system_key = 'POKER_TABLE:' || c.table_ids[1]
+where c.invalid_table_marker = false
+  and cardinality(c.table_ids) <= 1
+  and (
+    cardinality(c.table_ids) = 0
+    or (
+      (p.id is null or upper(p.status) = 'CLOSED')
+      and ea.id is not null
+      and ea.balance = 0
+    )
+  )
+  and exists (select 1 from public.chips_entries e where e.transaction_id = c.id)
+order by c.created_at asc, c.id asc
+limit $2::int;
+`;
+
+const ENTRIES_SQL = `
+select
+  e.id::text as id,
+  e.transaction_id::text as transaction_id,
+  e.account_id::text as account_id,
+  e.entry_seq::text as entry_seq,
+  e.amount::text as amount,
+  e.metadata,
+  e.created_at::text as created_at,
+  a.id::text as account_row_id,
+  a.account_type::text as account_type,
+  a.user_id::text as account_user_id,
+  a.system_key as account_system_key,
+  a.status::text as account_status,
+  a.label as account_label
+from public.chips_entries e
+join public.chips_accounts a on a.id = e.account_id
+where e.transaction_id = any($1::uuid[])
+order by e.transaction_id asc, e.id asc;
+`;
+
+const HELP = `Usage: node scripts/ops/chips-ledger-archive-export.mjs [options]
+
+Required:
+  --target stage|prod             Explicit target; no default.
+
+Selection:
+  --cutoff <timestamp>            Strict upper bound for transaction.created_at.
+  --cutoff-days <integer>         Default: 30; ignored when --cutoff is set.
+  --batch-size <integer>          Default/max: 5000.
+  --after-created-at <timestamp>  Resume cursor timestamp.
+  --after-id <uuid>               Resume cursor UUID tie-breaker.
+
+Output:
+  --output <path>                 Default: ./chips-ledger-archive-<target>.jsonl.gz
+  --manifest <path>               Default: <output>.manifest.json
+
+The selected database transaction is REPEATABLE READ and READ ONLY. The script
+does not upload, delete, update, insert, or alter any ledger or poker row.
+`;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+export function toBigIntString(value, label = "bigint") {
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" && Number.isSafeInteger(value)) return String(value);
+  const normalized = text(value);
+  if (!INTEGER_RE.test(normalized)) fail(`${label} is not an integer value`);
+  return normalized;
+}
+
+function nullableText(value) {
+  return value == null ? null : text(value) || null;
+}
+
+function normalizeJson(value) {
+  if (typeof value !== "string") return value ?? null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    fail("database JSON value could not be parsed");
+  }
+}
+
+export function timestampToMicros(value) {
+  const normalized = text(value).replace(" ", "T").replace(/([+-][0-9]{2})([0-9]{2})$/, "$1:$2").replace(/\+00$/, "Z");
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,6}))?(Z|[+-]\d{2}:\d{2})$/.exec(normalized);
+  if (!match) fail("timestamp must include an explicit timezone and at most six fractional digits");
+  const baseMillis = Date.parse(`${match[1]}${match[3]}`);
+  if (!Number.isFinite(baseMillis)) fail("timestamp is invalid");
+  const micros = (match[2] || "").padEnd(6, "0");
+  return BigInt(baseMillis) * 1000n + BigInt(micros || "0");
+}
+
+export function normalizeTimestamp(value, label = "timestamp") {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) fail(`${label} is invalid`);
+    return value.toISOString();
+  }
+  const normalized = text(value).replace(" ", "T").replace(/([+-][0-9]{2})([0-9]{2})$/, "$1:$2").replace(/\+00$/, "Z");
+  try {
+    timestampToMicros(normalized);
+  } catch (error) {
+    fail(`${label} is invalid: ${error.message}`);
+  }
+  return normalized;
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function compareTransactions(left, right) {
+  const leftTransaction = left?.transaction || left;
+  const rightTransaction = right?.transaction || right;
+  const leftMicros = timestampToMicros(leftTransaction?.created_at ?? leftTransaction?.createdAt);
+  const rightMicros = timestampToMicros(rightTransaction?.created_at ?? rightTransaction?.createdAt);
+  if (leftMicros < rightMicros) return -1;
+  if (leftMicros > rightMicros) return 1;
+  return compareText(text(leftTransaction?.id), text(rightTransaction?.id));
+}
+
+function compareEntries(left, right) {
+  const leftId = BigInt(toBigIntString(left?.id, "entry.id"));
+  const rightId = BigInt(toBigIntString(right?.id, "entry.id"));
+  return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+}
+
+export function sortRecords(records) {
+  return [...records].sort(compareTransactions);
+}
+
+export function stringifyJson(value) {
+  return JSON.stringify(value, (_key, nested) => (typeof nested === "bigint" ? nested.toString() : nested));
+}
+
+export function serializeRecords(records) {
+  if (!records.length) return "";
+  return `${records.map((record) => stringifyJson(record)).join("\n")}\n`;
+}
+
+export function parseJsonl(rawText) {
+  if (rawText === "") return [];
+  if (!rawText.endsWith("\n")) fail("JSONL artifact has no final newline");
+  return rawText.slice(0, -1).split("\n").map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      fail("JSONL artifact contains invalid JSON");
+    }
+  });
+}
+
+export function buildArchiveBytes(records) {
+  const rawText = serializeRecords(records);
+  const rawBytes = Buffer.from(rawText, "utf8");
+  const compressedBytes = gzipSync(rawBytes, { level: 9, mtime: 0 });
+  return {
+    rawText,
+    rawBytes,
+    compressedBytes,
+    rawSha256: crypto.createHash("sha256").update(rawBytes).digest("hex"),
+    compressedSha256: crypto.createHash("sha256").update(compressedBytes).digest("hex"),
+  };
+}
+
+export function evaluateTableEligibility(candidate) {
+  const tableId = text(candidate?.table_id ?? candidate?.tableId);
+  const related = candidate?.table_related === true || candidate?.tableRelated === true || Boolean(tableId);
+  if (!related) return { eligible: true, reason: "not_poker_table_lifecycle" };
+  if (candidate?.invalid_table_marker === true || candidate?.invalidTableMarker === true) {
+    return { eligible: false, reason: "invalid_table_marker" };
+  }
+  if (!UUID_RE.test(tableId)) return { eligible: false, reason: "invalid_table_id" };
+  if (!text(candidate?.escrow_account_id ?? candidate?.escrowAccountId)) {
+    return { eligible: false, reason: "escrow_missing" };
+  }
+  if (toBigIntString(candidate?.escrow_balance ?? candidate?.escrowBalance, "escrow.balance") !== "0") {
+    return { eligible: false, reason: "escrow_non_zero" };
+  }
+  const tableExists = candidate?.table_exists === true || candidate?.tableExists === true;
+  if (tableExists && text(candidate?.table_status ?? candidate?.tableStatus).toUpperCase() !== "CLOSED") {
+    return { eligible: false, reason: "table_not_closed" };
+  }
+  return { eligible: true, reason: tableExists ? "closed_table" : "retained_escrow_after_table_retention" };
+}
+
+function buildTableContext(candidate) {
+  if (!candidate?.table_related && !candidate?.tableRelated && !candidate?.table_id && !candidate?.tableId) return null;
+  return {
+    table_id: text(candidate.table_id ?? candidate.tableId),
+    table_exists: candidate.table_exists === true || candidate.tableExists === true,
+    table_status: nullableText(candidate.table_status ?? candidate.tableStatus)?.toUpperCase() || null,
+    escrow_account_id: nullableText(candidate.escrow_account_id ?? candidate.escrowAccountId),
+    escrow_status: nullableText(candidate.escrow_status ?? candidate.escrowStatus)?.toLowerCase() || null,
+    escrow_balance: toBigIntString(candidate.escrow_balance ?? candidate.escrowBalance, "escrow.balance"),
+  };
+}
+
+export function buildExportRecord(candidate, rawEntries) {
+  const transactionId = text(candidate?.id);
+  if (!UUID_RE.test(transactionId)) fail("transaction.id is not a UUID");
+  const entries = [...rawEntries].sort(compareEntries).map((entry) => ({
+    id: toBigIntString(entry.id, "entry.id"),
+    transaction_id: text(entry.transaction_id),
+    account_id: text(entry.account_id),
+    entry_seq: toBigIntString(entry.entry_seq, "entry.entry_seq"),
+    amount: toBigIntString(entry.amount, "entry.amount"),
+    metadata: normalizeJson(entry.metadata),
+    created_at: normalizeTimestamp(entry.created_at, "entry.created_at"),
+    account: {
+      id: text(entry.account_row_id || entry.account_id),
+      account_type: text(entry.account_type),
+      user_id: nullableText(entry.account_user_id),
+      system_key: nullableText(entry.account_system_key),
+      status: nullableText(entry.account_status),
+      label: nullableText(entry.account_label),
+    },
+  }));
+
+  return {
+    schema_version: EXPORT_SCHEMA_VERSION,
+    record_type: "chips_transaction",
+    transaction: {
+      id: transactionId,
+      sequence: toBigIntString(candidate.sequence, "transaction.sequence"),
+      tx_type: text(candidate.tx_type),
+      idempotency_key: text(candidate.idempotency_key),
+      payload_hash: text(candidate.payload_hash),
+      user_id: nullableText(candidate.user_id),
+      reference: nullableText(candidate.reference),
+      description: nullableText(candidate.description),
+      metadata: normalizeJson(candidate.metadata),
+      created_by: nullableText(candidate.created_by),
+      created_at: normalizeTimestamp(candidate.created_at, "transaction.created_at"),
+    },
+    table_context: buildTableContext(candidate),
+    entries,
+  };
+}
+
+function candidateId(candidate) {
+  return text(candidate?.id);
+}
+
+export function validateBatch({ candidates, records, cutoff }) {
+  if (!Array.isArray(candidates) || !Array.isArray(records)) fail("batch must contain arrays");
+  if (candidates.length !== records.length) fail("batch transaction count mismatch");
+
+  const candidatesById = new Map();
+  for (const candidate of candidates) {
+    const id = candidateId(candidate);
+    if (!UUID_RE.test(id) || candidatesById.has(id)) fail("duplicate transaction in candidate batch");
+    candidatesById.set(id, candidate);
+  }
+
+  const expectedOrder = [...candidates].sort((left, right) => compareTransactions(left, right)).map(candidateId);
+  const seenTransactions = new Set();
+  const seenEntries = new Set();
+  const txTypeCounts = {};
+  let entryCount = 0;
+
+  records.forEach((record, index) => {
+    const transaction = record?.transaction;
+    const id = text(transaction?.id);
+    if (record?.schema_version !== EXPORT_SCHEMA_VERSION || record?.record_type !== "chips_transaction") {
+      fail("unsupported or malformed export record");
+    }
+    if (id !== expectedOrder[index]) fail("transaction order is not deterministic");
+    if (seenTransactions.has(id)) fail("duplicate transaction in exported batch");
+    seenTransactions.add(id);
+
+    const candidate = candidatesById.get(id);
+    if (!candidate) fail("exported transaction was not selected by the database query");
+    if (cutoff && timestampToMicros(transaction.created_at) >= timestampToMicros(cutoff)) {
+      fail("exported transaction is not older than cutoff");
+    }
+    const eligibility = evaluateTableEligibility(candidate);
+    if (!eligibility.eligible) fail(`ineligible poker transaction: ${eligibility.reason}`);
+
+    const expectedEntries = BigInt(toBigIntString(candidate.entry_count, "database entry count"));
+    if (!Array.isArray(record.entries) || BigInt(record.entries.length) !== expectedEntries) {
+      fail(`incomplete entry set for transaction ${id}`);
+    }
+    const expectedEntryOrder = [...record.entries].sort(compareEntries).map((entry) => toBigIntString(entry.id, "entry.id"));
+    if (record.entries.map((entry) => toBigIntString(entry.id, "entry.id")).some((entryId, entryIndex) => entryId !== expectedEntryOrder[entryIndex])) {
+      fail(`entry order is not deterministic: ${id}`);
+    }
+
+    let total = 0n;
+    for (const entry of record.entries) {
+      if (text(entry.transaction_id) !== id) fail(`entry points to another transaction: ${id}`);
+      const entryId = toBigIntString(entry.id, "entry.id");
+      if (seenEntries.has(entryId)) fail(`duplicate entry in exported batch: ${entryId}`);
+      seenEntries.add(entryId);
+      if (text(entry.account_id) !== text(entry.account?.id)) fail(`entry account identity mismatch: ${entryId}`);
+      total += BigInt(toBigIntString(entry.amount, "entry.amount"));
+    }
+    if (total !== 0n) fail(`transaction is not conserved: ${id}`);
+    const txType = text(transaction.tx_type);
+    if (!txType) fail(`transaction type is missing: ${id}`);
+    txTypeCounts[txType] = (txTypeCounts[txType] || 0) + 1;
+    entryCount += record.entries.length;
+  });
+
+  return {
+    transactionCount: records.length,
+    entryCount,
+    txTypeCounts: Object.fromEntries(Object.entries(txTypeCounts).sort(([left], [right]) => compareText(left, right))),
+  };
+}
+
+export function buildManifest({ target, cutoff, batchSize, cursor, records, archive, outputPath }) {
+  const validation = validateBatch({ candidates: records.map((record) => ({
+    id: record.transaction.id,
+    created_at: record.transaction.created_at,
+    entry_count: String(record.entries.length),
+    table_related: Boolean(record.table_context),
+    table_id: record.table_context?.table_id,
+    table_exists: record.table_context?.table_exists,
+    table_status: record.table_context?.table_status,
+    escrow_account_id: record.table_context?.escrow_account_id,
+    escrow_balance: record.table_context?.escrow_balance,
+  })), records, cutoff: null });
+  const first = records[0]?.transaction || null;
+  const last = records.at(-1)?.transaction || null;
+  const compressionRatio = archive.rawBytes.length === 0
+    ? null
+    : Number((archive.compressedBytes.length / archive.rawBytes.length).toFixed(6));
+  const endCursor = last ? { created_at: last.created_at, id: last.id } : null;
+
+  return {
+    schema_version: EXPORT_SCHEMA_VERSION,
+    artifact_type: "chips_ledger_archive",
+    format: "jsonl.gz",
+    target,
+    cutoff: {
+      created_at: cutoff,
+      rule: "transaction.created_at < cutoff",
+    },
+    batch: {
+      limit: batchSize,
+      transactions: validation.transactionCount,
+      entries: validation.entryCount,
+      tx_types: validation.txTypeCounts,
+    },
+    time_range: {
+      first_created_at: first?.created_at || null,
+      last_created_at: last?.created_at || null,
+    },
+    cursor: {
+      order: ["transaction.created_at ASC", "transaction.id ASC"],
+      start: cursor || null,
+      end: endCursor,
+      next: endCursor,
+    },
+    bytes: {
+      raw: archive.rawBytes.length,
+      compressed: archive.compressedBytes.length,
+      compression_ratio_compressed_over_raw: compressionRatio,
+    },
+    sha256: {
+      raw_jsonl: archive.rawSha256,
+      compressed_artifact: archive.compressedSha256,
+    },
+    artifact: path.basename(outputPath),
+  };
+}
+
+function parseArgs(argv) {
+  const keyMap = {
+    "target": "target",
+    "cutoff": "cutoff",
+    "cutoff-days": "cutoffDays",
+    "batch-size": "batchSize",
+    "after-created-at": "afterCreatedAt",
+    "after-id": "afterId",
+    "output": "output",
+    "manifest": "manifest",
+  };
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+    if (!token.startsWith("--") || !keyMap[token.slice(2)]) fail(`unknown argument: ${token}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${token} requires a value`);
+    args[keyMap[token.slice(2)]] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function parseBoundedInteger(value, name, { min, max }) {
+  const normalized = text(value);
+  if (!/^\d+$/.test(normalized)) fail(`${name} must be an integer`);
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) fail(`${name} must be between ${min} and ${max}`);
+  return parsed;
+}
+
+function deriveProjectRef(dbUrl) {
+  let url;
+  try {
+    url = new URL(dbUrl);
+  } catch {
+    fail("selected database URL is invalid");
+  }
+  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") fail("selected database URL must be PostgreSQL");
+  const direct = /^db\.([a-z0-9]{20})\.supabase\.co$/i.exec(url.hostname);
+  const pooler = /^[a-z0-9-]+\.pooler\.supabase\.com$/i.test(url.hostname);
+  const user = /^postgres\.([a-z0-9]{20})$/i.exec(decodeURIComponent(url.username || ""));
+  const ref = direct?.[1] || (pooler ? user?.[1] : null);
+  if (!ref) fail("selected database URL does not expose a supported Supabase project ref");
+  return ref.toLowerCase();
+}
+
+export function resolveTarget(targetValue, env = process.env) {
+  const target = text(targetValue);
+  const config = TARGETS[target];
+  if (!config) fail("target must be exactly stage or prod");
+
+  const expectedRefs = {};
+  for (const [name, targetConfig] of Object.entries(TARGETS)) {
+    const expected = text(env[targetConfig.expectedRefEnv] || env[targetConfig.legacyRefEnv]).toLowerCase();
+    if (!PROJECT_REF_RE.test(expected)) fail(`${targetConfig.expectedRefEnv} is required and must be a project ref`);
+    if (expected !== targetConfig.canonicalRef) fail(`${targetConfig.expectedRefEnv} does not match the versioned canonical ref`);
+    expectedRefs[name] = expected;
+  }
+  if (expectedRefs.stage === expectedRefs.prod) fail("stage and production project refs must differ");
+
+  const dbUrl = text(env[config.dbEnv]);
+  if (!dbUrl) fail(`${config.dbEnv} is required for target ${target}`);
+  const dbProjectRef = deriveProjectRef(dbUrl);
+  if (dbProjectRef !== config.canonicalRef) fail(`${config.dbEnv} does not match the canonical ${target} project ref`);
+
+  return { target, label: config.label, dbUrl, projectRef: dbProjectRef };
+}
+
+function resolveCursor(args) {
+  const hasCreatedAt = args.afterCreatedAt != null;
+  const hasId = args.afterId != null;
+  if (hasCreatedAt !== hasId) fail("--after-created-at and --after-id must be supplied together");
+  if (!hasCreatedAt) return null;
+  const createdAt = normalizeTimestamp(args.afterCreatedAt, "--after-created-at");
+  const id = text(args.afterId).toLowerCase();
+  if (!UUID_RE.test(id)) fail("--after-id must be a UUID");
+  return { created_at: createdAt, id };
+}
+
+function resolveOptions(args, env, cwd, now) {
+  const target = resolveTarget(args.target || env.LEDGER_ARCHIVE_TARGET, env);
+  const cutoff = args.cutoff
+    ? normalizeTimestamp(args.cutoff, "--cutoff")
+    : (() => {
+        const days = args.cutoffDays == null ? DEFAULT_CUTOFF_DAYS : parseBoundedInteger(args.cutoffDays, "--cutoff-days", { min: 0, max: 36500 });
+        return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+      })();
+  const batchSize = args.batchSize == null
+    ? DEFAULT_BATCH_SIZE
+    : parseBoundedInteger(args.batchSize, "--batch-size", { min: 1, max: MAX_BATCH_SIZE });
+  const outputPath = path.resolve(cwd, args.output || `chips-ledger-archive-${target.target}.jsonl.gz`);
+  const manifestPath = path.resolve(cwd, args.manifest || `${outputPath}.manifest.json`);
+  if (outputPath === manifestPath) fail("--output and --manifest must be different paths");
+  if (fs.existsSync(outputPath)) fail(`refusing to overwrite existing artifact: ${outputPath}`);
+  if (fs.existsSync(manifestPath)) fail(`refusing to overwrite existing manifest: ${manifestPath}`);
+  return { ...target, cutoff, batchSize, cursor: resolveCursor(args), outputPath, manifestPath };
+}
+
+async function readSnapshot(sql, options) {
+  return sql.begin(async (tx) => {
+    await tx.unsafe("set transaction isolation level repeatable read, read only;");
+    const candidates = await tx.unsafe(CANDIDATE_SQL, [
+      options.cutoff,
+      options.batchSize,
+      options.cursor?.created_at || null,
+      options.cursor?.id || null,
+    ]);
+    const ids = candidates.map((candidate) => text(candidate.id));
+    const entries = ids.length ? await tx.unsafe(ENTRIES_SQL, [ids]) : [];
+    return { candidates, entries };
+  });
+}
+
+function groupEntries(rows, candidateIds) {
+  const groups = new Map();
+  for (const row of rows) {
+    const transactionId = text(row.transaction_id);
+    if (!candidateIds.has(transactionId)) fail("database returned an entry outside the selected transaction batch");
+    const current = groups.get(transactionId) || [];
+    current.push(row);
+    groups.set(transactionId, current);
+  }
+  return groups;
+}
+
+function writeExclusive(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  let descriptor = null;
+  let created = false;
+  try {
+    descriptor = fs.openSync(filePath, "wx", 0o600);
+    created = true;
+    fs.writeSync(descriptor, data);
+    fs.fsyncSync(descriptor);
+  } catch (error) {
+    if (created) {
+      try { fs.unlinkSync(filePath); } catch { /* best effort cleanup of our own partial artifact */ }
+    }
+    throw error;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+function writeOutput(options, archive, manifest) {
+  let artifactCreated = false;
+  let manifestCreated = false;
+  try {
+    writeExclusive(options.outputPath, archive.compressedBytes);
+    artifactCreated = true;
+    writeExclusive(options.manifestPath, `${stringifyJson(manifest)}\n`);
+    manifestCreated = true;
+  } catch (error) {
+    if (manifestCreated) {
+      try { fs.unlinkSync(options.manifestPath); } catch { /* best effort cleanup of our own artifact */ }
+    }
+    if (artifactCreated) {
+      try { fs.unlinkSync(options.outputPath); } catch { /* best effort cleanup of our own artifact */ }
+    }
+    throw error;
+  }
+}
+
+function outputMetrics(manifest, options) {
+  const summary = {
+    event: "chips_ledger_archive_export",
+    read_only: true,
+    target: options.target,
+    project_ref: options.projectRef,
+    artifact: options.outputPath,
+    manifest: options.manifestPath,
+    transactions: manifest.batch.transactions,
+    entries: manifest.batch.entries,
+    time_range: manifest.time_range,
+    cursor: manifest.cursor,
+    tx_types: manifest.batch.tx_types,
+    raw_bytes: manifest.bytes.raw,
+    compressed_bytes: manifest.bytes.compressed,
+    compression_ratio_compressed_over_raw: manifest.bytes.compression_ratio_compressed_over_raw,
+    sha256: manifest.sha256,
+  };
+  process.stdout.write(`${stringifyJson(summary)}\n`);
+}
+
+export async function runExport({ argv = process.argv.slice(2), env = process.env, cwd = process.cwd(), now = new Date() } = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return null;
+  }
+  const options = resolveOptions(args, env, cwd, now);
+  const sql = postgres(options.dbUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 10,
+    idle_timeout: 30,
+  });
+
+  try {
+    const snapshot = await readSnapshot(sql, options);
+    const candidateIds = new Set(snapshot.candidates.map((candidate) => text(candidate.id)));
+    const entriesByTransaction = groupEntries(snapshot.entries, candidateIds);
+    const records = sortRecords(snapshot.candidates.map((candidate) => buildExportRecord(
+      candidate,
+      entriesByTransaction.get(text(candidate.id)) || [],
+    )));
+    validateBatch({ candidates: snapshot.candidates, records, cutoff: options.cutoff });
+
+    const archive = buildArchiveBytes(records);
+    const roundTripRaw = gunzipSync(archive.compressedBytes);
+    if (!roundTripRaw.equals(archive.rawBytes)) fail("gzip round-trip verification failed");
+    const roundTripRecords = parseJsonl(roundTripRaw.toString("utf8"));
+    validateBatch({ candidates: snapshot.candidates, records: roundTripRecords, cutoff: options.cutoff });
+    if (serializeRecords(roundTripRecords) !== archive.rawText) fail("JSONL round-trip verification failed");
+
+    const manifest = buildManifest({
+      target: options.target,
+      cutoff: options.cutoff,
+      batchSize: options.batchSize,
+      cursor: options.cursor,
+      records,
+      archive,
+      outputPath: options.outputPath,
+    });
+    if (manifest.sha256.compressed_artifact !== crypto.createHash("sha256").update(archive.compressedBytes).digest("hex")) {
+      fail("manifest checksum verification failed");
+    }
+    writeOutput(options, archive, manifest);
+    outputMetrics(manifest, options);
+    return manifest;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runExport().catch((error) => {
+    process.stderr.write(`chips-ledger-archive-export failed: ${error?.message || error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -157,7 +157,7 @@ Selection:
   --after-id <uuid>               Resume cursor UUID tie-breaker.
 
 Output:
-  --output <path>                 Default: ./chips-ledger-archive-<target>.jsonl.gz
+  --output <path>                 Required; use a private path outside checkout.
   --manifest <path>               Default: <output>.manifest.json
 
 The selected database transaction is REPEATABLE READ and READ ONLY. The script
@@ -563,7 +563,8 @@ function resolveCursor(args) {
 }
 
 function resolveOptions(args, env, cwd, now) {
-  const target = resolveTarget(args.target || env.LEDGER_ARCHIVE_TARGET, env);
+  if (!args.output) fail("--output is required; use a private path outside the repository");
+  const target = resolveTarget(args.target, env);
   const cutoff = args.cutoff
     ? normalizeTimestamp(args.cutoff, "--cutoff")
     : (() => {
@@ -573,7 +574,7 @@ function resolveOptions(args, env, cwd, now) {
   const batchSize = args.batchSize == null
     ? DEFAULT_BATCH_SIZE
     : parseBoundedInteger(args.batchSize, "--batch-size", { min: 1, max: MAX_BATCH_SIZE });
-  const outputPath = path.resolve(cwd, args.output || `chips-ledger-archive-${target.target}.jsonl.gz`);
+  const outputPath = path.resolve(cwd, args.output);
   const manifestPath = path.resolve(cwd, args.manifest || `${outputPath}.manifest.json`);
   if (outputPath === manifestPath) fail("--output and --manifest must be different paths");
   if (fs.existsSync(outputPath)) fail(`refusing to overwrite existing artifact: ${outputPath}`);

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -48,6 +48,7 @@ run("node", ["tests/poker-bot-cashout.userId-is-bot.unit.test.mjs"], "poker-bot-
 run("node", ["tests/chips-ledger.escrow-only.null-user.unit.test.mjs"], "chips-ledger-escrow-only-null-user");
 run("node", ["tests/chips-ledger.human.buyin.unit.test.mjs"], "chips-ledger-human-buyin");
 run("node", ["tests/chips-ledger-pagination.behavior.test.mjs"], "chips-ledger-pagination-behavior");
+run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-archive-export");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/bonus-campaigns-endpoint.behavior.test.mjs"], "bonus-campaigns-endpoint-behavior");
 run("node", ["tests/bonus-campaigns-scheduler.behavior.test.mjs"], "bonus-campaigns-scheduler-behavior");

--- a/tests/chips/chips-ledger-archive-export.test.mjs
+++ b/tests/chips/chips-ledger-archive-export.test.mjs
@@ -3,6 +3,7 @@ import {
   buildArchiveBytes,
   buildExportRecord,
   evaluateTableEligibility,
+  runExport,
   serializeRecords,
   resolveTarget,
   sortRecords,
@@ -65,6 +66,14 @@ const recordA = makeRecord(candidateA, 1);
 const recordB = makeRecord(candidateB, 3);
 
 assert.throws(() => resolveTarget("unknown", {}), /target must be exactly stage or prod/);
+await assert.rejects(
+  () => runExport({ argv: ["--target", "stage"], env: {}, cwd: "/tmp" }),
+  /--output is required/,
+);
+await assert.rejects(
+  () => runExport({ argv: ["--output", "/tmp/chips-ledger-review.jsonl.gz"], env: { LEDGER_ARCHIVE_TARGET: "prod" }, cwd: "/tmp" }),
+  /target must be exactly stage or prod/,
+);
 assert.equal(stringifyJson({ id: 123n, amount: -7n }), '{"id":"123","amount":"-7"}');
 assert.equal(recordA.entries[0].amount, "10");
 assert.equal(recordA.entries[1].amount, "-10");

--- a/tests/chips/chips-ledger-archive-export.test.mjs
+++ b/tests/chips/chips-ledger-archive-export.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import {
+  buildArchiveBytes,
+  buildExportRecord,
+  evaluateTableEligibility,
+  serializeRecords,
+  resolveTarget,
+  sortRecords,
+  stringifyJson,
+  validateBatch,
+} from "../../scripts/ops/chips-ledger-archive-export.mjs";
+
+const TX_A = "00000000-0000-4000-8000-00000000000a";
+const TX_B = "00000000-0000-4000-8000-00000000000b";
+const USER = "00000000-0000-4000-8000-000000000010";
+const SYSTEM = "00000000-0000-4000-8000-000000000011";
+
+function candidate(id, createdAt, overrides = {}) {
+  return {
+    id,
+    sequence: "100",
+    tx_type: "BUY_IN",
+    idempotency_key: `test:${id}`,
+    payload_hash: "hash",
+    user_id: USER,
+    reference: null,
+    description: "test",
+    metadata: {},
+    created_by: USER,
+    created_at: createdAt,
+    entry_count: "2",
+    table_related: false,
+    ...overrides,
+  };
+}
+
+function entry(id, transactionId, amount, accountId) {
+  return {
+    id: String(id),
+    transaction_id: transactionId,
+    account_id: accountId,
+    entry_seq: String(id),
+    amount: String(amount),
+    metadata: {},
+    created_at: "2026-01-01T00:00:00.000000Z",
+    account_row_id: accountId,
+    account_type: accountId === USER ? "USER" : "SYSTEM",
+    account_user_id: accountId === USER ? USER : null,
+    account_system_key: accountId === SYSTEM ? "TREASURY" : null,
+    account_status: "active",
+    account_label: null,
+  };
+}
+
+function makeRecord(tx, firstEntryId = 1) {
+  return buildExportRecord(tx, [
+    entry(firstEntryId + 1, tx.id, -10, SYSTEM),
+    entry(firstEntryId, tx.id, 10, USER),
+  ]);
+}
+
+const candidateA = candidate(TX_A, "2026-01-01T00:00:00.000001Z");
+const candidateB = candidate(TX_B, "2026-01-01T00:00:00.000001Z");
+const recordA = makeRecord(candidateA, 1);
+const recordB = makeRecord(candidateB, 3);
+
+assert.throws(() => resolveTarget("unknown", {}), /target must be exactly stage or prod/);
+assert.equal(stringifyJson({ id: 123n, amount: -7n }), '{"id":"123","amount":"-7"}');
+assert.equal(recordA.entries[0].amount, "10");
+assert.equal(recordA.entries[1].amount, "-10");
+
+const ordered = sortRecords([recordB, recordA]);
+assert.deepEqual(ordered.map((record) => record.transaction.id), [TX_A, TX_B]);
+assert.equal(serializeRecords(sortRecords([recordA, recordB])), serializeRecords(sortRecords([recordB, recordA])));
+
+const validBatch = validateBatch({
+  candidates: [candidateB, candidateA],
+  records: ordered,
+  cutoff: "2026-02-01T00:00:00Z",
+});
+assert.deepEqual(validBatch.txTypeCounts, { BUY_IN: 2 });
+assert.equal(validBatch.entryCount, 4);
+const archiveOne = buildArchiveBytes(ordered);
+const archiveTwo = buildArchiveBytes(sortRecords([recordB, recordA]));
+assert.equal(archiveOne.rawSha256, archiveTwo.rawSha256);
+assert.equal(archiveOne.compressedSha256, archiveTwo.compressedSha256);
+
+assert.throws(
+  () => validateBatch({
+    candidates: [candidateA],
+    records: [buildExportRecord(candidateA, [entry(1, TX_A, 10, USER)])],
+    cutoff: "2026-02-01T00:00:00Z",
+  }),
+  /incomplete entry set/,
+);
+
+assert.throws(
+  () => validateBatch({
+    candidates: [candidateA],
+    records: [buildExportRecord(candidateA, [entry(1, TX_A, 10, USER), entry(2, TX_A, -9, SYSTEM)])],
+    cutoff: "2026-02-01T00:00:00Z",
+  }),
+  /not conserved/,
+);
+
+const tableId = "00000000-0000-4000-8000-000000000020";
+const tableCandidate = {
+  table_related: true,
+  table_id: tableId,
+  escrow_account_id: "00000000-0000-4000-8000-000000000021",
+  escrow_balance: "0",
+  table_exists: true,
+  table_status: "OPEN",
+};
+assert.equal(evaluateTableEligibility(tableCandidate).eligible, false);
+assert.equal(evaluateTableEligibility({ ...tableCandidate, table_status: "CLOSED" }).eligible, true);
+assert.equal(evaluateTableEligibility({ ...tableCandidate, table_exists: false, table_status: null }).eligible, true);
+assert.equal(evaluateTableEligibility({ ...tableCandidate, table_exists: false, escrow_balance: "1" }).eligible, false);
+assert.equal(evaluateTableEligibility({ table_related: false }).eligible, true);
+
+process.stdout.write("chips-ledger-archive-export tests passed\n");


### PR DESCRIPTION
## Summary

Implements Stage 2B.1 as a read-only local ledger archive measurement prototype for Issue #874.

- Adds `scripts/ops/chips-ledger-archive-export.mjs`.
- Exports complete immutable `chips_transactions` rows with all corresponding `chips_entries` as one JSONL record per transaction.
- Writes deterministic local `.jsonl.gz` output plus a local `.manifest.json` sidecar.
- Keeps bigint columns (transaction sequence, entry id/sequence/amount) as strings.
- Adds account identity to every entry, including `account_type`, `user_id`, and `system_key`.
- Adds focused fundamental contract tests and Stage 2B.1 documentation.

## Eligibility contract

- Strictly `transaction.created_at < cutoff`; default cutoff is 30 days.
- Deterministic order is `created_at ASC, id ASC`, with `--after-created-at` + `--after-id` keyset resume.
- Poker lifecycle association follows current consumers: `metadata.tableId`, `table:`/`poker-rebuy:` references, and `POKER_TABLE:<tableId>` escrow entries.
- Poker transactions require a `CLOSED` table or an absent retained table, plus an existing corresponding escrow account with balance exactly zero.
- Transactions without poker lifecycle markers receive no artificial poker restrictions.
- Incomplete, ambiguous, duplicate, or non-conserving batches fail before any output is created.

## Verification and manifest

The exporter uses one PostgreSQL `REPEATABLE READ, READ ONLY` transaction, validates entry completeness, exact double-entry conservation, duplicate IDs, deterministic ordering, JSONL/gzip round-trip, byte counts, and SHA-256 hashes. The manifest reports transaction/entry counts, `tx_type` distribution, time range, cursor, raw/compressed bytes, compressed-over-raw ratio, and raw/compressed SHA-256.

## Operational safety

This is a read-only prototype. It does not upload to Storage, create a bucket, write a remote manifest, delete/prune ledger rows, run migrations, or modify runtime/WS/accounting behavior. Stage is the documented first run:

```sh
node scripts/ops/chips-ledger-archive-export.mjs \
  --target stage --cutoff-days 30 --batch-size 5000 \
  --output /private/path/chips-ledger-stage.jsonl.gz
```

Target-specific DB URLs and canonical project-ref guards follow the existing operations convention. Production was not run.

## Checks

- `npm test` — passed (after installing the already-declared `ws-server` lockfile dependency in the isolated worktree).
- `npm run check:all` — passed.
- `npm run ci:guards` — passed.
- `node scripts/check-db-migrations.mjs` — passed.
- `node tests/chips/chips-ledger-archive-export.test.mjs` — passed.
- `git diff --check origin/main...HEAD` — passed.

Stage integration export was run from the preview VPS against exact HEAD `69e506b0a39c2f101ceeafc2e54efc2e2a6e4166` with an explicit cutoff set at test start. It exported 5,000 transactions and 10,000 entries from Stage; complete-entry, conservation, gzip round-trip, manifest, byte-count and SHA-256 validations passed. No Production connection was attempted.

Related: #874

Breaking impact: none expected.