### PR TITLE
Issue #874: add controlled Stage ledger archive pruning

### DIFF
--- a/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
+++ b/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
@@ -70,7 +70,9 @@ empty receipt together. Registry identity and replay snapshots remain online;
 runtime replay never needs Storage.
 
 Every execute call repeats the complete validation. A successful dry-run is
-diagnostic evidence, not authorization for a later execute.
+diagnostic evidence, not authorization for a later execute. The database
+rejects a `NULL` execute flag, and only literal `TRUE` can enter the mutation
+path.
 
 ## Eligibility and concurrency gates
 
@@ -119,6 +121,10 @@ The manifest guard blocks deletion, makes the original proof fields and
 `NULL -> complete` transition for both archive ID proof and prune receipt. The
 registry guard permits only one `NULL -> archive_batch_id` transition and
 continues to prohibit registry deletion and identity/replay replacement.
+Proof, receipt, and mapping transitions require
+`current_user = 'chips_ledger_archive_pruner'`; even the direct operations role
+cannot write them, and proof plus receipt cannot be set in one update. The
+initial measurement intentionally has no index on `archive_batch_id`.
 
 ## CLI and recovery copy
 
@@ -151,6 +157,11 @@ overwrite, per-file `fsync`, and parent-directory `fsync`. An exact existing
 bundle may be reused for an idempotent retry; a partial or different bundle
 fails closed. The CLI rechecks both local files, gzip, both archive hashes,
 counts, conservation, and ordered ID hashes before every database attempt.
+
+Before any database preflight and again after a successful destructive commit,
+the CLI reads (but never creates or updates) the Storage bucket configuration
+and requires the exact `chips-ledger-archive` name, `public=false`, only
+`application/gzip`, and the 6 MiB object limit.
 
 After commit, the CLI downloads the private Storage object again, verifies its
 compressed and raw hashes and full archive contract, and checks the database

--- a/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
+++ b/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
@@ -1,0 +1,210 @@
+# Issue #874 — Stage 2B.4 controlled ledger pruning
+
+Stage 2B.4 adds a manual, bounded pruning path for one previously committed
+and verified Stage archive. It removes only the exact hot transaction and
+entry IDs contained in that archive. A cutoff, timestamp range, or cursor is
+evidence checked against the archive manifest; none of them is a deletion
+selector.
+
+This first version is deliberately narrow. It accepts only technical
+`TABLE_BUY_IN` and `TABLE_CASH_OUT` transactions with `user_id IS NULL`, no
+entries for `USER` accounts, exactly one `SYSTEM` entry, exactly one `ESCROW`
+entry, and exactly one unambiguous table ID per transaction. It processes one
+all-or-nothing batch of at most 5,000 transactions. It does not prune user
+ledger history, upload or delete Storage objects, run on a schedule, or support
+Production.
+
+## Immutable archive proof
+
+The CLI privately downloads the committed object, verifies the complete Stage
+2B.1/2B.2 contract, and derives ordered ID proofs from the JSONL bytes. Proof
+registration is a separate, non-destructive database transaction. A committed
+manifest may transition once from no proof to a complete proof; the guard
+prevents replacing or clearing it.
+
+The bytes hashed by Node and PostgreSQL are defined exactly:
+
+- transaction proof: every `transaction.id` as a lowercase canonical UUID in
+  JSONL record order, UTF-8 encoded and followed by one LF byte (`0a`);
+- entry proof: every `entry.id` as canonical positive decimal bigint text with
+  no leading zeroes, in JSONL record order and then entry-array order within
+  each record, UTF-8 encoded and followed by one LF byte;
+- there is no BOM, whitespace, separator other than LF, or extra empty value;
+  the final ID is also followed by LF.
+
+The shared known vector is:
+
+```text
+transactions:
+00000000-0000-4000-8000-00000000000a\n00000000-0000-4000-8000-00000000000b\n
+SHA-256: 726400e7a16ea9e7ca71ee707fb025934613059de29366a5ae7f626256b688fa
+
+entries:
+1\n2\n10\n9007199254740993\n
+SHA-256: 58eb8c6b6deb82261f809eb3277a61b010224ae0fe568f199ced00f51f7dd8ac
+```
+
+Proof registration compares the archive-derived counts, `tx_types`, amount
+totals, raw/compressed sizes and hashes, cutoff, cursor, and first/last
+timestamps with the immutable committed manifest before storing the two ID
+hashes. Registration does not change ledger rows.
+
+## Database state machine
+
+The pruning function locks the manifest first and then follows this order:
+
+1. A complete matching receipt requires all mapped registry rows and no hot
+   transaction or entry rows. It returns `already_pruned` without trying to
+   validate rows that were intentionally removed.
+2. With no receipt, no mappings may exist. The complete hot batch must still
+   exist and pass every current eligibility and accounting check before a
+   dry-run can return `ready` or execute can prune it.
+3. A partial receipt, partial hot batch, partial or foreign mapping, or mapping
+   without a receipt fails closed.
+
+Execute maps each durable idempotency row to the archive batch, deletes the
+exact entry IDs, deletes the exact transaction IDs, verifies exact row counts
+and unchanged account balances and `next_entry_seq`, and writes one immutable
+receipt in the same transaction. A rollback restores mappings, rows, and the
+empty receipt together. Registry identity and replay snapshots remain online;
+runtime replay never needs Storage.
+
+Every execute call repeats the complete validation. A successful dry-run is
+diagnostic evidence, not authorization for a later execute.
+
+## Eligibility and concurrency gates
+
+For every transaction, the function rechecks:
+
+- the exact `TABLE_BUY_IN`/`TABLE_CASH_OUT` whitelist and direction of amounts;
+- `user_id IS NULL`, zero `USER` entries, two complete entries, and exact
+  double-entry conservation;
+- one table marker derived consistently from metadata, reference, or escrow
+  account context;
+- transaction age below the committed cutoff;
+- an absent retained table or an existing table in `CLOSED` state;
+- an existing active table escrow account whose balance is exactly `0`;
+- a matching durable idempotency identity row;
+- exact counts, order, ID hashes, `tx_types`, amount totals, time range, and
+  cursor end from the committed archive.
+
+All distinct table IDs and all affected tables, accounts, registry rows,
+transactions, and entries are locked in deterministic order. The CLI owns the
+transaction boundary: it uses `SERIALIZABLE`, a local five-second lock timeout,
+and a local 120-second statement timeout. Execute retries at most three times,
+and only for a serialization failure or lock timeout. Other errors fail
+immediately. The whole batch is atomic.
+
+## Stage-only authorization
+
+Both the CLI and the database function require canonical Stage. The database
+function reads PostgreSQL's stable system identifier and accepts only
+`7656985631720456337`; it explicitly rejects Production identifier
+`7575202818581710058`. The committed manifest project ref must also be
+`krydukthwdvccggbyjfw`. The manifest value is a secondary consistency check,
+not the server identity gate.
+
+The destructive function is `SECURITY DEFINER`, has an empty `search_path`,
+and is owned by the `NOLOGIN`, `NOINHERIT`, `NOBYPASSRLS` role
+`chips_ledger_archive_pruner`. Its tables and functions are schema-qualified.
+The role has only the table, column, row-lock, and delete permissions needed by
+the operation, plus role-specific RLS policies. `PUBLIC`, `anon`,
+`authenticated`, and `service_role` cannot execute the proof or pruning
+functions. The CLI connects through the existing direct Stage PostgreSQL
+operations credential; Storage authorization is used only for private
+downloads.
+
+The manifest guard blocks deletion, makes the original proof fields and
+`batch_id` immutable, permits only `pending -> committed`, and permits one
+`NULL -> complete` transition for both archive ID proof and prune receipt. The
+registry guard permits only one `NULL -> archive_batch_id` transition and
+continues to prohibit registry deletion and identity/replay replacement.
+
+## CLI and recovery copy
+
+The command has no Production or implicit execute mode:
+
+```sh
+node scripts/ops/chips-ledger-archive-prune.mjs \
+  --target stage \
+  --object-path v1/sha256/<compressed-sha256>.jsonl.gz \
+  --confirm-sha <compressed-sha256>
+```
+
+The default is database dry-run. Use `--register-proof` once after full private
+Storage verification. Execution requires both `--execute` and an explicit
+private recovery location:
+
+```sh
+node scripts/ops/chips-ledger-archive-prune.mjs \
+  --target stage \
+  --object-path v1/sha256/<compressed-sha256>.jsonl.gz \
+  --confirm-sha <compressed-sha256> \
+  --execute \
+  --recovery-dir /private/recovery-directory
+```
+
+Before opening the destructive database transaction, execute writes the
+verified `.jsonl.gz` and a recovery manifest to a real directory owned by the
+operator with mode `0700`. Files use mode `0600`, exclusive creation without
+overwrite, per-file `fsync`, and parent-directory `fsync`. An exact existing
+bundle may be reused for an idempotent retry; a partial or different bundle
+fails closed. The CLI rechecks both local files, gzip, both archive hashes,
+counts, conservation, and ordered ID hashes before every database attempt.
+
+After commit, the CLI downloads the private Storage object again, verifies its
+compressed and raw hashes and full archive contract, and checks the database
+receipt, mappings, and absence of hot rows. A post-commit verification failure
+cannot roll back a committed transaction: the CLI reports a distinct failure,
+retains the recovery bundle, and operators must stop further pruning while the
+receipt and archive are reconciled. It never performs remote cleanup.
+
+## Stage procedure and evidence
+
+Apply the migration through the existing exact-HEAD Stage workflow. For a
+committed candidate object, run proof registration, dry-run, execute with a
+new private recovery directory, and an identical execute retry. Confirm
+`ready`, then `pruned`, then `already_pruned`; exactly one receipt and one
+registry mapping per transaction; zero matching hot rows; unchanged balances
+and account sequences; and an unchanged, privately downloadable Storage
+object. Retain the recovery bundle until the operational evidence has been
+reviewed.
+
+Record only aggregate evidence in Issue #874 and the PR:
+
+- exact PR HEAD, Stage project ref, and PostgreSQL system identifier;
+- bucket, object path, compressed SHA-256, and both ordered ID SHA-256 values;
+- cutoff, cursor, first/last timestamps, counts, `tx_types`, and amount totals;
+- user transaction count, USER entry count, and distinct table count;
+- dry-run, execute, receipt, mapping, retry, and post-commit download results;
+- before/after hot relation counts and sizes, while noting that ordinary
+  PostgreSQL deletes do not immediately return physical relation space;
+- recovery directory/file permission checks and confirmation that Production
+  and Storage were not mutated.
+
+Before any Production design can be approved, complete at least two independent
+Stage prune/retry cycles, exercise interruption recovery, prove stable user and
+admin runtime behavior, quantify history/API impact, verify idempotency parity
+after pruning, review database capacity effects including the still-linear
+registry, and obtain explicit approval for a Production migration and retention
+policy. The Production system identifier must remain rejected by this version.
+
+## Breaking impact and scope boundary
+
+Balances, conservation, account sequences, active-table provenance, terminal
+cash-out, recovery invariants, and current idempotent replay are preserved.
+Because this version rejects transactions and entries associated with `USER`
+accounts, user ledger history and user `afterSeq` pagination are not changed.
+
+The intentional Stage breaking impact is removal of the selected technical
+transactions from hot global, admin, and table-history queries. Those callers
+will no longer find the pruned rows in PostgreSQL; no cold-history API is added
+here. That loss must be accepted for each Stage candidate and separately
+designed before Production.
+
+This stage does not modify balances, upload or delete Storage objects, create
+new archives, prune user transactions, run on Production, add a scheduler,
+change runtime/WS/UI code, or add environment variables. It also does not make
+database growth fully bounded: `chips_transaction_idempotency` remains durable
+and grows linearly. Issue #874 therefore cannot be closed solely because one
+Stage 2B.4 batch succeeds.

--- a/scripts/ops/_shared/chips-ledger-archive-files.mjs
+++ b/scripts/ops/_shared/chips-ledger-archive-files.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function fsyncDirectory(directoryPath) {
+  let descriptor = null;
+  try {
+    descriptor = fs.openSync(directoryPath, fs.constants.O_RDONLY);
+    fs.fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+function writeExclusive(filePath, data) {
+  let descriptor = null;
+  let created = false;
+  try {
+    descriptor = fs.openSync(filePath, "wx", 0o600);
+    created = true;
+    fs.writeFileSync(descriptor, data);
+    fs.fsyncSync(descriptor);
+  } catch (error) {
+    if (created) {
+      try { fs.unlinkSync(filePath); } catch { /* cleanup only the partial file created here */ }
+    }
+    throw error;
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+export function ensurePrivateDirectory(directoryPath) {
+  const resolved = path.resolve(directoryPath);
+  if (!fs.existsSync(resolved)) fs.mkdirSync(resolved, { mode: 0o700 });
+  const stat = fs.lstatSync(resolved);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) fail("recovery directory must be a real directory");
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) fail("recovery directory must belong to the current user");
+  if ((stat.mode & 0o777) !== 0o700) fail("recovery directory permissions must be 0700");
+  return resolved;
+}
+
+export function writeExclusiveFiles(files, { createDirectories = true } = {}) {
+  if (!Array.isArray(files) || files.length === 0) fail("at least one output file is required");
+  const normalized = files.map((file) => ({
+    path: path.resolve(file.path),
+    data: file.data,
+  }));
+  if (new Set(normalized.map((file) => file.path)).size !== normalized.length) fail("output file paths must be unique");
+  const directories = [...new Set(normalized.map((file) => path.dirname(file.path)))];
+  if (createDirectories) {
+    for (const directory of directories) fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+
+  const created = [];
+  try {
+    for (const file of normalized) {
+      writeExclusive(file.path, file.data);
+      created.push(file.path);
+    }
+    for (const directory of directories) fsyncDirectory(directory);
+  } catch (error) {
+    for (const filePath of created.reverse()) {
+      try { fs.unlinkSync(filePath); } catch { /* cleanup only files created by this call */ }
+    }
+    for (const directory of directories) {
+      try { fsyncDirectory(directory); } catch { /* preserve the original write error */ }
+    }
+    throw error;
+  }
+  return normalized.map((file) => file.path);
+}
+
+export function assertPrivateRegularFile(filePath) {
+  const resolved = path.resolve(filePath);
+  const stat = fs.lstatSync(resolved);
+  if (!stat.isFile() || stat.isSymbolicLink()) fail("recovery bundle members must be regular files");
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) fail("recovery bundle members must belong to the current user");
+  if ((stat.mode & 0o777) !== 0o600) fail("recovery bundle member permissions must be 0600");
+  return resolved;
+}

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
 import postgres from "postgres";
+import { writeExclusiveFiles } from "./_shared/chips-ledger-archive-files.mjs";
 
 export const EXPORT_SCHEMA_VERSION = 1;
 export const DEFAULT_CUTOFF_DAYS = 30;
@@ -626,42 +627,11 @@ function groupEntries(rows, candidateIds) {
   return groups;
 }
 
-function writeExclusive(filePath, data) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  let descriptor = null;
-  let created = false;
-  try {
-    descriptor = fs.openSync(filePath, "wx", 0o600);
-    created = true;
-    fs.writeSync(descriptor, data);
-    fs.fsyncSync(descriptor);
-  } catch (error) {
-    if (created) {
-      try { fs.unlinkSync(filePath); } catch { /* best effort cleanup of our own partial artifact */ }
-    }
-    throw error;
-  } finally {
-    if (descriptor !== null) fs.closeSync(descriptor);
-  }
-}
-
 function writeOutput(options, archive, manifest) {
-  let artifactCreated = false;
-  let manifestCreated = false;
-  try {
-    writeExclusive(options.outputPath, archive.compressedBytes);
-    artifactCreated = true;
-    writeExclusive(options.manifestPath, `${stringifyJson(manifest)}\n`);
-    manifestCreated = true;
-  } catch (error) {
-    if (manifestCreated) {
-      try { fs.unlinkSync(options.manifestPath); } catch { /* best effort cleanup of our own artifact */ }
-    }
-    if (artifactCreated) {
-      try { fs.unlinkSync(options.outputPath); } catch { /* best effort cleanup of our own artifact */ }
-    }
-    throw error;
-  }
+  writeExclusiveFiles([
+    { path: options.outputPath, data: archive.compressedBytes },
+    { path: options.manifestPath, data: `${stringifyJson(manifest)}\n` },
+  ]);
 }
 
 function outputMetrics(manifest, options) {

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -600,13 +600,14 @@ function resolveOptions(args, env, cwd, now) {
   return { ...target, cutoff, batchSize, cursor: resolveCursor(args), outputPath, manifestPath };
 }
 
-async function readSnapshot(sql, options) {
+export async function readSnapshot(sql, options) {
+  const timestampParam = (value) => value == null || typeof sql.typed !== "function" ? value : sql.typed(value, 25);
   return sql.begin(async (tx) => {
     await tx.unsafe("set transaction isolation level repeatable read, read only;");
     const candidates = await tx.unsafe(CANDIDATE_SQL, [
-      options.cutoff,
+      timestampParam(options.cutoff),
       options.batchSize,
-      options.cursor?.created_at || null,
+      timestampParam(options.cursor?.created_at || null),
       options.cursor?.id || null,
     ]);
     const ids = candidates.map((candidate) => text(candidate.id));

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -9,6 +9,7 @@ import {
   buildObjectPath,
   downloadPrivateArchiveObject,
   resolveStorageTarget,
+  verifyArchiveBucket,
   verifyArchiveBytes,
 } from "./chips-ledger-archive-store.mjs";
 import {
@@ -530,7 +531,10 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     idle_timeout: 30,
   }));
   const store = deps.pruneStore || createPruneStore(sql);
+  const verifyBucket = deps.verifyBucket
+    || ((storageTarget) => verifyArchiveBucket(storageTarget, deps));
   try {
+    await verifyBucket(target);
     const identity = await store.getIdentity();
     const row = await store.getManifest(args.objectPath);
     assertStageIdentity(identity, row);
@@ -589,6 +593,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     let postCommitDownloadMs = null;
     if (args.execute) {
       try {
+        await verifyBucket(target);
         const postCommitDownload = deps.downloadArchive
           ? await deps.downloadArchive(target, row.object_path)
           : await downloadPrivateArchiveObject(target, row.object_path, deps);

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -388,6 +388,7 @@ function manifestSelectSql() {
 
 export function createPruneStore(sql) {
   if (!sql || typeof sql.unsafe !== "function" || typeof sql.begin !== "function") fail("PostgreSQL prune adapter is required");
+  const timestampParam = (value) => value == null || typeof sql.typed !== "function" ? value : sql.typed(value, 25);
   return {
     async getIdentity() {
       const rows = await sql.unsafe("select system_identifier::text as system_identifier from pg_catalog.pg_control_system();");
@@ -407,8 +408,8 @@ export function createPruneStore(sql) {
           $15::bigint, $16, $17, $18::numeric, $19::numeric, $20::numeric
         ) as result;`, [
           row.object_path, evidence.transactionIds, evidence.entryIds, row.project_ref,
-          row.format_version, row.cutoff, row.cursor_start_created_at, row.cursor_start_id,
-          row.cursor_end_created_at, row.cursor_end_id, row.first_created_at, row.last_created_at,
+          row.format_version, timestampParam(row.cutoff), timestampParam(row.cursor_start_created_at), row.cursor_start_id,
+          timestampParam(row.cursor_end_created_at), row.cursor_end_id, timestampParam(row.first_created_at), timestampParam(row.last_created_at),
           row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
           row.credits, row.debits, row.net_amount,
         ]);

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -1,0 +1,626 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { stringifyJson } from "./chips-ledger-archive-export.mjs";
+import {
+  ARCHIVE_BUCKET,
+  buildObjectPath,
+  downloadPrivateArchiveObject,
+  resolveStorageTarget,
+  verifyArchiveBytes,
+} from "./chips-ledger-archive-store.mjs";
+import {
+  assertPrivateRegularFile,
+  ensurePrivateDirectory,
+  writeExclusiveFiles,
+} from "./_shared/chips-ledger-archive-files.mjs";
+
+export const STAGE_SYSTEM_IDENTIFIER = "7656985631720456337";
+export const PRODUCTION_SYSTEM_IDENTIFIER = "7575202818581710058";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ENTRY_ID_RE = /^[1-9][0-9]*$/;
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const ALLOWED_TX_TYPES = new Set(["TABLE_BUY_IN", "TABLE_CASH_OUT"]);
+const MAX_BATCH_SIZE = 5000;
+const MAX_EXECUTE_ATTEMPTS = 3;
+
+const HELP = `Usage: node scripts/ops/chips-ledger-archive-prune.mjs [options]
+
+Required:
+  --target stage                 Canonical Stage only; Production is rejected.
+  --object-path <path>           Committed v1/sha256/<sha>.jsonl.gz object.
+  --confirm-sha <sha256>         Explicit compressed object SHA-256 confirmation.
+
+Modes (mutually exclusive):
+  default                        Validate Storage and run a database dry-run.
+  --register-proof               Persist immutable ordered transaction/entry ID proof.
+  --execute                      Prune exact proof-bound IDs after all checks.
+
+Execute-only:
+  --recovery-dir <path>          Required private 0700 recovery directory.
+
+The command is Stage-only, processes one batch of at most 5000 transactions,
+never overwrites recovery files, never changes balances, and never mutates Storage.
+`;
+
+function fail(message, code = null) {
+  const error = new Error(message);
+  if (code) error.code = code;
+  throw error;
+}
+
+function text(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function canonicalUuid(value, label) {
+  if (typeof value !== "string" || !UUID_RE.test(value)) fail(`${label} must be a lowercase canonical UUID`);
+  return value;
+}
+
+function canonicalEntryId(value) {
+  if (typeof value !== "string" || !ENTRY_ID_RE.test(value) || BigInt(value).toString(10) !== value) {
+    fail("entry.id must be a canonical positive decimal bigint string");
+  }
+  return value;
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function hashCanonicalLines(values) {
+  return sha256(Buffer.from(values.map((value) => `${value}\n`).join(""), "utf8"));
+}
+
+export function computeArchiveIdProofs(records) {
+  if (!Array.isArray(records) || records.length < 1 || records.length > MAX_BATCH_SIZE) {
+    fail("archive proof requires 1 to 5000 transaction records");
+  }
+  const transactionIds = [];
+  const entryIds = [];
+  for (const record of records) {
+    transactionIds.push(canonicalUuid(record?.transaction?.id, "transaction.id"));
+    if (!Array.isArray(record?.entries) || record.entries.length === 0) fail("archive transaction has no entries");
+    for (const entry of record.entries) entryIds.push(canonicalEntryId(entry?.id));
+  }
+  if (new Set(transactionIds).size !== transactionIds.length || new Set(entryIds).size !== entryIds.length) {
+    fail("archive proof contains duplicate IDs");
+  }
+  return {
+    transactionIds,
+    entryIds,
+    transactionIdsSha256: hashCanonicalLines(transactionIds),
+    entryIdsSha256: hashCanonicalLines(entryIds),
+  };
+}
+
+function addTableMarker(markers, value) {
+  const marker = text(value).toLowerCase();
+  if (!marker) return;
+  if (!UUID_RE.test(marker)) fail("archive transaction contains an invalid table marker");
+  markers.add(marker);
+}
+
+function tableIdForRecord(record) {
+  const markers = new Set();
+  const metadata = record?.transaction?.metadata;
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata)) addTableMarker(markers, metadata.tableId);
+  const reference = text(record?.transaction?.reference);
+  const normalizedReference = reference.toLowerCase();
+  if (normalizedReference.startsWith("table:") || normalizedReference.startsWith("poker-rebuy:")) {
+    addTableMarker(markers, reference.split(":")[1]);
+  }
+  for (const entry of record.entries) {
+    const systemKey = text(entry?.account?.system_key);
+    if (text(entry?.account?.account_type).toUpperCase() === "ESCROW" && systemKey.toUpperCase().startsWith("POKER_TABLE:")) {
+      addTableMarker(markers, systemKey.slice("POKER_TABLE:".length));
+    }
+  }
+  addTableMarker(markers, record?.table_context?.table_id);
+  if (markers.size !== 1) fail("archive transaction must have exactly one unambiguous table marker");
+  return [...markers][0];
+}
+
+export function buildPruneEvidence(localArchive) {
+  const proofs = computeArchiveIdProofs(localArchive.records);
+  const txTypes = {};
+  const tables = new Set();
+  let userTransactions = 0;
+  let userEntries = 0;
+
+  for (const record of localArchive.records) {
+    const transaction = record.transaction;
+    const txType = text(transaction.tx_type);
+    if (!ALLOWED_TX_TYPES.has(txType)) fail(`archive tx_type is outside the Stage 2B.4 whitelist: ${txType}`);
+    if (transaction.user_id !== null) userTransactions += 1;
+    const tableId = tableIdForRecord(record);
+    tables.add(tableId);
+    if (record.entries.length !== 2) fail("technical archive transaction must contain exactly two entries");
+
+    const systemEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "SYSTEM");
+    const escrowEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "ESCROW");
+    userEntries += record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "USER").length;
+    if (systemEntries.length !== 1 || escrowEntries.length !== 1 || userEntries !== 0) {
+      fail("technical archive transaction must contain one SYSTEM and one ESCROW entry and no USER entry");
+    }
+    if (text(escrowEntries[0].account.system_key) !== `POKER_TABLE:${tableId}`) {
+      fail("archive escrow entry does not match its table marker");
+    }
+    const systemAmount = BigInt(systemEntries[0].amount);
+    const escrowAmount = BigInt(escrowEntries[0].amount);
+    if (systemAmount + escrowAmount !== 0n) fail("technical archive transaction is not conserved");
+    if (txType === "TABLE_BUY_IN" && !(systemAmount < 0n && escrowAmount > 0n)) {
+      fail("TABLE_BUY_IN archive entry direction is invalid");
+    }
+    if (txType === "TABLE_CASH_OUT" && !(escrowAmount < 0n && systemAmount > 0n)) {
+      fail("TABLE_CASH_OUT archive entry direction is invalid");
+    }
+    txTypes[txType] = (txTypes[txType] || 0) + 1;
+  }
+  if (userTransactions !== 0 || userEntries !== 0) fail("Stage 2B.4 cannot prune USER ledger history");
+  if (canonicalJson(txTypes) !== canonicalJson(localArchive.manifest.batch.tx_types)) fail("technical tx_type evidence differs from archive manifest");
+  return {
+    ...proofs,
+    transactionCount: proofs.transactionIds.length,
+    entryCount: proofs.entryIds.length,
+    txTypes,
+    userTransactions,
+    userEntries,
+    distinctTables: tables.size,
+    credits: localArchive.summary.credits,
+    debits: localArchive.summary.debits,
+    net: localArchive.summary.netAmount,
+  };
+}
+
+function parseArgs(argv) {
+  const valueArgs = new Map([
+    ["--target", "target"],
+    ["--object-path", "objectPath"],
+    ["--confirm-sha", "confirmSha"],
+    ["--recovery-dir", "recoveryDir"],
+  ]);
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+    if (token === "--register-proof" || token === "--execute") {
+      const key = token === "--register-proof" ? "registerProof" : "execute";
+      if (args[key]) fail(`${token} was supplied more than once`);
+      args[key] = true;
+      continue;
+    }
+    const key = valueArgs.get(token);
+    if (!key) fail(`unknown argument: ${token}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`${token} requires a value`);
+    if (args[key] !== undefined) fail(`${token} was supplied more than once`);
+    args[key] = value;
+    index += 1;
+  }
+  if (args.registerProof && args.execute) fail("--register-proof and --execute are mutually exclusive");
+  return args;
+}
+
+function assertStageIdentity(identity, manifest) {
+  if (identity === PRODUCTION_SYSTEM_IDENTIFIER) fail("Production database is forbidden");
+  if (identity !== STAGE_SYSTEM_IDENTIFIER) fail("database is not canonical Stage");
+  if (manifest.project_ref !== "krydukthwdvccggbyjfw") fail("archive manifest is not canonical Stage");
+}
+
+function parseManifestRow(row) {
+  if (!row) fail("archive manifest was not found");
+  return {
+    ...row,
+    format_version: Number(row.format_version),
+    transaction_count: Number(row.transaction_count),
+    entry_count: Number(row.entry_count),
+    tx_types: typeof row.tx_types === "string" ? JSON.parse(row.tx_types) : row.tx_types,
+    raw_bytes: Number(row.raw_bytes),
+    compressed_bytes: Number(row.compressed_bytes),
+    credits: String(row.credits),
+    debits: String(row.debits),
+    net_amount: String(row.net_amount),
+    batch_id: String(row.batch_id),
+  };
+}
+
+function exporterManifestFromDatabase(row, target) {
+  const ratio = row.raw_bytes === 0 ? null : Number((row.compressed_bytes / row.raw_bytes).toFixed(6));
+  const cursorStart = row.cursor_start_created_at ? { created_at: row.cursor_start_created_at, id: row.cursor_start_id } : null;
+  const cursorEnd = row.cursor_end_created_at ? { created_at: row.cursor_end_created_at, id: row.cursor_end_id } : null;
+  return {
+    schema_version: row.format_version,
+    artifact_type: "chips_ledger_archive",
+    format: "jsonl.gz",
+    target: target.target,
+    cutoff: { created_at: row.cutoff, rule: "transaction.created_at < cutoff" },
+    batch: {
+      limit: MAX_BATCH_SIZE,
+      transactions: row.transaction_count,
+      entries: row.entry_count,
+      tx_types: row.tx_types,
+    },
+    amounts: { credits: row.credits, debits: row.debits, net: row.net_amount },
+    time_range: { first_created_at: row.first_created_at, last_created_at: row.last_created_at },
+    cursor: {
+      order: ["transaction.created_at ASC", "transaction.id ASC"],
+      start: cursorStart,
+      end: cursorEnd,
+      next: cursorEnd,
+    },
+    bytes: {
+      raw: row.raw_bytes,
+      compressed: row.compressed_bytes,
+      compression_ratio_compressed_over_raw: ratio,
+    },
+    sha256: { raw_jsonl: row.raw_sha256, compressed_artifact: row.compressed_sha256 },
+    artifact: path.basename(row.object_path),
+  };
+}
+
+function recoveryManifest(row, identity, evidence) {
+  return {
+    recovery_schema_version: 1,
+    artifact_type: "chips_ledger_archive_prune_recovery",
+    target: "stage",
+    project_ref: row.project_ref,
+    postgres_system_identifier: identity,
+    bucket: ARCHIVE_BUCKET,
+    object_path: row.object_path,
+    archive: {
+      batch_id: row.batch_id,
+      format_version: row.format_version,
+      cutoff: row.cutoff,
+      cursor_start_created_at: row.cursor_start_created_at,
+      cursor_start_id: row.cursor_start_id,
+      cursor_end_created_at: row.cursor_end_created_at,
+      cursor_end_id: row.cursor_end_id,
+      first_created_at: row.first_created_at,
+      last_created_at: row.last_created_at,
+      transaction_count: row.transaction_count,
+      entry_count: row.entry_count,
+      tx_types: row.tx_types,
+      raw_bytes: row.raw_bytes,
+      compressed_bytes: row.compressed_bytes,
+      raw_sha256: row.raw_sha256,
+      compressed_sha256: row.compressed_sha256,
+      credits: row.credits,
+      debits: row.debits,
+      net_amount: row.net_amount,
+    },
+    id_proof: {
+      transaction_ids_sha256: evidence.transactionIdsSha256,
+      entry_ids_sha256: evidence.entryIdsSha256,
+    },
+  };
+}
+
+export function writeRecoveryBundle({ recoveryDir, archiveBytes, row, identity, evidence }) {
+  const directory = ensurePrivateDirectory(recoveryDir);
+  const baseName = `chips-ledger-${row.compressed_sha256}`;
+  const artifactPath = path.join(directory, `${baseName}.jsonl.gz`);
+  const manifestPath = path.join(directory, `${baseName}.recovery.json`);
+  const manifest = recoveryManifest(row, identity, evidence);
+  const manifestBytes = Buffer.from(`${stringifyJson(manifest)}\n`, "utf8");
+  const artifactExists = fs.existsSync(artifactPath);
+  const manifestExists = fs.existsSync(manifestPath);
+  if (artifactExists !== manifestExists) fail("recovery bundle is partial; refusing to overwrite it");
+  let reused = false;
+  if (artifactExists) {
+    assertPrivateRegularFile(artifactPath);
+    assertPrivateRegularFile(manifestPath);
+    if (!fs.readFileSync(artifactPath).equals(archiveBytes) || !fs.readFileSync(manifestPath).equals(manifestBytes)) {
+      fail("existing recovery bundle differs from the verified archive");
+    }
+    reused = true;
+  } else {
+    writeExclusiveFiles([
+      { path: artifactPath, data: archiveBytes },
+      { path: manifestPath, data: manifestBytes },
+    ], { createDirectories: false });
+  }
+  assertPrivateRegularFile(artifactPath);
+  assertPrivateRegularFile(manifestPath);
+  return { directory, artifactPath, manifestPath, manifest, reused };
+}
+
+export function verifyRecoveryBundle({ bundle, row, target, identity, expectedEvidence }) {
+  ensurePrivateDirectory(bundle.directory);
+  assertPrivateRegularFile(bundle.artifactPath);
+  assertPrivateRegularFile(bundle.manifestPath);
+  const manifest = JSON.parse(fs.readFileSync(bundle.manifestPath, "utf8"));
+  const expectedManifest = recoveryManifest(row, identity, expectedEvidence);
+  if (canonicalJson(manifest) !== canonicalJson(expectedManifest)) fail("recovery manifest no longer matches archive evidence");
+  const verified = verifyArchiveBytes({
+    compressedBytes: fs.readFileSync(bundle.artifactPath),
+    manifest: exporterManifestFromDatabase(row, target),
+    target,
+    artifactName: path.basename(row.object_path),
+  });
+  const evidence = buildPruneEvidence(verified);
+  if (evidence.transactionIdsSha256 !== expectedEvidence.transactionIdsSha256
+    || evidence.entryIdsSha256 !== expectedEvidence.entryIdsSha256) {
+    fail("recovery archive ID proof no longer matches");
+  }
+  return { verified, evidence };
+}
+
+function manifestSelectSql() {
+  return `select
+    object_path, batch_id::text as batch_id, project_ref, format_version::text as format_version,
+    cutoff::text as cutoff, cursor_start_created_at::text as cursor_start_created_at,
+    cursor_start_id::text as cursor_start_id, cursor_end_created_at::text as cursor_end_created_at,
+    cursor_end_id::text as cursor_end_id, first_created_at::text as first_created_at,
+    last_created_at::text as last_created_at, transaction_count::text as transaction_count,
+    entry_count::text as entry_count, tx_types::text as tx_types, raw_bytes::text as raw_bytes,
+    compressed_bytes::text as compressed_bytes, raw_sha256, compressed_sha256,
+    credits::text as credits, debits::text as debits, net_amount::text as net_amount,
+    status, committed_at::text as committed_at,
+    archived_transaction_ids_sha256, archived_entry_ids_sha256,
+    archive_proof_verified_at::text as archive_proof_verified_at,
+    pruned_at::text as pruned_at, pruned_transaction_count::text as pruned_transaction_count,
+    pruned_entry_count::text as pruned_entry_count, pruned_transaction_ids_sha256,
+    pruned_entry_ids_sha256
+  from public.chips_ledger_archive_batches where object_path = $1;`;
+}
+
+export function createPruneStore(sql) {
+  if (!sql || typeof sql.unsafe !== "function" || typeof sql.begin !== "function") fail("PostgreSQL prune adapter is required");
+  return {
+    async getIdentity() {
+      const rows = await sql.unsafe("select system_identifier::text as system_identifier from pg_catalog.pg_control_system();");
+      return text(rows[0]?.system_identifier);
+    },
+    async getManifest(objectPath) {
+      const rows = await sql.unsafe(manifestSelectSql(), [objectPath]);
+      return parseManifestRow(rows[0]);
+    },
+    async registerProof(row, evidence) {
+      return sql.begin(async (tx) => {
+        await tx.unsafe("set transaction isolation level repeatable read;");
+        const rows = await tx.unsafe(`select public.chips_register_archive_id_proof(
+          $1, $2::uuid[], $3::bigint[], $4, $5::integer, $6::timestamptz,
+          $7::timestamptz, $8::uuid, $9::timestamptz, $10::uuid,
+          $11::timestamptz, $12::timestamptz, $13::jsonb, $14::bigint,
+          $15::bigint, $16, $17, $18::numeric, $19::numeric, $20::numeric
+        ) as result;`, [
+          row.object_path, evidence.transactionIds, evidence.entryIds, row.project_ref,
+          row.format_version, row.cutoff, row.cursor_start_created_at, row.cursor_start_id,
+          row.cursor_end_created_at, row.cursor_end_id, row.first_created_at, row.last_created_at,
+          row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
+          row.credits, row.debits, row.net_amount,
+        ]);
+        return rows[0]?.result;
+      });
+    },
+    async prune(objectPath, evidence, execute) {
+      return sql.begin(async (tx) => {
+        await tx.unsafe("set transaction isolation level serializable;");
+        await tx.unsafe("set local lock_timeout = '5s';");
+        await tx.unsafe("set local statement_timeout = '120s';");
+        const rows = await tx.unsafe(`select public.chips_prune_committed_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::boolean
+        ) as result;`, [objectPath, evidence.transactionIds, evidence.entryIds, execute]);
+        return rows[0]?.result;
+      });
+    },
+    async verifyCommitted(row, evidence) {
+      const rows = await sql.unsafe(`select
+        batches.pruned_at::text as pruned_at,
+        batches.pruned_transaction_count::text as pruned_transaction_count,
+        batches.pruned_entry_count::text as pruned_entry_count,
+        batches.pruned_transaction_ids_sha256,
+        batches.pruned_entry_ids_sha256,
+        (select count(*)::text from public.chips_transaction_idempotency registry
+          where registry.transaction_id = any($2::uuid[]) and registry.archive_batch_id = batches.batch_id) as mapping_count,
+        (select count(*)::text from public.chips_transaction_idempotency registry
+          where registry.archive_batch_id = batches.batch_id and not (registry.transaction_id = any($2::uuid[]))) as extra_mapping_count,
+        (select count(*)::text from public.chips_transactions transactions where transactions.id = any($2::uuid[])) as hot_transaction_count,
+        (select count(*)::text from public.chips_entries entries
+          where entries.transaction_id = any($2::uuid[]) or entries.id = any($3::bigint[])) as hot_entry_count
+      from public.chips_ledger_archive_batches batches where batches.object_path = $1;`, [
+        row.object_path, evidence.transactionIds, evidence.entryIds,
+      ]);
+      return rows[0] || null;
+    },
+  };
+}
+
+export async function executeArchivePrune({ store, objectPath, evidence, execute, beforeAttempt = null }) {
+  const attempts = execute ? MAX_EXECUTE_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (beforeAttempt) await beforeAttempt();
+    try {
+      return await store.prune(objectPath, evidence, execute);
+    } catch (error) {
+      if (!execute || attempt === attempts || (error?.code !== "40001" && error?.code !== "55P03")) throw error;
+    }
+  }
+  fail("archive pruning retry budget was exhausted");
+}
+
+function assertProofMatches(row, evidence) {
+  if (!row.archive_proof_verified_at) fail("immutable archive ID proof is not registered");
+  if (row.archived_transaction_ids_sha256 !== evidence.transactionIdsSha256
+    || row.archived_entry_ids_sha256 !== evidence.entryIdsSha256) {
+    fail("local archive IDs do not match immutable database proof");
+  }
+}
+
+function assertPostCommitVerification(verification, evidence) {
+  if (!verification?.pruned_at
+    || Number(verification.pruned_transaction_count) !== evidence.transactionCount
+    || Number(verification.pruned_entry_count) !== evidence.entryCount
+    || verification.pruned_transaction_ids_sha256 !== evidence.transactionIdsSha256
+    || verification.pruned_entry_ids_sha256 !== evidence.entryIdsSha256
+    || Number(verification.mapping_count) !== evidence.transactionCount
+    || Number(verification.extra_mapping_count) !== 0
+    || Number(verification.hot_transaction_count) !== 0
+    || Number(verification.hot_entry_count) !== 0) {
+    fail("post-commit database verification failed", "post_commit_verification_failed");
+  }
+}
+
+function outputResult(result) {
+  process.stdout.write(`${stringifyJson({
+    event: "chips_ledger_archive_prune",
+    target: "stage",
+    project_ref: result.row.project_ref,
+    postgres_system_identifier: result.identity,
+    bucket: ARCHIVE_BUCKET,
+    object_path: result.row.object_path,
+    mode: result.mode,
+    state: result.state,
+    transactions: result.evidence.transactionCount,
+    entries: result.evidence.entryCount,
+    tx_types: result.evidence.txTypes,
+    amounts: { credits: result.evidence.credits, debits: result.evidence.debits, net: result.evidence.net },
+    user_transactions: result.evidence.userTransactions,
+    user_entries: result.evidence.userEntries,
+    distinct_tables: result.evidence.distinctTables,
+    id_proof: {
+      transaction_ids_sha256: result.evidence.transactionIdsSha256,
+      entry_ids_sha256: result.evidence.entryIdsSha256,
+    },
+    storage_download_ms: result.storageDownloadMs,
+    post_commit_download_ms: result.postCommitDownloadMs ?? null,
+    recovery_bundle_reused: result.recoveryBundle?.reused ?? null,
+  })}\n`);
+}
+
+export async function pruneArchive({ argv = process.argv.slice(2), env = process.env, cwd = process.cwd(), deps = {} } = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(HELP);
+    return null;
+  }
+  if (args.target !== "stage") fail("--target must be explicitly set to stage; Production is unsupported");
+  if (!args.objectPath) fail("--object-path is required");
+  if (!SHA256_RE.test(text(args.confirmSha))) fail("--confirm-sha must be a lowercase SHA-256");
+  if (args.objectPath !== buildObjectPath(args.confirmSha)) fail("--object-path does not match --confirm-sha");
+  if (args.execute && !args.recoveryDir) fail("--recovery-dir is required with --execute");
+  if (!args.execute && args.recoveryDir) fail("--recovery-dir is only valid with --execute");
+
+  const target = resolveStorageTarget(args.target, env);
+  const sql = deps.sql || (deps.pruneStore ? null : postgres(target.dbUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 10,
+    idle_timeout: 30,
+  }));
+  const store = deps.pruneStore || createPruneStore(sql);
+  try {
+    const identity = await store.getIdentity();
+    const row = await store.getManifest(args.objectPath);
+    assertStageIdentity(identity, row);
+    if (row.status !== "committed" || !row.committed_at) fail("archive manifest is not committed");
+    if (row.compressed_sha256 !== args.confirmSha) fail("--confirm-sha does not match committed manifest");
+
+    const downloaded = deps.downloadArchive
+      ? await deps.downloadArchive(target, row.object_path)
+      : await downloadPrivateArchiveObject(target, row.object_path, deps);
+    const archiveBytes = Buffer.from(downloaded.bytes);
+    const archiveManifest = exporterManifestFromDatabase(row, target);
+    const localArchive = verifyArchiveBytes({
+      compressedBytes: archiveBytes,
+      manifest: archiveManifest,
+      target,
+      artifactName: path.basename(row.object_path),
+    });
+    const evidence = buildPruneEvidence(localArchive);
+
+    if (args.registerProof) {
+      const proof = await store.registerProof(row, evidence);
+      const result = {
+        row,
+        identity,
+        evidence,
+        mode: "register-proof",
+        state: proof?.state || "proof_registered",
+        storageDownloadMs: downloaded.downloadMs,
+      };
+      if (deps.emit !== false) outputResult(result);
+      return result;
+    }
+
+    if (args.execute) assertProofMatches(row, evidence);
+    let recoveryBundle = null;
+    if (args.execute) {
+      recoveryBundle = writeRecoveryBundle({
+        recoveryDir: path.resolve(cwd, args.recoveryDir),
+        archiveBytes,
+        row,
+        identity,
+        evidence,
+      });
+    }
+
+    const pruneResult = await executeArchivePrune({
+      store,
+      objectPath: row.object_path,
+      evidence,
+      execute: Boolean(args.execute),
+      beforeAttempt: recoveryBundle
+        ? () => verifyRecoveryBundle({ bundle: recoveryBundle, row, target, identity, expectedEvidence: evidence })
+        : null,
+    });
+
+    let postCommitDownloadMs = null;
+    if (args.execute) {
+      try {
+        const postCommitDownload = deps.downloadArchive
+          ? await deps.downloadArchive(target, row.object_path)
+          : await downloadPrivateArchiveObject(target, row.object_path, deps);
+        postCommitDownloadMs = postCommitDownload.downloadMs;
+        verifyArchiveBytes({
+          compressedBytes: postCommitDownload.bytes,
+          manifest: archiveManifest,
+          target,
+          artifactName: path.basename(row.object_path),
+        });
+        assertPostCommitVerification(await store.verifyCommitted(row, evidence), evidence);
+      } catch (error) {
+        if (error?.code === "post_commit_verification_failed") throw error;
+        fail(`post-commit verification failed: ${error?.message || error}`, "post_commit_verification_failed");
+      }
+    }
+
+    const result = {
+      row,
+      identity,
+      evidence,
+      mode: args.execute ? "execute" : "dry-run",
+      state: pruneResult?.state || "unknown",
+      storageDownloadMs: downloaded.downloadMs,
+      postCommitDownloadMs,
+      recoveryBundle,
+    };
+    if (deps.emit !== false) outputResult(result);
+    return result;
+  } finally {
+    if (sql) await sql.end({ timeout: 5 });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  pruneArchive().catch((error) => {
+    process.stderr.write(`chips-ledger-archive-prune failed: ${error?.message || error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -151,25 +151,30 @@ export function buildPruneEvidence(localArchive) {
 
     const systemEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "SYSTEM");
     const escrowEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "ESCROW");
-    userEntries += record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "USER").length;
-    if (systemEntries.length !== 1 || escrowEntries.length !== 1 || userEntries !== 0) {
+    const recordUserEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "USER").length;
+    userEntries += recordUserEntries;
+    if (escrowEntries.length !== 1 || (recordUserEntries === 0 && systemEntries.length !== 1)) {
       fail("technical archive transaction must contain one SYSTEM and one ESCROW entry and no USER entry");
     }
     if (text(escrowEntries[0].account.system_key) !== `POKER_TABLE:${tableId}`) {
       fail("archive escrow entry does not match its table marker");
     }
-    const systemAmount = BigInt(systemEntries[0].amount);
-    const escrowAmount = BigInt(escrowEntries[0].amount);
-    if (systemAmount + escrowAmount !== 0n) fail("technical archive transaction is not conserved");
-    if (txType === "TABLE_BUY_IN" && !(systemAmount < 0n && escrowAmount > 0n)) {
-      fail("TABLE_BUY_IN archive entry direction is invalid");
-    }
-    if (txType === "TABLE_CASH_OUT" && !(escrowAmount < 0n && systemAmount > 0n)) {
-      fail("TABLE_CASH_OUT archive entry direction is invalid");
+    if (recordUserEntries === 0) {
+      const systemAmount = BigInt(systemEntries[0].amount);
+      const escrowAmount = BigInt(escrowEntries[0].amount);
+      if (systemAmount + escrowAmount !== 0n) fail("technical archive transaction is not conserved");
+      if (txType === "TABLE_BUY_IN" && !(systemAmount < 0n && escrowAmount > 0n)) {
+        fail("TABLE_BUY_IN archive entry direction is invalid");
+      }
+      if (txType === "TABLE_CASH_OUT" && !(escrowAmount < 0n && systemAmount > 0n)) {
+        fail("TABLE_CASH_OUT archive entry direction is invalid");
+      }
     }
     txTypes[txType] = (txTypes[txType] || 0) + 1;
   }
-  if (userTransactions !== 0 || userEntries !== 0) fail("Stage 2B.4 cannot prune USER ledger history");
+  if (userTransactions !== 0 || userEntries !== 0) {
+    fail(`Stage 2B.4 cannot prune USER ledger history (user_transactions=${userTransactions}, user_entries=${userEntries}, distinct_tables=${tables.size})`);
+  }
   if (canonicalJson(txTypes) !== canonicalJson(localArchive.manifest.batch.tx_types)) fail("technical tx_type evidence differs from archive manifest");
   return {
     ...proofs,

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -143,13 +143,13 @@ function verifyCursor(cursor, label) {
   return { created_at: text(cursor.created_at), id: text(cursor.id).toLowerCase() };
 }
 
-function verifyManifestShape(manifest, artifactPath, target) {
+function verifyManifestShape(manifest, artifactName, target) {
   if (!manifest || typeof manifest !== "object") fail("local manifest must be an object");
   if (manifest.schema_version !== EXPORT_SCHEMA_VERSION || manifest.artifact_type !== "chips_ledger_archive" || manifest.format !== "jsonl.gz") {
     fail("local manifest has an unsupported archive format");
   }
   if (manifest.target !== target.target) fail("local manifest target does not match --target");
-  if (manifest.artifact !== path.basename(artifactPath)) fail("local manifest artifact name does not match --artifact");
+  if (manifest.artifact !== artifactName) fail("local manifest artifact name does not match the archive");
   if (!manifest.cutoff || typeof manifest.cutoff.created_at !== "string") fail("local manifest cutoff is missing");
   timestampToMicros(manifest.cutoff.created_at);
   if (manifest.cutoff.rule !== "transaction.created_at < cutoff") fail("local manifest cutoff rule is unsupported");
@@ -274,16 +274,10 @@ export function buildObjectPath(manifestOrSha) {
   return `v1/sha256/${sha}.jsonl.gz`;
 }
 
-export function verifyLocalArchive({ artifactPath, manifestPath, target }) {
-  if (!artifactPath || !manifestPath) fail("--artifact and --manifest are required");
-  const artifact = path.resolve(artifactPath);
-  const manifestFile = path.resolve(manifestPath);
-  const stat = fs.statSync(artifact);
-  if (!stat.isFile()) fail("artifact must be a regular file");
-  if (stat.size > ARCHIVE_MAX_BYTES) fail("artifact exceeds the 6 MiB Storage limit");
-  const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
-  const { cursorStart, cursorEnd } = verifyManifestShape(manifest, artifact, target);
-  const compressedBytes = fs.readFileSync(artifact);
+export function verifyArchiveBytes({ compressedBytes: inputBytes, manifest, target, artifactName }) {
+  const compressedBytes = Buffer.from(inputBytes || []);
+  if (compressedBytes.length > ARCHIVE_MAX_BYTES) fail("artifact exceeds the 6 MiB Storage limit");
+  const { cursorStart, cursorEnd } = verifyManifestShape(manifest, artifactName, target);
   const compressedSha256 = crypto.createHash("sha256").update(compressedBytes).digest("hex");
   if (compressedBytes.length !== manifest.bytes.compressed || compressedSha256 !== manifest.sha256.compressed_artifact) {
     fail("local compressed artifact does not match its manifest");
@@ -303,8 +297,6 @@ export function verifyLocalArchive({ artifactPath, manifestPath, target }) {
   const expectedRatio = rawBytes.length === 0 ? null : Number((compressedBytes.length / rawBytes.length).toFixed(6));
   if (manifest.bytes.compression_ratio_compressed_over_raw !== expectedRatio) fail("local compression ratio does not match its manifest");
   return {
-    artifactPath: artifact,
-    manifestPath: manifestFile,
     manifest,
     compressedBytes,
     rawBytes,
@@ -313,6 +305,25 @@ export function verifyLocalArchive({ artifactPath, manifestPath, target }) {
     cursorStart,
     cursorEnd,
     summary,
+  };
+}
+
+export function verifyLocalArchive({ artifactPath, manifestPath, target }) {
+  if (!artifactPath || !manifestPath) fail("--artifact and --manifest are required");
+  const artifact = path.resolve(artifactPath);
+  const manifestFile = path.resolve(manifestPath);
+  const stat = fs.statSync(artifact);
+  if (!stat.isFile()) fail("artifact must be a regular file");
+  const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+  return {
+    artifactPath: artifact,
+    manifestPath: manifestFile,
+    ...verifyArchiveBytes({
+      compressedBytes: fs.readFileSync(artifact),
+      manifest,
+      target,
+      artifactName: path.basename(artifact),
+    }),
   };
 }
 
@@ -457,6 +468,16 @@ async function downloadObject(localArchive, storageTarget, deps = {}) {
   const response = await storageRequest(storageTarget, objectRequestPath(localArchive.objectPath), { method: "GET" }, deps);
   if (!response.ok) return { response, downloaded: null };
   return { response, downloaded: Buffer.from(await response.arrayBuffer()) };
+}
+
+export async function downloadPrivateArchiveObject(storageTarget, objectPath, deps = {}) {
+  const startedAt = Date.now();
+  const response = await storageRequest(storageTarget, objectRequestPath(objectPath), { method: "GET" }, deps);
+  if (!response.ok) storageFailure("private object download", response);
+  return {
+    bytes: Buffer.from(await response.arrayBuffer()),
+    downloadMs: Date.now() - startedAt,
+  };
 }
 
 export async function uploadOrVerifyObject(localArchive, storageTarget, deps = {}) {

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -379,6 +379,12 @@ function verifyBucket(bucket) {
   return bucket;
 }
 
+export async function verifyArchiveBucket(storageTarget, deps = {}) {
+  const response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
+  if (!response.ok) storageFailure("bucket verification", response);
+  return verifyBucket(await readJsonResponse(response, "bucket verification"));
+}
+
 export async function ensureArchiveBucket(storageTarget, deps = {}) {
   let response = await storageRequest(storageTarget, bucketRequestPath(), { method: "GET" }, deps);
   if (await isMissingStorageResponse(response)) {

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -50,6 +50,7 @@ run("node", ["tests/chips-ledger.human.buyin.unit.test.mjs"], "chips-ledger-huma
 run("node", ["tests/chips-ledger-pagination.behavior.test.mjs"], "chips-ledger-pagination-behavior");
 run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-archive-export");
 run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger-archive-storage");
+run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/bonus-campaigns-endpoint.behavior.test.mjs"], "bonus-campaigns-endpoint-behavior");
 run("node", ["tests/bonus-campaigns-scheduler.behavior.test.mjs"], "bonus-campaigns-scheduler-behavior");

--- a/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
+++ b/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
@@ -1,0 +1,1093 @@
+begin;
+
+alter table public.chips_ledger_archive_batches
+  add column batch_id bigint generated always as identity,
+  add column archived_transaction_ids_sha256 text,
+  add column archived_entry_ids_sha256 text,
+  add column archive_proof_verified_at timestamptz,
+  add column pruned_at timestamptz,
+  add column pruned_transaction_count bigint,
+  add column pruned_entry_count bigint,
+  add column pruned_transaction_ids_sha256 text,
+  add column pruned_entry_ids_sha256 text,
+  add constraint chips_ledger_archive_batches_batch_id_key unique (batch_id),
+  add constraint chips_ledger_archive_batches_archive_proof_check check (
+    (
+      archived_transaction_ids_sha256 is null
+      and archived_entry_ids_sha256 is null
+      and archive_proof_verified_at is null
+    ) or (
+      status = 'committed'
+      and archived_transaction_ids_sha256 ~ '^[0-9a-f]{64}$'
+      and archived_entry_ids_sha256 ~ '^[0-9a-f]{64}$'
+      and archive_proof_verified_at is not null
+    )
+  ),
+  add constraint chips_ledger_archive_batches_prune_receipt_check check (
+    (
+      pruned_at is null
+      and pruned_transaction_count is null
+      and pruned_entry_count is null
+      and pruned_transaction_ids_sha256 is null
+      and pruned_entry_ids_sha256 is null
+    ) or (
+      archive_proof_verified_at is not null
+      and pruned_at is not null
+      and pruned_transaction_count = transaction_count
+      and pruned_entry_count = entry_count
+      and pruned_transaction_count > 0
+      and pruned_entry_count > 0
+      and pruned_transaction_ids_sha256 = archived_transaction_ids_sha256
+      and pruned_entry_ids_sha256 = archived_entry_ids_sha256
+    )
+  );
+
+alter table public.chips_transaction_idempotency
+  add column archive_batch_id bigint,
+  add constraint chips_transaction_idempotency_archive_batch_fk
+    foreign key (archive_batch_id)
+    references public.chips_ledger_archive_batches(batch_id)
+    on delete restrict;
+
+create index chips_transaction_idempotency_archive_batch_idx
+  on public.chips_transaction_idempotency (archive_batch_id)
+  where archive_batch_id is not null;
+
+create or replace function public.chips_guard_archive_batch_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  old_proof_count integer;
+  new_proof_count integer;
+  old_receipt_count integer;
+  new_receipt_count integer;
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Archive batch rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.object_path is distinct from old.object_path
+    or new.batch_id is distinct from old.batch_id
+    or new.project_ref is distinct from old.project_ref
+    or new.format_version is distinct from old.format_version
+    or new.cutoff is distinct from old.cutoff
+    or new.cursor_start_created_at is distinct from old.cursor_start_created_at
+    or new.cursor_start_id is distinct from old.cursor_start_id
+    or new.cursor_end_created_at is distinct from old.cursor_end_created_at
+    or new.cursor_end_id is distinct from old.cursor_end_id
+    or new.first_created_at is distinct from old.first_created_at
+    or new.last_created_at is distinct from old.last_created_at
+    or new.transaction_count is distinct from old.transaction_count
+    or new.entry_count is distinct from old.entry_count
+    or new.tx_types is distinct from old.tx_types
+    or new.raw_bytes is distinct from old.raw_bytes
+    or new.compressed_bytes is distinct from old.compressed_bytes
+    or new.raw_sha256 is distinct from old.raw_sha256
+    or new.compressed_sha256 is distinct from old.compressed_sha256
+    or new.credits is distinct from old.credits
+    or new.debits is distinct from old.debits
+    or new.net_amount is distinct from old.net_amount
+    or new.created_at is distinct from old.created_at then
+    raise exception 'Archive batch proof fields are immutable';
+  end if;
+
+  if new.status is distinct from old.status then
+    if old.status <> 'pending' or new.status <> 'committed'
+      or old.committed_at is not null or new.committed_at is null then
+      raise exception 'Archive batch status may only transition pending to committed';
+    end if;
+  elsif new.committed_at is distinct from old.committed_at then
+    raise exception 'Archive batch committed_at is immutable';
+  end if;
+
+  old_proof_count := pg_catalog.num_nonnulls(
+    old.archived_transaction_ids_sha256,
+    old.archived_entry_ids_sha256,
+    old.archive_proof_verified_at
+  );
+  new_proof_count := pg_catalog.num_nonnulls(
+    new.archived_transaction_ids_sha256,
+    new.archived_entry_ids_sha256,
+    new.archive_proof_verified_at
+  );
+  if old_proof_count = 0 then
+    if new_proof_count not in (0, 3) then
+      raise exception 'Archive ID proof must transition from empty to complete';
+    end if;
+    if new_proof_count = 3 and new.status <> 'committed' then
+      raise exception 'Archive ID proof requires a committed batch';
+    end if;
+  elsif new.archived_transaction_ids_sha256 is distinct from old.archived_transaction_ids_sha256
+    or new.archived_entry_ids_sha256 is distinct from old.archived_entry_ids_sha256
+    or new.archive_proof_verified_at is distinct from old.archive_proof_verified_at then
+    raise exception 'Archive ID proof cannot be replaced or cleared';
+  end if;
+
+  old_receipt_count := pg_catalog.num_nonnulls(
+    old.pruned_at,
+    old.pruned_transaction_count,
+    old.pruned_entry_count,
+    old.pruned_transaction_ids_sha256,
+    old.pruned_entry_ids_sha256
+  );
+  new_receipt_count := pg_catalog.num_nonnulls(
+    new.pruned_at,
+    new.pruned_transaction_count,
+    new.pruned_entry_count,
+    new.pruned_transaction_ids_sha256,
+    new.pruned_entry_ids_sha256
+  );
+  if old_receipt_count = 0 then
+    if new_receipt_count not in (0, 5) then
+      raise exception 'Archive prune receipt must transition from empty to complete';
+    end if;
+    if new_receipt_count = 5 and new_proof_count <> 3 then
+      raise exception 'Archive prune receipt requires an immutable ID proof';
+    end if;
+  elsif new.pruned_at is distinct from old.pruned_at
+    or new.pruned_transaction_count is distinct from old.pruned_transaction_count
+    or new.pruned_entry_count is distinct from old.pruned_entry_count
+    or new.pruned_transaction_ids_sha256 is distinct from old.pruned_transaction_ids_sha256
+    or new.pruned_entry_ids_sha256 is distinct from old.pruned_entry_ids_sha256 then
+    raise exception 'Archive prune receipt cannot be replaced or cleared';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger chips_ledger_archive_batches_guard
+before update or delete on public.chips_ledger_archive_batches
+for each row execute function public.chips_guard_archive_batch_mutations();
+
+create or replace function public.chips_guard_idempotency_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Idempotency registry rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.idempotency_key is distinct from old.idempotency_key
+    or new.transaction_id is distinct from old.transaction_id
+    or new.payload_hash is distinct from old.payload_hash
+    or new.tx_type is distinct from old.tx_type
+    or new.user_id is distinct from old.user_id
+    or new.transaction_created_at is distinct from old.transaction_created_at
+    or new.created_at is distinct from old.created_at then
+    raise exception 'Idempotency registry identity is immutable';
+  end if;
+
+  if old.replay_transaction is not null
+    or old.replay_entries is not null
+    or old.replay_completed_at is not null then
+    if new.replay_transaction is distinct from old.replay_transaction
+      or new.replay_entries is distinct from old.replay_entries
+      or new.replay_completed_at is distinct from old.replay_completed_at then
+      raise exception 'Completed idempotency replay cannot be replaced or cleared';
+    end if;
+  elsif not (
+    new.replay_transaction is null
+    and new.replay_entries is null
+    and new.replay_completed_at is null
+  ) and not (
+    new.replay_transaction is not null
+    and new.replay_entries is not null
+    and new.replay_completed_at is not null
+  ) then
+    raise exception 'Idempotency replay must transition from empty to complete';
+  end if;
+
+  if old.archive_batch_id is not null
+    and new.archive_batch_id is distinct from old.archive_batch_id then
+    raise exception 'Idempotency archive mapping cannot be replaced or cleared';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.chips_reject_ledger_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' and current_user = 'chips_ledger_archive_pruner' then
+    return old;
+  end if;
+  raise exception 'Ledger rows are append-only; % is not permitted on %', tg_op, tg_table_name;
+end;
+$$;
+
+do $$
+begin
+  if not exists (select 1 from pg_catalog.pg_roles where rolname = 'chips_ledger_archive_pruner') then
+    create role chips_ledger_archive_pruner;
+  end if;
+end;
+$$;
+
+alter role chips_ledger_archive_pruner
+  nologin noinherit nosuperuser nocreatedb nocreaterole noreplication nobypassrls;
+
+grant usage on schema public, extensions to chips_ledger_archive_pruner;
+grant execute on function pg_catalog.pg_control_system() to chips_ledger_archive_pruner;
+grant execute on function extensions.digest(bytea, text) to chips_ledger_archive_pruner;
+
+grant select on table
+  public.chips_ledger_archive_batches,
+  public.chips_transaction_idempotency,
+  public.chips_accounts,
+  public.chips_transactions,
+  public.chips_entries,
+  public.poker_tables
+to chips_ledger_archive_pruner;
+
+grant update (
+  archived_transaction_ids_sha256,
+  archived_entry_ids_sha256,
+  archive_proof_verified_at,
+  pruned_at,
+  pruned_transaction_count,
+  pruned_entry_count,
+  pruned_transaction_ids_sha256,
+  pruned_entry_ids_sha256
+) on public.chips_ledger_archive_batches to chips_ledger_archive_pruner;
+grant update (archive_batch_id) on public.chips_transaction_idempotency to chips_ledger_archive_pruner;
+grant update (id) on public.chips_accounts to chips_ledger_archive_pruner;
+grant update (id) on public.chips_transactions to chips_ledger_archive_pruner;
+grant update (id) on public.chips_entries to chips_ledger_archive_pruner;
+grant update (id) on public.poker_tables to chips_ledger_archive_pruner;
+grant delete on public.chips_transactions, public.chips_entries to chips_ledger_archive_pruner;
+
+create policy chips_archive_pruner_manifest_select
+  on public.chips_ledger_archive_batches
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_manifest_update
+  on public.chips_ledger_archive_batches
+  for update to chips_ledger_archive_pruner
+  using (true) with check (true);
+
+create policy chips_archive_pruner_registry_select
+  on public.chips_transaction_idempotency
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_registry_update
+  on public.chips_transaction_idempotency
+  for update to chips_ledger_archive_pruner
+  using (true) with check (true);
+
+create policy chips_archive_pruner_accounts_select
+  on public.chips_accounts
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_accounts_lock
+  on public.chips_accounts
+  for update to chips_ledger_archive_pruner
+  using (true) with check (false);
+
+create policy chips_archive_pruner_transactions_select
+  on public.chips_transactions
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_transactions_lock
+  on public.chips_transactions
+  for update to chips_ledger_archive_pruner
+  using (true) with check (false);
+create policy chips_archive_pruner_transactions_delete
+  on public.chips_transactions
+  for delete to chips_ledger_archive_pruner
+  using (true);
+
+create policy chips_archive_pruner_entries_select
+  on public.chips_entries
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_entries_lock
+  on public.chips_entries
+  for update to chips_ledger_archive_pruner
+  using (true) with check (false);
+create policy chips_archive_pruner_entries_delete
+  on public.chips_entries
+  for delete to chips_ledger_archive_pruner
+  using (true);
+
+create policy chips_archive_pruner_tables_select
+  on public.poker_tables
+  for select to chips_ledger_archive_pruner
+  using (true);
+create policy chips_archive_pruner_tables_lock
+  on public.poker_tables
+  for update to chips_ledger_archive_pruner
+  using (true) with check (false);
+
+create or replace function public.chips_archive_uuid_ids_sha256(p_ids uuid[])
+returns text
+language plpgsql
+immutable
+strict
+set search_path = ''
+as $$
+declare
+  payload text;
+begin
+  if pg_catalog.cardinality(p_ids) = 0
+    or pg_catalog.array_ndims(p_ids) <> 1
+    or pg_catalog.array_position(p_ids, null) is not null then
+    raise exception 'Transaction ID proof requires a non-empty one-dimensional UUID array';
+  end if;
+  select pg_catalog.string_agg(p_ids[position]::text || E'\n', '' order by position)
+    into payload
+    from pg_catalog.generate_subscripts(p_ids, 1) as positions(position);
+  return pg_catalog.encode(
+    extensions.digest(pg_catalog.convert_to(payload, 'UTF8'), 'sha256'),
+    'hex'
+  );
+end;
+$$;
+
+create or replace function public.chips_archive_bigint_ids_sha256(p_ids bigint[])
+returns text
+language plpgsql
+immutable
+strict
+set search_path = ''
+as $$
+declare
+  payload text;
+begin
+  if pg_catalog.cardinality(p_ids) = 0
+    or pg_catalog.array_ndims(p_ids) <> 1
+    or pg_catalog.array_position(p_ids, null) is not null
+    or exists (select 1 from pg_catalog.unnest(p_ids) as value where value <= 0) then
+    raise exception 'Entry ID proof requires a non-empty one-dimensional positive bigint array';
+  end if;
+  select pg_catalog.string_agg(p_ids[position]::text || E'\n', '' order by position)
+    into payload
+    from pg_catalog.generate_subscripts(p_ids, 1) as positions(position);
+  return pg_catalog.encode(
+    extensions.digest(pg_catalog.convert_to(payload, 'UTF8'), 'sha256'),
+    'hex'
+  );
+end;
+$$;
+
+create or replace function public.chips_assert_archive_prune_stage()
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  system_identifier text;
+begin
+  select control.system_identifier::text
+    into system_identifier
+    from pg_catalog.pg_control_system() as control;
+  if system_identifier = '7575202818581710058' then
+    raise exception 'Ledger archive pruning is forbidden on Production';
+  end if;
+  if system_identifier <> '7656985631720456337' then
+    raise exception 'Ledger archive pruning is restricted to canonical Stage';
+  end if;
+  return system_identifier;
+end;
+$$;
+
+create or replace function public.chips_register_archive_id_proof(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_project_ref text,
+  p_format_version integer,
+  p_cutoff timestamptz,
+  p_cursor_start_created_at timestamptz,
+  p_cursor_start_id uuid,
+  p_cursor_end_created_at timestamptz,
+  p_cursor_end_id uuid,
+  p_first_created_at timestamptz,
+  p_last_created_at timestamptz,
+  p_tx_types jsonb,
+  p_raw_bytes bigint,
+  p_compressed_bytes bigint,
+  p_raw_sha256 text,
+  p_compressed_sha256 text,
+  p_credits numeric,
+  p_debits numeric,
+  p_net_amount numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch public.chips_ledger_archive_batches%rowtype;
+  transaction_ids_sha256 text;
+  entry_ids_sha256 text;
+  tx_type_count bigint;
+  updated_count bigint;
+begin
+  perform public.chips_assert_archive_prune_stage();
+  if pg_catalog.cardinality(p_transaction_ids) between 1 and 5000 is not true
+    or pg_catalog.cardinality(p_entry_ids) < 1 then
+    raise exception 'Archive ID proof batch size is invalid';
+  end if;
+  if (select pg_catalog.count(*) from pg_catalog.unnest(p_transaction_ids) as id)
+      <> (select pg_catalog.count(distinct id) from pg_catalog.unnest(p_transaction_ids) as id)
+    or (select pg_catalog.count(*) from pg_catalog.unnest(p_entry_ids) as id)
+      <> (select pg_catalog.count(distinct id) from pg_catalog.unnest(p_entry_ids) as id) then
+    raise exception 'Archive ID proof contains duplicate IDs';
+  end if;
+
+  transaction_ids_sha256 := public.chips_archive_uuid_ids_sha256(p_transaction_ids);
+  entry_ids_sha256 := public.chips_archive_bigint_ids_sha256(p_entry_ids);
+
+  select coalesce(pg_catalog.sum(value::bigint), 0)
+    into tx_type_count
+    from pg_catalog.jsonb_each_text(p_tx_types) as types(key, value);
+  if tx_type_count <> pg_catalog.cardinality(p_transaction_ids) then
+    raise exception 'Archive ID proof tx_type counts do not match transaction IDs';
+  end if;
+
+  select batches.*
+    into batch
+    from public.chips_ledger_archive_batches as batches
+    where batches.object_path = p_object_path
+    for update;
+  if not found then raise exception 'Committed archive manifest was not found'; end if;
+  if batch.status <> 'committed' or batch.project_ref <> 'krydukthwdvccggbyjfw' then
+    raise exception 'Archive manifest is not committed canonical Stage evidence';
+  end if;
+  if batch.object_path <> ('v1/sha256/' || p_compressed_sha256 || '.jsonl.gz') then
+    raise exception 'Archive object path does not match compressed SHA-256';
+  end if;
+  if batch.project_ref is distinct from p_project_ref
+    or batch.format_version is distinct from p_format_version
+    or batch.cutoff is distinct from p_cutoff
+    or batch.cursor_start_created_at is distinct from p_cursor_start_created_at
+    or batch.cursor_start_id is distinct from p_cursor_start_id
+    or batch.cursor_end_created_at is distinct from p_cursor_end_created_at
+    or batch.cursor_end_id is distinct from p_cursor_end_id
+    or batch.first_created_at is distinct from p_first_created_at
+    or batch.last_created_at is distinct from p_last_created_at
+    or batch.transaction_count is distinct from pg_catalog.cardinality(p_transaction_ids)::bigint
+    or batch.entry_count is distinct from pg_catalog.cardinality(p_entry_ids)::bigint
+    or batch.tx_types is distinct from p_tx_types
+    or batch.raw_bytes is distinct from p_raw_bytes
+    or batch.compressed_bytes is distinct from p_compressed_bytes
+    or batch.raw_sha256 is distinct from p_raw_sha256
+    or batch.compressed_sha256 is distinct from p_compressed_sha256
+    or batch.credits is distinct from p_credits
+    or batch.debits is distinct from p_debits
+    or batch.net_amount is distinct from p_net_amount then
+    raise exception 'Archive ID proof does not match committed manifest evidence';
+  end if;
+
+  if batch.archive_proof_verified_at is not null then
+    if batch.archived_transaction_ids_sha256 is distinct from transaction_ids_sha256
+      or batch.archived_entry_ids_sha256 is distinct from entry_ids_sha256 then
+      raise exception 'Committed archive already has a different immutable ID proof';
+    end if;
+    return pg_catalog.jsonb_build_object(
+      'state', 'proof_exists',
+      'transactions', batch.transaction_count,
+      'entries', batch.entry_count,
+      'transaction_ids_sha256', transaction_ids_sha256,
+      'entry_ids_sha256', entry_ids_sha256
+    );
+  end if;
+
+  update public.chips_ledger_archive_batches as batches
+     set archived_transaction_ids_sha256 = transaction_ids_sha256,
+         archived_entry_ids_sha256 = entry_ids_sha256,
+         archive_proof_verified_at = pg_catalog.timezone('utc', pg_catalog.now())
+   where batches.batch_id = batch.batch_id
+     and batches.archive_proof_verified_at is null;
+  get diagnostics updated_count = row_count;
+  if updated_count <> 1 then raise exception 'Archive ID proof transition was not unique'; end if;
+
+  return pg_catalog.jsonb_build_object(
+    'state', 'proof_registered',
+    'transactions', batch.transaction_count,
+    'entries', batch.entry_count,
+    'transaction_ids_sha256', transaction_ids_sha256,
+    'entry_ids_sha256', entry_ids_sha256
+  );
+end;
+$$;
+
+create or replace function public.chips_prune_committed_archive_batch(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_execute boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch public.chips_ledger_archive_batches%rowtype;
+  transaction_ids_sha256 text;
+  entry_ids_sha256 text;
+  transaction_count bigint := pg_catalog.cardinality(p_transaction_ids);
+  entry_count bigint := pg_catalog.cardinality(p_entry_ids);
+  receipt_field_count integer;
+  registry_count bigint;
+  matching_mapping_count bigint;
+  wrong_mapping_count bigint;
+  extra_mapping_count bigint;
+  hot_transaction_count bigint;
+  hot_entry_count bigint;
+  actual_transaction_ids uuid[];
+  actual_entry_ids bigint[];
+  table_ids uuid[];
+  account_ids uuid[];
+  invalid_marker_count bigint;
+  invalid_shape_count bigint;
+  identity_mismatch_count bigint;
+  active_table_count bigint;
+  invalid_escrow_count bigint;
+  user_transaction_count bigint;
+  user_entry_count bigint;
+  distinct_table_count bigint;
+  actual_tx_types jsonb;
+  actual_credits numeric;
+  actual_debits numeric;
+  actual_net numeric;
+  actual_first_created_at timestamptz;
+  actual_last_created_at timestamptz;
+  actual_cursor_end_created_at timestamptz;
+  actual_cursor_end_id uuid;
+  accounts_before jsonb;
+  accounts_after jsonb;
+  mapped_count bigint;
+  deleted_entry_count bigint;
+  deleted_transaction_count bigint;
+  receipt_count bigint;
+begin
+  perform public.chips_assert_archive_prune_stage();
+  if pg_catalog.current_setting('transaction_isolation') <> 'serializable' then
+    raise exception 'Ledger archive pruning requires SERIALIZABLE isolation';
+  end if;
+  if transaction_count between 1 and 5000 is not true or entry_count < 1 then
+    raise exception 'Archive prune batch size is invalid';
+  end if;
+  if (select pg_catalog.count(*) from pg_catalog.unnest(p_transaction_ids) as id)
+      <> (select pg_catalog.count(distinct id) from pg_catalog.unnest(p_transaction_ids) as id)
+    or (select pg_catalog.count(*) from pg_catalog.unnest(p_entry_ids) as id)
+      <> (select pg_catalog.count(distinct id) from pg_catalog.unnest(p_entry_ids) as id) then
+    raise exception 'Archive prune batch contains duplicate IDs';
+  end if;
+
+  transaction_ids_sha256 := public.chips_archive_uuid_ids_sha256(p_transaction_ids);
+  entry_ids_sha256 := public.chips_archive_bigint_ids_sha256(p_entry_ids);
+
+  select batches.*
+    into batch
+    from public.chips_ledger_archive_batches as batches
+    where batches.object_path = p_object_path
+    for update;
+  if not found then raise exception 'Committed archive manifest was not found'; end if;
+  if batch.status <> 'committed' or batch.project_ref <> 'krydukthwdvccggbyjfw' then
+    raise exception 'Archive manifest is not committed canonical Stage evidence';
+  end if;
+  if batch.archive_proof_verified_at is null then
+    if p_execute then raise exception 'Archive ID proof must be registered before execute'; end if;
+    return pg_catalog.jsonb_build_object('state', 'proof_missing');
+  end if;
+  if batch.archived_transaction_ids_sha256 is distinct from transaction_ids_sha256
+    or batch.archived_entry_ids_sha256 is distinct from entry_ids_sha256
+    or batch.transaction_count is distinct from transaction_count
+    or batch.entry_count is distinct from entry_count then
+    raise exception 'Archive prune IDs do not match immutable archive proof';
+  end if;
+
+  receipt_field_count := pg_catalog.num_nonnulls(
+    batch.pruned_at,
+    batch.pruned_transaction_count,
+    batch.pruned_entry_count,
+    batch.pruned_transaction_ids_sha256,
+    batch.pruned_entry_ids_sha256
+  );
+  if receipt_field_count not in (0, 5) then
+    raise exception 'Archive prune receipt is partial';
+  end if;
+
+  select pg_catalog.count(*) into registry_count
+    from public.chips_transaction_idempotency as registry
+    where registry.transaction_id = any(p_transaction_ids);
+  select pg_catalog.count(*) into matching_mapping_count
+    from public.chips_transaction_idempotency as registry
+    where registry.transaction_id = any(p_transaction_ids)
+      and registry.archive_batch_id = batch.batch_id;
+  select pg_catalog.count(*) into wrong_mapping_count
+    from public.chips_transaction_idempotency as registry
+    where registry.transaction_id = any(p_transaction_ids)
+      and registry.archive_batch_id is not null
+      and registry.archive_batch_id <> batch.batch_id;
+  select pg_catalog.count(*) into extra_mapping_count
+    from public.chips_transaction_idempotency as registry
+    where registry.archive_batch_id = batch.batch_id
+      and not (registry.transaction_id = any(p_transaction_ids));
+  select pg_catalog.count(*) into hot_transaction_count
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids);
+  select pg_catalog.count(*) into hot_entry_count
+    from public.chips_entries as entries
+    where entries.transaction_id = any(p_transaction_ids)
+       or entries.id = any(p_entry_ids);
+
+  if receipt_field_count = 5 then
+    if batch.pruned_transaction_count is distinct from transaction_count
+      or batch.pruned_entry_count is distinct from entry_count
+      or batch.pruned_transaction_ids_sha256 is distinct from transaction_ids_sha256
+      or batch.pruned_entry_ids_sha256 is distinct from entry_ids_sha256
+      or hot_transaction_count <> 0
+      or hot_entry_count <> 0
+      or registry_count <> transaction_count
+      or matching_mapping_count <> transaction_count
+      or wrong_mapping_count <> 0
+      or extra_mapping_count <> 0 then
+      raise exception 'Archive already-pruned state is inconsistent';
+    end if;
+    return pg_catalog.jsonb_build_object(
+      'state', 'already_pruned',
+      'transactions', transaction_count,
+      'entries', entry_count
+    );
+  end if;
+
+  if matching_mapping_count <> 0 or wrong_mapping_count <> 0 or extra_mapping_count <> 0 then
+    raise exception 'Archive mappings exist without a complete prune receipt';
+  end if;
+  if hot_transaction_count <> transaction_count or hot_entry_count <> entry_count then
+    raise exception 'Archive hot ledger batch is incomplete';
+  end if;
+  if registry_count <> transaction_count then
+    raise exception 'Archive hot ledger batch has incomplete registry identity';
+  end if;
+
+  select pg_catalog.array_agg(transactions.id order by transactions.created_at, transactions.id)
+    into actual_transaction_ids
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids);
+  if actual_transaction_ids is distinct from p_transaction_ids then
+    raise exception 'Archive transaction order does not match the hot ledger';
+  end if;
+
+  with wanted as (
+    select ids.id, ids.ordinality
+      from pg_catalog.unnest(p_transaction_ids) with ordinality as ids(id, ordinality)
+  )
+  select pg_catalog.array_agg(entries.id order by wanted.ordinality, entries.id)
+    into actual_entry_ids
+    from wanted
+    join public.chips_entries as entries on entries.transaction_id = wanted.id;
+  if actual_entry_ids is distinct from p_entry_ids then
+    raise exception 'Archive entry order does not match the hot ledger';
+  end if;
+
+  with selected as (
+    select transactions.*
+      from public.chips_transactions as transactions
+      where transactions.id = any(p_transaction_ids)
+  ), markers as (
+    select selected.id as transaction_id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '')) as table_id
+      from selected
+      where nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '') is not null
+    union all
+    select selected.id,
+           case
+             when pg_catalog.lower(selected.reference) like 'table:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             when pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             else null
+           end
+      from selected
+      where pg_catalog.lower(selected.reference) like 'table:%'
+         or pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+    union all
+    select selected.id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.substr(accounts.system_key, 13)), ''))
+      from selected
+      join public.chips_entries as entries on entries.transaction_id = selected.id
+      join public.chips_accounts as accounts on accounts.id = entries.account_id
+      where accounts.account_type = 'ESCROW'
+        and pg_catalog.upper(accounts.system_key) like 'POKER_TABLE:%'
+  ), marker_summary as (
+    select markers.transaction_id,
+           pg_catalog.array_agg(distinct markers.table_id) filter (where markers.table_id is not null) as table_ids,
+           pg_catalog.bool_or(
+             markers.table_id is null
+             or markers.table_id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           ) as invalid_marker
+      from markers
+      group by markers.transaction_id
+  )
+  select pg_catalog.count(*)
+    into invalid_marker_count
+    from selected
+    left join marker_summary on marker_summary.transaction_id = selected.id
+    where coalesce(marker_summary.invalid_marker, false)
+       or pg_catalog.cardinality(coalesce(marker_summary.table_ids, array[]::text[])) <> 1;
+  if invalid_marker_count <> 0 then
+    raise exception 'Archive batch contains missing, invalid, or ambiguous table markers';
+  end if;
+
+  with selected as (
+    select transactions.*
+      from public.chips_transactions as transactions
+      where transactions.id = any(p_transaction_ids)
+  ), markers as (
+    select selected.id as transaction_id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '')) as table_id
+      from selected
+      where nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '') is not null
+    union all
+    select selected.id,
+           case
+             when pg_catalog.lower(selected.reference) like 'table:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             when pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             else null
+           end
+      from selected
+      where pg_catalog.lower(selected.reference) like 'table:%'
+         or pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+    union all
+    select selected.id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.substr(accounts.system_key, 13)), ''))
+      from selected
+      join public.chips_entries as entries on entries.transaction_id = selected.id
+      join public.chips_accounts as accounts on accounts.id = entries.account_id
+      where accounts.account_type = 'ESCROW'
+        and pg_catalog.upper(accounts.system_key) like 'POKER_TABLE:%'
+  ), marker_summary as (
+    select markers.transaction_id, pg_catalog.min(markers.table_id)::uuid as table_id
+      from markers
+      group by markers.transaction_id
+  )
+  select pg_catalog.array_agg(distinct marker_summary.table_id order by marker_summary.table_id)
+    into table_ids
+    from marker_summary;
+
+  select pg_catalog.array_agg(distinct entries.account_id order by entries.account_id)
+    into account_ids
+    from public.chips_entries as entries
+    where entries.transaction_id = any(p_transaction_ids);
+
+  perform tables.id
+    from public.poker_tables as tables
+    where tables.id = any(table_ids)
+    order by tables.id
+    for update;
+  perform accounts.id
+    from public.chips_accounts as accounts
+    where accounts.id = any(account_ids)
+    order by accounts.id
+    for update;
+  perform registry.idempotency_key
+    from public.chips_transaction_idempotency as registry
+    where registry.transaction_id = any(p_transaction_ids)
+    order by registry.transaction_id, registry.idempotency_key
+    for update;
+  perform transactions.id
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids)
+    order by transactions.created_at, transactions.id
+    for update;
+  perform entries.id
+    from pg_catalog.unnest(p_transaction_ids) with ordinality as wanted(id, ordinality)
+    join public.chips_entries as entries on entries.transaction_id = wanted.id
+    order by wanted.ordinality, entries.id
+    for update of entries;
+
+  select pg_catalog.count(*) into active_table_count
+    from public.poker_tables as tables
+    where tables.id = any(table_ids)
+      and pg_catalog.upper(tables.status) <> 'CLOSED';
+  select pg_catalog.count(*) into invalid_escrow_count
+    from pg_catalog.unnest(table_ids) as table_id
+    left join public.chips_accounts as accounts
+      on accounts.account_type = 'ESCROW'
+     and accounts.system_key = 'POKER_TABLE:' || table_id::text
+    where accounts.id is null
+       or accounts.status <> 'active'
+       or accounts.balance <> 0;
+  if active_table_count <> 0 or invalid_escrow_count <> 0 then
+    raise exception 'Archive batch contains an active table or non-zero/missing escrow';
+  end if;
+
+  with selected as (
+    select transactions.*
+      from public.chips_transactions as transactions
+      where transactions.id = any(p_transaction_ids)
+  ), markers as (
+    select selected.id as transaction_id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '')) as table_id
+      from selected
+      where nullif(pg_catalog.btrim(selected.metadata->>'tableId'), '') is not null
+    union all
+    select selected.id,
+           case
+             when pg_catalog.lower(selected.reference) like 'table:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             when pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+               then pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.split_part(selected.reference, ':', 2)), ''))
+             else null
+           end
+      from selected
+      where pg_catalog.lower(selected.reference) like 'table:%'
+         or pg_catalog.lower(selected.reference) like 'poker-rebuy:%'
+    union all
+    select selected.id,
+           pg_catalog.lower(nullif(pg_catalog.btrim(pg_catalog.substr(accounts.system_key, 13)), ''))
+      from selected
+      join public.chips_entries as entries on entries.transaction_id = selected.id
+      join public.chips_accounts as accounts on accounts.id = entries.account_id
+      where accounts.account_type = 'ESCROW'
+        and pg_catalog.upper(accounts.system_key) like 'POKER_TABLE:%'
+  ), marker_summary as (
+    select markers.transaction_id, pg_catalog.min(markers.table_id) as table_id
+      from markers
+      group by markers.transaction_id
+  ), invalid as (
+    select selected.id
+      from selected
+      join marker_summary on marker_summary.transaction_id = selected.id
+      join public.chips_entries as entries on entries.transaction_id = selected.id
+      join public.chips_accounts as accounts on accounts.id = entries.account_id
+      group by selected.id, selected.tx_type, selected.user_id, selected.created_at, marker_summary.table_id
+      having selected.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+         or selected.user_id is not null
+         or selected.created_at >= batch.cutoff
+         or pg_catalog.count(*) <> 2
+         or pg_catalog.count(*) filter (where accounts.account_type = 'USER') <> 0
+         or pg_catalog.count(*) filter (where accounts.account_type = 'SYSTEM') <> 1
+         or pg_catalog.count(*) filter (where accounts.account_type = 'ESCROW') <> 1
+         or pg_catalog.count(*) filter (
+              where accounts.account_type = 'ESCROW'
+                and accounts.system_key = 'POKER_TABLE:' || marker_summary.table_id
+            ) <> 1
+         or not pg_catalog.bool_and(accounts.status = 'active')
+         or pg_catalog.sum(entries.amount) <> 0
+         or (
+           selected.tx_type::text = 'TABLE_BUY_IN'
+           and (
+             pg_catalog.sum(entries.amount) filter (where accounts.account_type = 'SYSTEM') >= 0
+             or pg_catalog.sum(entries.amount) filter (where accounts.account_type = 'ESCROW') <= 0
+           )
+         )
+         or (
+           selected.tx_type::text = 'TABLE_CASH_OUT'
+           and (
+             pg_catalog.sum(entries.amount) filter (where accounts.account_type = 'ESCROW') >= 0
+             or pg_catalog.sum(entries.amount) filter (where accounts.account_type = 'SYSTEM') <= 0
+           )
+         )
+  )
+  select pg_catalog.count(*) into invalid_shape_count from invalid;
+  if invalid_shape_count <> 0 then
+    raise exception 'Archive batch is outside the technical TABLE_BUY_IN/TABLE_CASH_OUT whitelist';
+  end if;
+
+  select pg_catalog.count(*) into identity_mismatch_count
+    from public.chips_transactions as transactions
+    left join public.chips_transaction_idempotency as registry
+      on registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+     and registry.payload_hash = transactions.payload_hash
+     and registry.tx_type = transactions.tx_type
+     and registry.user_id is not distinct from transactions.user_id
+     and registry.transaction_created_at = transactions.created_at
+    where transactions.id = any(p_transaction_ids)
+      and registry.idempotency_key is null;
+  if identity_mismatch_count <> 0 then
+    raise exception 'Archive batch registry identity is incomplete or inconsistent';
+  end if;
+
+  select pg_catalog.count(*) into user_transaction_count
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids) and transactions.user_id is not null;
+  select pg_catalog.count(*) into user_entry_count
+    from public.chips_entries as entries
+    join public.chips_accounts as accounts on accounts.id = entries.account_id
+    where entries.transaction_id = any(p_transaction_ids) and accounts.account_type = 'USER';
+  distinct_table_count := pg_catalog.cardinality(table_ids);
+
+  select pg_catalog.jsonb_object_agg(types.tx_type, types.count order by types.tx_type)
+    into actual_tx_types
+    from (
+      select transactions.tx_type::text as tx_type, pg_catalog.count(*) as count
+        from public.chips_transactions as transactions
+        where transactions.id = any(p_transaction_ids)
+        group by transactions.tx_type::text
+    ) as types;
+  select
+    coalesce(pg_catalog.sum(case when entries.amount > 0 then entries.amount else 0 end), 0),
+    coalesce(pg_catalog.sum(case when entries.amount < 0 then -entries.amount else 0 end), 0),
+    coalesce(pg_catalog.sum(entries.amount), 0)
+    into actual_credits, actual_debits, actual_net
+    from public.chips_entries as entries
+    where entries.transaction_id = any(p_transaction_ids);
+  select pg_catalog.min(transactions.created_at), pg_catalog.max(transactions.created_at)
+    into actual_first_created_at, actual_last_created_at
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids);
+  select transactions.created_at, transactions.id
+    into actual_cursor_end_created_at, actual_cursor_end_id
+    from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids)
+    order by transactions.created_at desc, transactions.id desc
+    limit 1;
+
+  if actual_tx_types is distinct from batch.tx_types
+    or actual_credits is distinct from batch.credits
+    or actual_debits is distinct from batch.debits
+    or actual_net is distinct from batch.net_amount
+    or actual_first_created_at is distinct from batch.first_created_at
+    or actual_last_created_at is distinct from batch.last_created_at
+    or actual_cursor_end_created_at is distinct from batch.cursor_end_created_at
+    or actual_cursor_end_id is distinct from batch.cursor_end_id
+    or user_transaction_count <> 0
+    or user_entry_count <> 0 then
+    raise exception 'Archive hot ledger aggregates do not match committed evidence';
+  end if;
+
+  select pg_catalog.jsonb_object_agg(
+           accounts.id::text,
+           pg_catalog.jsonb_build_array(accounts.balance::text, accounts.next_entry_seq::text)
+           order by accounts.id::text
+         )
+    into accounts_before
+    from public.chips_accounts as accounts
+    where accounts.id = any(account_ids);
+
+  if not p_execute then
+    return pg_catalog.jsonb_build_object(
+      'state', 'ready',
+      'transactions', transaction_count,
+      'entries', entry_count,
+      'tx_types', actual_tx_types,
+      'credits', actual_credits::text,
+      'debits', actual_debits::text,
+      'net', actual_net::text,
+      'user_transactions', user_transaction_count,
+      'user_entries', user_entry_count,
+      'distinct_tables', distinct_table_count
+    );
+  end if;
+
+  update public.chips_transaction_idempotency as registry
+     set archive_batch_id = batch.batch_id
+    from public.chips_transactions as transactions
+   where transactions.id = any(p_transaction_ids)
+     and registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+     and registry.payload_hash = transactions.payload_hash
+     and registry.tx_type = transactions.tx_type
+     and registry.user_id is not distinct from transactions.user_id
+     and registry.transaction_created_at = transactions.created_at
+     and registry.archive_batch_id is null;
+  get diagnostics mapped_count = row_count;
+  if mapped_count <> transaction_count then raise exception 'Archive registry mapping count mismatch'; end if;
+
+  delete from public.chips_entries as entries
+    where entries.id = any(p_entry_ids)
+      and entries.transaction_id = any(p_transaction_ids);
+  get diagnostics deleted_entry_count = row_count;
+  if deleted_entry_count <> entry_count then raise exception 'Archive entry DELETE count mismatch'; end if;
+
+  delete from public.chips_transactions as transactions
+    where transactions.id = any(p_transaction_ids);
+  get diagnostics deleted_transaction_count = row_count;
+  if deleted_transaction_count <> transaction_count then raise exception 'Archive transaction DELETE count mismatch'; end if;
+
+  select pg_catalog.jsonb_object_agg(
+           accounts.id::text,
+           pg_catalog.jsonb_build_array(accounts.balance::text, accounts.next_entry_seq::text)
+           order by accounts.id::text
+         )
+    into accounts_after
+    from public.chips_accounts as accounts
+    where accounts.id = any(account_ids);
+  if accounts_after is distinct from accounts_before then
+    raise exception 'Archive pruning changed account balances or entry sequences';
+  end if;
+  if exists (select 1 from public.chips_transactions where id = any(p_transaction_ids))
+    or exists (
+      select 1 from public.chips_entries
+       where transaction_id = any(p_transaction_ids) or id = any(p_entry_ids)
+    ) then
+    raise exception 'Archive pruning left hot ledger rows behind';
+  end if;
+
+  update public.chips_ledger_archive_batches as batches
+     set pruned_at = pg_catalog.timezone('utc', pg_catalog.now()),
+         pruned_transaction_count = batches.transaction_count,
+         pruned_entry_count = batches.entry_count,
+         pruned_transaction_ids_sha256 = batches.archived_transaction_ids_sha256,
+         pruned_entry_ids_sha256 = batches.archived_entry_ids_sha256
+   where batches.batch_id = batch.batch_id
+     and batches.pruned_at is null;
+  get diagnostics receipt_count = row_count;
+  if receipt_count <> 1 then raise exception 'Archive prune receipt transition was not unique'; end if;
+
+  return pg_catalog.jsonb_build_object(
+    'state', 'pruned',
+    'transactions', deleted_transaction_count,
+    'entries', deleted_entry_count,
+    'tx_types', actual_tx_types,
+    'credits', actual_credits::text,
+    'debits', actual_debits::text,
+    'net', actual_net::text,
+    'user_transactions', user_transaction_count,
+    'user_entries', user_entry_count,
+    'distinct_tables', distinct_table_count
+  );
+end;
+$$;
+
+alter function public.chips_archive_uuid_ids_sha256(uuid[]) owner to chips_ledger_archive_pruner;
+alter function public.chips_archive_bigint_ids_sha256(bigint[]) owner to chips_ledger_archive_pruner;
+alter function public.chips_assert_archive_prune_stage() owner to chips_ledger_archive_pruner;
+alter function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) owner to chips_ledger_archive_pruner;
+alter function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  owner to chips_ledger_archive_pruner;
+
+revoke all on function public.chips_archive_uuid_ids_sha256(uuid[]) from public, anon, authenticated, service_role;
+revoke all on function public.chips_archive_bigint_ids_sha256(bigint[]) from public, anon, authenticated, service_role;
+revoke all on function public.chips_assert_archive_prune_stage() from public, anon, authenticated, service_role;
+revoke all on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) from public, anon, authenticated, service_role;
+revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  from public, anon, authenticated, service_role;
+
+grant execute on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) to postgres;
+grant execute on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  to postgres;
+
+commit;

--- a/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
+++ b/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
@@ -244,7 +244,6 @@ end;
 $$;
 
 grant usage on schema public, extensions to chips_ledger_archive_pruner;
-grant execute on function pg_catalog.pg_control_system() to chips_ledger_archive_pruner;
 grant execute on function extensions.digest(bytea, text) to chips_ledger_archive_pruner;
 
 grant select on table
@@ -1068,9 +1067,11 @@ begin
 end;
 $$;
 
+grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
+
 alter function public.chips_archive_uuid_ids_sha256(uuid[]) owner to chips_ledger_archive_pruner;
 alter function public.chips_archive_bigint_ids_sha256(bigint[]) owner to chips_ledger_archive_pruner;
-alter function public.chips_assert_archive_prune_stage() owner to chips_ledger_archive_pruner;
 alter function public.chips_register_archive_id_proof(
   text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
   timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
@@ -1078,6 +1079,9 @@ alter function public.chips_register_archive_id_proof(
 ) owner to chips_ledger_archive_pruner;
 alter function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
   owner to chips_ledger_archive_pruner;
+
+revoke create on schema public from chips_ledger_archive_pruner;
+revoke chips_ledger_archive_pruner from postgres;
 
 revoke all on function public.chips_archive_uuid_ids_sha256(uuid[]) from public, anon, authenticated, service_role;
 revoke all on function public.chips_archive_bigint_ids_sha256(bigint[]) from public, anon, authenticated, service_role;
@@ -1090,6 +1094,8 @@ revoke all on function public.chips_register_archive_id_proof(
 revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
   from public, anon, authenticated, service_role;
 
+grant execute on function public.chips_assert_archive_prune_stage()
+  to chips_ledger_archive_pruner;
 grant execute on function public.chips_register_archive_id_proof(
   text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
   timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,

--- a/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
+++ b/supabase/migrations/20260812100000_chips_ledger_archive_pruning.sql
@@ -227,13 +227,21 @@ $$;
 do $$
 begin
   if not exists (select 1 from pg_catalog.pg_roles where rolname = 'chips_ledger_archive_pruner') then
-    create role chips_ledger_archive_pruner;
+    create role chips_ledger_archive_pruner nologin noinherit;
+  end if;
+  if exists (
+    select 1
+      from pg_catalog.pg_roles
+      where rolname = 'chips_ledger_archive_pruner'
+        and (
+          rolsuper or rolcreatedb or rolcreaterole or rolreplication
+          or rolbypassrls or rolcanlogin or rolinherit
+        )
+  ) then
+    raise exception 'chips_ledger_archive_pruner has unsafe role attributes';
   end if;
 end;
 $$;
-
-alter role chips_ledger_archive_pruner
-  nologin noinherit nosuperuser nocreatedb nocreaterole noreplication nobypassrls;
 
 grant usage on schema public, extensions to chips_ledger_archive_pruner;
 grant execute on function pg_catalog.pg_control_system() to chips_ledger_archive_pruner;

--- a/supabase/migrations/20260812103000_chips_ledger_archive_pruning_acl_fix.sql
+++ b/supabase/migrations/20260812103000_chips_ledger_archive_pruning_acl_fix.sql
@@ -91,10 +91,17 @@ begin
       from pg_catalog.pg_auth_members memberships
       join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
       join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+      join pg_catalog.pg_roles grantor_role on grantor_role.oid = memberships.grantor
       where granted_role.rolname = 'chips_ledger_archive_pruner'
-        and member_role.rolname = 'postgres'
+        and not (
+          member_role.rolname = 'postgres'
+          and grantor_role.rolname = 'supabase_admin'
+          and memberships.admin_option
+          and not memberships.inherit_option
+          and not memberships.set_option
+        )
   ) then
-    raise exception 'Temporary archive pruner membership was not revoked';
+    raise exception 'Unsafe archive pruner membership remains';
   end if;
 end;
 $$;

--- a/supabase/migrations/20260812103000_chips_ledger_archive_pruning_acl_fix.sql
+++ b/supabase/migrations/20260812103000_chips_ledger_archive_pruning_acl_fix.sql
@@ -1,0 +1,102 @@
+begin;
+
+revoke all on function public.chips_assert_archive_prune_stage()
+  from public, anon, authenticated, service_role;
+grant execute on function public.chips_assert_archive_prune_stage()
+  to chips_ledger_archive_pruner;
+
+grant chips_ledger_archive_pruner to postgres;
+set role chips_ledger_archive_pruner;
+
+revoke all on function public.chips_archive_uuid_ids_sha256(uuid[])
+  from public, anon, authenticated, service_role;
+revoke all on function public.chips_archive_bigint_ids_sha256(bigint[])
+  from public, anon, authenticated, service_role;
+revoke all on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) from public, anon, authenticated, service_role;
+revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  from public, anon, authenticated, service_role;
+
+grant execute on function public.chips_archive_uuid_ids_sha256(uuid[]) to postgres;
+grant execute on function public.chips_archive_bigint_ids_sha256(bigint[]) to postgres;
+grant execute on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) to postgres;
+grant execute on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  to postgres;
+
+reset role;
+revoke chips_ledger_archive_pruner from postgres;
+
+do $$
+begin
+  if pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     ) then
+    raise exception 'Archive proof or prune function remains executable by an API role';
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'postgres',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or not pg_catalog.has_function_privilege(
+       'postgres',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or not pg_catalog.has_function_privilege(
+       'chips_ledger_archive_pruner',
+       'public.chips_assert_archive_prune_stage()',
+       'execute'
+     ) then
+    raise exception 'Archive proof or prune function is missing its required executor';
+  end if;
+
+  if exists (
+    select 1
+      from pg_catalog.pg_auth_members memberships
+      join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
+      join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+      where granted_role.rolname = 'chips_ledger_archive_pruner'
+        and member_role.rolname = 'postgres'
+  ) then
+    raise exception 'Temporary archive pruner membership was not revoked';
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260812110000_chips_ledger_archive_pruning_hardening.sql
+++ b/supabase/migrations/20260812110000_chips_ledger_archive_pruning_hardening.sql
@@ -1,0 +1,300 @@
+begin;
+
+drop index if exists public.chips_transaction_idempotency_archive_batch_idx;
+
+create or replace function public.chips_guard_archive_batch_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  old_proof_count integer;
+  new_proof_count integer;
+  old_receipt_count integer;
+  new_receipt_count integer;
+  proof_changed boolean;
+  receipt_changed boolean;
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Archive batch rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.object_path is distinct from old.object_path
+    or new.batch_id is distinct from old.batch_id
+    or new.project_ref is distinct from old.project_ref
+    or new.format_version is distinct from old.format_version
+    or new.cutoff is distinct from old.cutoff
+    or new.cursor_start_created_at is distinct from old.cursor_start_created_at
+    or new.cursor_start_id is distinct from old.cursor_start_id
+    or new.cursor_end_created_at is distinct from old.cursor_end_created_at
+    or new.cursor_end_id is distinct from old.cursor_end_id
+    or new.first_created_at is distinct from old.first_created_at
+    or new.last_created_at is distinct from old.last_created_at
+    or new.transaction_count is distinct from old.transaction_count
+    or new.entry_count is distinct from old.entry_count
+    or new.tx_types is distinct from old.tx_types
+    or new.raw_bytes is distinct from old.raw_bytes
+    or new.compressed_bytes is distinct from old.compressed_bytes
+    or new.raw_sha256 is distinct from old.raw_sha256
+    or new.compressed_sha256 is distinct from old.compressed_sha256
+    or new.credits is distinct from old.credits
+    or new.debits is distinct from old.debits
+    or new.net_amount is distinct from old.net_amount
+    or new.created_at is distinct from old.created_at then
+    raise exception 'Archive batch proof fields are immutable';
+  end if;
+
+  proof_changed := new.archived_transaction_ids_sha256 is distinct from old.archived_transaction_ids_sha256
+    or new.archived_entry_ids_sha256 is distinct from old.archived_entry_ids_sha256
+    or new.archive_proof_verified_at is distinct from old.archive_proof_verified_at;
+  receipt_changed := new.pruned_at is distinct from old.pruned_at
+    or new.pruned_transaction_count is distinct from old.pruned_transaction_count
+    or new.pruned_entry_count is distinct from old.pruned_entry_count
+    or new.pruned_transaction_ids_sha256 is distinct from old.pruned_transaction_ids_sha256
+    or new.pruned_entry_ids_sha256 is distinct from old.pruned_entry_ids_sha256;
+
+  if proof_changed and receipt_changed then
+    raise exception 'Archive proof and prune receipt require separate transitions';
+  end if;
+  if proof_changed and current_user <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive ID proof may only be written by the archive pruner';
+  end if;
+  if receipt_changed and current_user <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive prune receipt may only be written by the archive pruner';
+  end if;
+
+  if new.status is distinct from old.status then
+    if old.status <> 'pending' or new.status <> 'committed'
+      or old.committed_at is not null or new.committed_at is null then
+      raise exception 'Archive batch status may only transition pending to committed';
+    end if;
+  elsif new.committed_at is distinct from old.committed_at then
+    raise exception 'Archive batch committed_at is immutable';
+  end if;
+
+  old_proof_count := pg_catalog.num_nonnulls(
+    old.archived_transaction_ids_sha256,
+    old.archived_entry_ids_sha256,
+    old.archive_proof_verified_at
+  );
+  new_proof_count := pg_catalog.num_nonnulls(
+    new.archived_transaction_ids_sha256,
+    new.archived_entry_ids_sha256,
+    new.archive_proof_verified_at
+  );
+  if old_proof_count = 0 then
+    if new_proof_count not in (0, 3) then
+      raise exception 'Archive ID proof must transition from empty to complete';
+    end if;
+    if new_proof_count = 3 and new.status <> 'committed' then
+      raise exception 'Archive ID proof requires a committed batch';
+    end if;
+  elsif proof_changed then
+    raise exception 'Archive ID proof cannot be replaced or cleared';
+  end if;
+
+  old_receipt_count := pg_catalog.num_nonnulls(
+    old.pruned_at,
+    old.pruned_transaction_count,
+    old.pruned_entry_count,
+    old.pruned_transaction_ids_sha256,
+    old.pruned_entry_ids_sha256
+  );
+  new_receipt_count := pg_catalog.num_nonnulls(
+    new.pruned_at,
+    new.pruned_transaction_count,
+    new.pruned_entry_count,
+    new.pruned_transaction_ids_sha256,
+    new.pruned_entry_ids_sha256
+  );
+  if old_receipt_count = 0 then
+    if new_receipt_count not in (0, 5) then
+      raise exception 'Archive prune receipt must transition from empty to complete';
+    end if;
+    if new_receipt_count = 5 and new_proof_count <> 3 then
+      raise exception 'Archive prune receipt requires an immutable ID proof';
+    end if;
+  elsif receipt_changed then
+    raise exception 'Archive prune receipt cannot be replaced or cleared';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.chips_guard_idempotency_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Idempotency registry rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.idempotency_key is distinct from old.idempotency_key
+    or new.transaction_id is distinct from old.transaction_id
+    or new.payload_hash is distinct from old.payload_hash
+    or new.tx_type is distinct from old.tx_type
+    or new.user_id is distinct from old.user_id
+    or new.transaction_created_at is distinct from old.transaction_created_at
+    or new.created_at is distinct from old.created_at then
+    raise exception 'Idempotency registry identity is immutable';
+  end if;
+
+  if old.replay_transaction is not null
+    or old.replay_entries is not null
+    or old.replay_completed_at is not null then
+    if new.replay_transaction is distinct from old.replay_transaction
+      or new.replay_entries is distinct from old.replay_entries
+      or new.replay_completed_at is distinct from old.replay_completed_at then
+      raise exception 'Completed idempotency replay cannot be replaced or cleared';
+    end if;
+  elsif not (
+    new.replay_transaction is null
+    and new.replay_entries is null
+    and new.replay_completed_at is null
+  ) and not (
+    new.replay_transaction is not null
+    and new.replay_entries is not null
+    and new.replay_completed_at is not null
+  ) then
+    raise exception 'Idempotency replay must transition from empty to complete';
+  end if;
+
+  if new.archive_batch_id is distinct from old.archive_batch_id then
+    if current_user <> 'chips_ledger_archive_pruner' then
+      raise exception 'Idempotency archive mapping may only be written by the archive pruner';
+    end if;
+    if old.archive_batch_id is not null then
+      raise exception 'Idempotency archive mapping cannot be replaced or cleared';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
+set role chips_ledger_archive_pruner;
+
+alter function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  rename to chips_prune_committed_archive_batch_internal;
+alter function public.chips_prune_committed_archive_batch_internal(text, uuid[], bigint[], boolean)
+  strict;
+
+revoke all on function public.chips_prune_committed_archive_batch_internal(text, uuid[], bigint[], boolean)
+  from public, anon, authenticated, service_role, postgres;
+
+create function public.chips_prune_committed_archive_batch(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_execute boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if p_execute is null then
+    raise exception 'Ledger archive pruning execute flag must not be NULL';
+  end if;
+  return public.chips_prune_committed_archive_batch_internal(
+    p_object_path,
+    p_transaction_ids,
+    p_entry_ids,
+    p_execute is true
+  );
+end;
+$$;
+
+revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  from public, anon, authenticated, service_role;
+grant execute on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  to postgres;
+
+reset role;
+revoke create on schema public from chips_ledger_archive_pruner;
+revoke chips_ledger_archive_pruner from postgres;
+
+do $$
+begin
+  if pg_catalog.to_regclass('public.chips_transaction_idempotency_archive_batch_idx') is not null then
+    raise exception 'Archive mapping index must be absent for the initial measurement contract';
+  end if;
+
+  if not (
+    select procedures.proisstrict
+      from pg_catalog.pg_proc procedures
+      where procedures.oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+  ) then
+    raise exception 'Internal archive pruning implementation must reject NULL arguments';
+  end if;
+
+  if exists (
+       select 1
+         from pg_catalog.pg_proc procedures
+         cross join lateral pg_catalog.aclexplode(
+           coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))
+         ) as privileges
+         where procedures.oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+           and privileges.grantee = 'postgres'::pg_catalog.regrole::oid
+           and privileges.privilege_type = 'EXECUTE'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or not exists (
+       select 1
+         from pg_catalog.pg_proc procedures
+         cross join lateral pg_catalog.aclexplode(
+           coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))
+         ) as privileges
+         where procedures.oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+           and privileges.grantee = 'postgres'::pg_catalog.regrole::oid
+           and privileges.privilege_type = 'EXECUTE'
+     ) then
+    raise exception 'Archive pruning wrapper has unsafe execute privileges';
+  end if;
+
+  if exists (
+    select 1
+      from pg_catalog.pg_auth_members memberships
+      join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
+      join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+      join pg_catalog.pg_roles grantor_role on grantor_role.oid = memberships.grantor
+      where granted_role.rolname = 'chips_ledger_archive_pruner'
+        and not (
+          member_role.rolname = 'postgres'
+          and grantor_role.rolname = 'supabase_admin'
+          and memberships.admin_option
+          and not memberships.inherit_option
+          and not memberships.set_option
+        )
+  ) then
+    raise exception 'Unsafe archive pruner membership remains';
+  end if;
+end;
+$$;
+
+commit;

--- a/tests/chips/chips-ledger-archive-export.test.mjs
+++ b/tests/chips/chips-ledger-archive-export.test.mjs
@@ -4,6 +4,7 @@ import {
   buildExportRecord,
   buildManifest,
   evaluateTableEligibility,
+  readSnapshot,
   runExport,
   serializeRecords,
   resolveTarget,
@@ -66,6 +67,39 @@ const candidateA = candidate(TX_A, "2026-01-01T00:00:00.000001Z");
 const candidateB = candidate(TX_B, "2026-01-01T00:00:00.000001Z");
 const recordA = makeRecord(candidateA, 1);
 const recordB = makeRecord(candidateB, 3);
+
+async function assertSnapshotTimestampBindings() {
+  const queries = [];
+  const sql = {
+    typed: (value, type) => ({ value, type }),
+    begin: async (callback) => callback({
+      unsafe: async (query, parameters = []) => {
+        queries.push({ query, parameters });
+        return [];
+      },
+    }),
+  };
+  const cutoff = "2026-08-07T03:32:29.388506Z";
+  const cursorCreatedAt = "2026-08-07T03:32:24.544123Z";
+  const cursor = { created_at: cursorCreatedAt, id: TX_A };
+
+  await readSnapshot(sql, { cutoff, batchSize: 2, cursor });
+  const boundPage = queries.find(({ parameters }) => parameters.length === 4);
+  assert.deepEqual(boundPage?.parameters, [
+    { value: cutoff, type: 25 },
+    2,
+    { value: cursorCreatedAt, type: 25 },
+    TX_A,
+  ]);
+
+  queries.length = 0;
+  await readSnapshot(sql, { cutoff, batchSize: 2, cursor: null });
+  const unboundedPage = queries.find(({ parameters }) => parameters.length === 4);
+  assert.equal(unboundedPage?.parameters[2], null);
+  assert.equal(unboundedPage?.parameters[3], null);
+}
+
+await assertSnapshotTimestampBindings();
 
 assert.throws(() => resolveTarget("unknown", {}), /target must be exactly stage or prod/);
 await assert.rejects(

--- a/tests/chips/chips-ledger-archive-pruning.test.mjs
+++ b/tests/chips/chips-ledger-archive-pruning.test.mjs
@@ -241,9 +241,12 @@ assert.deepEqual(localEvidence.txTypes, { TABLE_BUY_IN: 1, TABLE_CASH_OUT: 1 });
 
 const userRecords = structuredClone(records);
 userRecords[0].transaction.user_id = "00000000-0000-4000-8000-000000000099";
+userRecords[0].entries[0].account.account_type = "USER";
+userRecords[0].entries[0].account.user_id = userRecords[0].transaction.user_id;
+userRecords[0].entries[0].account.system_key = null;
 assert.throws(
   () => buildPruneEvidence({ records: userRecords, manifest: localManifest, summary: localEvidence }),
-  /cannot prune USER ledger history/,
+  /cannot prune USER ledger history \(user_transactions=1, user_entries=1, distinct_tables=1\)/,
 );
 
 process.stdout.write("chips-ledger-archive-pruning tests passed\n");

--- a/tests/chips/chips-ledger-archive-pruning.test.mjs
+++ b/tests/chips/chips-ledger-archive-pruning.test.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildArchiveBytes,
+  buildExportRecord,
+  buildManifest,
+} from "../../scripts/ops/chips-ledger-archive-export.mjs";
+import { buildObjectPath } from "../../scripts/ops/chips-ledger-archive-store.mjs";
+import {
+  STAGE_SYSTEM_IDENTIFIER,
+  buildPruneEvidence,
+  computeArchiveIdProofs,
+  pruneArchive,
+} from "../../scripts/ops/chips-ledger-archive-prune.mjs";
+
+const TX_A = "00000000-0000-4000-8000-00000000000a";
+const TX_B = "00000000-0000-4000-8000-00000000000b";
+const TABLE_ID = "00000000-0000-4000-8000-000000000020";
+const SYSTEM_ID = "00000000-0000-4000-8000-000000000030";
+const ESCROW_ID = "00000000-0000-4000-8000-000000000031";
+
+const ENV = {
+  EXPECTED_SUPABASE_STAGE_PROJECT_REF: "krydukthwdvccggbyjfw",
+  EXPECTED_SUPABASE_PROD_PROJECT_REF: "otbqfijerkieoxwpxjnm",
+  SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
+  SUPABASE_URL: "https://krydukthwdvccggbyjfw.supabase.co",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+};
+
+function candidate(id, createdAt, txType) {
+  return {
+    id,
+    sequence: id === TX_A ? "1" : "2",
+    tx_type: txType,
+    idempotency_key: `archive-prune:${id}`,
+    payload_hash: "a".repeat(64),
+    user_id: null,
+    reference: `table:${TABLE_ID}`,
+    description: "technical table lifecycle",
+    metadata: { actor: "BOT", tableId: TABLE_ID },
+    created_by: SYSTEM_ID,
+    created_at: createdAt,
+    entry_count: "2",
+    table_related: true,
+    table_id: TABLE_ID,
+    table_exists: false,
+    table_status: null,
+    escrow_account_id: ESCROW_ID,
+    escrow_status: "active",
+    escrow_balance: "0",
+  };
+}
+
+function entry(id, transactionId, accountId, accountType, systemKey, amount) {
+  return {
+    id: String(id),
+    transaction_id: transactionId,
+    account_id: accountId,
+    entry_seq: String(id),
+    amount: String(amount),
+    metadata: {},
+    created_at: "2026-01-01T00:00:00.000000Z",
+    account_row_id: accountId,
+    account_type: accountType,
+    account_user_id: null,
+    account_system_key: systemKey,
+    account_status: "active",
+    account_label: null,
+  };
+}
+
+function record(tx, firstEntryId, amount) {
+  const buyIn = tx.tx_type === "TABLE_BUY_IN";
+  return buildExportRecord(tx, [
+    entry(firstEntryId, tx.id, SYSTEM_ID, "SYSTEM", "POKER_BOT_BANKROLL", buyIn ? -amount : amount),
+    entry(firstEntryId + 1, tx.id, ESCROW_ID, "ESCROW", `POKER_TABLE:${TABLE_ID}`, buyIn ? amount : -amount),
+  ]);
+}
+
+const records = [
+  record(candidate(TX_A, "2026-01-01T00:00:00.000001Z", "TABLE_BUY_IN"), 1, 10),
+  buildExportRecord(candidate(TX_B, "2026-01-01T00:00:00.000002Z", "TABLE_CASH_OUT"), [
+    entry(10, TX_B, SYSTEM_ID, "SYSTEM", "POKER_BOT_BANKROLL", 10),
+    entry("9007199254740993", TX_B, ESCROW_ID, "ESCROW", `POKER_TABLE:${TABLE_ID}`, -10),
+  ]),
+];
+const archive = buildArchiveBytes(records);
+const localManifest = buildManifest({
+  target: "stage",
+  cutoff: "2026-02-01T00:00:00.000000Z",
+  batchSize: 5000,
+  cursor: null,
+  records,
+  archive,
+  outputPath: `/private/${archive.compressedSha256}.jsonl.gz`,
+});
+const objectPath = buildObjectPath(localManifest);
+const proof = computeArchiveIdProofs(records);
+
+assert.equal(proof.transactionIdsSha256, "726400e7a16ea9e7ca71ee707fb025934613059de29366a5ae7f626256b688fa");
+assert.equal(proof.entryIdsSha256, "58eb8c6b6deb82261f809eb3277a61b010224ae0fe568f199ced00f51f7dd8ac");
+
+function manifestRow(overrides = {}) {
+  return {
+    object_path: objectPath,
+    batch_id: "1",
+    project_ref: "krydukthwdvccggbyjfw",
+    format_version: 1,
+    cutoff: localManifest.cutoff.created_at,
+    cursor_start_created_at: null,
+    cursor_start_id: null,
+    cursor_end_created_at: localManifest.cursor.end.created_at,
+    cursor_end_id: localManifest.cursor.end.id,
+    first_created_at: localManifest.time_range.first_created_at,
+    last_created_at: localManifest.time_range.last_created_at,
+    transaction_count: localManifest.batch.transactions,
+    entry_count: localManifest.batch.entries,
+    tx_types: localManifest.batch.tx_types,
+    raw_bytes: localManifest.bytes.raw,
+    compressed_bytes: localManifest.bytes.compressed,
+    raw_sha256: localManifest.sha256.raw_jsonl,
+    compressed_sha256: localManifest.sha256.compressed_artifact,
+    credits: localManifest.amounts.credits,
+    debits: localManifest.amounts.debits,
+    net_amount: localManifest.amounts.net,
+    status: "committed",
+    committed_at: "2026-01-02T00:00:00.000000Z",
+    archived_transaction_ids_sha256: proof.transactionIdsSha256,
+    archived_entry_ids_sha256: proof.entryIdsSha256,
+    archive_proof_verified_at: "2026-01-02T00:01:00.000000Z",
+    pruned_at: null,
+    pruned_transaction_count: null,
+    pruned_entry_count: null,
+    pruned_transaction_ids_sha256: null,
+    pruned_entry_ids_sha256: null,
+    ...overrides,
+  };
+}
+
+function fakeStore(row, states = ["pruned"]) {
+  let pruneCalls = 0;
+  return {
+    getIdentity: async () => STAGE_SYSTEM_IDENTIFIER,
+    getManifest: async () => row,
+    registerProof: async () => ({ state: "proof_registered" }),
+    prune: async (_path, _evidence, execute) => {
+      assert.equal(execute, true);
+      const state = states[Math.min(pruneCalls, states.length - 1)];
+      pruneCalls += 1;
+      return { state };
+    },
+    verifyCommitted: async () => ({
+      pruned_at: "2026-01-02T00:02:00.000000Z",
+      pruned_transaction_count: "2",
+      pruned_entry_count: "4",
+      pruned_transaction_ids_sha256: proof.transactionIdsSha256,
+      pruned_entry_ids_sha256: proof.entryIdsSha256,
+      mapping_count: "2",
+      extra_mapping_count: "0",
+      hot_transaction_count: "0",
+      hot_entry_count: "0",
+    }),
+    get pruneCalls() { return pruneCalls; },
+  };
+}
+
+const baseArgs = ["--target", "stage", "--object-path", objectPath, "--confirm-sha", archive.compressedSha256, "--execute"];
+await assert.rejects(
+  () => pruneArchive({
+    argv: ["--target", "prod", "--object-path", objectPath, "--confirm-sha", archive.compressedSha256],
+    env: ENV,
+    deps: { emit: false },
+  }),
+  /explicitly set to stage/,
+);
+await assert.rejects(
+  () => pruneArchive({ argv: baseArgs, env: ENV, deps: { emit: false } }),
+  /--recovery-dir is required/,
+);
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-prune-test-"));
+const recoveryDir = path.join(tempRoot, "recovery");
+const store = fakeStore(manifestRow(), ["pruned", "already_pruned"]);
+const downloadArchive = async () => ({ bytes: archive.compressedBytes, downloadMs: 1 });
+
+try {
+  const first = await pruneArchive({
+    argv: [...baseArgs, "--recovery-dir", recoveryDir],
+    env: ENV,
+    deps: { pruneStore: store, downloadArchive, emit: false },
+  });
+  assert.equal(first.state, "pruned");
+  assert.equal(first.evidence.userTransactions, 0);
+  assert.equal(first.evidence.userEntries, 0);
+  assert.equal(first.evidence.distinctTables, 1);
+  assert.equal(fs.statSync(recoveryDir).mode & 0o777, 0o700);
+  assert.equal(fs.statSync(first.recoveryBundle.artifactPath).mode & 0o777, 0o600);
+  assert.equal(fs.statSync(first.recoveryBundle.manifestPath).mode & 0o777, 0o600);
+
+  const retry = await pruneArchive({
+    argv: [...baseArgs, "--recovery-dir", recoveryDir],
+    env: ENV,
+    deps: { pruneStore: store, downloadArchive, emit: false },
+  });
+  assert.equal(retry.state, "already_pruned");
+  assert.equal(retry.recoveryBundle.reused, true);
+  assert.equal(store.pruneCalls, 2);
+
+  const failedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-prune-postcommit-"));
+  const failedRecovery = path.join(failedRoot, "recovery");
+  let downloads = 0;
+  await assert.rejects(
+    () => pruneArchive({
+      argv: [...baseArgs, "--recovery-dir", failedRecovery],
+      env: ENV,
+      deps: {
+        pruneStore: fakeStore(manifestRow()),
+        downloadArchive: async () => {
+          downloads += 1;
+          return { bytes: downloads === 1 ? archive.compressedBytes : Buffer.from("corrupt"), downloadMs: 1 };
+        },
+        emit: false,
+      },
+    }),
+    (error) => error?.code === "post_commit_verification_failed",
+  );
+  assert.equal(fs.readdirSync(failedRecovery).length, 2, "post-commit failure must retain the recovery bundle");
+  fs.rmSync(failedRoot, { recursive: true, force: true });
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+const localEvidence = buildPruneEvidence({ records, manifest: localManifest, summary: {
+  credits: localManifest.amounts.credits,
+  debits: localManifest.amounts.debits,
+  netAmount: localManifest.amounts.net,
+} });
+assert.deepEqual(localEvidence.txTypes, { TABLE_BUY_IN: 1, TABLE_CASH_OUT: 1 });
+
+const userRecords = structuredClone(records);
+userRecords[0].transaction.user_id = "00000000-0000-4000-8000-000000000099";
+assert.throws(
+  () => buildPruneEvidence({ records: userRecords, manifest: localManifest, summary: localEvidence }),
+  /cannot prune USER ledger history/,
+);
+
+process.stdout.write("chips-ledger-archive-pruning tests passed\n");

--- a/tests/chips/chips-ledger-archive-pruning.test.mjs
+++ b/tests/chips/chips-ledger-archive-pruning.test.mjs
@@ -183,13 +183,35 @@ await assert.rejects(
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-prune-test-"));
 const recoveryDir = path.join(tempRoot, "recovery");
 const store = fakeStore(manifestRow(), ["pruned", "already_pruned"]);
-const downloadArchive = async () => ({ bytes: archive.compressedBytes, downloadMs: 1 });
+let archiveDownloads = 0;
+let bucketChecks = 0;
+const downloadArchive = async () => {
+  archiveDownloads += 1;
+  return { bytes: archive.compressedBytes, downloadMs: 1 };
+};
+const verifyBucket = async () => { bucketChecks += 1; };
 
 try {
+  const bucketRejectedStore = fakeStore(manifestRow());
+  await assert.rejects(
+    () => pruneArchive({
+      argv: baseArgs.slice(0, -1),
+      env: ENV,
+      deps: {
+        pruneStore: bucketRejectedStore,
+        verifyBucket: async () => { throw new Error("Storage archive bucket must be private"); },
+        downloadArchive: async () => { throw new Error("archive download must not run"); },
+        emit: false,
+      },
+    }),
+    /must be private/,
+  );
+  assert.equal(bucketRejectedStore.pruneCalls, 0);
+
   const first = await pruneArchive({
     argv: [...baseArgs, "--recovery-dir", recoveryDir],
     env: ENV,
-    deps: { pruneStore: store, downloadArchive, emit: false },
+    deps: { pruneStore: store, downloadArchive, verifyBucket, emit: false },
   });
   assert.equal(first.state, "pruned");
   assert.equal(first.evidence.userTransactions, 0);
@@ -198,15 +220,19 @@ try {
   assert.equal(fs.statSync(recoveryDir).mode & 0o777, 0o700);
   assert.equal(fs.statSync(first.recoveryBundle.artifactPath).mode & 0o777, 0o600);
   assert.equal(fs.statSync(first.recoveryBundle.manifestPath).mode & 0o777, 0o600);
+  assert.equal(bucketChecks, 2, "execute must verify bucket configuration before and after commit");
+  assert.equal(archiveDownloads, 2, "execute must download the private archive before and after commit");
 
   const retry = await pruneArchive({
     argv: [...baseArgs, "--recovery-dir", recoveryDir],
     env: ENV,
-    deps: { pruneStore: store, downloadArchive, emit: false },
+    deps: { pruneStore: store, downloadArchive, verifyBucket, emit: false },
   });
   assert.equal(retry.state, "already_pruned");
   assert.equal(retry.recoveryBundle.reused, true);
   assert.equal(store.pruneCalls, 2);
+  assert.equal(bucketChecks, 4);
+  assert.equal(archiveDownloads, 4);
 
   const failedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-prune-postcommit-"));
   const failedRecovery = path.join(failedRoot, "recovery");
@@ -217,6 +243,7 @@ try {
       env: ENV,
       deps: {
         pruneStore: fakeStore(manifestRow()),
+        verifyBucket,
         downloadArchive: async () => {
           downloads += 1;
           return { bytes: downloads === 1 ? archive.compressedBytes : Buffer.from("corrupt"), downloadMs: 1 };

--- a/tests/chips/chips-ledger-archive-storage.test.mjs
+++ b/tests/chips/chips-ledger-archive-storage.test.mjs
@@ -7,7 +7,14 @@ import {
   buildExportRecord,
   buildManifest,
 } from "../../scripts/ops/chips-ledger-archive-export.mjs";
-import { ARCHIVE_BUCKET, ARCHIVE_MAX_BYTES, createManifestStore, storeArchive } from "../../scripts/ops/chips-ledger-archive-store.mjs";
+import {
+  ARCHIVE_BUCKET,
+  ARCHIVE_MAX_BYTES,
+  createManifestStore,
+  resolveStorageTarget,
+  storeArchive,
+  verifyArchiveBucket,
+} from "../../scripts/ops/chips-ledger-archive-store.mjs";
 
 const TX_ID = "00000000-0000-4000-8000-000000000001";
 const USER_ID = "00000000-0000-4000-8000-000000000002";
@@ -36,7 +43,7 @@ function bucket() {
   };
 }
 
-function makeFetch({ initialObject = null, bucketInitiallyExists = false } = {}) {
+function makeFetch({ initialObject = null, bucketInitiallyExists = false, bucketValue = bucket() } = {}) {
   let object = initialObject;
   let bucketExists = bucketInitiallyExists;
   const calls = [];
@@ -45,7 +52,7 @@ function makeFetch({ initialObject = null, bucketInitiallyExists = false } = {})
     const method = init.method || "GET";
     calls.push({ method, path: requestUrl.pathname, headers: new Headers(init.headers || {}) });
     if (requestUrl.pathname === `/storage/v1/bucket/${ARCHIVE_BUCKET}` && method === "GET") {
-      return bucketExists ? responseJson(bucket()) : responseJson({ message: "not found" }, 400);
+      return bucketExists ? responseJson(bucketValue) : responseJson({ message: "not found" }, 400);
     }
     if (requestUrl.pathname === "/storage/v1/bucket" && method === "POST") {
       bucketExists = true;
@@ -130,6 +137,20 @@ fs.writeFileSync(artifactPath, archive.compressedBytes, { mode: 0o600 });
 fs.writeFileSync(manifestPath, `${JSON.stringify(localManifest)}\n`, { mode: 0o600 });
 
 try {
+  const publicBucketStorage = makeFetch({
+    bucketInitiallyExists: true,
+    bucketValue: { ...bucket(), public: true },
+  });
+  await assert.rejects(
+    () => verifyArchiveBucket(resolveStorageTarget("stage", ENV), { fetch: publicBucketStorage.fetch }),
+    /must be private/,
+  );
+  assert.deepEqual(
+    publicBucketStorage.calls.map(({ method, path: requestPath }) => [method, requestPath]),
+    [["GET", `/storage/v1/bucket/${ARCHIVE_BUCKET}`]],
+    "read-only bucket verification must never create or update a bucket",
+  );
+
   const firstStorage = makeFetch();
   const firstStore = makeStore();
   const first = await storeArchive({

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -705,6 +705,20 @@ async function assertIdempotencyRegistryParity(sql) {
   };
 }
 
+async function expectSavepointError(tx, savepoint, operation, expectedMessage) {
+  assert.match(savepoint, /^[a-z_]+$/);
+  await tx.unsafe(`savepoint ${savepoint};`);
+  let caught = null;
+  try {
+    await operation();
+  } catch (error) {
+    caught = error;
+  }
+  await tx.unsafe(`rollback to savepoint ${savepoint};`);
+  await tx.unsafe(`release savepoint ${savepoint};`);
+  assert.match(caught?.message || "", expectedMessage);
+}
+
 async function assertArchivePrunerRoleContracts(sql) {
   const hashes = await sql`
     select
@@ -743,6 +757,13 @@ async function assertArchivePrunerRoleContracts(sql) {
         select proowner from pg_catalog.pg_proc
         where oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::regprocedure
       )) as prune_owner,
+      pg_catalog.pg_get_userbyid((
+        select proowner from pg_catalog.pg_proc
+        where oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::regprocedure
+      )) as prune_internal_owner,
+      (select proisstrict from pg_catalog.pg_proc
+       where oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::regprocedure) as prune_internal_strict,
+      pg_catalog.to_regclass('public.chips_transaction_idempotency_archive_batch_idx') is not null as archive_mapping_index_exists,
       exists (
         select 1
           from pg_catalog.pg_auth_members memberships
@@ -763,6 +784,9 @@ async function assertArchivePrunerRoleContracts(sql) {
   `;
   assert.equal(functionOwners[0].gate_owner, "postgres", "read-only Stage identity gate must retain its privileged owner");
   assert.equal(functionOwners[0].prune_owner, "chips_ledger_archive_pruner", "destructive function must use the NOLOGIN owner");
+  assert.equal(functionOwners[0].prune_internal_owner, "chips_ledger_archive_pruner", "internal pruning implementation must use the NOLOGIN owner");
+  assert.equal(functionOwners[0].prune_internal_strict, true, "internal pruning implementation must never receive NULL arguments");
+  assert.equal(functionOwners[0].archive_mapping_index_exists, false, "initial pruning measurement must not add an archive mapping index");
   assert.equal(functionOwners[0].unsafe_membership, false, "only the managed non-inheriting ADMIN membership may remain");
   assert.equal(functionOwners[0].public_schema_usage, true, "pruner needs schema usage for qualified objects");
   assert.equal(functionOwners[0].public_schema_create, false, "temporary schema CREATE must be revoked");
@@ -772,14 +796,34 @@ async function assertArchivePrunerRoleContracts(sql) {
       has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as service_role_execute,
       has_function_privilege('anon', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as anon_execute,
       has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as authenticated_execute,
+      has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)', 'execute') as service_role_internal_execute,
+      has_function_privilege('anon', 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)', 'execute') as anon_internal_execute,
+      has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)', 'execute') as authenticated_internal_execute,
       has_function_privilege('service_role', 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)', 'execute') as service_role_proof_execute,
-      has_function_privilege('postgres', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as postgres_execute;
+      exists (
+        select 1 from pg_catalog.pg_proc procedures
+        cross join lateral pg_catalog.aclexplode(coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))) privileges
+        where procedures.oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::regprocedure
+          and privileges.grantee = 'postgres'::regrole::oid
+          and privileges.privilege_type = 'EXECUTE'
+      ) as postgres_execute,
+      exists (
+        select 1 from pg_catalog.pg_proc procedures
+        cross join lateral pg_catalog.aclexplode(coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))) privileges
+        where procedures.oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::regprocedure
+          and privileges.grantee = 'postgres'::regrole::oid
+          and privileges.privilege_type = 'EXECUTE'
+      ) as postgres_internal_execute;
   `;
   assert.equal(acl[0].service_role_execute, false, "service_role must not execute the destructive function");
   assert.equal(acl[0].anon_execute, false, "anon must not execute the destructive function");
   assert.equal(acl[0].authenticated_execute, false, "authenticated must not execute the destructive function");
+  assert.equal(acl[0].service_role_internal_execute, false, "service_role must not execute the internal destructive function");
+  assert.equal(acl[0].anon_internal_execute, false, "anon must not execute the internal destructive function");
+  assert.equal(acl[0].authenticated_internal_execute, false, "authenticated must not execute the internal destructive function");
   assert.equal(acl[0].service_role_proof_execute, false, "service_role must not register immutable archive proof");
   assert.equal(acl[0].postgres_execute, true, "the explicit operations role must execute the destructive function");
+  assert.equal(acl[0].postgres_internal_execute, false, "the operations role must not bypass the NULL-safe wrapper");
 
   const ROLLBACK = new Error("archive-pruner-probe-rollback");
   await sql.begin(async (tx) => {
@@ -844,12 +888,56 @@ async function assertArchivePrunerRoleContracts(sql) {
     ]);
     const batchId = String(manifestRows[0].batch_id);
     const objectPath = `v1/sha256/${compressedHash}.jsonl.gz`;
+    const generatedHashes = await tx.unsafe(`select
+      public.chips_archive_uuid_ids_sha256($1::uuid[]) as transaction_hash,
+      public.chips_archive_bigint_ids_sha256($2::bigint[]) as entry_hash;`, [transactionIds, entryIds]);
+    const transactionHash = generatedHashes[0].transaction_hash;
+    const entryHash = generatedHashes[0].entry_hash;
+
+    await expectSavepointError(tx, "archive_direct_proof", () => tx.unsafe(`update public.chips_ledger_archive_batches
+      set archived_transaction_ids_sha256 = $2,
+          archived_entry_ids_sha256 = $3,
+          archive_proof_verified_at = timezone('utc', now())
+      where batch_id = $1;`, [batchId, transactionHash, entryHash]), /proof may only be written by the archive pruner/i);
+    await expectSavepointError(tx, "archive_direct_mapping", () => tx.unsafe(`update public.chips_transaction_idempotency
+      set archive_batch_id = $2
+      where transaction_id = $1::uuid;`, [transactionIds[0], batchId]), /mapping may only be written by the archive pruner/i);
+    await expectSavepointError(tx, "archive_combined_transition", async () => {
+      await tx.unsafe("set local role chips_ledger_archive_pruner;");
+      await tx.unsafe(`update public.chips_ledger_archive_batches
+        set archived_transaction_ids_sha256 = $2,
+            archived_entry_ids_sha256 = $3,
+            archive_proof_verified_at = timezone('utc', now()),
+            pruned_at = timezone('utc', now()),
+            pruned_transaction_count = 2,
+            pruned_entry_count = 4,
+            pruned_transaction_ids_sha256 = $2,
+            pruned_entry_ids_sha256 = $3
+        where batch_id = $1;`, [batchId, transactionHash, entryHash]);
+    }, /proof and prune receipt require separate transitions/i);
+
+    const untouchedGuardState = await tx.unsafe(`select
+      (select archive_proof_verified_at from public.chips_ledger_archive_batches where batch_id = $1) as proof_at,
+      (select pruned_at from public.chips_ledger_archive_batches where batch_id = $1) as pruned_at,
+      (select count(*) from public.chips_transaction_idempotency where archive_batch_id = $1) as mappings;`, [batchId]);
+    assert.equal(untouchedGuardState[0].proof_at, null);
+    assert.equal(untouchedGuardState[0].pruned_at, null);
+    assert.equal(Number(untouchedGuardState[0].mappings), 0);
+
     const proofRows = await tx.unsafe(`select public.chips_register_archive_id_proof(
       $1, $2::uuid[], $3::bigint[], 'krydukthwdvccggbyjfw', 1, '2026-02-01T00:00:00Z',
       null, null, $4::timestamptz, $5::uuid, $6::timestamptz, $4::timestamptz,
       '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb, 100, 80, $7, $8, 20, 20, 0
     ) as result;`, [objectPath, transactionIds, entryIds, createdAt[1], transactionIds[1], createdAt[0], "1".repeat(64), compressedHash]);
     assert.equal(proofRows[0].result.state, "proof_registered", "real proof function must pass through owner-role RLS");
+
+    await expectSavepointError(tx, "archive_direct_receipt", () => tx.unsafe(`update public.chips_ledger_archive_batches
+      set pruned_at = timezone('utc', now()),
+          pruned_transaction_count = 2,
+          pruned_entry_count = 4,
+          pruned_transaction_ids_sha256 = $2,
+          pruned_entry_ids_sha256 = $3
+      where batch_id = $1;`, [batchId, transactionHash, entryHash]), /receipt may only be written by the archive pruner/i);
 
     await tx.unsafe("savepoint archive_active_table_probe;");
     let activeTableError = null;
@@ -865,6 +953,21 @@ async function assertArchivePrunerRoleContracts(sql) {
     await tx.unsafe("release savepoint archive_active_table_probe;");
     assert.match(activeTableError?.message || "", /active table or non-zero\/missing escrow/i);
     await tx`update public.poker_tables set status = 'CLOSED' where id = ${tableId};`;
+
+    await expectSavepointError(tx, "archive_null_execute", () => tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], $4::boolean) as result;",
+      [objectPath, transactionIds, entryIds, null],
+    ), /execute flag must not be NULL/i);
+    const nullExecuteState = await tx.unsafe(`select
+      (select count(*) from public.chips_transactions where id = any($1::uuid[])) as hot_transactions,
+      (select count(*) from public.chips_entries where id = any($2::bigint[])) as hot_entries,
+      (select count(*) from public.chips_transaction_idempotency where transaction_id = any($1::uuid[]) and archive_batch_id is not null) as mappings,
+      (select pruned_at from public.chips_ledger_archive_batches where batch_id = $3) as pruned_at;`,
+      [transactionIds, entryIds, batchId]);
+    assert.equal(Number(nullExecuteState[0].hot_transactions), 2, "NULL execute must not delete transactions");
+    assert.equal(Number(nullExecuteState[0].hot_entries), 4, "NULL execute must not delete entries");
+    assert.equal(Number(nullExecuteState[0].mappings), 0, "NULL execute must not create archive mappings");
+    assert.equal(nullExecuteState[0].pruned_at, null, "NULL execute must not write a prune receipt");
 
     const dryRows = await tx.unsafe(
       "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], false) as result;",

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import postgres from "postgres";
+import { createPruneStore } from "../../scripts/ops/chips-ledger-archive-prune.mjs";
 
 const dbUrl = process.env.CHIPS_MIGRATIONS_TEST_DB_URL;
 const allowDrop = process.env.CHIPS_MIGRATIONS_ALLOW_DROP === "1";
@@ -18,10 +19,10 @@ const seedKey = "seed:treasury:v1";
 const seedAmount = 1000000;
 const botBankrollSeedKey = "seed:poker-bot-bankroll:v1";
 const botBankrollSeedAmount = 1000000;
-const primaryUserId = "00000000-0000-0000-0000-000000000001";
-const idempotentUserId = "00000000-0000-0000-0000-000000000002";
-const conflictUserId = "00000000-0000-0000-0000-000000000003";
-const crossUserId = "00000000-0000-0000-0000-000000000004";
+const primaryUserId = "00000000-0000-4000-8000-000000000001";
+const idempotentUserId = "00000000-0000-4000-8000-000000000002";
+const conflictUserId = "00000000-0000-4000-8000-000000000003";
+const crossUserId = "00000000-0000-4000-8000-000000000004";
 const assertTestDatabase = async (sql) => {
   const rows = await sql`select current_database() as name;`;
   const name = rows?.[0]?.name || "";
@@ -837,6 +838,9 @@ async function assertArchivePrunerRoleContracts(sql) {
       "00000000-0000-4000-8000-00000000b403",
       "00000000-0000-4000-8000-00000000b404",
     ];
+    const cursorStartId = "00000000-0000-4000-8000-00000000b400";
+    const cutoff = "2026-02-01T00:00:00.123456Z";
+    const cursorStartCreatedAt = "2025-12-31T23:59:59.654321Z";
     const createdAt = ["2026-01-01T00:00:00.000001Z", "2026-01-01T00:00:00.000002Z"];
     await tx`insert into public.poker_tables (id, status) values (${tableId}, 'ACTIVE');`;
     await tx`
@@ -848,7 +852,7 @@ async function assertArchivePrunerRoleContracts(sql) {
         id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id, created_at
       ) values ($1::uuid, $2, $3::jsonb, $4, $5, $6, null, $7::timestamptz);`, [
         transactionIds[index], `table:${tableId}`, { tableId }, `archive-pruner-probe:${index}`,
-        (index === 0 ? "a" : "b").repeat(64), index === 0 ? "TABLE_BUY_IN" : "TABLE_CASH_OUT", createdAt[index],
+        (index === 0 ? "a" : "b").repeat(64), index === 0 ? "TABLE_BUY_IN" : "TABLE_CASH_OUT", sql.typed(createdAt[index], 25),
       ]);
     }
     const entryIds = [];
@@ -875,16 +879,19 @@ async function assertArchivePrunerRoleContracts(sql) {
     `;
     const compressedHash = "2".repeat(64);
     const manifestRows = await tx.unsafe(`insert into public.chips_ledger_archive_batches (
-      object_path, project_ref, format_version, cutoff, cursor_end_created_at, cursor_end_id,
+      object_path, project_ref, format_version, cutoff, cursor_start_created_at, cursor_start_id,
+      cursor_end_created_at, cursor_end_id,
       first_created_at, last_created_at, transaction_count, entry_count, tx_types,
       raw_bytes, compressed_bytes, raw_sha256, compressed_sha256, credits, debits,
       net_amount, status, committed_at
     ) values (
-      $1, 'krydukthwdvccggbyjfw', 1, '2026-02-01T00:00:00Z', $2::timestamptz, $3::uuid,
-      $4::timestamptz, $2::timestamptz, 2, 4, '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb,
-      100, 80, $5, $6, 20, 20, 0, 'committed', timezone('utc', now())
+      $1, 'krydukthwdvccggbyjfw', 1, $2::timestamptz, $3::timestamptz, $4::uuid,
+      $5::timestamptz, $6::uuid, $7::timestamptz, $5::timestamptz,
+      2, 4, '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb,
+      100, 80, $8, $9, 20, 20, 0, 'committed', timezone('utc', now())
     ) returning batch_id;`, [
-      `v1/sha256/${compressedHash}.jsonl.gz`, createdAt[1], transactionIds[1], createdAt[0], "1".repeat(64), compressedHash,
+      `v1/sha256/${compressedHash}.jsonl.gz`, sql.typed(cutoff, 25), sql.typed(cursorStartCreatedAt, 25), cursorStartId,
+      sql.typed(createdAt[1], 25), transactionIds[1], sql.typed(createdAt[0], 25), "1".repeat(64), compressedHash,
     ]);
     const batchId = String(manifestRows[0].batch_id);
     const objectPath = `v1/sha256/${compressedHash}.jsonl.gz`;
@@ -924,12 +931,25 @@ async function assertArchivePrunerRoleContracts(sql) {
     assert.equal(untouchedGuardState[0].pruned_at, null);
     assert.equal(Number(untouchedGuardState[0].mappings), 0);
 
-    const proofRows = await tx.unsafe(`select public.chips_register_archive_id_proof(
-      $1, $2::uuid[], $3::bigint[], 'krydukthwdvccggbyjfw', 1, '2026-02-01T00:00:00Z',
-      null, null, $4::timestamptz, $5::uuid, $6::timestamptz, $4::timestamptz,
-      '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb, 100, 80, $7, $8, 20, 20, 0
-    ) as result;`, [objectPath, transactionIds, entryIds, createdAt[1], transactionIds[1], createdAt[0], "1".repeat(64), compressedHash]);
-    assert.equal(proofRows[0].result.state, "proof_registered", "real proof function must pass through owner-role RLS");
+    const pruneStore = createPruneStore({
+      unsafe: (...args) => tx.unsafe(...args),
+      begin: async (callback) => callback({
+        unsafe: (query, parameters) => query === "set transaction isolation level repeatable read;"
+          ? Promise.resolve([])
+          : tx.unsafe(query, parameters),
+      }),
+      typed: (value, type) => sql.typed(value, type),
+    });
+    const adapterManifest = await pruneStore.getManifest(objectPath);
+    assert.deepEqual([
+      adapterManifest.cutoff, adapterManifest.cursor_start_created_at,
+      adapterManifest.cursor_end_created_at, adapterManifest.first_created_at, adapterManifest.last_created_at,
+    ], [
+      "2026-02-01 00:00:00.123456+00", "2025-12-31 23:59:59.654321+00",
+      "2026-01-01 00:00:00.000002+00", "2026-01-01 00:00:00.000001+00", "2026-01-01 00:00:00.000002+00",
+    ], "real PostgreSQL adapter must preserve manifest microseconds");
+    const proofResult = await pruneStore.registerProof(adapterManifest, { transactionIds, entryIds });
+    assert.equal(proofResult.state, "proof_registered", "real PostgreSQL adapter must preserve microseconds when registering proof");
 
     await expectSavepointError(tx, "archive_direct_receipt", () => tx.unsafe(`update public.chips_ledger_archive_batches
       set pruned_at = timezone('utc', now()),

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -705,6 +705,151 @@ async function assertIdempotencyRegistryParity(sql) {
   };
 }
 
+async function assertArchivePrunerRoleContracts(sql) {
+  const hashes = await sql`
+    select
+      public.chips_archive_uuid_ids_sha256(array[
+        '00000000-0000-4000-8000-00000000000a'::uuid,
+        '00000000-0000-4000-8000-00000000000b'::uuid
+      ]) as transaction_hash,
+      public.chips_archive_bigint_ids_sha256(array[1::bigint, 2, 10, 9007199254740993]) as entry_hash;
+  `;
+  assert.equal(hashes[0].transaction_hash, "726400e7a16ea9e7ca71ee707fb025934613059de29366a5ae7f626256b688fa");
+  assert.equal(hashes[0].entry_hash, "58eb8c6b6deb82261f809eb3277a61b010224ae0fe568f199ced00f51f7dd8ac");
+
+  const acl = await sql`
+    select
+      has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as service_role_execute,
+      has_function_privilege('anon', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as anon_execute,
+      has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as authenticated_execute;
+  `;
+  assert.equal(acl[0].service_role_execute, false, "service_role must not execute the destructive function");
+  assert.equal(acl[0].anon_execute, false, "anon must not execute the destructive function");
+  assert.equal(acl[0].authenticated_execute, false, "authenticated must not execute the destructive function");
+
+  const ROLLBACK = new Error("archive-pruner-probe-rollback");
+  await sql.begin(async (tx) => {
+    await tx.unsafe("set transaction isolation level serializable;");
+    await tx.unsafe(`create or replace function public.chips_assert_archive_prune_stage()
+      returns text language sql security definer set search_path = ''
+      as $override$ select '7656985631720456337'::text $override$;`);
+    const tableId = "00000000-0000-4000-8000-00000000b401";
+    const escrowId = "00000000-0000-4000-8000-00000000b402";
+    const transactionIds = [
+      "00000000-0000-4000-8000-00000000b403",
+      "00000000-0000-4000-8000-00000000b404",
+    ];
+    const createdAt = ["2026-01-01T00:00:00.000001Z", "2026-01-01T00:00:00.000002Z"];
+    await tx`insert into public.poker_tables (id, status) values (${tableId}, 'ACTIVE');`;
+    await tx`
+      insert into public.chips_accounts (id, account_type, system_key, status)
+      values (${escrowId}, 'ESCROW', ${`POKER_TABLE:${tableId}`}, 'active');
+    `;
+    for (let index = 0; index < transactionIds.length; index += 1) {
+      await tx.unsafe(`insert into public.chips_transactions (
+        id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id, created_at
+      ) values ($1::uuid, $2, $3::jsonb, $4, $5, $6, null, $7::timestamptz);`, [
+        transactionIds[index], `table:${tableId}`, { tableId }, `archive-pruner-probe:${index}`,
+        (index === 0 ? "a" : "b").repeat(64), index === 0 ? "TABLE_BUY_IN" : "TABLE_CASH_OUT", createdAt[index],
+      ]);
+    }
+    const entryIds = [];
+    for (let index = 0; index < transactionIds.length; index += 1) {
+      const entryRows = await tx.unsafe(`with accounts as (
+        select id, system_key from public.chips_accounts
+        where (account_type = 'SYSTEM' and system_key = 'GENESIS') or id = $2::uuid
+      )
+      insert into public.chips_entries (transaction_id, account_id, amount, metadata)
+      select $1::uuid, id,
+             case
+               when $3::boolean and system_key = 'GENESIS' then -10
+               when $3::boolean then 10
+               when system_key = 'GENESIS' then 10
+               else -10
+             end,
+             '{}'::jsonb
+      from accounts order by system_key returning id;`, [transactionIds[index], escrowId, index === 0]);
+      entryIds.push(...entryRows.map((row) => String(row.id)).sort((left, right) => BigInt(left) < BigInt(right) ? -1 : 1));
+    }
+    const accountsBefore = await tx`
+      select id, balance, next_entry_seq from public.chips_accounts
+      where system_key in ('GENESIS', ${`POKER_TABLE:${tableId}`}) order by id;
+    `;
+    const compressedHash = "2".repeat(64);
+    const manifestRows = await tx.unsafe(`insert into public.chips_ledger_archive_batches (
+      object_path, project_ref, format_version, cutoff, cursor_end_created_at, cursor_end_id,
+      first_created_at, last_created_at, transaction_count, entry_count, tx_types,
+      raw_bytes, compressed_bytes, raw_sha256, compressed_sha256, credits, debits,
+      net_amount, status, committed_at
+    ) values (
+      $1, 'krydukthwdvccggbyjfw', 1, '2026-02-01T00:00:00Z', $2::timestamptz, $3::uuid,
+      $4::timestamptz, $2::timestamptz, 2, 4, '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb,
+      100, 80, $5, $6, 20, 20, 0, 'committed', timezone('utc', now())
+    ) returning batch_id;`, [
+      `v1/sha256/${compressedHash}.jsonl.gz`, createdAt[1], transactionIds[1], createdAt[0], "1".repeat(64), compressedHash,
+    ]);
+    const batchId = String(manifestRows[0].batch_id);
+    const objectPath = `v1/sha256/${compressedHash}.jsonl.gz`;
+    const proofRows = await tx.unsafe(`select public.chips_register_archive_id_proof(
+      $1, $2::uuid[], $3::bigint[], 'krydukthwdvccggbyjfw', 1, '2026-02-01T00:00:00Z',
+      null, null, $4::timestamptz, $5::uuid, $6::timestamptz, $4::timestamptz,
+      '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb, 100, 80, $7, $8, 20, 20, 0
+    ) as result;`, [objectPath, transactionIds, entryIds, createdAt[1], transactionIds[1], createdAt[0], "1".repeat(64), compressedHash]);
+    assert.equal(proofRows[0].result.state, "proof_registered", "real proof function must pass through owner-role RLS");
+
+    await tx.unsafe("savepoint archive_active_table_probe;");
+    let activeTableError = null;
+    try {
+      await tx.unsafe(
+        "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], false) as result;",
+        [objectPath, transactionIds, entryIds],
+      );
+    } catch (error) {
+      activeTableError = error;
+    }
+    await tx.unsafe("rollback to savepoint archive_active_table_probe;");
+    await tx.unsafe("release savepoint archive_active_table_probe;");
+    assert.match(activeTableError?.message || "", /active table or non-zero\/missing escrow/i);
+    await tx`update public.poker_tables set status = 'CLOSED' where id = ${tableId};`;
+
+    const dryRows = await tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], false) as result;",
+      [objectPath, transactionIds, entryIds],
+    );
+    assert.equal(dryRows[0].result.state, "ready", "validated batch must be ready before DELETE");
+    const executeRows = await tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], true) as result;",
+      [objectPath, transactionIds, entryIds],
+    );
+    assert.equal(executeRows[0].result.state, "pruned", "real destructive function must pass through owner-role RLS");
+    await tx.unsafe("set constraints all immediate;");
+    const retryRows = await tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], true) as result;",
+      [objectPath, transactionIds, entryIds],
+    );
+    assert.equal(retryRows[0].result.state, "already_pruned", "retry must not require deleted hot rows");
+
+    const accountsAfter = await tx`
+      select id, balance, next_entry_seq from public.chips_accounts
+      where system_key in ('GENESIS', ${`POKER_TABLE:${tableId}`}) order by id;
+    `;
+    assert.deepEqual(accountsAfter, accountsBefore, "pruning must preserve balances and account sequences exactly");
+    const receiptRows = await tx.unsafe(`select
+      (select count(*) from public.chips_transactions where id = any($1::uuid[])) as hot_transactions,
+      (select count(*) from public.chips_entries where id = any($2::bigint[])) as hot_entries,
+      (select count(*) from public.chips_transaction_idempotency where transaction_id = any($1::uuid[]) and archive_batch_id = $3) as mappings,
+      (select pruned_transaction_count from public.chips_ledger_archive_batches where batch_id = $3) as receipt_count;`,
+      [transactionIds, entryIds, batchId]);
+    assert.equal(Number(receiptRows[0].hot_transactions), 0);
+    assert.equal(Number(receiptRows[0].hot_entries), 0);
+    assert.equal(Number(receiptRows[0].mappings), 2);
+    assert.equal(Number(receiptRows[0].receipt_count), 2);
+    throw ROLLBACK;
+  }).catch((error) => {
+    if (error !== ROLLBACK) throw error;
+  });
+}
+
 async function assertBuyInSequencing(sql, expectedTreasurySeq) {
   const { getUserBalance, listUserLedger } = await withLedger();
   const userId = primaryUserId;
@@ -799,6 +944,7 @@ async function main() {
 
   await runMigrations(sql, migrationsWithoutBootstrapSeeds);
   await ensureGenesisFixture(sql);
+  await assertArchivePrunerRoleContracts(sql);
   await expectNegativeBalanceGuard(sql);
   await expectInsufficientBuyIn(sql);
   await expectInvalidMetadata(sql);

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -717,6 +717,22 @@ async function assertArchivePrunerRoleContracts(sql) {
   assert.equal(hashes[0].transaction_hash, "726400e7a16ea9e7ca71ee707fb025934613059de29366a5ae7f626256b688fa");
   assert.equal(hashes[0].entry_hash, "58eb8c6b6deb82261f809eb3277a61b010224ae0fe568f199ced00f51f7dd8ac");
 
+  const roleRows = await sql`
+    select rolsuper, rolcreatedb, rolcreaterole, rolreplication,
+           rolbypassrls, rolcanlogin, rolinherit
+      from pg_catalog.pg_roles
+      where rolname = 'chips_ledger_archive_pruner';
+  `;
+  assert.deepEqual(roleRows[0], {
+    rolsuper: false,
+    rolcreatedb: false,
+    rolcreaterole: false,
+    rolreplication: false,
+    rolbypassrls: false,
+    rolcanlogin: false,
+    rolinherit: false,
+  }, "archive pruner must remain a least-privilege NOLOGIN role");
+
   const acl = await sql`
     select
       has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as service_role_execute,

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -764,11 +764,15 @@ async function assertArchivePrunerRoleContracts(sql) {
     select
       has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as service_role_execute,
       has_function_privilege('anon', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as anon_execute,
-      has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as authenticated_execute;
+      has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as authenticated_execute,
+      has_function_privilege('service_role', 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)', 'execute') as service_role_proof_execute,
+      has_function_privilege('postgres', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as postgres_execute;
   `;
   assert.equal(acl[0].service_role_execute, false, "service_role must not execute the destructive function");
   assert.equal(acl[0].anon_execute, false, "anon must not execute the destructive function");
   assert.equal(acl[0].authenticated_execute, false, "authenticated must not execute the destructive function");
+  assert.equal(acl[0].service_role_proof_execute, false, "service_role must not register immutable archive proof");
+  assert.equal(acl[0].postgres_execute, true, "the explicit operations role must execute the destructive function");
 
   const ROLLBACK = new Error("archive-pruner-probe-rollback");
   await sql.begin(async (tx) => {

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -748,15 +748,22 @@ async function assertArchivePrunerRoleContracts(sql) {
           from pg_catalog.pg_auth_members memberships
           join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
           join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+          join pg_catalog.pg_roles grantor_role on grantor_role.oid = memberships.grantor
           where granted_role.rolname = 'chips_ledger_archive_pruner'
-            and member_role.rolname = 'postgres'
-      ) as postgres_membership,
+            and not (
+              member_role.rolname = 'postgres'
+              and grantor_role.rolname = 'supabase_admin'
+              and memberships.admin_option
+              and not memberships.inherit_option
+              and not memberships.set_option
+            )
+      ) as unsafe_membership,
       pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'usage') as public_schema_usage,
       pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'create') as public_schema_create;
   `;
   assert.equal(functionOwners[0].gate_owner, "postgres", "read-only Stage identity gate must retain its privileged owner");
   assert.equal(functionOwners[0].prune_owner, "chips_ledger_archive_pruner", "destructive function must use the NOLOGIN owner");
-  assert.equal(functionOwners[0].postgres_membership, false, "temporary pruner membership must be revoked");
+  assert.equal(functionOwners[0].unsafe_membership, false, "only the managed non-inheriting ADMIN membership may remain");
   assert.equal(functionOwners[0].public_schema_usage, true, "pruner needs schema usage for qualified objects");
   assert.equal(functionOwners[0].public_schema_create, false, "temporary schema CREATE must be revoked");
 

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -733,6 +733,33 @@ async function assertArchivePrunerRoleContracts(sql) {
     rolinherit: false,
   }, "archive pruner must remain a least-privilege NOLOGIN role");
 
+  const functionOwners = await sql`
+    select
+      pg_catalog.pg_get_userbyid((
+        select proowner from pg_catalog.pg_proc
+        where oid = 'public.chips_assert_archive_prune_stage()'::regprocedure
+      )) as gate_owner,
+      pg_catalog.pg_get_userbyid((
+        select proowner from pg_catalog.pg_proc
+        where oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::regprocedure
+      )) as prune_owner,
+      exists (
+        select 1
+          from pg_catalog.pg_auth_members memberships
+          join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
+          join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+          where granted_role.rolname = 'chips_ledger_archive_pruner'
+            and member_role.rolname = 'postgres'
+      ) as postgres_membership,
+      pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'usage') as public_schema_usage,
+      pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'create') as public_schema_create;
+  `;
+  assert.equal(functionOwners[0].gate_owner, "postgres", "read-only Stage identity gate must retain its privileged owner");
+  assert.equal(functionOwners[0].prune_owner, "chips_ledger_archive_pruner", "destructive function must use the NOLOGIN owner");
+  assert.equal(functionOwners[0].postgres_membership, false, "temporary pruner membership must be revoked");
+  assert.equal(functionOwners[0].public_schema_usage, true, "pruner needs schema usage for qualified objects");
+  assert.equal(functionOwners[0].public_schema_create, false, "temporary schema CREATE must be revoked");
+
   const acl = await sql`
     select
       has_function_privilege('service_role', 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)', 'execute') as service_role_execute,


### PR DESCRIPTION
## Summary

Implements Issue #874 Stage 2B.4 as a deliberately narrow, manual Stage-only pruning path:

- binds exact ordered transaction and entry IDs to an existing committed, checksum-verified archive;
- adds immutable archive proof, durable idempotency mappings, and an atomic prune receipt;
- adds a default dry-run / explicit proof registration / explicit execute CLI;
- requires a private fsynced recovery copy before every execute;
- privately re-downloads and verifies the Storage object after commit;
- permits only technical `TABLE_BUY_IN` / `TABLE_CASH_OUT` rows with no user history.

## Safety contract

- Database and CLI both require canonical Stage project `krydukthwdvccggbyjfw`.
- The database verifies PostgreSQL system identifier `7656985631720456337` and explicitly rejects Production identifier `7575202818581710058`.
- Cutoff/range/cursor are verification evidence only; deletion uses exact archive-derived IDs.
- The pruning transaction is `SERIALIZABLE`, all-or-nothing, and retries only serialization/lock-timeout failures.
- Complete receipt retries return `already_pruned` without requiring deleted hot rows; partial states fail closed.
- Balances and `next_entry_seq` are snapshotted and must remain byte-for-byte equivalent.
- `PUBLIC`, `anon`, `authenticated`, and `service_role` cannot execute proof/prune functions.
- No Storage mutation, Production operation, runtime/WS/UI change, scheduler, or new persistent env is included.

## Recovery

`--execute` requires `--recovery-dir`. The CLI writes the verified gzip and recovery manifest with directory mode `0700`, file mode `0600`, exclusive creation, file fsync, and directory fsync. It revalidates the recovery copy before each database attempt. A post-commit verification failure retains the recovery bundle and stops further pruning.

## Tests

- `npm test`
- `npm run check:all`
- `npm run ci:guards`
- `npm run lint:games`
- `node scripts/check-db-migrations.mjs`
- `node scripts/syntax-check.mjs`
- `git diff --check`
- PostgreSQL contract probe: Node/SQL proof-vector parity, actual owner-role RLS execution, active-table rejection, dry-run, prune, deferred constraints, balance/sequence preservation, and `already_pruned` retry.

All repository checks above pass locally and all current GitHub checks are green.

## Stage status

The Stage migrations are applied. The current exact PR HEAD is `834a5a1693a3b2245fca873f94c5746cb35c54c3`; canonical Stage is project `krydukthwdvccggbyjfw` with PostgreSQL system identifier `7656985631720456337`.

The earlier committed 5,000-transaction candidate remains historical fail-closed evidence: full archive verification passed, but pruning correctly stopped before proof because 13 transactions and 13 entries contained USER history. Its rows remained hot and no proof, mapping, receipt, or delete was produced. See the [rejected-candidate evidence](https://github.com/krzysztofcal/arcadePlatform/pull/883#issuecomment-5263667555).

A later independent all-technical candidate completed the first full Stage cycle: `proof_registered → ready → pruned → already_pruned`. The committed batch contained 1,000 transactions and 2,000 entries (`TABLE_BUY_IN=664`, `TABLE_CASH_OUT=336`), no USER transactions or entries, and 121 distinct tables. Execute deleted exactly those 1,000/2,000 hot rows, preserved `accounts_before == accounts_after`, committed one receipt and 1,000 registry mappings, passed registry-only replay, privately re-downloaded the unchanged object, and reused the fully verified private recovery bundle on the idempotent retry. Final candidate state is proof `1`, receipt `1`, mappings `1,000`, hot rows `0/0`. See the [complete aggregate evidence](https://github.com/krzysztofcal/arcadePlatform/pull/883#issuecomment-5265652584).

Immediate whole-table before/after row counts and physical table/index/total byte sizes were not retained for this cycle and are deliberately not reconstructed. Exact candidate counts before/after are retained. Ordinary PostgreSQL `DELETE` need not immediately reduce physical relation size because freed pages can remain allocated for reuse.

Intentional Stage impact: these selected technical records are no longer available in hot global/admin/table-history queries. USER history and USER `afterSeq` history were not changed. Balances and `next_entry_seq` were unchanged; Storage was not mutated and Production was not contacted.

This PR remains **draft and not merge-ready**. A second independent Stage cycle and the remaining interruption-recovery, runtime/history, and capacity evidence are required before any Production pruning design. Issue #874 remains open.

Part of #874.
