### PR TITLE
Stage 2B.2: verified immutable ledger archive in Supabase Storage

### DIFF
--- a/docs/issue-874-stage-2b2-ledger-archive-storage.md
+++ b/docs/issue-874-stage-2b2-ledger-archive-storage.md
@@ -1,0 +1,138 @@
+# Issue #874 — Stage 2B.2 verified immutable ledger archive in Storage
+
+Stage 2B.2 extends the local Stage 2B.1 prototype with one verified, private
+Supabase Storage archive. It is an operational prototype: the ledger remains
+read-only, there is no pruning, and no archive object is deleted.
+
+## Storage contract
+
+The fixed bucket is `chips-ledger-archive`. It is created and inspected only
+through the Supabase Storage API, never by writing `storage.buckets` or
+`storage.objects` from SQL. The bucket must remain:
+
+- private (`public: false`);
+- restricted to `application/gzip`;
+- limited to `6291456` bytes (6 MiB) per object.
+
+The deterministic object path is:
+
+```text
+v1/sha256/<lowercase-compressed-sha256>.jsonl.gz
+```
+
+The uploader uses a standard Storage upload with `x-upsert: false`. It never
+overwrites an object. An existing object is downloaded through the private
+authenticated endpoint and compared byte-for-byte with the local artifact.
+
+## Local artifact and PostgreSQL manifest
+
+The `.jsonl.gz` and local sidecar manifest keep the Stage 2B.1 format and
+`schema_version: 1`. Each JSONL line is one complete transaction with all its
+entries. IDs, `sequence`, `entry_seq`, and amounts are decimal strings. Every
+entry includes its account context, including `account_type`, `user_id`, and
+`system_key`.
+
+The local manifest additionally contains exact decimal-string totals:
+
+```json
+"amounts": {
+  "credits": "9007199254740993",
+  "debits": "9007199254740993",
+  "net": "0"
+}
+```
+
+Before Storage access, the uploader verifies gzip round-trip, raw and
+compressed bytes, both SHA-256 values, counts, `tx_type` distribution, cursor,
+time range, account context, duplicate IDs, deterministic order, and
+double-entry conservation. The object must also be no larger than 6 MiB.
+
+The migration creates `public.chips_ledger_archive_batches`, keyed by
+`object_path`. It records the project ref, archive format version, cutoff,
+cursor start/end, first/last timestamps, counts, `tx_types`, raw/compressed
+sizes and hashes, credits, absolute debits, net amount, status, and creation
+and commit timestamps. The only state transition is `pending -> committed`.
+Constraints require non-negative counts/sizes, 64-character lowercase SHA-256
+values, equal credits/debits, net `0`, and a matching `committed_at` for each
+state. RLS is enabled and `anon` and `authenticated` have no privileges or
+policies. The table is a manifest registry, not a balance source.
+
+## Required environment and commands
+
+The uploader requires all of the following existing environment values:
+
+- `SUPABASE_URL` — the HTTPS Supabase API origin for the selected target;
+- `SUPABASE_SERVICE_ROLE_KEY` — used transiently for Storage API requests;
+- `SUPABASE_STAGE_DB_URL` or `SUPABASE_PROD_DB_URL` — selected by the explicit
+  target;
+- `EXPECTED_SUPABASE_STAGE_PROJECT_REF` and
+  `EXPECTED_SUPABASE_PROD_PROJECT_REF` (the existing legacy project-ref names
+  remain accepted as compatibility aliases).
+
+The script requires explicit paths and has no target or path defaults:
+
+```sh
+node scripts/ops/chips-ledger-archive-store.mjs \
+  --target stage \
+  --artifact /private/path/chips-ledger-stage.jsonl.gz \
+  --manifest /private/path/chips-ledger-stage.manifest.json
+```
+
+Before any database or Storage connection, it validates the selected target,
+both canonical project refs, the HTTPS API origin, and the API/DB project-ref
+match. It does not print the DB URL or service-role key. The Stage procedure
+must set `--target stage`; Production is not part of this prototype run.
+
+## Retry and recovery
+
+The uploader first verifies the local files, then inserts one `pending` row
+using `object_path` as the primary key. Existing rows are compared across all
+immutable fields; any difference fails closed. A pending row may be retried:
+
+1. if the object is absent, upload once with no upsert, download it privately,
+   verify its exact size and compressed SHA-256, and commit the row;
+2. if the object already exists, never upload over it; download, verify, and
+   commit the pending row;
+3. if the row is already committed, download and verify the object and return
+   an idempotent success without an upload.
+
+An upload or download failure leaves the manifest pending and performs no
+remote cleanup. A mismatching object is never committed. A committed row with
+a missing object fails closed and requires operational investigation; the
+uploader does not silently recreate it. The conditional SQL update changes
+only a `pending` row, so retry cannot create a second manifest for the same
+object path.
+
+## Stage procedure and evidence
+
+After the migration workflow has applied the exact PR HEAD to the shared Stage
+database, run the exporter with a private temporary output directory and a
+cutoff that produces a non-empty batch. Then run the uploader twice against
+the same local files. The second run must report an idempotent success and no
+Storage overwrite. Confirm that an unauthenticated public-object request is
+rejected; private-object verification must use the authenticated download.
+
+Leave the one valid Stage object and its `committed` manifest row in place as
+the 2B.2 evidence. Remove only the local temporary gzip and sidecar manifest,
+and clear transient secret variables after collecting aggregate output. Do not
+print records, user IDs, idempotency keys, URLs containing credentials, or
+service-role keys.
+
+Record in Issue #874 and the PR:
+
+- exact PR HEAD and Stage project ref;
+- bucket and object path;
+- cutoff and cursor start/end;
+- transaction/entry counts and `tx_type` distribution;
+- credits, absolute debits, and net amount;
+- raw/compressed bytes and both SHA-256 values;
+- upload and private-download durations;
+- first-run and second-run/idempotency results;
+- public-access rejection;
+- confirmation that Production, ledger rows, and Storage deletion were not
+  used.
+
+Stage 2B.3 and 2B.4, remote manifest expansion, cold-history APIs/UI,
+idempotency registries, pruning, deletion, schedulers, and Production rollout
+remain out of scope. This PR adds no runtime, WebSocket, browser, or persistent
+environment configuration.

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -370,6 +370,9 @@ export function validateBatch({ candidates, records, cutoff }) {
   const seenEntries = new Set();
   const txTypeCounts = {};
   let entryCount = 0;
+  let credits = 0n;
+  let debits = 0n;
+  let netAmount = 0n;
 
   records.forEach((record, index) => {
     const transaction = record?.transaction;
@@ -405,7 +408,11 @@ export function validateBatch({ candidates, records, cutoff }) {
       if (seenEntries.has(entryId)) fail(`duplicate entry in exported batch: ${entryId}`);
       seenEntries.add(entryId);
       if (text(entry.account_id) !== text(entry.account?.id)) fail(`entry account identity mismatch: ${entryId}`);
-      total += BigInt(toBigIntString(entry.amount, "entry.amount"));
+      const amount = BigInt(toBigIntString(entry.amount, "entry.amount"));
+      total += amount;
+      netAmount += amount;
+      if (amount > 0n) credits += amount;
+      if (amount < 0n) debits -= amount;
     }
     if (total !== 0n) fail(`transaction is not conserved: ${id}`);
     const txType = text(transaction.tx_type);
@@ -414,10 +421,15 @@ export function validateBatch({ candidates, records, cutoff }) {
     entryCount += record.entries.length;
   });
 
+  if (netAmount !== 0n || credits !== debits) fail("batch is not conserved");
+
   return {
     transactionCount: records.length,
     entryCount,
     txTypeCounts: Object.fromEntries(Object.entries(txTypeCounts).sort(([left], [right]) => compareText(left, right))),
+    credits: credits.toString(),
+    debits: debits.toString(),
+    netAmount: netAmount.toString(),
   };
 }
 
@@ -454,6 +466,11 @@ export function buildManifest({ target, cutoff, batchSize, cursor, records, arch
       transactions: validation.transactionCount,
       entries: validation.entryCount,
       tx_types: validation.txTypeCounts,
+    },
+    amounts: {
+      credits: validation.credits,
+      debits: validation.debits,
+      net: validation.netAmount,
     },
     time_range: {
       first_created_at: first?.created_at || null,
@@ -660,6 +677,7 @@ function outputMetrics(manifest, options) {
     time_range: manifest.time_range,
     cursor: manifest.cursor,
     tx_types: manifest.batch.tx_types,
+    amounts: manifest.amounts,
     raw_bytes: manifest.bytes.raw,
     compressed_bytes: manifest.bytes.compressed,
     compression_ratio_compressed_over_raw: manifest.bytes.compression_ratio_compressed_over_raw,

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -349,6 +349,13 @@ async function readJsonResponse(response, operation) {
   }
 }
 
+async function isMissingBucketResponse(response) {
+  if (response.status === 404) return true;
+  if (response.status !== 400) return false;
+  const body = await response.text().catch(() => "");
+  return /not found|does not exist/i.test(body);
+}
+
 function verifyBucket(bucket) {
   if (!bucket || bucket.id !== ARCHIVE_BUCKET || bucket.name !== ARCHIVE_BUCKET) {
     fail("Storage archive bucket has an unexpected name");
@@ -363,7 +370,7 @@ function verifyBucket(bucket) {
 
 export async function ensureArchiveBucket(storageTarget, deps = {}) {
   let response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
-  if (response.status === 404) {
+  if (await isMissingBucketResponse(response)) {
     const createResponse = await storageRequest(storageTarget, "/storage/v1/bucket", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -1,0 +1,641 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+import postgres from "postgres";
+import {
+  EXPORT_SCHEMA_VERSION,
+  compareTransactions,
+  parseJsonl,
+  resolveTarget,
+  serializeRecords,
+  stringifyJson,
+  timestampToMicros,
+} from "./chips-ledger-archive-export.mjs";
+
+export const ARCHIVE_BUCKET = "chips-ledger-archive";
+export const ARCHIVE_MIME_TYPE = "application/gzip";
+export const ARCHIVE_MAX_BYTES = 6 * 1024 * 1024;
+
+const INTEGER_RE = /^-?(?:0|[1-9][0-9]*)$/;
+const NON_NEGATIVE_INTEGER_RE = /^(?:0|[1-9][0-9]*)$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CURSOR_ORDER = ["transaction.created_at ASC", "transaction.id ASC"];
+
+const HELP = `Usage: node scripts/ops/chips-ledger-archive-store.mjs [options]
+
+Required:
+  --target stage|prod       Explicit target; no default.
+  --artifact <path>        Existing .jsonl.gz artifact.
+  --manifest <path>        Existing local exporter manifest.
+
+The script creates/verifies a private Storage bucket, uploads without upsert,
+verifies a private download, and records pending -> committed metadata. It
+does not modify ledger rows and never deletes Storage objects.
+`;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+function hasOwn(value, key) {
+  return value !== null && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function assertSafeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) fail(`${label} must be a non-negative integer`);
+  return value;
+}
+
+function assertIntegerString(value, label, { nonNegative = false } = {}) {
+  if (typeof value !== "string") fail(`${label} must be serialized as a string`);
+  const pattern = nonNegative ? NON_NEGATIVE_INTEGER_RE : INTEGER_RE;
+  if (!pattern.test(value)) fail(`${label} must be an integer string`);
+  return value;
+}
+
+function assertSha(value, label) {
+  if (typeof value !== "string" || !SHA256_RE.test(value)) fail(`${label} must be a lowercase SHA-256`);
+  return value;
+}
+
+function sameTimestamp(left, right) {
+  if (left == null || right == null) return left == null && right == null;
+  return timestampToMicros(left) === timestampToMicros(right);
+}
+
+function sameValue(left, right, field) {
+  if (field.endsWith("_at") || field === "cutoff") return sameTimestamp(left, right);
+  if (field === "tx_types") return canonicalJson(left) === canonicalJson(right);
+  return String(left ?? "") === String(right ?? "");
+}
+
+function sameCursor(left, right) {
+  if (left == null || right == null) return left == null && right == null;
+  return sameTimestamp(left.created_at, right.created_at) && text(left.id).toLowerCase() === text(right.id).toLowerCase();
+}
+
+function parseArgs(argv) {
+  const keyMap = { target: "target", artifact: "artifact", manifest: "manifest" };
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+    const key = token.startsWith("--") ? keyMap[token.slice(2)] : null;
+    if (!key) fail(`unknown argument: ${token}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${token} requires a value`);
+    if (args[key] !== undefined) fail(`${token} was supplied more than once`);
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+export function resolveStorageTarget(targetValue, env = process.env) {
+  const target = resolveTarget(targetValue, env);
+  const rawUrl = text(env.SUPABASE_URL);
+  if (!rawUrl) fail("SUPABASE_URL is required");
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    fail("SUPABASE_URL is invalid");
+  }
+  if (url.protocol !== "https:" || url.pathname !== "/" || url.search || url.hash || url.username || url.password) {
+    fail("SUPABASE_URL must be an HTTPS Supabase origin");
+  }
+  const projectMatch = /^([a-z0-9]{20})\.supabase\.co$/i.exec(url.hostname);
+  if (!projectMatch) fail("SUPABASE_URL must expose a supported Supabase project ref");
+  const apiProjectRef = projectMatch[1].toLowerCase();
+  if (apiProjectRef !== target.projectRef) fail(`SUPABASE_URL does not match the canonical ${target.target} project ref`);
+  const serviceKey = text(env.SUPABASE_SERVICE_ROLE_KEY);
+  if (!serviceKey) fail("SUPABASE_SERVICE_ROLE_KEY is required");
+  return {
+    ...target,
+    baseUrl: url.origin,
+    apiProjectRef,
+    serviceKey,
+  };
+}
+
+function verifyCursor(cursor, label) {
+  if (cursor == null) return null;
+  if (!cursor || typeof cursor !== "object" || !UUID_RE.test(text(cursor.id))) fail(`${label} is invalid`);
+  timestampToMicros(cursor.created_at);
+  return { created_at: text(cursor.created_at), id: text(cursor.id).toLowerCase() };
+}
+
+function verifyManifestShape(manifest, artifactPath, target) {
+  if (!manifest || typeof manifest !== "object") fail("local manifest must be an object");
+  if (manifest.schema_version !== EXPORT_SCHEMA_VERSION || manifest.artifact_type !== "chips_ledger_archive" || manifest.format !== "jsonl.gz") {
+    fail("local manifest has an unsupported archive format");
+  }
+  if (manifest.target !== target.target) fail("local manifest target does not match --target");
+  if (manifest.artifact !== path.basename(artifactPath)) fail("local manifest artifact name does not match --artifact");
+  if (!manifest.cutoff || typeof manifest.cutoff.created_at !== "string") fail("local manifest cutoff is missing");
+  timestampToMicros(manifest.cutoff.created_at);
+  if (manifest.cutoff.rule !== "transaction.created_at < cutoff") fail("local manifest cutoff rule is unsupported");
+
+  const batch = manifest.batch;
+  if (!batch || !Number.isSafeInteger(batch.limit) || batch.limit < 1 || batch.limit > 5000) fail("local manifest batch limit is invalid");
+  assertSafeInteger(batch.transactions, "batch.transactions");
+  assertSafeInteger(batch.entries, "batch.entries");
+  if (!batch.tx_types || typeof batch.tx_types !== "object" || Array.isArray(batch.tx_types)) fail("local manifest tx_types is invalid");
+  let txTypeTotal = 0;
+  for (const [txType, count] of Object.entries(batch.tx_types)) {
+    if (!txType || !Number.isSafeInteger(count) || count < 0) fail("local manifest tx_types is invalid");
+    txTypeTotal += count;
+  }
+  if (txTypeTotal !== batch.transactions) fail("local manifest tx_types count mismatch");
+
+  const amounts = manifest.amounts;
+  if (!amounts) fail("local manifest amounts are missing");
+  assertIntegerString(amounts.credits, "amounts.credits", { nonNegative: true });
+  assertIntegerString(amounts.debits, "amounts.debits", { nonNegative: true });
+  if (assertIntegerString(amounts.net, "amounts.net") !== "0") fail("local manifest net amount is not zero");
+  if (amounts.credits !== amounts.debits) fail("local manifest credits and debits differ");
+
+  const bytes = manifest.bytes;
+  if (!bytes || !Number.isSafeInteger(bytes.raw) || bytes.raw < 0 || !Number.isSafeInteger(bytes.compressed) || bytes.compressed < 0 || bytes.compressed > ARCHIVE_MAX_BYTES) {
+    fail("local manifest byte counts are invalid");
+  }
+  if (!manifest.sha256) fail("local manifest checksums are missing");
+  assertSha(manifest.sha256.raw_jsonl, "raw_jsonl SHA-256");
+  assertSha(manifest.sha256.compressed_artifact, "compressed_artifact SHA-256");
+  if (!manifest.time_range || !manifest.cursor || canonicalJson(manifest.cursor.order) !== canonicalJson(CURSOR_ORDER)) {
+    fail("local manifest cursor is invalid");
+  }
+  const cursorStart = verifyCursor(manifest.cursor.start, "cursor.start");
+  const cursorEnd = verifyCursor(manifest.cursor.end, "cursor.end");
+  const cursorNext = verifyCursor(manifest.cursor.next, "cursor.next");
+  if (!sameCursor(cursorEnd, cursorNext)) fail("cursor.next does not match cursor.end");
+  return { cursorStart, cursorEnd };
+}
+
+function summarizeRecords(records, manifest) {
+  if (!Array.isArray(records)) fail("JSONL artifact must contain records");
+  const sorted = [...records].sort(compareTransactions);
+  const seenTransactions = new Set();
+  const seenEntries = new Set();
+  const txTypes = {};
+  let entryCount = 0;
+  let credits = 0n;
+  let debits = 0n;
+  let netAmount = 0n;
+  const cutoff = timestampToMicros(manifest.cutoff.created_at);
+
+  records.forEach((record, recordIndex) => {
+    if (record !== sorted[recordIndex]) fail("JSONL transaction order is not deterministic");
+    const transaction = record?.transaction;
+    const transactionId = text(transaction?.id).toLowerCase();
+    if (record?.schema_version !== EXPORT_SCHEMA_VERSION || record?.record_type !== "chips_transaction" || !UUID_RE.test(transactionId)) {
+      fail("JSONL artifact contains a malformed transaction");
+    }
+    if (seenTransactions.has(transactionId)) fail("JSONL artifact contains duplicate transactions");
+    seenTransactions.add(transactionId);
+    const createdAt = text(transaction.created_at);
+    if (timestampToMicros(createdAt) >= cutoff) fail("JSONL artifact contains a transaction at or after cutoff");
+    const txType = text(transaction.tx_type);
+    if (!txType) fail("JSONL artifact contains a transaction without tx_type");
+    txTypes[txType] = (txTypes[txType] || 0) + 1;
+
+    if (!Array.isArray(record.entries)) fail(`JSONL artifact has no entries array for ${transactionId}`);
+    const sortedEntries = [...record.entries].sort((left, right) => {
+      const leftId = BigInt(assertIntegerString(left?.id, "entry.id", { nonNegative: true }));
+      const rightId = BigInt(assertIntegerString(right?.id, "entry.id", { nonNegative: true }));
+      return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+    });
+    if (record.entries.some((entry, entryIndex) => entry !== sortedEntries[entryIndex])) {
+      fail(`JSONL entry order is not deterministic for ${transactionId}`);
+    }
+    let transactionTotal = 0n;
+    for (const entry of record.entries) {
+      const entryId = assertIntegerString(entry?.id, "entry.id", { nonNegative: true });
+      if (seenEntries.has(entryId)) fail(`JSONL artifact contains duplicate entry ${entryId}`);
+      seenEntries.add(entryId);
+      if (text(entry.transaction_id).toLowerCase() !== transactionId || text(entry.account_id) !== text(entry.account?.id)) {
+        fail(`JSONL entry identity mismatch for ${transactionId}`);
+      }
+      if (!entry.account || !text(entry.account.account_type) || !hasOwn(entry.account, "user_id") || !hasOwn(entry.account, "system_key")) {
+        fail(`JSONL entry account context is incomplete for ${transactionId}`);
+      }
+      assertIntegerString(entry.entry_seq, "entry.entry_seq", { nonNegative: true });
+      timestampToMicros(entry.created_at);
+      const amount = BigInt(assertIntegerString(entry.amount, "entry.amount"));
+      transactionTotal += amount;
+      netAmount += amount;
+      if (amount > 0n) credits += amount;
+      if (amount < 0n) debits -= amount;
+    }
+    if (transactionTotal !== 0n) fail(`JSONL transaction is not conserved: ${transactionId}`);
+    entryCount += record.entries.length;
+  });
+
+  if (netAmount !== 0n || credits !== debits) fail("JSONL batch is not conserved");
+  const first = records[0]?.transaction?.created_at || null;
+  const last = records.at(-1)?.transaction?.created_at || null;
+  const expectedEnd = last ? { created_at: last, id: records.at(-1).transaction.id.toLowerCase() } : null;
+  if (!sameTimestamp(first, manifest.time_range.first_created_at) || !sameTimestamp(last, manifest.time_range.last_created_at)) {
+    fail("local manifest time range does not match JSONL");
+  }
+  if (!sameCursor(expectedEnd, manifest.cursor.end)) fail("local manifest cursor end does not match JSONL");
+  if (manifest.cursor.next && !sameCursor(expectedEnd, manifest.cursor.next)) fail("local manifest cursor next does not match JSONL");
+  if (records.length !== manifest.batch.transactions || entryCount !== manifest.batch.entries) fail("local manifest counts do not match JSONL");
+  if (canonicalJson(Object.fromEntries(Object.entries(txTypes).sort(([left], [right]) => left.localeCompare(right)))) !== canonicalJson(manifest.batch.tx_types)) {
+    fail("local manifest tx_types do not match JSONL");
+  }
+  if (credits.toString() !== manifest.amounts.credits || debits.toString() !== manifest.amounts.debits || netAmount.toString() !== manifest.amounts.net) {
+    fail("local manifest amounts do not match JSONL");
+  }
+  return { transactionCount: records.length, entryCount, txTypes, credits: credits.toString(), debits: debits.toString(), netAmount: netAmount.toString() };
+}
+
+export function buildObjectPath(manifestOrSha) {
+  const sha = typeof manifestOrSha === "string" ? manifestOrSha : manifestOrSha?.sha256?.compressed_artifact;
+  assertSha(sha, "compressed_artifact SHA-256");
+  return `v1/sha256/${sha}.jsonl.gz`;
+}
+
+export function verifyLocalArchive({ artifactPath, manifestPath, target }) {
+  if (!artifactPath || !manifestPath) fail("--artifact and --manifest are required");
+  const artifact = path.resolve(artifactPath);
+  const manifestFile = path.resolve(manifestPath);
+  const stat = fs.statSync(artifact);
+  if (!stat.isFile()) fail("artifact must be a regular file");
+  if (stat.size > ARCHIVE_MAX_BYTES) fail("artifact exceeds the 6 MiB Storage limit");
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+  const { cursorStart, cursorEnd } = verifyManifestShape(manifest, artifact, target);
+  const compressedBytes = fs.readFileSync(artifact);
+  const compressedSha256 = crypto.createHash("sha256").update(compressedBytes).digest("hex");
+  if (compressedBytes.length !== manifest.bytes.compressed || compressedSha256 !== manifest.sha256.compressed_artifact) {
+    fail("local compressed artifact does not match its manifest");
+  }
+  let rawBytes;
+  try {
+    rawBytes = gunzipSync(compressedBytes);
+  } catch {
+    fail("local artifact is not a valid gzip stream");
+  }
+  const rawSha256 = crypto.createHash("sha256").update(rawBytes).digest("hex");
+  if (rawBytes.length !== manifest.bytes.raw || rawSha256 !== manifest.sha256.raw_jsonl) fail("local raw JSONL does not match its manifest");
+  const rawText = rawBytes.toString("utf8");
+  const records = parseJsonl(rawText);
+  if (serializeRecords(records) !== rawText) fail("local JSONL round-trip verification failed");
+  const summary = summarizeRecords(records, manifest);
+  const expectedRatio = rawBytes.length === 0 ? null : Number((compressedBytes.length / rawBytes.length).toFixed(6));
+  if (manifest.bytes.compression_ratio_compressed_over_raw !== expectedRatio) fail("local compression ratio does not match its manifest");
+  return {
+    artifactPath: artifact,
+    manifestPath: manifestFile,
+    manifest,
+    compressedBytes,
+    rawBytes,
+    records,
+    objectPath: buildObjectPath(manifest),
+    cursorStart,
+    cursorEnd,
+    summary,
+  };
+}
+
+function bucketRequestPath() {
+  return `/storage/v1/bucket/${encodeURIComponent(ARCHIVE_BUCKET)}`;
+}
+
+function objectRequestPath(objectPath, mode = "authenticated") {
+  const accessSegment = mode ? `/${mode}` : "";
+  return `/storage/v1/object${accessSegment}/${encodeURIComponent(ARCHIVE_BUCKET)}/${objectPath.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+async function storageRequest(storageTarget, requestPath, options = {}, deps = {}) {
+  const fetchImpl = deps.fetch || fetch;
+  return fetchImpl(`${storageTarget.baseUrl}${requestPath}`, {
+    ...options,
+    headers: {
+      apikey: storageTarget.serviceKey,
+      Authorization: `Bearer ${storageTarget.serviceKey}`,
+      ...(options.headers || {}),
+    },
+  });
+}
+
+function storageFailure(operation, response) {
+  fail(`Storage API ${operation} failed with HTTP ${response.status}`);
+}
+
+async function readJsonResponse(response, operation) {
+  try {
+    return await response.json();
+  } catch {
+    fail(`Storage API ${operation} returned invalid JSON`);
+  }
+}
+
+function verifyBucket(bucket) {
+  if (!bucket || bucket.id !== ARCHIVE_BUCKET || bucket.name !== ARCHIVE_BUCKET) {
+    fail("Storage archive bucket has an unexpected name");
+  }
+  if (bucket.public !== false) fail("Storage archive bucket must be private");
+  if (Number(bucket.file_size_limit) !== ARCHIVE_MAX_BYTES) fail("Storage archive bucket has an unexpected file size limit");
+  if (!Array.isArray(bucket.allowed_mime_types) || bucket.allowed_mime_types.length !== 1 || bucket.allowed_mime_types[0] !== ARCHIVE_MIME_TYPE) {
+    fail("Storage archive bucket has an unexpected MIME policy");
+  }
+  return bucket;
+}
+
+export async function ensureArchiveBucket(storageTarget, deps = {}) {
+  let response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
+  if (response.status === 404) {
+    const createResponse = await storageRequest(storageTarget, "/storage/v1/bucket", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        id: ARCHIVE_BUCKET,
+        name: ARCHIVE_BUCKET,
+        public: false,
+        allowed_mime_types: [ARCHIVE_MIME_TYPE],
+        file_size_limit: ARCHIVE_MAX_BYTES,
+      }),
+    }, deps);
+    if (!createResponse.ok && createResponse.status !== 409) storageFailure("bucket creation", createResponse);
+    response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
+  }
+  if (!response.ok) storageFailure("bucket verification/creation", response);
+  return verifyBucket(await readJsonResponse(response, "bucket verification/creation"));
+}
+
+function manifestRow(manifest, storageTarget, objectPath) {
+  const start = manifest.cursor.start;
+  const end = manifest.cursor.end;
+  return {
+    object_path: objectPath,
+    project_ref: storageTarget.projectRef,
+    format_version: String(manifest.schema_version),
+    cutoff: manifest.cutoff.created_at,
+    cursor_start_created_at: start?.created_at || null,
+    cursor_start_id: start?.id || null,
+    cursor_end_created_at: end?.created_at || null,
+    cursor_end_id: end?.id || null,
+    first_created_at: manifest.time_range.first_created_at || null,
+    last_created_at: manifest.time_range.last_created_at || null,
+    transaction_count: String(manifest.batch.transactions),
+    entry_count: String(manifest.batch.entries),
+    tx_types: manifest.batch.tx_types,
+    raw_bytes: String(manifest.bytes.raw),
+    compressed_bytes: String(manifest.bytes.compressed),
+    raw_sha256: manifest.sha256.raw_jsonl,
+    compressed_sha256: manifest.sha256.compressed_artifact,
+    credits: manifest.amounts.credits,
+    debits: manifest.amounts.debits,
+    net_amount: manifest.amounts.net,
+    status: "pending",
+  };
+}
+
+const IMMUTABLE_FIELDS = [
+  "object_path", "project_ref", "format_version", "cutoff", "cursor_start_created_at", "cursor_start_id",
+  "cursor_end_created_at", "cursor_end_id", "first_created_at", "last_created_at", "transaction_count",
+  "entry_count", "tx_types", "raw_bytes", "compressed_bytes", "raw_sha256", "compressed_sha256", "credits", "debits", "net_amount",
+];
+
+function assertSameManifest(existing, expected) {
+  if (!existing) fail("archive manifest disappeared during storage operation");
+  if (existing.status !== "pending" && existing.status !== "committed") fail("archive manifest has an invalid state");
+  for (const field of IMMUTABLE_FIELDS) {
+    if (!sameValue(existing[field], expected[field], field)) fail(`archive manifest differs in immutable field: ${field}`);
+  }
+  return existing;
+}
+
+export async function loadOrCreatePendingBatch(localArchive, storageTarget, deps = {}) {
+  const store = deps.manifestStore;
+  if (!store || typeof store.get !== "function" || typeof store.insertPending !== "function") fail("manifest store adapter is required");
+  const expected = manifestRow(localArchive.manifest, storageTarget, localArchive.objectPath);
+  const existing = await store.get(expected.object_path);
+  if (existing) return { row: assertSameManifest(existing, expected), created: false, expected };
+  await store.insertPending(expected);
+  const current = await store.get(expected.object_path);
+  return { row: assertSameManifest(current, expected), created: true, expected };
+}
+
+function verifyDownloadedBytes(localArchive, downloaded) {
+  if (downloaded.length !== localArchive.compressedBytes.length || !downloaded.equals(localArchive.compressedBytes)) {
+    fail("downloaded Storage object does not match the local artifact");
+  }
+  return {
+    compressedBytes: downloaded.length,
+    compressedSha256: crypto.createHash("sha256").update(downloaded).digest("hex"),
+  };
+}
+
+async function downloadObject(localArchive, storageTarget, deps = {}) {
+  const response = await storageRequest(storageTarget, objectRequestPath(localArchive.objectPath), { method: "GET" }, deps);
+  if (!response.ok) return { response, downloaded: null };
+  return { response, downloaded: Buffer.from(await response.arrayBuffer()) };
+}
+
+export async function uploadOrVerifyObject(localArchive, storageTarget, deps = {}) {
+  const initialDownloadStarted = Date.now();
+  const existing = await downloadObject(localArchive, storageTarget, deps);
+  const initialDownloadMs = Date.now() - initialDownloadStarted;
+  let objectExisted = false;
+  let uploaded = false;
+  let uploadMs = 0;
+  if (existing.response.ok) {
+    objectExisted = true;
+    const verified = verifyDownloadedBytes(localArchive, existing.downloaded);
+    return { objectExisted, uploaded, uploadMs, downloadMs: initialDownloadMs, ...verified };
+  }
+  if (existing.response.status !== 404) storageFailure("object lookup", existing.response);
+  if (deps.manifestStatus === "committed") fail("committed archive object is missing");
+  const uploadStarted = Date.now();
+  const uploadResponse = await storageRequest(storageTarget, objectRequestPath(localArchive.objectPath, ""), {
+    method: "POST",
+    headers: { "content-type": ARCHIVE_MIME_TYPE, "x-upsert": "false" },
+    body: localArchive.compressedBytes,
+  }, deps);
+  uploadMs = Date.now() - uploadStarted;
+  if (!uploadResponse.ok && uploadResponse.status !== 400 && uploadResponse.status !== 409) {
+    storageFailure("object upload", uploadResponse);
+  }
+  uploaded = uploadResponse.ok;
+  objectExisted = !uploaded;
+  const downloadStarted = Date.now();
+  const downloaded = await downloadObject(localArchive, storageTarget, deps);
+  const downloadMs = Date.now() - downloadStarted;
+  if (!downloaded.response.ok) storageFailure("object download", downloaded.response);
+  const verified = verifyDownloadedBytes(localArchive, downloaded.downloaded);
+  return { objectExisted, uploaded, uploadMs, downloadMs, ...verified };
+}
+
+export async function markBatchCommitted(batch, deps = {}) {
+  const store = deps.manifestStore;
+  if (!store || typeof store.markCommitted !== "function") fail("manifest store adapter is required");
+  const committed = await store.markCommitted(batch.expected.object_path);
+  const row = assertSameManifest(committed, batch.expected);
+  if (row.status !== "committed") fail("archive manifest was not committed");
+  return row;
+}
+
+function selectManifestSql() {
+  return `select
+    object_path,
+    project_ref,
+    format_version::text as format_version,
+    cutoff::text as cutoff,
+    cursor_start_created_at::text as cursor_start_created_at,
+    cursor_start_id::text as cursor_start_id,
+    cursor_end_created_at::text as cursor_end_created_at,
+    cursor_end_id::text as cursor_end_id,
+    first_created_at::text as first_created_at,
+    last_created_at::text as last_created_at,
+    transaction_count::text as transaction_count,
+    entry_count::text as entry_count,
+    tx_types::text as tx_types,
+    raw_bytes::text as raw_bytes,
+    compressed_bytes::text as compressed_bytes,
+    raw_sha256,
+    compressed_sha256,
+    credits::text as credits,
+    debits::text as debits,
+    net_amount::text as net_amount,
+    status
+  from public.chips_ledger_archive_batches
+  where object_path = $1;`;
+}
+
+function normalizeManifestRow(row) {
+  if (!row) return null;
+  return {
+    ...row,
+    format_version: String(row.format_version),
+    tx_types: typeof row.tx_types === "string" ? JSON.parse(row.tx_types) : row.tx_types,
+    transaction_count: String(row.transaction_count),
+    entry_count: String(row.entry_count),
+    raw_bytes: String(row.raw_bytes),
+    compressed_bytes: String(row.compressed_bytes),
+    credits: String(row.credits),
+    debits: String(row.debits),
+    net_amount: String(row.net_amount),
+  };
+}
+
+export function createManifestStore(sql) {
+  if (!sql || typeof sql.unsafe !== "function") fail("postgres manifest adapter is required");
+  const get = async (objectPath) => {
+    const rows = await sql.unsafe(selectManifestSql(), [objectPath]);
+    return normalizeManifestRow(rows[0]);
+  };
+  return {
+    get,
+    async insertPending(row) {
+      await sql.unsafe(`insert into public.chips_ledger_archive_batches
+        (object_path, project_ref, format_version, cutoff, cursor_start_created_at, cursor_start_id,
+         cursor_end_created_at, cursor_end_id, first_created_at, last_created_at, transaction_count,
+         entry_count, tx_types, raw_bytes, compressed_bytes, raw_sha256, compressed_sha256,
+         credits, debits, net_amount, status)
+        values ($1, $2, $3::integer, $4::timestamptz, $5::timestamptz, $6::uuid,
+                $7::timestamptz, $8::uuid, $9::timestamptz, $10::timestamptz, $11::bigint,
+                $12::bigint, $13::jsonb, $14::bigint, $15::bigint, $16, $17,
+                $18::numeric, $19::numeric, $20::numeric, 'pending')
+        on conflict (object_path) do nothing;`, [
+        row.object_path, row.project_ref, row.format_version, row.cutoff, row.cursor_start_created_at, row.cursor_start_id,
+        row.cursor_end_created_at, row.cursor_end_id, row.first_created_at, row.last_created_at, row.transaction_count,
+        row.entry_count, JSON.stringify(row.tx_types), row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
+        row.credits, row.debits, row.net_amount,
+      ]);
+    },
+    async markCommitted(objectPath) {
+      const rows = await sql.unsafe(`update public.chips_ledger_archive_batches
+        set status = 'committed', committed_at = timezone('utc', now())
+        where object_path = $1 and status = 'pending'
+        returning object_path;`, [objectPath]);
+      if (!rows.length) return get(objectPath);
+      return get(objectPath);
+    },
+  };
+}
+
+function outputMetrics(result) {
+  process.stdout.write(`${stringifyJson({
+    event: "chips_ledger_archive_store",
+    read_only_ledger: true,
+    target: result.target,
+    project_ref: result.projectRef,
+    bucket: ARCHIVE_BUCKET,
+    object_path: result.objectPath,
+    status: result.manifest.status,
+    idempotent: result.idempotent,
+    transactions: result.local.summary.transactionCount,
+    entries: result.local.summary.entryCount,
+    tx_types: result.local.manifest.batch.tx_types,
+    amounts: result.local.manifest.amounts,
+    raw_bytes: result.local.manifest.bytes.raw,
+    compressed_bytes: result.local.manifest.bytes.compressed,
+    sha256: result.local.manifest.sha256,
+    uploaded: result.object.uploaded,
+    object_existed: result.object.objectExisted,
+    upload_ms: result.object.uploadMs,
+    download_ms: result.object.downloadMs,
+  })}\n`);
+}
+
+export async function storeArchive({ argv = process.argv.slice(2), env = process.env, cwd = process.cwd(), deps = {} } = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return null;
+  }
+  if (!args.target) fail("--target is required; no default target is allowed");
+  if (!args.artifact) fail("--artifact is required; no default path is allowed");
+  if (!args.manifest) fail("--manifest is required; no default path is allowed");
+  const storageTarget = resolveStorageTarget(args.target, env);
+  const local = verifyLocalArchive({ artifactPath: path.resolve(cwd, args.artifact), manifestPath: path.resolve(cwd, args.manifest), target: storageTarget });
+  const sql = deps.sql || (deps.manifestStore ? null : postgres(storageTarget.dbUrl, { max: 1, prepare: false, connect_timeout: 10, idle_timeout: 30 }));
+  const manifestStore = deps.manifestStore || createManifestStore(sql);
+  const adapterDeps = { ...deps, manifestStore };
+  try {
+    const batch = await loadOrCreatePendingBatch(local, storageTarget, adapterDeps);
+    await ensureArchiveBucket(storageTarget, deps);
+    const object = await uploadOrVerifyObject(local, storageTarget, { ...deps, manifestStatus: batch.row.status });
+    const manifest = await markBatchCommitted(batch, adapterDeps);
+    const result = {
+      target: storageTarget.target,
+      projectRef: storageTarget.projectRef,
+      objectPath: local.objectPath,
+      local,
+      object,
+      manifest,
+      idempotent: manifest.status === "committed" && !object.uploaded,
+    };
+    if (deps.emit !== false) outputMetrics(result);
+    return result;
+  } finally {
+    if (sql) await sql.end({ timeout: 5 });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  storeArchive().catch((error) => {
+    process.stderr.write(`chips-ledger-archive-store failed: ${error?.message || error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -540,6 +540,7 @@ function normalizeManifestRow(row) {
 
 export function createManifestStore(sql) {
   if (!sql || typeof sql.unsafe !== "function") fail("postgres manifest adapter is required");
+  const timestampParam = (value) => value == null || typeof sql.typed !== "function" ? value : sql.typed(value, 25);
   const get = async (objectPath) => {
     const rows = await sql.unsafe(selectManifestSql(), [objectPath]);
     return normalizeManifestRow(rows[0]);
@@ -557,8 +558,8 @@ export function createManifestStore(sql) {
                 $12::bigint, $13::jsonb, $14::bigint, $15::bigint, $16, $17,
                 $18::numeric, $19::numeric, $20::numeric, 'pending')
         on conflict (object_path) do nothing;`, [
-        row.object_path, row.project_ref, row.format_version, row.cutoff, row.cursor_start_created_at, row.cursor_start_id,
-        row.cursor_end_created_at, row.cursor_end_id, row.first_created_at, row.last_created_at, row.transaction_count,
+        row.object_path, row.project_ref, row.format_version, timestampParam(row.cutoff), timestampParam(row.cursor_start_created_at), row.cursor_start_id,
+        timestampParam(row.cursor_end_created_at), row.cursor_end_id, timestampParam(row.first_created_at), timestampParam(row.last_created_at), row.transaction_count,
         row.entry_count, row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
         row.credits, row.debits, row.net_amount,
       ]);

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -559,7 +559,7 @@ export function createManifestStore(sql) {
         on conflict (object_path) do nothing;`, [
         row.object_path, row.project_ref, row.format_version, row.cutoff, row.cursor_start_created_at, row.cursor_start_id,
         row.cursor_end_created_at, row.cursor_end_id, row.first_created_at, row.last_created_at, row.transaction_count,
-        row.entry_count, JSON.stringify(row.tx_types), row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
+        row.entry_count, row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
         row.credits, row.debits, row.net_amount,
       ]);
     },

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -349,7 +349,7 @@ async function readJsonResponse(response, operation) {
   }
 }
 
-async function isMissingBucketResponse(response) {
+async function isMissingStorageResponse(response) {
   if (response.status === 404) return true;
   if (response.status !== 400) return false;
   const body = await response.text().catch(() => "");
@@ -370,7 +370,7 @@ function verifyBucket(bucket) {
 
 export async function ensureArchiveBucket(storageTarget, deps = {}) {
   let response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
-  if (await isMissingBucketResponse(response)) {
+  if (await isMissingStorageResponse(response)) {
     const createResponse = await storageRequest(storageTarget, "/storage/v1/bucket", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -471,7 +471,7 @@ export async function uploadOrVerifyObject(localArchive, storageTarget, deps = {
     const verified = verifyDownloadedBytes(localArchive, existing.downloaded);
     return { objectExisted, uploaded, uploadMs, downloadMs: initialDownloadMs, ...verified };
   }
-  if (existing.response.status !== 404) storageFailure("object lookup", existing.response);
+  if (!(await isMissingStorageResponse(existing.response))) storageFailure("object lookup", existing.response);
   if (deps.manifestStatus === "committed") fail("committed archive object is missing");
   const uploadStarted = Date.now();
   const uploadResponse = await storageRequest(storageTarget, objectRequestPath(localArchive.objectPath, ""), {

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -49,6 +49,7 @@ run("node", ["tests/chips-ledger.escrow-only.null-user.unit.test.mjs"], "chips-l
 run("node", ["tests/chips-ledger.human.buyin.unit.test.mjs"], "chips-ledger-human-buyin");
 run("node", ["tests/chips-ledger-pagination.behavior.test.mjs"], "chips-ledger-pagination-behavior");
 run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-archive-export");
+run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger-archive-storage");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/bonus-campaigns-endpoint.behavior.test.mjs"], "bonus-campaigns-endpoint-behavior");
 run("node", ["tests/bonus-campaigns-scheduler.behavior.test.mjs"], "bonus-campaigns-scheduler-behavior");

--- a/supabase/migrations/20260811150000_chips_ledger_archive_storage.sql
+++ b/supabase/migrations/20260811150000_chips_ledger_archive_storage.sql
@@ -1,0 +1,58 @@
+create table public.chips_ledger_archive_batches (
+  object_path text primary key,
+  project_ref text not null,
+  format_version integer not null,
+  cutoff timestamptz not null,
+  cursor_start_created_at timestamptz,
+  cursor_start_id uuid,
+  cursor_end_created_at timestamptz,
+  cursor_end_id uuid,
+  first_created_at timestamptz,
+  last_created_at timestamptz,
+  transaction_count bigint not null,
+  entry_count bigint not null,
+  tx_types jsonb not null,
+  raw_bytes bigint not null,
+  compressed_bytes bigint not null,
+  raw_sha256 text not null,
+  compressed_sha256 text not null,
+  credits numeric not null,
+  debits numeric not null,
+  net_amount numeric not null,
+  status text not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  committed_at timestamptz,
+  constraint chips_ledger_archive_batches_object_path_check
+    check (object_path ~ '^v1/sha256/[0-9a-f]{64}\.jsonl\.gz$'),
+  constraint chips_ledger_archive_batches_project_ref_check
+    check (project_ref ~ '^[a-z0-9]{20}$'),
+  constraint chips_ledger_archive_batches_format_version_check
+    check (format_version > 0),
+  constraint chips_ledger_archive_batches_cursor_start_pair_check
+    check ((cursor_start_created_at is null) = (cursor_start_id is null)),
+  constraint chips_ledger_archive_batches_cursor_end_pair_check
+    check ((cursor_end_created_at is null) = (cursor_end_id is null)),
+  constraint chips_ledger_archive_batches_time_range_check
+    check (first_created_at is null or last_created_at is null or first_created_at <= last_created_at),
+  constraint chips_ledger_archive_batches_counts_check
+    check (transaction_count >= 0 and entry_count >= 0),
+  constraint chips_ledger_archive_batches_sizes_check
+    check (raw_bytes >= 0 and compressed_bytes >= 0),
+  constraint chips_ledger_archive_batches_tx_types_check
+    check (jsonb_typeof(tx_types) = 'object'),
+  constraint chips_ledger_archive_batches_sha256_check
+    check (raw_sha256 ~ '^[0-9a-f]{64}$' and compressed_sha256 ~ '^[0-9a-f]{64}$'),
+  constraint chips_ledger_archive_batches_amounts_check
+    check (credits >= 0 and debits >= 0 and credits = debits and net_amount = 0),
+  constraint chips_ledger_archive_batches_status_check
+    check (status in ('pending', 'committed')),
+  constraint chips_ledger_archive_batches_commit_state_check
+    check (
+      (status = 'pending' and committed_at is null)
+      or (status = 'committed' and committed_at is not null)
+    )
+);
+
+alter table public.chips_ledger_archive_batches enable row level security;
+
+revoke all on table public.chips_ledger_archive_batches from anon, authenticated;

--- a/tests/chips/chips-ledger-archive-export.test.mjs
+++ b/tests/chips/chips-ledger-archive-export.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   buildArchiveBytes,
   buildExportRecord,
+  buildManifest,
   evaluateTableEligibility,
   runExport,
   serializeRecords,
@@ -53,10 +54,11 @@ function entry(id, transactionId, amount, accountId) {
   };
 }
 
-function makeRecord(tx, firstEntryId = 1) {
+function makeRecord(tx, firstEntryId = 1, amount = 10) {
+  const positiveAmount = String(amount).replace(/^-/, "");
   return buildExportRecord(tx, [
-    entry(firstEntryId + 1, tx.id, -10, SYSTEM),
-    entry(firstEntryId, tx.id, 10, USER),
+    entry(firstEntryId + 1, tx.id, `-${positiveAmount}`, SYSTEM),
+    entry(firstEntryId, tx.id, positiveAmount, USER),
   ]);
 }
 
@@ -89,10 +91,31 @@ const validBatch = validateBatch({
 });
 assert.deepEqual(validBatch.txTypeCounts, { BUY_IN: 2 });
 assert.equal(validBatch.entryCount, 4);
+assert.equal(validBatch.credits, "20");
+assert.equal(validBatch.debits, "20");
+assert.equal(validBatch.netAmount, "0");
+const hugeBatch = validateBatch({
+  candidates: [candidateA],
+  records: [makeRecord(candidateA, 5, "9007199254740993")],
+  cutoff: "2026-02-01T00:00:00Z",
+});
+assert.equal(hugeBatch.credits, "9007199254740993");
+assert.equal(hugeBatch.debits, "9007199254740993");
+assert.equal(hugeBatch.netAmount, "0");
 const archiveOne = buildArchiveBytes(ordered);
 const archiveTwo = buildArchiveBytes(sortRecords([recordB, recordA]));
 assert.equal(archiveOne.rawSha256, archiveTwo.rawSha256);
 assert.equal(archiveOne.compressedSha256, archiveTwo.compressedSha256);
+const manifest = buildManifest({
+  target: "stage",
+  cutoff: "2026-02-01T00:00:00Z",
+  batchSize: 5000,
+  cursor: null,
+  records: ordered,
+  archive: archiveOne,
+  outputPath: "/private/chips-ledger-stage.jsonl.gz",
+});
+assert.deepEqual(manifest.amounts, { credits: "20", debits: "20", net: "0" });
 
 assert.throws(
   () => validateBatch({

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildArchiveBytes,
+  buildExportRecord,
+  buildManifest,
+} from "../../scripts/ops/chips-ledger-archive-export.mjs";
+import { ARCHIVE_BUCKET, ARCHIVE_MAX_BYTES, storeArchive } from "../../scripts/ops/chips-ledger-archive-store.mjs";
+
+const TX_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const SYSTEM_ID = "00000000-0000-4000-8000-000000000003";
+
+const ENV = {
+  EXPECTED_SUPABASE_STAGE_PROJECT_REF: "krydukthwdvccggbyjfw",
+  EXPECTED_SUPABASE_PROD_PROJECT_REF: "otbqfijerkieoxwpxjnm",
+  SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
+  SUPABASE_PROD_DB_URL: "postgresql://postgres.otbqfijerkieoxwpxjnm@db.otbqfijerkieoxwpxjnm.supabase.co:5432/postgres",
+  SUPABASE_URL: "https://krydukthwdvccggbyjfw.supabase.co",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+};
+
+function responseJson(value, status = 200) {
+  return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+}
+
+function bucket() {
+  return {
+    id: ARCHIVE_BUCKET,
+    name: ARCHIVE_BUCKET,
+    public: false,
+    file_size_limit: ARCHIVE_MAX_BYTES,
+    allowed_mime_types: ["application/gzip"],
+  };
+}
+
+function makeFetch({ initialObject = null, bucketInitiallyExists = false } = {}) {
+  let object = initialObject;
+  let bucketExists = bucketInitiallyExists;
+  const calls = [];
+  const fetch = async (url, init = {}) => {
+    const requestUrl = new URL(url);
+    const method = init.method || "GET";
+    calls.push({ method, path: requestUrl.pathname, headers: new Headers(init.headers || {}) });
+    if (requestUrl.pathname === `/storage/v1/bucket/${ARCHIVE_BUCKET}` && method === "GET") {
+      return bucketExists ? responseJson(bucket()) : responseJson({ message: "not found" }, 404);
+    }
+    if (requestUrl.pathname === "/storage/v1/bucket" && method === "POST") {
+      bucketExists = true;
+      return responseJson(bucket(), 200);
+    }
+    if (requestUrl.pathname.includes(`/storage/v1/object/authenticated/${ARCHIVE_BUCKET}/`) && method === "GET") {
+      return object ? new Response(object, { status: 200 }) : new Response(null, { status: 404 });
+    }
+    if (requestUrl.pathname.includes(`/storage/v1/object/${ARCHIVE_BUCKET}/`) && method === "POST") {
+      assert.equal(new Headers(init.headers).get("x-upsert"), "false");
+      if (object) return responseJson({ message: "Asset Already Exists" }, 400);
+      object = Buffer.from(init.body);
+      return responseJson({ Key: requestUrl.pathname }, 200);
+    }
+    return responseJson({ message: "unexpected fake request" }, 500);
+  };
+  return { fetch, calls, get object() { return object; } };
+}
+
+function makeStore(initial = null) {
+  let row = initial;
+  let insertCount = 0;
+  let commitCount = 0;
+  return {
+    get: async () => row,
+    insertPending: async (expected) => {
+      insertCount += 1;
+      if (!row) row = { ...expected };
+    },
+    markCommitted: async () => {
+      commitCount += 1;
+      if (row?.status === "pending") row = { ...row, status: "committed" };
+      return row;
+    },
+    get insertCount() { return insertCount; },
+    get commitCount() { return commitCount; },
+    get row() { return row; },
+  };
+}
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-storage-test-"));
+const artifactPath = path.join(tempDir, "chips-ledger-stage.jsonl.gz");
+const manifestPath = path.join(tempDir, "chips-ledger-stage.manifest.json");
+const candidate = {
+  id: TX_ID,
+  sequence: "1",
+  tx_type: "BUY_IN",
+  idempotency_key: "storage-test:1",
+  payload_hash: "hash",
+  user_id: USER_ID,
+  reference: null,
+  description: "storage test",
+  metadata: {},
+  created_by: USER_ID,
+  created_at: "2026-01-01T00:00:00.000000Z",
+  entry_count: "2",
+  table_related: false,
+};
+const record = buildExportRecord(candidate, [
+  {
+    id: "2", transaction_id: TX_ID, account_id: SYSTEM_ID, entry_seq: "2", amount: "-9007199254740993",
+    metadata: {}, created_at: "2026-01-01T00:00:00.000000Z", account_row_id: SYSTEM_ID, account_type: "SYSTEM",
+    account_user_id: null, account_system_key: "TREASURY", account_status: "active", account_label: null,
+  },
+  {
+    id: "1", transaction_id: TX_ID, account_id: USER_ID, entry_seq: "1", amount: "9007199254740993",
+    metadata: {}, created_at: "2026-01-01T00:00:00.000000Z", account_row_id: USER_ID, account_type: "USER",
+    account_user_id: USER_ID, account_system_key: null, account_status: "active", account_label: null,
+  },
+]);
+const archive = buildArchiveBytes([record]);
+const localManifest = buildManifest({
+  target: "stage",
+  cutoff: "2026-02-01T00:00:00.000000Z",
+  batchSize: 5000,
+  cursor: null,
+  records: [record],
+  archive,
+  outputPath: artifactPath,
+});
+fs.writeFileSync(artifactPath, archive.compressedBytes, { mode: 0o600 });
+fs.writeFileSync(manifestPath, `${JSON.stringify(localManifest)}\n`, { mode: 0o600 });
+
+try {
+  const firstStorage = makeFetch();
+  const firstStore = makeStore();
+  const first = await storeArchive({
+    argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+    env: ENV,
+    deps: { fetch: firstStorage.fetch, manifestStore: firstStore, emit: false },
+  });
+  assert.equal(first.manifest.status, "committed");
+  assert.equal(first.object.uploaded, true);
+  assert.equal(firstStore.insertCount, 1);
+  assert.equal(firstStore.commitCount, 1);
+  assert.equal(firstStorage.calls.filter((call) => call.method === "POST" && call.path.includes("/object/")).length, 1);
+
+  const retryStore = makeStore({ ...firstStore.row, status: "pending" });
+  const retry = await storeArchive({
+    argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+    env: ENV,
+    deps: { fetch: firstStorage.fetch, manifestStore: retryStore, emit: false },
+  });
+  assert.equal(retry.manifest.status, "committed");
+  assert.equal(retry.idempotent, true);
+  assert.equal(retry.object.uploaded, false);
+  assert.equal(firstStorage.calls.filter((call) => call.method === "POST" && call.path.includes("/object/")).length, 1);
+
+  const mismatchStorage = makeFetch({ initialObject: Buffer.from("different object"), bucketInitiallyExists: true });
+  const mismatchStore = makeStore({ ...firstStore.row, status: "pending" });
+  await assert.rejects(
+    () => storeArchive({
+      argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+      env: ENV,
+      deps: { fetch: mismatchStorage.fetch, manifestStore: mismatchStore, emit: false },
+    }),
+    /does not match the local artifact/,
+  );
+  assert.equal(mismatchStore.commitCount, 0);
+  assert.equal(mismatchStore.row.status, "pending");
+} finally {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+}
+
+process.stdout.write("chips-ledger-archive-storage tests passed\n");

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -7,7 +7,7 @@ import {
   buildExportRecord,
   buildManifest,
 } from "../../scripts/ops/chips-ledger-archive-export.mjs";
-import { ARCHIVE_BUCKET, ARCHIVE_MAX_BYTES, storeArchive } from "../../scripts/ops/chips-ledger-archive-store.mjs";
+import { ARCHIVE_BUCKET, ARCHIVE_MAX_BYTES, createManifestStore, storeArchive } from "../../scripts/ops/chips-ledger-archive-store.mjs";
 
 const TX_ID = "00000000-0000-4000-8000-000000000001";
 const USER_ID = "00000000-0000-4000-8000-000000000002";
@@ -142,6 +142,12 @@ try {
   assert.equal(firstStore.insertCount, 1);
   assert.equal(firstStore.commitCount, 1);
   assert.equal(firstStorage.calls.filter((call) => call.method === "POST" && call.path.includes("/object/")).length, 1);
+
+  const sqlCalls = [];
+  const sqlAdapter = createManifestStore({ unsafe: async (query, values) => { sqlCalls.push({ query, values }); return []; } });
+  await sqlAdapter.insertPending(firstStore.row);
+  assert.equal(typeof sqlCalls[0].values[12], "object");
+  assert.deepEqual(sqlCalls[0].values[12], firstStore.row.tx_types);
 
   const retryStore = makeStore({ ...firstStore.row, status: "pending" });
   const retry = await storeArchive({

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -45,7 +45,7 @@ function makeFetch({ initialObject = null, bucketInitiallyExists = false } = {})
     const method = init.method || "GET";
     calls.push({ method, path: requestUrl.pathname, headers: new Headers(init.headers || {}) });
     if (requestUrl.pathname === `/storage/v1/bucket/${ARCHIVE_BUCKET}` && method === "GET") {
-      return bucketExists ? responseJson(bucket()) : responseJson({ message: "not found" }, 404);
+      return bucketExists ? responseJson(bucket()) : responseJson({ message: "not found" }, 400);
     }
     if (requestUrl.pathname === "/storage/v1/bucket" && method === "POST") {
       bucketExists = true;

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -52,7 +52,7 @@ function makeFetch({ initialObject = null, bucketInitiallyExists = false } = {})
       return responseJson(bucket(), 200);
     }
     if (requestUrl.pathname.includes(`/storage/v1/object/authenticated/${ARCHIVE_BUCKET}/`) && method === "GET") {
-      return object ? new Response(object, { status: 200 }) : new Response(null, { status: 404 });
+      return object ? new Response(object, { status: 200 }) : responseJson({ message: "not found" }, 400);
     }
     if (requestUrl.pathname.includes(`/storage/v1/object/${ARCHIVE_BUCKET}/`) && method === "POST") {
       assert.equal(new Headers(init.headers).get("x-upsert"), "false");

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -144,10 +144,14 @@ try {
   assert.equal(firstStorage.calls.filter((call) => call.method === "POST" && call.path.includes("/object/")).length, 1);
 
   const sqlCalls = [];
-  const sqlAdapter = createManifestStore({ unsafe: async (query, values) => { sqlCalls.push({ query, values }); return []; } });
+  const sqlAdapter = createManifestStore({
+    typed: (value, type) => ({ value, type }),
+    unsafe: async (query, values) => { sqlCalls.push({ query, values }); return []; },
+  });
   await sqlAdapter.insertPending(firstStore.row);
   assert.equal(typeof sqlCalls[0].values[12], "object");
   assert.deepEqual(sqlCalls[0].values[12], firstStore.row.tx_types);
+  assert.deepEqual(sqlCalls[0].values[3], { value: firstStore.row.cutoff, type: 25 });
 
   const retryStore = makeStore({ ...firstStore.row, status: "pending" });
   const retry = await storeArchive({


### PR DESCRIPTION
## Summary

Implements Issue #874 Stage 2B.2 on top of the merged Stage 2B.1 exporter.

- Adds `chips_ledger_archive_batches` as a small PostgreSQL manifest registry.
- Extends the local exporter manifest with exact bigint-safe credits, absolute debits, and net totals.
- Adds a native `fetch` + `postgres` Storage uploader with explicit target, HTTPS/project-ref checks, private bucket verification/creation through the Storage API, no-upsert upload, private download verification, and conditional `pending -> committed` state.
- Adds fundamental exporter and Storage fake-adapter tests plus the Stage 2B.2 runbook.

## Safety boundary

The ledger is read-only. This PR has no ledger `DELETE`, pruning, Storage delete, overwrite, migration of `storage.*`, scheduler, idempotency registry for runtime accounting, cold-history API/UI, runtime/WS/browser changes, or new persistent environment variables. Production is not used by validation; the uploader only permits Production when explicitly selected and independently project-ref validated.

The bucket is `chips-ledger-archive`, private, `application/gzip`, and 6 MiB maximum. Object paths are `v1/sha256/<compressed-sha256>.jsonl.gz`. A private download must match the local compressed size and SHA before a manifest can commit.

## Verification

Local verification completed:

- `npm test` — passed (the separate existing `ws-server` lockfile was installed locally because root dependencies do not include `ws`).
- `npm run check:all` — passed.
- `npm run ci:guards` — passed.
- `npm run lint:games` — passed.
- `node scripts/check-db-migrations.mjs` — passed.
- `node scripts/syntax-check.mjs` — passed.
- `git diff --check` — passed.

Stage verification completed on the exact final HEAD `a34bc7b070f5d312e1fd457da3d2085bb5aaa0af`:

- `DB Stage Apply PR` succeeded and applied the manifest migration on Stage.
- A non-empty 5000-transaction export was uploaded without overwrite, downloaded privately, verified, and committed.
- An identical second run was idempotent and did not upload.
- Public unauthenticated access was rejected.
- The detailed aggregate metrics are recorded in Issue #874 and this PR.
- One earlier pending manifest row from a failed pre-fix attempt remains intentionally untouched for fail-closed recovery; the selected final object path has exactly one object and one committed manifest.

No Production migration, archive run, or ledger mutation was used.