### PR TITLE
Add bounded Production ledger archive canary

### DIFF
--- a/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
+++ b/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
@@ -2,7 +2,7 @@
 
 Stage 2B.4 adds a manual, bounded pruning path for one previously committed
 and verified archive. Stage remains capped at 5,000 transactions; the
-Production canary is capped at exactly 2 transactions. It removes only the exact hot transaction and
+Production canary is capped at at most 2 transactions. It removes only the exact hot transaction and
 entry IDs contained in that archive. A cutoff, timestamp range, or cursor is
 evidence checked against the archive manifest; none of them is a deletion
 selector.

--- a/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
+++ b/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
@@ -2,7 +2,7 @@
 
 Stage 2B.4 adds a manual, bounded pruning path for one previously committed
 and verified archive. Stage remains capped at 5,000 transactions; the
-Production canary is capped at at most 2 transactions. It removes only the exact hot transaction and
+Production canary is limited to at most 2 transactions. It removes only the exact hot transaction and
 entry IDs contained in that archive. A cutoff, timestamp range, or cursor is
 evidence checked against the archive manifest; none of them is a deletion
 selector.

--- a/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
+++ b/docs/issue-874-stage-2b4-controlled-ledger-pruning.md
@@ -1,7 +1,8 @@
-# Issue #874 — Stage 2B.4 controlled ledger pruning
+# Issue #874 — Stage 2B.4 controlled ledger pruning and Production canary
 
 Stage 2B.4 adds a manual, bounded pruning path for one previously committed
-and verified Stage archive. It removes only the exact hot transaction and
+and verified archive. Stage remains capped at 5,000 transactions; the
+Production canary is capped at exactly 2 transactions. It removes only the exact hot transaction and
 entry IDs contained in that archive. A cutoff, timestamp range, or cursor is
 evidence checked against the archive manifest; none of them is a deletion
 selector.
@@ -10,13 +11,13 @@ This first version is deliberately narrow. It accepts only technical
 `TABLE_BUY_IN` and `TABLE_CASH_OUT` transactions with `user_id IS NULL`, no
 entries for `USER` accounts, exactly one `SYSTEM` entry, exactly one `ESCROW`
 entry, and exactly one unambiguous table ID per transaction. It processes one
-all-or-nothing batch of at most 5,000 transactions. It does not prune user
-ledger history, upload or delete Storage objects, run on a schedule, or support
-Production.
+all-or-nothing batch of at most the target cap. It does not prune user ledger
+history, upload or delete Storage objects, or run on a schedule. Production is
+manual-canary only and is never selected implicitly.
 
 ## Immutable archive proof
 
-The CLI privately downloads the committed object, verifies the complete Stage
+The CLI privately downloads the committed object, verifies the complete target
 2B.1/2B.2 contract, and derives ordered ID proofs from the JSONL bytes. Proof
 registration is a separate, non-destructive database transaction. A committed
 manifest may transition once from no proof to a complete proof; the guard
@@ -97,14 +98,14 @@ and a local 120-second statement timeout. Execute retries at most three times,
 and only for a serialization failure or lock timeout. Other errors fail
 immediately. The whole batch is atomic.
 
-## Stage-only authorization
+## Target authorization
 
-Both the CLI and the database function require canonical Stage. The database
-function reads PostgreSQL's stable system identifier and accepts only
-`7656985631720456337`; it explicitly rejects Production identifier
-`7575202818581710058`. The committed manifest project ref must also be
-`krydukthwdvccggbyjfw`. The manifest value is a secondary consistency check,
-not the server identity gate.
+Both the CLI and the database functions require an explicit target and the
+matching canonical pair. Stage is
+`krydukthwdvccggbyjfw` / `7656985631720456337`; Production is
+`otbqfijerkieoxwpxjnm` / `7575202818581710058`. Any mixed pair or unknown
+system identifier fails closed. The database cap is 5,000 for Stage and 2 for
+Production; the CLI and committed-manifest validation enforce the same caps.
 
 The destructive function is `SECURITY DEFINER`, has an empty `search_path`,
 and is owned by the `NOLOGIN`, `NOINHERIT`, `NOBYPASSRLS` role
@@ -112,7 +113,7 @@ and is owned by the `NOLOGIN`, `NOINHERIT`, `NOBYPASSRLS` role
 The role has only the table, column, row-lock, and delete permissions needed by
 the operation, plus role-specific RLS policies. `PUBLIC`, `anon`,
 `authenticated`, and `service_role` cannot execute the proof or pruning
-functions. The CLI connects through the existing direct Stage PostgreSQL
+functions. The CLI connects through the existing target-specific PostgreSQL
 operations credential; Storage authorization is used only for private
 downloads.
 
@@ -128,7 +129,7 @@ initial measurement intentionally has no index on `archive_batch_id`.
 
 ## CLI and recovery copy
 
-The command has no Production or implicit execute mode:
+The command has no implicit target or execute mode. A Stage dry-run is:
 
 ```sh
 node scripts/ops/chips-ledger-archive-prune.mjs \
@@ -149,6 +150,12 @@ node scripts/ops/chips-ledger-archive-prune.mjs \
   --execute \
   --recovery-dir /private/recovery-directory
 ```
+
+The Production canary uses the same manual sequence with `--target prod` and
+the canonical Production project-bound credentials. It may contain at most two
+technical transactions; a third transaction is rejected by both CLI validation
+and the database function. No scheduler, automatic pruning, or Production
+candidate selection is provided by this change.
 
 Before opening the destructive database transaction, execute writes the
 verified `.jsonl.gz` and a recovery manifest to a real directory owned by the
@@ -183,7 +190,7 @@ reviewed.
 
 Record only aggregate evidence in Issue #874 and the PR:
 
-- exact PR HEAD, Stage project ref, and PostgreSQL system identifier;
+- exact PR HEAD, selected target project ref, and PostgreSQL system identifier;
 - bucket, object path, compressed SHA-256, and both ordered ID SHA-256 values;
 - cutoff, cursor, first/last timestamps, counts, `tx_types`, and amount totals;
 - user transaction count, USER entry count, and distinct table count;
@@ -198,7 +205,9 @@ Stage prune/retry cycles, exercise interruption recovery, prove stable user and
 admin runtime behavior, quantify history/API impact, verify idempotency parity
 after pruning, review database capacity effects including the still-linear
 registry, and obtain explicit approval for a Production migration and retention
-policy. The Production system identifier must remain rejected by this version.
+policy. A future Production canary must repeat the same proof, dry-run,
+recovery, and explicit prune approvals against the Production pair; this
+document does not authorize or execute that operation.
 
 ## Breaking impact and scope boundary
 
@@ -213,9 +222,9 @@ will no longer find the pruned rows in PostgreSQL; no cold-history API is added
 here. That loss must be accepted for each Stage candidate and separately
 designed before Production.
 
-This stage does not modify balances, upload or delete Storage objects, create
-new archives, prune user transactions, run on Production, add a scheduler,
+This operator path does not modify balances, upload or delete Storage objects,
+create new archives, prune user transactions, run automatically, add a scheduler,
 change runtime/WS/UI code, or add environment variables. It also does not make
 database growth fully bounded: `chips_transaction_idempotency` remains durable
 and grows linearly. Issue #874 therefore cannot be closed solely because one
-Stage 2B.4 batch succeeds.
+archive batch succeeds.

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -10,6 +10,7 @@ export const EXPORT_SCHEMA_VERSION = 1;
 export const DEFAULT_CUTOFF_DAYS = 30;
 export const DEFAULT_BATCH_SIZE = 5000;
 export const MAX_BATCH_SIZE = 5000;
+export const PRODUCTION_MAX_BATCH_SIZE = 2;
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const INTEGER_RE = /^-?(?:0|[1-9][0-9]*)$/;
@@ -153,7 +154,7 @@ Required:
 Selection:
   --cutoff <timestamp>            Strict upper bound for transaction.created_at.
   --cutoff-days <integer>         Default: 30; ignored when --cutoff is set.
-  --batch-size <integer>          Default/max: 5000.
+  --batch-size <integer>          Stage default/max: 5000; Production max: 2.
   --after-created-at <timestamp>  Resume cursor timestamp.
   --after-id <uuid>               Resume cursor UUID tie-breaker.
 
@@ -531,6 +532,12 @@ function parseBoundedInteger(value, name, { min, max }) {
   return parsed;
 }
 
+export function maxBatchSizeForTarget(target) {
+  if (target === "stage") return MAX_BATCH_SIZE;
+  if (target === "prod") return PRODUCTION_MAX_BATCH_SIZE;
+  fail("target must be exactly stage or prod");
+}
+
 function deriveProjectRef(dbUrl) {
   let url;
   try {
@@ -589,9 +596,10 @@ function resolveOptions(args, env, cwd, now) {
         const days = args.cutoffDays == null ? DEFAULT_CUTOFF_DAYS : parseBoundedInteger(args.cutoffDays, "--cutoff-days", { min: 0, max: 36500 });
         return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
       })();
+  const maxBatchSize = maxBatchSizeForTarget(target.target);
   const batchSize = args.batchSize == null
-    ? DEFAULT_BATCH_SIZE
-    : parseBoundedInteger(args.batchSize, "--batch-size", { min: 1, max: MAX_BATCH_SIZE });
+    ? Math.min(DEFAULT_BATCH_SIZE, maxBatchSize)
+    : parseBoundedInteger(args.batchSize, "--batch-size", { min: 1, max: maxBatchSize });
   const outputPath = path.resolve(cwd, args.output);
   const manifestPath = path.resolve(cwd, args.manifest || `${outputPath}.manifest.json`);
   if (outputPath === manifestPath) fail("--output and --manifest must be different paths");

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { stringifyJson } from "./chips-ledger-archive-export.mjs";
+import { maxBatchSizeForTarget, stringifyJson } from "./chips-ledger-archive-export.mjs";
 import {
   ARCHIVE_BUCKET,
   buildObjectPath,
@@ -25,13 +25,13 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const ENTRY_ID_RE = /^[1-9][0-9]*$/;
 const SHA256_RE = /^[0-9a-f]{64}$/;
 const ALLOWED_TX_TYPES = new Set(["TABLE_BUY_IN", "TABLE_CASH_OUT"]);
-const MAX_BATCH_SIZE = 5000;
+const MAX_BATCH_SIZE = maxBatchSizeForTarget("stage");
 const MAX_EXECUTE_ATTEMPTS = 3;
 
 const HELP = `Usage: node scripts/ops/chips-ledger-archive-prune.mjs [options]
 
 Required:
-  --target stage                 Canonical Stage only; Production is rejected.
+  --target stage|prod            Explicit canonical target; no default.
   --object-path <path>           Committed v1/sha256/<sha>.jsonl.gz object.
   --confirm-sha <sha256>         Explicit compressed object SHA-256 confirmation.
 
@@ -43,8 +43,9 @@ Modes (mutually exclusive):
 Execute-only:
   --recovery-dir <path>          Required private 0700 recovery directory.
 
-The command is Stage-only, processes one batch of at most 5000 transactions,
-never overwrites recovery files, never changes balances, and never mutates Storage.
+The command processes one batch of at most 5000 Stage or 2 Production
+transactions, never overwrites recovery files, never changes balances, and
+never mutates Storage.
 `;
 
 function fail(message, code = null) {
@@ -85,9 +86,9 @@ function hashCanonicalLines(values) {
   return sha256(Buffer.from(values.map((value) => `${value}\n`).join(""), "utf8"));
 }
 
-export function computeArchiveIdProofs(records) {
-  if (!Array.isArray(records) || records.length < 1 || records.length > MAX_BATCH_SIZE) {
-    fail("archive proof requires 1 to 5000 transaction records");
+export function computeArchiveIdProofs(records, { maxBatchSize = MAX_BATCH_SIZE } = {}) {
+  if (!Array.isArray(records) || records.length < 1 || records.length > maxBatchSize) {
+    fail(`archive proof requires 1 to ${maxBatchSize} transaction records`);
   }
   const transactionIds = [];
   const entryIds = [];
@@ -134,8 +135,8 @@ function tableIdForRecord(record) {
   return [...markers][0];
 }
 
-export function buildPruneEvidence(localArchive) {
-  const proofs = computeArchiveIdProofs(localArchive.records);
+export function buildPruneEvidence(localArchive, { maxBatchSize = MAX_BATCH_SIZE } = {}) {
+  const proofs = computeArchiveIdProofs(localArchive.records, { maxBatchSize });
   const txTypes = {};
   const tables = new Set();
   let userTransactions = 0;
@@ -144,7 +145,7 @@ export function buildPruneEvidence(localArchive) {
   for (const record of localArchive.records) {
     const transaction = record.transaction;
     const txType = text(transaction.tx_type);
-    if (!ALLOWED_TX_TYPES.has(txType)) fail(`archive tx_type is outside the Stage 2B.4 whitelist: ${txType}`);
+    if (!ALLOWED_TX_TYPES.has(txType)) fail(`archive tx_type is outside the technical whitelist: ${txType}`);
     if (transaction.user_id !== null) userTransactions += 1;
     const tableId = tableIdForRecord(record);
     tables.add(tableId);
@@ -174,7 +175,7 @@ export function buildPruneEvidence(localArchive) {
     txTypes[txType] = (txTypes[txType] || 0) + 1;
   }
   if (userTransactions !== 0 || userEntries !== 0) {
-    fail(`Stage 2B.4 cannot prune USER ledger history (user_transactions=${userTransactions}, user_entries=${userEntries}, distinct_tables=${tables.size})`);
+    fail(`cannot prune USER ledger history (user_transactions=${userTransactions}, user_entries=${userEntries}, distinct_tables=${tables.size})`);
   }
   if (canonicalJson(txTypes) !== canonicalJson(localArchive.manifest.batch.tx_types)) fail("technical tx_type evidence differs from archive manifest");
   return {
@@ -223,10 +224,30 @@ function parseArgs(argv) {
   return args;
 }
 
-function assertStageIdentity(identity, manifest) {
-  if (identity === PRODUCTION_SYSTEM_IDENTIFIER) fail("Production database is forbidden");
-  if (identity !== STAGE_SYSTEM_IDENTIFIER) fail("database is not canonical Stage");
-  if (manifest.project_ref !== "krydukthwdvccggbyjfw") fail("archive manifest is not canonical Stage");
+function targetPolicy(target) {
+  if (target === "stage") {
+    return {
+      target,
+      projectRef: "krydukthwdvccggbyjfw",
+      systemIdentifier: STAGE_SYSTEM_IDENTIFIER,
+      maxBatchSize: maxBatchSizeForTarget(target),
+    };
+  }
+  if (target === "prod") {
+    return {
+      target,
+      projectRef: "otbqfijerkieoxwpxjnm",
+      systemIdentifier: PRODUCTION_SYSTEM_IDENTIFIER,
+      maxBatchSize: maxBatchSizeForTarget(target),
+    };
+  }
+  fail("target must be exactly stage or prod");
+}
+
+function assertTargetIdentity(identity, manifest, target) {
+  const policy = targetPolicy(target.target);
+  if (identity !== policy.systemIdentifier) fail(`database is not canonical ${target.label}`);
+  if (manifest.project_ref !== policy.projectRef) fail(`archive manifest is not canonical ${target.label}`);
 }
 
 function parseManifestRow(row) {
@@ -257,7 +278,7 @@ function exporterManifestFromDatabase(row, target) {
     target: target.target,
     cutoff: { created_at: row.cutoff, rule: "transaction.created_at < cutoff" },
     batch: {
-      limit: MAX_BATCH_SIZE,
+      limit: targetPolicy(target.target).maxBatchSize,
       transactions: row.transaction_count,
       entries: row.entry_count,
       tx_types: row.tx_types,
@@ -280,11 +301,11 @@ function exporterManifestFromDatabase(row, target) {
   };
 }
 
-function recoveryManifest(row, identity, evidence) {
+function recoveryManifest(row, identity, evidence, target) {
   return {
     recovery_schema_version: 1,
     artifact_type: "chips_ledger_archive_prune_recovery",
-    target: "stage",
+    target: target.target,
     project_ref: row.project_ref,
     postgres_system_identifier: identity,
     bucket: ARCHIVE_BUCKET,
@@ -317,12 +338,12 @@ function recoveryManifest(row, identity, evidence) {
   };
 }
 
-export function writeRecoveryBundle({ recoveryDir, archiveBytes, row, identity, evidence }) {
+export function writeRecoveryBundle({ recoveryDir, archiveBytes, row, identity, evidence, target }) {
   const directory = ensurePrivateDirectory(recoveryDir);
   const baseName = `chips-ledger-${row.compressed_sha256}`;
   const artifactPath = path.join(directory, `${baseName}.jsonl.gz`);
   const manifestPath = path.join(directory, `${baseName}.recovery.json`);
-  const manifest = recoveryManifest(row, identity, evidence);
+  const manifest = recoveryManifest(row, identity, evidence, target);
   const manifestBytes = Buffer.from(`${stringifyJson(manifest)}\n`, "utf8");
   const artifactExists = fs.existsSync(artifactPath);
   const manifestExists = fs.existsSync(manifestPath);
@@ -351,7 +372,7 @@ export function verifyRecoveryBundle({ bundle, row, target, identity, expectedEv
   assertPrivateRegularFile(bundle.artifactPath);
   assertPrivateRegularFile(bundle.manifestPath);
   const manifest = JSON.parse(fs.readFileSync(bundle.manifestPath, "utf8"));
-  const expectedManifest = recoveryManifest(row, identity, expectedEvidence);
+  const expectedManifest = recoveryManifest(row, identity, expectedEvidence, target);
   if (canonicalJson(manifest) !== canonicalJson(expectedManifest)) fail("recovery manifest no longer matches archive evidence");
   const verified = verifyArchiveBytes({
     compressedBytes: fs.readFileSync(bundle.artifactPath),
@@ -359,7 +380,7 @@ export function verifyRecoveryBundle({ bundle, row, target, identity, expectedEv
     target,
     artifactName: path.basename(row.object_path),
   });
-  const evidence = buildPruneEvidence(verified);
+  const evidence = buildPruneEvidence(verified, { maxBatchSize: targetPolicy(target.target).maxBatchSize });
   if (evidence.transactionIdsSha256 !== expectedEvidence.transactionIdsSha256
     || evidence.entryIdsSha256 !== expectedEvidence.entryIdsSha256) {
     fail("recovery archive ID proof no longer matches");
@@ -487,7 +508,7 @@ function assertPostCommitVerification(verification, evidence) {
 function outputResult(result) {
   process.stdout.write(`${stringifyJson({
     event: "chips_ledger_archive_prune",
-    target: "stage",
+    target: result.target.target,
     project_ref: result.row.project_ref,
     postgres_system_identifier: result.identity,
     bucket: ARCHIVE_BUCKET,
@@ -517,7 +538,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     process.stdout.write(HELP);
     return null;
   }
-  if (args.target !== "stage") fail("--target must be explicitly set to stage; Production is unsupported");
+  if (args.target !== "stage" && args.target !== "prod") fail("--target must be explicitly set to stage or prod");
   if (!args.objectPath) fail("--object-path is required");
   if (!SHA256_RE.test(text(args.confirmSha))) fail("--confirm-sha must be a lowercase SHA-256");
   if (args.objectPath !== buildObjectPath(args.confirmSha)) fail("--object-path does not match --confirm-sha");
@@ -538,7 +559,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     await verifyBucket(target);
     const identity = await store.getIdentity();
     const row = await store.getManifest(args.objectPath);
-    assertStageIdentity(identity, row);
+    assertTargetIdentity(identity, row, target);
     if (row.status !== "committed" || !row.committed_at) fail("archive manifest is not committed");
     if (row.compressed_sha256 !== args.confirmSha) fail("--confirm-sha does not match committed manifest");
 
@@ -553,7 +574,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
       target,
       artifactName: path.basename(row.object_path),
     });
-    const evidence = buildPruneEvidence(localArchive);
+    const evidence = buildPruneEvidence(localArchive, { maxBatchSize: targetPolicy(target.target).maxBatchSize });
 
     if (args.registerProof) {
       const proof = await store.registerProof(row, evidence);
@@ -561,6 +582,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
         row,
         identity,
         evidence,
+        target,
         mode: "register-proof",
         state: proof?.state || "proof_registered",
         storageDownloadMs: downloaded.downloadMs,
@@ -578,6 +600,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
         row,
         identity,
         evidence,
+        target,
       });
     }
 
@@ -615,6 +638,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     const result = {
       row,
       identity,
+      target,
       evidence,
       mode: args.execute ? "execute" : "dry-run",
       state: pruneResult?.state || "unknown",

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -7,6 +7,7 @@ import postgres from "postgres";
 import {
   EXPORT_SCHEMA_VERSION,
   compareTransactions,
+  maxBatchSizeForTarget,
   parseJsonl,
   resolveTarget,
   serializeRecords,
@@ -155,9 +156,11 @@ function verifyManifestShape(manifest, artifactName, target) {
   if (manifest.cutoff.rule !== "transaction.created_at < cutoff") fail("local manifest cutoff rule is unsupported");
 
   const batch = manifest.batch;
-  if (!batch || !Number.isSafeInteger(batch.limit) || batch.limit < 1 || batch.limit > 5000) fail("local manifest batch limit is invalid");
+  const maxBatchSize = maxBatchSizeForTarget(target.target);
+  if (!batch || !Number.isSafeInteger(batch.limit) || batch.limit < 1 || batch.limit > maxBatchSize) fail("local manifest batch limit is invalid for target");
   assertSafeInteger(batch.transactions, "batch.transactions");
   assertSafeInteger(batch.entries, "batch.entries");
+  if (batch.transactions > batch.limit) fail("local manifest transaction count exceeds target batch limit");
   if (!batch.tx_types || typeof batch.tx_types !== "object" || Array.isArray(batch.tx_types)) fail("local manifest tx_types is invalid");
   let txTypeTotal = 0;
   for (const [txType, count] of Object.entries(batch.tx_types)) {

--- a/supabase/migrations/20260813090000_chips_ledger_archive_production_canary.sql
+++ b/supabase/migrations/20260813090000_chips_ledger_archive_production_canary.sql
@@ -67,6 +67,14 @@ begin
 end;
 $$;
 
+-- Function replacement is owner-sensitive on hosted Postgres.  Temporarily
+-- delegate the migration session to the existing pruner owner, then remove
+-- the schema capability and temporary role grant before the transaction can
+-- commit.  A pre-existing managed non-inheriting membership is preserved.
+grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
+set role chips_ledger_archive_pruner;
+
 -- Patch the existing SECURITY DEFINER proof implementation in place so its
 -- owner, strictness, search_path, ACL, and immutable state machine remain
 -- unchanged while its identity check becomes target-aware.
@@ -172,11 +180,9 @@ begin
 end;
 $$;
 
-revoke all on function public.chips_assert_archive_prune_stage()
-  from public, anon, authenticated, service_role;
-grant execute on function public.chips_assert_archive_prune_stage()
-  to chips_ledger_archive_pruner;
-
+-- Reapply the function ACL while the pruner is the owner.  The internal
+-- implementation must not be explicitly executable by postgres; only the
+-- proof and public prune entry points receive that grant.
 revoke all on function public.chips_register_archive_id_proof(
   text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
   timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
@@ -188,9 +194,206 @@ grant execute on function public.chips_register_archive_id_proof(
   text, text, numeric, numeric, numeric
 ) to postgres;
 
-revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+revoke all on function public.chips_prune_committed_archive_batch_internal(
+  text, uuid[], bigint[], boolean
+) from public, anon, authenticated, service_role, postgres;
+
+revoke all on function public.chips_prune_committed_archive_batch(
+  text, uuid[], bigint[], boolean
+) from public, anon, authenticated, service_role;
+grant execute on function public.chips_prune_committed_archive_batch(
+  text, uuid[], bigint[], boolean
+) to postgres;
+
+reset role;
+revoke create on schema public from chips_ledger_archive_pruner;
+revoke chips_ledger_archive_pruner from postgres;
+
+revoke all on function public.chips_assert_archive_prune_stage()
   from public, anon, authenticated, service_role;
-grant execute on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
-  to postgres;
+grant execute on function public.chips_assert_archive_prune_stage()
+  to chips_ledger_archive_pruner;
+
+do $$
+declare
+  function_owner text;
+begin
+  select pg_catalog.pg_get_userbyid(proowner)
+    into function_owner
+    from pg_catalog.pg_proc
+   where oid = 'public.chips_assert_archive_prune_target(text,bigint)'::pg_catalog.regprocedure;
+  if function_owner <> 'postgres' then
+    raise exception 'Archive target gate owner must remain postgres';
+  end if;
+
+  select pg_catalog.pg_get_userbyid(proowner)
+    into function_owner
+    from pg_catalog.pg_proc
+   where oid = 'public.chips_assert_archive_prune_stage()'::pg_catalog.regprocedure;
+  if function_owner <> 'postgres' then
+    raise exception 'Archive stage gate owner must remain postgres';
+  end if;
+
+  select pg_catalog.pg_get_userbyid(proowner)
+    into function_owner
+    from pg_catalog.pg_proc
+   where oid = 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)'::pg_catalog.regprocedure;
+  if function_owner <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive proof function owner must remain chips_ledger_archive_pruner';
+  end if;
+
+  select pg_catalog.pg_get_userbyid(proowner)
+    into function_owner
+    from pg_catalog.pg_proc
+   where oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure;
+  if function_owner <> 'chips_ledger_archive_pruner' then
+    raise exception 'Internal archive prune function owner must remain chips_ledger_archive_pruner';
+  end if;
+
+  select pg_catalog.pg_get_userbyid(proowner)
+    into function_owner
+    from pg_catalog.pg_proc
+   where oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure;
+  if function_owner <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive prune wrapper owner must remain chips_ledger_archive_pruner';
+  end if;
+
+  if exists (
+    select 1
+      from pg_catalog.pg_auth_members memberships
+      join pg_catalog.pg_roles granted_role on granted_role.oid = memberships.roleid
+      join pg_catalog.pg_roles member_role on member_role.oid = memberships.member
+      join pg_catalog.pg_roles grantor_role on grantor_role.oid = memberships.grantor
+     where granted_role.rolname = 'chips_ledger_archive_pruner'
+       and not (
+         member_role.rolname = 'postgres'
+         and grantor_role.rolname = 'supabase_admin'
+         and memberships.admin_option
+         and not memberships.inherit_option
+         and not memberships.set_option
+       )
+  ) then
+    raise exception 'Temporary archive pruner role membership must not remain after migration';
+  end if;
+
+  if pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'create') then
+    raise exception 'Archive pruner schema CREATE must not remain after migration';
+  end if;
+
+  if pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_assert_archive_prune_stage()',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_assert_archive_prune_stage()',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_assert_archive_prune_stage()',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_assert_archive_prune_target(text,bigint)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_assert_archive_prune_target(text,bigint)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_assert_archive_prune_target(text,bigint)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     )
+    or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)',
+       'execute'
+     ) then
+    raise exception 'Archive proof or prune functions remain executable by an API role';
+  end if;
+
+  if not exists (
+    select 1
+      from pg_catalog.pg_proc procedures
+      cross join lateral pg_catalog.aclexplode(
+        coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))
+      ) as privileges
+     where procedures.oid = 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)'::pg_catalog.regprocedure
+       and privileges.grantee = 'postgres'::pg_catalog.regrole::oid
+       and privileges.privilege_type = 'EXECUTE'
+  )
+    or not exists (
+    select 1
+      from pg_catalog.pg_proc procedures
+      cross join lateral pg_catalog.aclexplode(
+        coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))
+      ) as privileges
+     where procedures.oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+       and privileges.grantee = 'postgres'::pg_catalog.regrole::oid
+       and privileges.privilege_type = 'EXECUTE'
+  ) then
+    raise exception 'Postgres must retain EXECUTE on public proof/prune entry points';
+  end if;
+
+  if exists (
+    select 1
+      from pg_catalog.pg_proc procedures
+      cross join lateral pg_catalog.aclexplode(
+        coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))
+      ) as privileges
+     where procedures.oid = 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+       and privileges.grantee = 'postgres'::pg_catalog.regrole::oid
+       and privileges.privilege_type = 'EXECUTE'
+  ) then
+    raise exception 'Postgres must not retain EXECUTE on internal archive prune';
+  end if;
+end;
+$$;
 
 commit;

--- a/supabase/migrations/20260813090000_chips_ledger_archive_production_canary.sql
+++ b/supabase/migrations/20260813090000_chips_ledger_archive_production_canary.sql
@@ -1,0 +1,196 @@
+begin;
+
+-- The identity pair is checked inside the privileged database path.  The
+-- Production cap is intentionally independent of the CLI cap.
+create or replace function public.chips_assert_archive_prune_target(
+  p_project_ref text,
+  p_transaction_count bigint
+)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  system_identifier text;
+  max_batch_size bigint;
+begin
+  select control.system_identifier::text
+    into system_identifier
+    from pg_catalog.pg_control_system() as control;
+
+  if system_identifier = '7656985631720456337'
+     and p_project_ref = 'krydukthwdvccggbyjfw' then
+    max_batch_size := 5000;
+  elsif system_identifier = '7575202818581710058'
+        and p_project_ref = 'otbqfijerkieoxwpxjnm' then
+    max_batch_size := 2;
+  else
+    raise exception 'Ledger archive pruning requires a canonical project ref/system identifier pair';
+  end if;
+
+  if p_transaction_count is null
+     or p_transaction_count < 1
+     or p_transaction_count > max_batch_size then
+    raise exception 'Ledger archive pruning target allows at most % transactions', max_batch_size;
+  end if;
+
+  return system_identifier;
+end;
+$$;
+
+alter function public.chips_assert_archive_prune_target(text, bigint) owner to postgres;
+revoke all on function public.chips_assert_archive_prune_target(text, bigint)
+  from public, anon, authenticated, service_role;
+grant execute on function public.chips_assert_archive_prune_target(text, bigint)
+  to chips_ledger_archive_pruner;
+
+-- Keep the old gate and its ACL for the internal implementation, but reject
+-- every unknown server identity.  The project-ref pair is checked by the
+-- target gate before proof/prune entry points are allowed to continue.
+create or replace function public.chips_assert_archive_prune_stage()
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  system_identifier text;
+begin
+  select control.system_identifier::text
+    into system_identifier
+    from pg_catalog.pg_control_system() as control;
+  if system_identifier not in ('7656985631720456337', '7575202818581710058') then
+    raise exception 'Ledger archive pruning is restricted to a canonical database identity';
+  end if;
+  return system_identifier;
+end;
+$$;
+
+-- Patch the existing SECURITY DEFINER proof implementation in place so its
+-- owner, strictness, search_path, ACL, and immutable state machine remain
+-- unchanged while its identity check becomes target-aware.
+do $$
+declare
+  definition text;
+  patched text;
+begin
+  select pg_catalog.pg_get_functiondef(
+    'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)'::pg_catalog.regprocedure
+  ) into definition;
+  patched := replace(
+    definition,
+    'perform public.chips_assert_archive_prune_stage();',
+    'perform public.chips_assert_archive_prune_target(p_project_ref, pg_catalog.cardinality(p_transaction_ids));'
+  );
+  patched := replace(patched, 'batch.project_ref <> ''krydukthwdvccggbyjfw''', 'batch.project_ref <> p_project_ref');
+  patched := replace(patched, 'Archive manifest is not committed canonical Stage evidence', 'Archive manifest is not committed target evidence');
+  if patched = definition
+     or pg_catalog.strpos(patched, 'batch.project_ref <> p_project_ref') = 0
+     or pg_catalog.strpos(patched, 'chips_assert_archive_prune_target(p_project_ref') = 0 then
+    raise exception 'Archive proof function shape changed; refusing an implicit migration';
+  end if;
+  execute patched;
+end;
+$$;
+
+-- Apply the same target check after the committed manifest is locked.  The
+-- existing implementation is kept byte-for-byte by pg_get_functiondef except
+-- for the canonical project gate and the independent Production count cap.
+do $$
+declare
+  definition text;
+  patched text;
+begin
+  select pg_catalog.pg_get_functiondef(
+    'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)'::pg_catalog.regprocedure
+  ) into definition;
+  patched := replace(
+    definition,
+    'batch.project_ref <> ''krydukthwdvccggbyjfw''',
+    'batch.project_ref not in (''krydukthwdvccggbyjfw'', ''otbqfijerkieoxwpxjnm'')'
+  );
+  patched := replace(patched, 'Archive manifest is not committed canonical Stage evidence', 'Archive manifest is not committed canonical target evidence');
+  patched := replace(
+    patched,
+    '  if batch.archive_proof_verified_at is null then',
+    '  perform public.chips_assert_archive_prune_target(batch.project_ref, transaction_count)'
+      || pg_catalog.chr(59) || pg_catalog.chr(10)
+      || '  if batch.archive_proof_verified_at is null then'
+  );
+  if patched = definition
+     or pg_catalog.strpos(patched, 'batch.project_ref not in (''krydukthwdvccggbyjfw'', ''otbqfijerkieoxwpxjnm'')') = 0
+     or pg_catalog.strpos(patched, 'chips_assert_archive_prune_target(batch.project_ref') = 0 then
+    raise exception 'Archive prune function shape changed; refusing an implicit migration';
+  end if;
+  execute patched;
+end;
+$$;
+
+-- The wrapper is the only callable destructive entry point.  It locks and
+-- validates the manifest target before delegating to the unchanged internal
+-- state machine, so a mixed pair or a three-transaction Production request is
+-- rejected before any ledger mutation.
+create or replace function public.chips_prune_committed_archive_batch(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_execute boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_project_ref text;
+begin
+  if p_execute is null then
+    raise exception 'Ledger archive pruning execute flag must not be NULL';
+  end if;
+
+  select batches.project_ref
+    into target_project_ref
+    from public.chips_ledger_archive_batches as batches
+    where batches.object_path = p_object_path
+    for update;
+  if not found then
+    raise exception 'Committed archive manifest was not found';
+  end if;
+
+  perform public.chips_assert_archive_prune_target(
+    target_project_ref,
+    pg_catalog.cardinality(p_transaction_ids)
+  );
+
+  return public.chips_prune_committed_archive_batch_internal(
+    p_object_path,
+    p_transaction_ids,
+    p_entry_ids,
+    p_execute is true
+  );
+end;
+$$;
+
+revoke all on function public.chips_assert_archive_prune_stage()
+  from public, anon, authenticated, service_role;
+grant execute on function public.chips_assert_archive_prune_stage()
+  to chips_ledger_archive_pruner;
+
+revoke all on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) from public, anon, authenticated, service_role;
+grant execute on function public.chips_register_archive_id_proof(
+  text, uuid[], bigint[], text, integer, timestamptz, timestamptz, uuid,
+  timestamptz, uuid, timestamptz, timestamptz, jsonb, bigint, bigint,
+  text, text, numeric, numeric, numeric
+) to postgres;
+
+revoke all on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  from public, anon, authenticated, service_role;
+grant execute on function public.chips_prune_committed_archive_batch(text, uuid[], bigint[], boolean)
+  to postgres;
+
+commit;

--- a/tests/chips/chips-ledger-archive-export.test.mjs
+++ b/tests/chips/chips-ledger-archive-export.test.mjs
@@ -110,6 +110,18 @@ await assert.rejects(
   () => runExport({ argv: ["--output", "/tmp/chips-ledger-review.jsonl.gz"], env: { LEDGER_ARCHIVE_TARGET: "prod" }, cwd: "/tmp" }),
   /target must be exactly stage or prod/,
 );
+await assert.rejects(
+  () => runExport({
+    argv: ["--target", "prod", "--batch-size", "3", "--output", "/tmp/chips-ledger-prod-too-large.jsonl.gz"],
+    env: {
+      EXPECTED_SUPABASE_STAGE_PROJECT_REF: "krydukthwdvccggbyjfw",
+      EXPECTED_SUPABASE_PROD_PROJECT_REF: "otbqfijerkieoxwpxjnm",
+      SUPABASE_PROD_DB_URL: "postgresql://postgres.otbqfijerkieoxwpxjnm@db.otbqfijerkieoxwpxjnm.supabase.co:5432/postgres",
+    },
+    cwd: "/tmp",
+  }),
+  /--batch-size must be between 1 and 2/,
+);
 assert.equal(stringifyJson({ id: 123n, amount: -7n }), '{"id":"123","amount":"-7"}');
 assert.equal(recordA.entries[0].amount, "10");
 assert.equal(recordA.entries[1].amount, "-10");

--- a/tests/chips/chips-ledger-archive-pruning.test.mjs
+++ b/tests/chips/chips-ledger-archive-pruning.test.mjs
@@ -304,7 +304,7 @@ try {
   assert.equal(JSON.parse(productionOutput).target, "prod");
   assert.equal(JSON.parse(fs.readFileSync(productionResult.recoveryBundle.manifestPath, "utf8")).target, "prod");
 
-  const thirdTx = candidate("00000000-0000-4000-8000-00000000000c", "2026-01-01T00:00:00.000003Z", { tx_type: "TABLE_BUY_IN" });
+  const thirdTx = candidate("00000000-0000-4000-8000-00000000000c", "2026-01-01T00:00:00.000003Z", "TABLE_BUY_IN");
   const threeRecords = [...records, record(thirdTx, 20, 10)];
   const threeArchive = buildArchiveBytes(threeRecords);
   const threeManifest = buildManifest({

--- a/tests/chips/chips-ledger-archive-pruning.test.mjs
+++ b/tests/chips/chips-ledger-archive-pruning.test.mjs
@@ -25,9 +25,11 @@ const ENV = {
   EXPECTED_SUPABASE_STAGE_PROJECT_REF: "krydukthwdvccggbyjfw",
   EXPECTED_SUPABASE_PROD_PROJECT_REF: "otbqfijerkieoxwpxjnm",
   SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
+  SUPABASE_PROD_DB_URL: "postgresql://postgres.otbqfijerkieoxwpxjnm@db.otbqfijerkieoxwpxjnm.supabase.co:5432/postgres",
   SUPABASE_URL: "https://krydukthwdvccggbyjfw.supabase.co",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
 };
+const PROD_ENV = { ...ENV, SUPABASE_URL: "https://otbqfijerkieoxwpxjnm.supabase.co" };
 
 function candidate(id, createdAt, txType) {
   return {
@@ -102,33 +104,34 @@ const proof = computeArchiveIdProofs(records);
 assert.equal(proof.transactionIdsSha256, "726400e7a16ea9e7ca71ee707fb025934613059de29366a5ae7f626256b688fa");
 assert.equal(proof.entryIdsSha256, "58eb8c6b6deb82261f809eb3277a61b010224ae0fe568f199ced00f51f7dd8ac");
 
-function manifestRow(overrides = {}) {
+function manifestRow(overrides = {}, sourceManifest = localManifest, sourceProof = proof) {
+  const sourceObjectPath = buildObjectPath(sourceManifest);
   return {
-    object_path: objectPath,
+    object_path: sourceObjectPath,
     batch_id: "1",
     project_ref: "krydukthwdvccggbyjfw",
     format_version: 1,
-    cutoff: localManifest.cutoff.created_at,
+    cutoff: sourceManifest.cutoff.created_at,
     cursor_start_created_at: null,
     cursor_start_id: null,
-    cursor_end_created_at: localManifest.cursor.end.created_at,
-    cursor_end_id: localManifest.cursor.end.id,
-    first_created_at: localManifest.time_range.first_created_at,
-    last_created_at: localManifest.time_range.last_created_at,
-    transaction_count: localManifest.batch.transactions,
-    entry_count: localManifest.batch.entries,
-    tx_types: localManifest.batch.tx_types,
-    raw_bytes: localManifest.bytes.raw,
-    compressed_bytes: localManifest.bytes.compressed,
-    raw_sha256: localManifest.sha256.raw_jsonl,
-    compressed_sha256: localManifest.sha256.compressed_artifact,
-    credits: localManifest.amounts.credits,
-    debits: localManifest.amounts.debits,
-    net_amount: localManifest.amounts.net,
+    cursor_end_created_at: sourceManifest.cursor.end.created_at,
+    cursor_end_id: sourceManifest.cursor.end.id,
+    first_created_at: sourceManifest.time_range.first_created_at,
+    last_created_at: sourceManifest.time_range.last_created_at,
+    transaction_count: sourceManifest.batch.transactions,
+    entry_count: sourceManifest.batch.entries,
+    tx_types: sourceManifest.batch.tx_types,
+    raw_bytes: sourceManifest.bytes.raw,
+    compressed_bytes: sourceManifest.bytes.compressed,
+    raw_sha256: sourceManifest.sha256.raw_jsonl,
+    compressed_sha256: sourceManifest.sha256.compressed_artifact,
+    credits: sourceManifest.amounts.credits,
+    debits: sourceManifest.amounts.debits,
+    net_amount: sourceManifest.amounts.net,
     status: "committed",
     committed_at: "2026-01-02T00:00:00.000000Z",
-    archived_transaction_ids_sha256: proof.transactionIdsSha256,
-    archived_entry_ids_sha256: proof.entryIdsSha256,
+    archived_transaction_ids_sha256: sourceProof.transactionIdsSha256,
+    archived_entry_ids_sha256: sourceProof.entryIdsSha256,
     archive_proof_verified_at: "2026-01-02T00:01:00.000000Z",
     pruned_at: null,
     pruned_transaction_count: null,
@@ -139,14 +142,14 @@ function manifestRow(overrides = {}) {
   };
 }
 
-function fakeStore(row, states = ["pruned"]) {
+function fakeStore(row, states = ["pruned"], { identity = STAGE_SYSTEM_IDENTIFIER, expectedExecute = true } = {}) {
   let pruneCalls = 0;
   return {
-    getIdentity: async () => STAGE_SYSTEM_IDENTIFIER,
+    getIdentity: async () => identity,
     getManifest: async () => row,
     registerProof: async () => ({ state: "proof_registered" }),
     prune: async (_path, _evidence, execute) => {
-      assert.equal(execute, true);
+      assert.equal(execute, expectedExecute);
       const state = states[Math.min(pruneCalls, states.length - 1)];
       pruneCalls += 1;
       return { state };
@@ -170,10 +173,15 @@ const baseArgs = ["--target", "stage", "--object-path", objectPath, "--confirm-s
 await assert.rejects(
   () => pruneArchive({
     argv: ["--target", "prod", "--object-path", objectPath, "--confirm-sha", archive.compressedSha256],
-    env: ENV,
-    deps: { emit: false },
+    env: PROD_ENV,
+    deps: {
+      pruneStore: fakeStore(manifestRow(), ["ready"], { identity: STAGE_SYSTEM_IDENTIFIER, expectedExecute: false }),
+      verifyBucket: async () => {},
+      downloadArchive: async () => ({ bytes: archive.compressedBytes, downloadMs: 1 }),
+      emit: false,
+    },
   }),
-  /explicitly set to stage/,
+  /database is not canonical Production/,
 );
 await assert.rejects(
   () => pruneArchive({ argv: baseArgs, env: ENV, deps: { emit: false } }),
@@ -257,6 +265,73 @@ try {
   fs.rmSync(failedRoot, { recursive: true, force: true });
 } finally {
   fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+const productionManifest = buildManifest({
+  target: "prod",
+  cutoff: localManifest.cutoff.created_at,
+  batchSize: 2,
+  cursor: null,
+  records,
+  archive,
+  outputPath: "/private/chips-ledger-prod.jsonl.gz",
+});
+const productionRow = manifestRow({
+  project_ref: "otbqfijerkieoxwpxjnm",
+}, productionManifest);
+const productionRoot = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-prune-prod-test-"));
+const productionRecovery = path.join(productionRoot, "recovery");
+try {
+  const productionStore = fakeStore(productionRow, ["pruned"], {
+    identity: "7575202818581710058",
+    expectedExecute: true,
+  });
+  let productionOutput = "";
+  const originalWrite = process.stdout.write;
+  process.stdout.write = (chunk) => { productionOutput += String(chunk); return true; };
+  let productionResult;
+  try {
+    productionResult = await pruneArchive({
+      argv: ["--target", "prod", "--object-path", objectPath, "--confirm-sha", archive.compressedSha256, "--execute", "--recovery-dir", productionRecovery],
+      env: PROD_ENV,
+      deps: { pruneStore: productionStore, downloadArchive, verifyBucket },
+    });
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  assert.equal(productionResult.state, "pruned");
+  assert.equal(productionResult.evidence.transactionCount, 2);
+  assert.equal(JSON.parse(productionOutput).target, "prod");
+  assert.equal(JSON.parse(fs.readFileSync(productionResult.recoveryBundle.manifestPath, "utf8")).target, "prod");
+
+  const thirdTx = candidate("00000000-0000-4000-8000-00000000000c", "2026-01-01T00:00:00.000003Z", { tx_type: "TABLE_BUY_IN" });
+  const threeRecords = [...records, record(thirdTx, 20, 10)];
+  const threeArchive = buildArchiveBytes(threeRecords);
+  const threeManifest = buildManifest({
+    target: "prod",
+    cutoff: localManifest.cutoff.created_at,
+    batchSize: 2,
+    cursor: null,
+    records: threeRecords,
+    archive: threeArchive,
+    outputPath: "/private/chips-ledger-prod-three.jsonl.gz",
+  });
+  const threeRow = manifestRow({ project_ref: "otbqfijerkieoxwpxjnm" }, threeManifest, computeArchiveIdProofs(threeRecords));
+  await assert.rejects(
+    () => pruneArchive({
+      argv: ["--target", "prod", "--object-path", buildObjectPath(threeManifest), "--confirm-sha", threeManifest.sha256.compressed_artifact],
+      env: PROD_ENV,
+      deps: {
+        pruneStore: fakeStore(threeRow, ["ready"], { identity: "7575202818581710058", expectedExecute: false }),
+        verifyBucket,
+        downloadArchive: async () => ({ bytes: threeArchive.compressedBytes, downloadMs: 1 }),
+        emit: false,
+      },
+    }),
+    /exceeds target batch limit|archive proof requires 1 to 2 transaction records/,
+  );
+} finally {
+  fs.rmSync(productionRoot, { recursive: true, force: true });
 }
 
 const localEvidence = buildPruneEvidence({ records, manifest: localManifest, summary: {

--- a/tests/chips/chips.migration.test.mjs
+++ b/tests/chips/chips.migration.test.mjs
@@ -756,6 +756,10 @@ async function assertArchivePrunerRoleContracts(sql) {
       )) as gate_owner,
       pg_catalog.pg_get_userbyid((
         select proowner from pg_catalog.pg_proc
+        where oid = 'public.chips_assert_archive_prune_target(text,bigint)'::regprocedure
+      )) as target_gate_owner,
+      pg_catalog.pg_get_userbyid((
+        select proowner from pg_catalog.pg_proc
         where oid = 'public.chips_prune_committed_archive_batch(text,uuid[],bigint[],boolean)'::regprocedure
       )) as prune_owner,
       pg_catalog.pg_get_userbyid((
@@ -784,6 +788,7 @@ async function assertArchivePrunerRoleContracts(sql) {
       pg_catalog.has_schema_privilege('chips_ledger_archive_pruner', 'public', 'create') as public_schema_create;
   `;
   assert.equal(functionOwners[0].gate_owner, "postgres", "read-only Stage identity gate must retain its privileged owner");
+  assert.equal(functionOwners[0].target_gate_owner, "postgres", "target identity gate must retain a privileged owner");
   assert.equal(functionOwners[0].prune_owner, "chips_ledger_archive_pruner", "destructive function must use the NOLOGIN owner");
   assert.equal(functionOwners[0].prune_internal_owner, "chips_ledger_archive_pruner", "internal pruning implementation must use the NOLOGIN owner");
   assert.equal(functionOwners[0].prune_internal_strict, true, "internal pruning implementation must never receive NULL arguments");
@@ -801,6 +806,11 @@ async function assertArchivePrunerRoleContracts(sql) {
       has_function_privilege('anon', 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)', 'execute') as anon_internal_execute,
       has_function_privilege('authenticated', 'public.chips_prune_committed_archive_batch_internal(text,uuid[],bigint[],boolean)', 'execute') as authenticated_internal_execute,
       has_function_privilege('service_role', 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)', 'execute') as service_role_proof_execute,
+      has_function_privilege('anon', 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)', 'execute') as anon_proof_execute,
+      has_function_privilege('authenticated', 'public.chips_register_archive_id_proof(text,uuid[],bigint[],text,integer,timestamptz,timestamptz,uuid,timestamptz,uuid,timestamptz,timestamptz,jsonb,bigint,bigint,text,text,numeric,numeric,numeric)', 'execute') as authenticated_proof_execute,
+      has_function_privilege('service_role', 'public.chips_assert_archive_prune_target(text,bigint)', 'execute') as service_role_target_gate_execute,
+      has_function_privilege('anon', 'public.chips_assert_archive_prune_target(text,bigint)', 'execute') as anon_target_gate_execute,
+      has_function_privilege('authenticated', 'public.chips_assert_archive_prune_target(text,bigint)', 'execute') as authenticated_target_gate_execute,
       exists (
         select 1 from pg_catalog.pg_proc procedures
         cross join lateral pg_catalog.aclexplode(coalesce(procedures.proacl, pg_catalog.acldefault('f', procedures.proowner))) privileges
@@ -823,6 +833,11 @@ async function assertArchivePrunerRoleContracts(sql) {
   assert.equal(acl[0].anon_internal_execute, false, "anon must not execute the internal destructive function");
   assert.equal(acl[0].authenticated_internal_execute, false, "authenticated must not execute the internal destructive function");
   assert.equal(acl[0].service_role_proof_execute, false, "service_role must not register immutable archive proof");
+  assert.equal(acl[0].anon_proof_execute, false, "anon must not register immutable archive proof");
+  assert.equal(acl[0].authenticated_proof_execute, false, "authenticated must not register immutable archive proof");
+  assert.equal(acl[0].service_role_target_gate_execute, false, "service_role must not call the target identity gate");
+  assert.equal(acl[0].anon_target_gate_execute, false, "anon must not call the target identity gate");
+  assert.equal(acl[0].authenticated_target_gate_execute, false, "authenticated must not call the target identity gate");
   assert.equal(acl[0].postgres_execute, true, "the explicit operations role must execute the destructive function");
   assert.equal(acl[0].postgres_internal_execute, false, "the operations role must not bypass the NULL-safe wrapper");
 
@@ -832,6 +847,18 @@ async function assertArchivePrunerRoleContracts(sql) {
     await tx.unsafe(`create or replace function public.chips_assert_archive_prune_stage()
       returns text language sql security definer set search_path = ''
       as $override$ select '7656985631720456337'::text $override$;`);
+    await tx.unsafe(`create or replace function public.chips_assert_archive_prune_target(p_project_ref text, p_transaction_count bigint)
+      returns text language plpgsql security definer set search_path = ''
+      as $override$
+      begin
+        if p_project_ref = 'krydukthwdvccggbyjfw' and p_transaction_count between 1 and 5000 then
+          return '7656985631720456337';
+        elsif p_project_ref = 'otbqfijerkieoxwpxjnm' and p_transaction_count between 1 and 2 then
+          return '7575202818581710058';
+        end if;
+        raise exception 'test target gate rejected request';
+      end
+      $override$;`);
     const tableId = "00000000-0000-4000-8000-00000000b401";
     const escrowId = "00000000-0000-4000-8000-00000000b402";
     const transactionIds = [
@@ -950,6 +977,42 @@ async function assertArchivePrunerRoleContracts(sql) {
     ], "real PostgreSQL adapter must preserve manifest microseconds");
     const proofResult = await pruneStore.registerProof(adapterManifest, { transactionIds, entryIds });
     assert.equal(proofResult.state, "proof_registered", "real PostgreSQL adapter must preserve microseconds when registering proof");
+
+    await tx`update public.poker_tables set status = 'CLOSED' where id = ${tableId};`;
+    const productionCompressedHash = "3".repeat(64);
+    const productionRawHash = "4".repeat(64);
+    const productionObjectPath = `v1/sha256/${productionCompressedHash}.jsonl.gz`;
+    await tx.unsafe(`insert into public.chips_ledger_archive_batches (
+      object_path, project_ref, format_version, cutoff, cursor_start_created_at, cursor_start_id,
+      cursor_end_created_at, cursor_end_id, first_created_at, last_created_at,
+      transaction_count, entry_count, tx_types, raw_bytes, compressed_bytes,
+      raw_sha256, compressed_sha256, credits, debits, net_amount, status, committed_at
+    ) values (
+      $1, 'otbqfijerkieoxwpxjnm', 1, $2::timestamptz, $3::timestamptz, $4::uuid,
+      $5::timestamptz, $6::uuid, $7::timestamptz, $5::timestamptz,
+      2, 4, '{"TABLE_BUY_IN":1,"TABLE_CASH_OUT":1}'::jsonb,
+      100, 80, $8, $9, 20, 20, 0, 'committed', timezone('utc', now())
+    );`, [
+      productionObjectPath, sql.typed(cutoff, 25), sql.typed(cursorStartCreatedAt, 25), cursorStartId,
+      sql.typed(createdAt[1], 25), transactionIds[1], sql.typed(createdAt[0], 25), productionRawHash, productionCompressedHash,
+    ]);
+    const productionManifest = await pruneStore.getManifest(productionObjectPath);
+    const productionProof = await pruneStore.registerProof(productionManifest, { transactionIds, entryIds });
+    assert.equal(productionProof.state, "proof_registered", "Production canary proof must work for two transactions");
+    const productionDryRows = await tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], false) as result;",
+      [productionObjectPath, transactionIds, entryIds],
+    );
+    assert.equal(productionDryRows[0].result.state, "ready", "Production canary must accept exactly two transactions");
+    await expectSavepointError(tx, "production_three_transaction_cap", () => tx.unsafe(
+      "select public.chips_prune_committed_archive_batch($1, $2::uuid[], $3::bigint[], false) as result;",
+      [productionObjectPath, [...transactionIds, cursorStartId], entryIds],
+    ), /test target gate rejected request/);
+    await expectSavepointError(tx, "mixed_identity_pair", () => tx.unsafe(
+      "select public.chips_assert_archive_prune_target($1, 2);",
+      ["unknown-project-ref"],
+    ), /test target gate rejected request/);
+    await tx`update public.poker_tables set status = 'ACTIVE' where id = ${tableId};`;
 
     await expectSavepointError(tx, "archive_direct_receipt", () => tx.unsafe(`update public.chips_ledger_archive_batches
       set pruned_at = timezone('utc', now()),


### PR DESCRIPTION
## Summary

Refs #874.

- Adds migration 20260813090000 for explicit canonical Stage/Production identity-pair gates.
- Keeps Stage capped at 5000 transactions and caps Production at 2 in export/store/prune validation and database proof/prune functions.
- Preserves exact technical eligibility, immutable proof/receipt/mappings, recovery bundle, exact-ID deletion, SECURITY DEFINER owners, RLS, and API-role ACLs.
- Makes prune output and recovery manifests target-aware and documents the manual Production canary; no scheduler, runtime/UI change, deploy, or canary execution is included.

## Identity gates

- Stage: krydukthwdvccggbyjfw / 7656985631720456337
- Production: otbqfijerkieoxwpxjnm / 7575202818581710058
- Mixed pairs and unknown system identifiers fail closed.

## Validation

- `npm test` (full existing runner)
- `npm run -s check:all`
- `npm run -s syntax`
- `node scripts/check-db-migrations.mjs`
- `CHIPS_MIGRATIONS_TEST_DB_URL=... node tests/chips/chips.migration.test.mjs` on one local PostgreSQL cluster
- Stage path, Production 2-record path, Production 3-record rejection, target-aware output/recovery, mixed/unknown identity rejection, and API-role proof/prune ACL contracts covered.

No Production/Stage connection, migration apply, ledger mutation, Storage operation, candidate selection, or pruning was performed.