### PR TITLE
Add Stage-only automatic chips ledger archive/pruning

### DIFF
--- a/.github/workflows/chips-ledger-stage-automation.yml
+++ b/.github/workflows/chips-ledger-stage-automation.yml
@@ -1,0 +1,38 @@
+name: Chips Ledger Stage Automation
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "17 2 * * *"
+
+concurrency:
+  group: chips-ledger-stage-automation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  stage-archive:
+    if: ${{ vars.CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED == '1' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SUPABASE_STAGE_DB_URL: ${{ secrets.SUPABASE_STAGE_DB_URL }}
+      SUPABASE_STAGE_URL: ${{ secrets.SUPABASE_STAGE_URL }}
+      SUPABASE_STAGE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_STAGE_SERVICE_ROLE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run one Stage automation cycle
+        run: node scripts/ops/chips-ledger-stage-automation.mjs

--- a/docs/chips-ledger-stage-automation.md
+++ b/docs/chips-ledger-stage-automation.md
@@ -45,6 +45,72 @@ or missing durable copy is fail-closed. After a post-commit runner failure,
 receipt/mappings and the normal `already_pruned` path are used; no blind retry or
 new batch is created.
 
+## Operator runbook
+
+The automation has no force, repair, or state-skipping mode. Do not invoke the
+pruner with `--execute` by hand, edit an archive manifest, clear an idempotency
+mapping, delete a Storage object, or enable the kill switch to get past one of
+the states below. Keep the Stage cycle blocked and preserve all evidence until
+the condition is resolved.
+
+### Pending, partial, or ambiguous manifest
+
+If the aggregate Job Summary reports `pending`, a partial proof/receipt, more
+than one incomplete manifest, an invalid policy, or another ambiguous state:
+
+1. Do not rerun the cycle and do not create a second batch.
+2. Record the aggregate state, object path, compressed SHA-256, policy ID,
+   transaction/entry counts, and timestamps from the Job Summary. Never copy
+   ledger rows, recovery contents, credentials, or database URLs into a ticket
+   or chat.
+3. Using read-only access, compare the single Stage manifest, its primary
+   private object, and the corresponding recovery paths. Check target identity,
+   policy ID, MIME type, object size, and SHA-256 before taking any repair
+   action.
+4. Escalate the exact evidence to the ledger owner. Leave the manifest and
+   Storage objects untouched unless the owner approves a controlled recovery
+   repair; the automation must continue to fail closed.
+
+### Missing or partial durable recovery
+
+For a proven or pruned cycle, both recovery objects are mandatory. If either
+object is missing, has the wrong MIME type/size/SHA-256, cannot be privately
+downloaded, or the pair is otherwise partial:
+
+1. Do not run `--execute`, register a new proof, overwrite an existing object,
+   or start a new archive batch. The primary archive object is not a substitute
+   for the recovery pair.
+2. Preserve the manifest and the surviving object. Confirm that the expected
+   paths are derived from the immutable compressed SHA-256 and that no object
+   at either path differs from the expected bytes.
+3. With explicit ledger-owner approval, restore only the missing copy from the
+   same verified archive/proof evidence using private, no-overwrite Storage
+   semantics. If the primary object is unavailable, use an independently
+   verified recovery source; never reconstruct bytes from a mutable or
+   unverified source.
+4. Privately download both recovery objects again and compare bytes and SHA-256
+   to the expected values. Only after both copies pass may the normal Stage
+   automation be allowed to resume. A mismatch remains blocked and is a manual
+   incident.
+
+### Proven without recovery
+
+This is the state `archive_proof_verified_at` is complete while `pruned_at` is
+still null and no complete durable pair exists. It is not permission to retry
+the prune. Stop the run, preserve the immutable proof and primary manifest,
+repair/verify the two private recovery objects through the procedure above,
+and then let the normal cycle repeat its dry-run and all revalidation checks.
+The next allowed path is proof revalidation followed by recovery verification
+and only then execute; there is no operator shortcut.
+
+### Post-commit or already-pruned recovery
+
+If the receipt and mappings are complete, the cycle is revalidated through
+`already_pruned`. It still requires the complete recovery pair and immutable
+proof. A missing or partial pair is an incident, not a reason to create a new
+batch. Keep the environment fail-closed until the pair is restored and passes
+private download and byte/SHA verification.
+
 ## Resume and locking
 
 GitHub Actions concurrency is complemented by a target-specific PostgreSQL

--- a/docs/chips-ledger-stage-automation.md
+++ b/docs/chips-ledger-stage-automation.md
@@ -1,0 +1,63 @@
+# Stage-only chips-ledger automation
+
+This workflow is related to closed Issue #874 and is intentionally unavailable
+for Production. The orchestrator has no target argument: it hardcodes the
+canonical Stage project `krydukthwdvccggbyjfw` and PostgreSQL system identifier
+`7656985631720456337`. The workflow passes only Stage credentials.
+
+## Policy
+
+- `CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED=1` is required; the variable is absent
+  or disabled by default at merge.
+- The schedule runs once per day with a strict 30-day cutoff.
+- One run can create at most one batch of 5,000 transactions. It never drains a
+  backlog in a loop.
+- Selection starts at the beginning of `(created_at, id)` on every new cycle and
+  chooses the oldest currently hot, unmapped, prunable technical rows. Manual
+  manifests without `source_policy_id` never drive the cursor.
+- A missing candidate is a successful no-op.
+
+The JSONL is produced by the prunable-only exporter mode. The manual exporter
+mode remains unchanged. The database pruner repeats the complete technical,
+registry, conservation, table, escrow, proof, receipt and mapping checks before
+any delete.
+
+## Recovery durability
+
+Before execute, the existing private `chips-ledger-archive` bucket must contain
+and privately return both deterministic, no-overwrite (`x-upsert=false`) gzip
+objects:
+
+```text
+recovery/v1/sha256/<compressed-sha>.jsonl.gz
+recovery/v1/sha256/<compressed-sha>.recovery.json.gz
+```
+
+Both objects use `application/gzip`. The first is a complete second copy of the
+verified archive. The second is the gzip-compressed recovery manifest containing
+the target identity, policy ID, archive metadata and immutable ID proof. Upload
+is followed by private download and byte/SHA verification for both objects.
+Execute is refused until both copies match the expected bytes. Restore uses
+these recovery objects and does not require the primary archive object.
+
+The local working bundle remains `0700` with `0600` files. A partial, different,
+or missing durable copy is fail-closed. After a post-commit runner failure,
+receipt/mappings and the normal `already_pruned` path are used; no blind retry or
+new batch is created.
+
+## Resume and locking
+
+GitHub Actions concurrency is complemented by a target-specific PostgreSQL
+session advisory lock held for the entire cycle. A busy lock is a no-op; a lost
+lock session aborts the cycle. Pending, partial, mismatched or otherwise
+ambiguous own manifests stop the run and are reported in the aggregate Job
+Summary. A committed manifest with no proof can resume only through the normal
+proof/dry-run path. A proven manifest must have a complete durable recovery
+pair; with that pair it is fully revalidated before execute, while a missing or
+partial pair is fail-closed. A pruned manifest with a complete pair is
+rechecked through `already_pruned`. Every allowed resume repeats identity,
+policy, archive, recovery, proof, receipt and mapping verification.
+
+Logs and Job Summary contain only aggregate counts, sizes, hashes and state. They
+never contain ledger records, credentials, DB URLs, service keys or recovery
+contents. No Actions artifact is used for recovery.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,19 @@
         "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.5",
         "@playwright/test": "^1.46.0",
         "acorn": "^8.15.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.7"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.5.tgz",
+      "integrity": "sha512-QeZ+oB7QaU4EJj2awrB8hwFZ5TXxLRBQ9Gfq0dQauYDdWsRtuWRCERgtri35vRfL07KQHlVlc/4Qxvn7a5AXeA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.5",
     "@playwright/test": "^1.46.0",
     "acorn": "^8.15.0",
     "husky": "^9.1.7",

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -11,6 +11,7 @@ export const DEFAULT_CUTOFF_DAYS = 30;
 export const DEFAULT_BATCH_SIZE = 5000;
 export const MAX_BATCH_SIZE = 5000;
 export const PRODUCTION_MAX_BATCH_SIZE = 2;
+export const STAGE_AUTOMATION_POLICY_ID = "stage-ledger-auto-retention-30d-v1";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const INTEGER_RE = /^-?(?:0|[1-9][0-9]*)$/;
@@ -122,6 +123,148 @@ where c.invalid_table_marker = false
   )
   and exists (select 1 from public.chips_entries e where e.transaction_id = c.id)
 order by c.created_at asc, c.id asc
+limit $2::int;
+`;
+
+// The manual exporter deliberately keeps its broad, lifecycle-safe selector.
+// Stage automation uses this independent selector so the JSONL itself is
+// prunable-only before Storage or proof state is created.
+const PRUNABLE_CANDIDATE_SQL = `
+with base as (
+  select t.*
+  from public.chips_transactions t
+  where t.created_at < $1::timestamptz
+    and (
+      $3::timestamptz is null
+      or t.created_at > $3::timestamptz
+      or (t.created_at = $3::timestamptz and t.id > $4::uuid)
+    )
+), markers as (
+  select b.id as transaction_id,
+         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id
+  from base b
+  where nullif(btrim(b.metadata->>'tableId'), '') is not null
+
+  union all
+
+  select b.id,
+         case
+           when lower(b.reference) like 'table:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           when lower(b.reference) like 'poker-rebuy:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           else null
+         end
+  from base b
+  where lower(b.reference) like 'table:%'
+     or lower(b.reference) like 'poker-rebuy:%'
+
+  union all
+
+  select b.id,
+         lower(nullif(btrim(substring(a.system_key from 13)), ''))
+  from base b
+  join public.chips_entries e on e.transaction_id = b.id
+  join public.chips_accounts a on a.id = e.account_id
+  where a.account_type::text = 'ESCROW'
+    and upper(a.system_key) like 'POKER_TABLE:%'
+), marker_summary as (
+  select transaction_id,
+         array_agg(distinct table_id) filter (where table_id is not null) as table_ids,
+         bool_or(table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
+  from markers
+  group by transaction_id
+), classified as (
+  select b.*,
+         coalesce(ms.table_ids, array[]::text[]) as table_ids,
+         coalesce(ms.invalid_table_marker, false) as invalid_table_marker
+  from base b
+  left join marker_summary ms on ms.transaction_id = b.id
+), eligible as (
+  select c.*,
+         p.id as table_row_id,
+         p.status::text as table_status,
+         ea.id::text as escrow_account_id,
+         ea.status::text as escrow_status,
+         ea.balance::text as escrow_balance
+  from classified c
+  left join public.poker_tables p on p.id::text = c.table_ids[1]
+  left join public.chips_accounts ea
+    on ea.account_type::text = 'ESCROW'
+   and ea.system_key = 'POKER_TABLE:' || c.table_ids[1]
+  where c.invalid_table_marker = false
+    and cardinality(c.table_ids) = 1
+    and c.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+    and c.user_id is null
+    and (p.id is null or upper(p.status::text) = 'CLOSED')
+    and ea.id is not null
+    and ea.status::text = 'active'
+    and ea.balance = 0
+), eligible_ids as (
+  select e.id
+  from eligible e
+  join public.chips_entries entries on entries.transaction_id = e.id
+  join public.chips_accounts accounts on accounts.id = entries.account_id
+  where exists (
+    select 1
+    from public.chips_transaction_idempotency registry
+    where registry.idempotency_key = e.idempotency_key
+      and registry.transaction_id = e.id
+      and registry.payload_hash = e.payload_hash
+      and registry.tx_type = e.tx_type
+      and registry.user_id is not distinct from e.user_id
+      and registry.transaction_created_at = e.created_at
+      and registry.archive_batch_id is null
+  )
+    and not exists (
+      select 1
+      from public.chips_transaction_idempotency mapped
+      where mapped.transaction_id = e.id
+        and mapped.archive_batch_id is not null
+    )
+  group by e.id, e.tx_type
+  having count(*) = 2
+     and count(*) filter (where accounts.account_type::text = 'USER') = 0
+     and count(*) filter (where accounts.account_type::text = 'SYSTEM') = 1
+     and count(*) filter (where accounts.account_type::text = 'ESCROW') = 1
+     and count(*) filter (
+       where accounts.account_type::text = 'ESCROW'
+         and accounts.system_key = 'POKER_TABLE:' || e.table_ids[1]
+     ) = 1
+     and bool_and(accounts.status::text = 'active')
+     and sum(entries.amount) = 0
+     and (
+       (e.tx_type::text = 'TABLE_BUY_IN'
+        and sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') < 0
+        and sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') > 0)
+       or
+       (e.tx_type::text = 'TABLE_CASH_OUT'
+        and sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') < 0
+        and sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') > 0)
+     )
+)
+select
+  e.id::text as id,
+  e.sequence::text as sequence,
+  e.tx_type::text as tx_type,
+  e.idempotency_key,
+  e.payload_hash,
+  e.user_id::text as user_id,
+  e.reference,
+  e.description,
+  e.metadata,
+  e.created_by::text as created_by,
+  e.created_at::text as created_at,
+  true as table_related,
+  e.table_ids[1] as table_id,
+  false as invalid_table_marker,
+  (e.table_row_id is not null) as table_exists,
+  e.table_status,
+  e.escrow_account_id,
+  e.escrow_status,
+  e.escrow_balance,
+  (select count(*)::text from public.chips_entries entries where entries.transaction_id = e.id) as entry_count
+from eligible e
+join eligible_ids ids on ids.id = e.id
+order by e.created_at asc, e.id asc
 limit $2::int;
 `;
 
@@ -435,7 +578,7 @@ export function validateBatch({ candidates, records, cutoff }) {
   };
 }
 
-export function buildManifest({ target, cutoff, batchSize, cursor, records, archive, outputPath }) {
+export function buildManifest({ target, cutoff, batchSize, cursor, records, archive, outputPath, sourcePolicyId = null }) {
   const validation = validateBatch({ candidates: records.map((record) => ({
     id: record.transaction.id,
     created_at: record.transaction.created_at,
@@ -459,6 +602,7 @@ export function buildManifest({ target, cutoff, batchSize, cursor, records, arch
     artifact_type: "chips_ledger_archive",
     format: "jsonl.gz",
     target,
+    ...(sourcePolicyId == null ? {} : { source_policy_id: sourcePolicyId }),
     cutoff: {
       created_at: cutoff,
       rule: "transaction.created_at < cutoff",
@@ -554,19 +698,22 @@ function deriveProjectRef(dbUrl) {
   return ref.toLowerCase();
 }
 
-export function resolveTarget(targetValue, env = process.env) {
+export function resolveTarget(targetValue, env = process.env, { singleTarget = false } = {}) {
   const target = text(targetValue);
   const config = TARGETS[target];
   if (!config) fail("target must be exactly stage or prod");
 
   const expectedRefs = {};
-  for (const [name, targetConfig] of Object.entries(TARGETS)) {
+  const targetEntries = singleTarget
+    ? [[target, config]]
+    : Object.entries(TARGETS);
+  for (const [name, targetConfig] of targetEntries) {
     const expected = text(env[targetConfig.expectedRefEnv] || env[targetConfig.legacyRefEnv]).toLowerCase();
     if (!PROJECT_REF_RE.test(expected)) fail(`${targetConfig.expectedRefEnv} is required and must be a project ref`);
     if (expected !== targetConfig.canonicalRef) fail(`${targetConfig.expectedRefEnv} does not match the versioned canonical ref`);
     expectedRefs[name] = expected;
   }
-  if (expectedRefs.stage === expectedRefs.prod) fail("stage and production project refs must differ");
+  if (!singleTarget && expectedRefs.stage === expectedRefs.prod) fail("stage and production project refs must differ");
 
   const dbUrl = text(env[config.dbEnv]);
   if (!dbUrl) fail(`${config.dbEnv} is required for target ${target}`);
@@ -587,9 +734,9 @@ function resolveCursor(args) {
   return { created_at: createdAt, id };
 }
 
-function resolveOptions(args, env, cwd, now) {
+function resolveOptions(args, env, cwd, now, targetOptions = {}) {
   if (!args.output) fail("--output is required; use a private path outside the repository");
-  const target = resolveTarget(args.target, env);
+  const target = resolveTarget(args.target, env, targetOptions);
   const cutoff = args.cutoff
     ? normalizeTimestamp(args.cutoff, "--cutoff")
     : (() => {
@@ -612,7 +759,13 @@ export async function readSnapshot(sql, options) {
   const timestampParam = (value) => value == null || typeof sql.typed !== "function" ? value : sql.typed(value, 25);
   return sql.begin(async (tx) => {
     await tx.unsafe("set transaction isolation level repeatable read, read only;");
-    const candidates = await tx.unsafe(CANDIDATE_SQL, [
+    const selector = options.selector || "standard";
+    const candidateSql = selector === "standard"
+      ? CANDIDATE_SQL
+      : selector === "prunable"
+        ? PRUNABLE_CANDIDATE_SQL
+        : fail("snapshot selector must be standard or prunable");
+    const candidates = await tx.unsafe(candidateSql, [
       timestampParam(options.cutoff),
       options.batchSize,
       timestampParam(options.cursor?.created_at || null),
@@ -665,14 +818,14 @@ function outputMetrics(manifest, options) {
   process.stdout.write(`${stringifyJson(summary)}\n`);
 }
 
-export async function runExport({ argv = process.argv.slice(2), env = process.env, cwd = process.cwd(), now = new Date() } = {}) {
+export async function runExport({ argv = process.argv.slice(2), env = process.env, cwd = process.cwd(), now = new Date(), deps = {} } = {}) {
   const args = parseArgs(argv);
   if (args.help) {
     process.stdout.write(HELP);
     return null;
   }
-  const options = resolveOptions(args, env, cwd, now);
-  const sql = postgres(options.dbUrl, {
+  const options = resolveOptions(args, env, cwd, now, deps.targetOptions || {});
+  const sql = deps.sql || postgres(options.dbUrl, {
     max: 1,
     prepare: false,
     connect_timeout: 10,
@@ -680,7 +833,10 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
   });
 
   try {
-    const snapshot = await readSnapshot(sql, options);
+    const snapshot = await readSnapshot(sql, { ...options, selector: deps.selector || "standard" });
+    if (deps.noCandidateIfEmpty && snapshot.candidates.length === 0) {
+      return { noCandidate: true, options };
+    }
     const candidateIds = new Set(snapshot.candidates.map((candidate) => text(candidate.id)));
     const entriesByTransaction = groupEntries(snapshot.entries, candidateIds);
     const records = sortRecords(snapshot.candidates.map((candidate) => buildExportRecord(
@@ -704,15 +860,16 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
       records,
       archive,
       outputPath: options.outputPath,
+      sourcePolicyId: deps.sourcePolicyId || null,
     });
     if (manifest.sha256.compressed_artifact !== crypto.createHash("sha256").update(archive.compressedBytes).digest("hex")) {
       fail("manifest checksum verification failed");
     }
     writeOutput(options, archive, manifest);
-    outputMetrics(manifest, options);
+    if (deps.emit !== false) outputMetrics(manifest, options);
     return manifest;
   } finally {
-    await sql.end({ timeout: 5 });
+    if (!deps.sql) await sql.end({ timeout: 5 });
   }
 }
 

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -129,7 +129,7 @@ limit $2::int;
 // The manual exporter deliberately keeps its broad, lifecycle-safe selector.
 // Stage automation uses this independent selector so the JSONL itself is
 // prunable-only before Storage or proof state is created.
-const PRUNABLE_CANDIDATE_SQL = `
+export const PRUNABLE_CANDIDATE_SQL = `
 with base as (
   select t.*
   from public.chips_transactions t

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -298,15 +298,17 @@ function exporterManifestFromDatabase(row, target) {
     },
     sha256: { raw_jsonl: row.raw_sha256, compressed_artifact: row.compressed_sha256 },
     artifact: path.basename(row.object_path),
+    ...(row.source_policy_id ? { source_policy_id: row.source_policy_id } : {}),
   };
 }
 
-function recoveryManifest(row, identity, evidence, target) {
+export function buildRecoveryManifest(row, identity, evidence, target) {
   return {
     recovery_schema_version: 1,
     artifact_type: "chips_ledger_archive_prune_recovery",
     target: target.target,
     project_ref: row.project_ref,
+    source_policy_id: row.source_policy_id || null,
     postgres_system_identifier: identity,
     bucket: ARCHIVE_BUCKET,
     object_path: row.object_path,
@@ -343,7 +345,7 @@ export function writeRecoveryBundle({ recoveryDir, archiveBytes, row, identity, 
   const baseName = `chips-ledger-${row.compressed_sha256}`;
   const artifactPath = path.join(directory, `${baseName}.jsonl.gz`);
   const manifestPath = path.join(directory, `${baseName}.recovery.json`);
-  const manifest = recoveryManifest(row, identity, evidence, target);
+  const manifest = buildRecoveryManifest(row, identity, evidence, target);
   const manifestBytes = Buffer.from(`${stringifyJson(manifest)}\n`, "utf8");
   const artifactExists = fs.existsSync(artifactPath);
   const manifestExists = fs.existsSync(manifestPath);
@@ -372,7 +374,7 @@ export function verifyRecoveryBundle({ bundle, row, target, identity, expectedEv
   assertPrivateRegularFile(bundle.artifactPath);
   assertPrivateRegularFile(bundle.manifestPath);
   const manifest = JSON.parse(fs.readFileSync(bundle.manifestPath, "utf8"));
-  const expectedManifest = recoveryManifest(row, identity, expectedEvidence, target);
+  const expectedManifest = buildRecoveryManifest(row, identity, expectedEvidence, target);
   if (canonicalJson(manifest) !== canonicalJson(expectedManifest)) fail("recovery manifest no longer matches archive evidence");
   const verified = verifyArchiveBytes({
     compressedBytes: fs.readFileSync(bundle.artifactPath),
@@ -399,6 +401,7 @@ function manifestSelectSql() {
     compressed_bytes::text as compressed_bytes, raw_sha256, compressed_sha256,
     credits::text as credits, debits::text as debits, net_amount::text as net_amount,
     status, committed_at::text as committed_at,
+    source_policy_id,
     archived_transaction_ids_sha256, archived_entry_ids_sha256,
     archive_proof_verified_at::text as archive_proof_verified_at,
     pruned_at::text as pruned_at, pruned_transaction_count::text as pruned_transaction_count,
@@ -545,7 +548,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
   if (args.execute && !args.recoveryDir) fail("--recovery-dir is required with --execute");
   if (!args.execute && args.recoveryDir) fail("--recovery-dir is only valid with --execute");
 
-  const target = resolveStorageTarget(args.target, env);
+  const target = deps.storageTarget || resolveStorageTarget(args.target, env, deps.targetOptions || {});
   const sql = deps.sql || (deps.pruneStore ? null : postgres(target.dbUrl, {
     max: 1,
     prepare: false,
@@ -649,7 +652,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     if (deps.emit !== false) outputResult(result);
     return result;
   } finally {
-    if (sql) await sql.end({ timeout: 5 });
+    if (sql && !deps.sql) await sql.end({ timeout: 5 });
   }
 }
 

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -9,6 +9,7 @@ import {
   compareTransactions,
   maxBatchSizeForTarget,
   parseJsonl,
+  STAGE_AUTOMATION_POLICY_ID,
   resolveTarget,
   serializeRecords,
   stringifyJson,
@@ -110,8 +111,8 @@ function parseArgs(argv) {
   return args;
 }
 
-export function resolveStorageTarget(targetValue, env = process.env) {
-  const target = resolveTarget(targetValue, env);
+export function resolveStorageTarget(targetValue, env = process.env, targetOptions = {}) {
+  const target = resolveTarget(targetValue, env, targetOptions);
   const rawUrl = text(env.SUPABASE_URL);
   if (!rawUrl) fail("SUPABASE_URL is required");
   let url;
@@ -150,6 +151,14 @@ function verifyManifestShape(manifest, artifactName, target) {
     fail("local manifest has an unsupported archive format");
   }
   if (manifest.target !== target.target) fail("local manifest target does not match --target");
+  if (manifest.source_policy_id !== undefined
+    && manifest.source_policy_id !== null
+    && manifest.source_policy_id !== STAGE_AUTOMATION_POLICY_ID) {
+    fail("local manifest source policy is unsupported");
+  }
+  if (manifest.source_policy_id === STAGE_AUTOMATION_POLICY_ID && target.target !== "stage") {
+    fail("Stage automation policy cannot be stored for a non-Stage target");
+  }
   if (manifest.artifact !== artifactName) fail("local manifest artifact name does not match the archive");
   if (!manifest.cutoff || typeof manifest.cutoff.created_at !== "string") fail("local manifest cutoff is missing");
   timestampToMicros(manifest.cutoff.created_at);
@@ -339,6 +348,18 @@ function objectRequestPath(objectPath, mode = "authenticated") {
   return `/storage/v1/object${accessSegment}/${encodeURIComponent(ARCHIVE_BUCKET)}/${objectPath.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+export function buildRecoveryArchiveObjectPath(manifestOrSha) {
+  const sha = typeof manifestOrSha === "string" ? manifestOrSha : manifestOrSha?.sha256?.compressed_artifact;
+  assertSha(sha, "compressed_artifact SHA-256");
+  return `recovery/v1/sha256/${sha}.jsonl.gz`;
+}
+
+export function buildRecoveryManifestObjectPath(manifestOrSha) {
+  const sha = typeof manifestOrSha === "string" ? manifestOrSha : manifestOrSha?.sha256?.compressed_artifact;
+  assertSha(sha, "compressed_artifact SHA-256");
+  return `recovery/v1/sha256/${sha}.recovery.json.gz`;
+}
+
 async function storageRequest(storageTarget, requestPath, options = {}, deps = {}) {
   const fetchImpl = deps.fetch || fetch;
   return fetchImpl(`${storageTarget.baseUrl}${requestPath}`, {
@@ -433,6 +454,7 @@ function manifestRow(manifest, storageTarget, objectPath) {
     credits: manifest.amounts.credits,
     debits: manifest.amounts.debits,
     net_amount: manifest.amounts.net,
+    source_policy_id: manifest.source_policy_id || null,
     status: "pending",
   };
 }
@@ -440,7 +462,7 @@ function manifestRow(manifest, storageTarget, objectPath) {
 const IMMUTABLE_FIELDS = [
   "object_path", "project_ref", "format_version", "cutoff", "cursor_start_created_at", "cursor_start_id",
   "cursor_end_created_at", "cursor_end_id", "first_created_at", "last_created_at", "transaction_count",
-  "entry_count", "tx_types", "raw_bytes", "compressed_bytes", "raw_sha256", "compressed_sha256", "credits", "debits", "net_amount",
+  "entry_count", "tx_types", "raw_bytes", "compressed_bytes", "raw_sha256", "compressed_sha256", "credits", "debits", "net_amount", "source_policy_id",
 ];
 
 function assertSameManifest(existing, expected) {
@@ -486,6 +508,58 @@ export async function downloadPrivateArchiveObject(storageTarget, objectPath, de
   return {
     bytes: Buffer.from(await response.arrayBuffer()),
     downloadMs: Date.now() - startedAt,
+  };
+}
+
+export async function downloadPrivateObjectIfExists(storageTarget, objectPath, deps = {}) {
+  const response = await storageRequest(storageTarget, objectRequestPath(objectPath), { method: "GET" }, deps);
+  if (await isMissingStorageResponse(response)) return null;
+  if (!response.ok) storageFailure("private object download", response);
+  if ((response.headers.get("content-type") || "").split(";", 1)[0].trim() !== ARCHIVE_MIME_TYPE) {
+    fail(`private recovery object has an unexpected MIME type: ${objectPath}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+export async function uploadOrVerifyPrivateObject({ storageTarget, objectPath, bytes, mimeType = ARCHIVE_MIME_TYPE, deps = {} }) {
+  const expected = Buffer.from(bytes || []);
+  if (expected.length < 1 || expected.length > ARCHIVE_MAX_BYTES) fail("private recovery object has an invalid size");
+  const initial = await storageRequest(storageTarget, objectRequestPath(objectPath), { method: "GET" }, deps);
+  let objectExisted = false;
+  let uploaded = false;
+  if (initial.ok) {
+    objectExisted = true;
+    if ((initial.headers.get("content-type") || "").split(";", 1)[0].trim() !== mimeType) {
+      fail(`private recovery object has an unexpected MIME type: ${objectPath}`);
+    }
+    const downloaded = Buffer.from(await initial.arrayBuffer());
+    if (!downloaded.equals(expected)) fail(`private recovery object differs: ${objectPath}`);
+  } else {
+    if (!(await isMissingStorageResponse(initial))) storageFailure("private recovery object lookup", initial);
+    const upload = await storageRequest(storageTarget, objectRequestPath(objectPath, ""), {
+      method: "POST",
+      headers: { "content-type": mimeType, "x-upsert": "false" },
+      body: expected,
+    }, deps);
+    if (!upload.ok && upload.status !== 400 && upload.status !== 409) {
+      storageFailure("private recovery object upload", upload);
+    }
+    uploaded = upload.ok;
+    objectExisted = !uploaded;
+  }
+  const verified = await storageRequest(storageTarget, objectRequestPath(objectPath), { method: "GET" }, deps);
+  if (!verified.ok) storageFailure("private recovery object verification", verified);
+  if ((verified.headers.get("content-type") || "").split(";", 1)[0].trim() !== mimeType) {
+    fail(`private recovery object verification has an unexpected MIME type: ${objectPath}`);
+  }
+  const downloaded = Buffer.from(await verified.arrayBuffer());
+  if (!downloaded.equals(expected)) fail(`private recovery object verification differs: ${objectPath}`);
+  return {
+    objectPath,
+    objectExisted,
+    uploaded,
+    bytes: downloaded.length,
+    sha256: crypto.createHash("sha256").update(downloaded).digest("hex"),
   };
 }
 
@@ -554,6 +628,7 @@ function selectManifestSql() {
     credits::text as credits,
     debits::text as debits,
     net_amount::text as net_amount,
+    source_policy_id,
     status
   from public.chips_ledger_archive_batches
   where object_path = $1;`;
@@ -572,6 +647,7 @@ function normalizeManifestRow(row) {
     credits: String(row.credits),
     debits: String(row.debits),
     net_amount: String(row.net_amount),
+    source_policy_id: row.source_policy_id || null,
   };
 }
 
@@ -589,16 +665,16 @@ export function createManifestStore(sql) {
         (object_path, project_ref, format_version, cutoff, cursor_start_created_at, cursor_start_id,
          cursor_end_created_at, cursor_end_id, first_created_at, last_created_at, transaction_count,
          entry_count, tx_types, raw_bytes, compressed_bytes, raw_sha256, compressed_sha256,
-         credits, debits, net_amount, status)
+         credits, debits, net_amount, source_policy_id, status)
         values ($1, $2, $3::integer, $4::timestamptz, $5::timestamptz, $6::uuid,
                 $7::timestamptz, $8::uuid, $9::timestamptz, $10::timestamptz, $11::bigint,
                 $12::bigint, $13::jsonb, $14::bigint, $15::bigint, $16, $17,
-                $18::numeric, $19::numeric, $20::numeric, 'pending')
+                $18::numeric, $19::numeric, $20::numeric, $21, 'pending')
         on conflict (object_path) do nothing;`, [
         row.object_path, row.project_ref, row.format_version, timestampParam(row.cutoff), timestampParam(row.cursor_start_created_at), row.cursor_start_id,
         timestampParam(row.cursor_end_created_at), row.cursor_end_id, timestampParam(row.first_created_at), timestampParam(row.last_created_at), row.transaction_count,
         row.entry_count, row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
-        row.credits, row.debits, row.net_amount,
+        row.credits, row.debits, row.net_amount, row.source_policy_id,
       ]);
     },
     async markCommitted(objectPath) {
@@ -645,7 +721,7 @@ export async function storeArchive({ argv = process.argv.slice(2), env = process
   if (!args.target) fail("--target is required; no default target is allowed");
   if (!args.artifact) fail("--artifact is required; no default path is allowed");
   if (!args.manifest) fail("--manifest is required; no default path is allowed");
-  const storageTarget = resolveStorageTarget(args.target, env);
+  const storageTarget = deps.storageTarget || resolveStorageTarget(args.target, env, deps.targetOptions || {});
   const local = verifyLocalArchive({ artifactPath: path.resolve(cwd, args.artifact), manifestPath: path.resolve(cwd, args.manifest), target: storageTarget });
   const sql = deps.sql || (deps.manifestStore ? null : postgres(storageTarget.dbUrl, { max: 1, prepare: false, connect_timeout: 10, idle_timeout: 30 }));
   const manifestStore = deps.manifestStore || createManifestStore(sql);
@@ -667,7 +743,7 @@ export async function storeArchive({ argv = process.argv.slice(2), env = process
     if (deps.emit !== false) outputMetrics(result);
     return result;
   } finally {
-    if (sql) await sql.end({ timeout: 5 });
+    if (sql && !deps.sql) await sql.end({ timeout: 5 });
   }
 }
 

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -141,10 +141,20 @@ export function validateStageEnvironment(env = process.env) {
 
 async function acquireAdvisoryLock(sql) {
   const rows = await sql.unsafe(
-    "select pg_catalog.pg_try_advisory_lock(pg_catalog.hashtextextended($1, 0)) as acquired;",
+    "select pg_catalog.pg_backend_pid()::text as backend_pid, pg_catalog.pg_try_advisory_lock(pg_catalog.hashtextextended($1, 0)) as acquired;",
     [STAGE_AUTOMATION_LOCK_KEY],
   );
-  return rows[0]?.acquired === true || rows[0]?.acquired === "t";
+  if (!(rows[0]?.acquired === true || rows[0]?.acquired === "t")) return null;
+  const backendPid = text(rows[0]?.backend_pid);
+  if (!backendPid) fail("Stage advisory lock session identity is unavailable");
+  return { backendPid };
+}
+
+async function assertAdvisoryLock(sql, lockSession) {
+  const rows = await sql.unsafe("select pg_catalog.pg_backend_pid()::text as backend_pid;");
+  if (text(rows[0]?.backend_pid) !== lockSession?.backendPid) {
+    fail("Stage advisory lock session was lost; aborting the cycle");
+  }
 }
 
 async function releaseAdvisoryLock(sql) {
@@ -329,8 +339,9 @@ function pruneArgs(row, mode, recoveryDir = null) {
   return args;
 }
 
-async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarget, downloadArchive = null, recoveryDir = null, verifyBucket = null }) {
+async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarget, downloadArchive = null, recoveryDir = null, verifyBucket = null, storageDeps = {} }) {
   const deps = {
+    ...storageDeps,
     sql,
     pruneStore,
     storageTarget,
@@ -346,8 +357,8 @@ async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarge
   });
 }
 
-async function verifyCompletedCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
-  const durable = await inspectDurableRecovery(storageTarget, row);
+async function verifyCompletedCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps = {} }) {
+  const durable = await inspectDurableRecovery(storageTarget, row, storageDeps);
   assertResumeRecoveryState(row, durable);
   if (!durable) fail("completed Stage automation cycle has no durable recovery copies");
   const dry = await runPruneStep({
@@ -359,6 +370,7 @@ async function verifyCompletedCycle({ row, identity, env, tempRoot, sql, pruneSt
     pruneStore,
     storageTarget,
     verifyBucket,
+    storageDeps,
     downloadArchive: async () => ({ bytes: durable.archiveBytes, downloadMs: 0 }),
   });
   if (dry.state !== "already_pruned") fail(`completed Stage automation cycle did not revalidate as already_pruned: ${dry.state}`);
@@ -375,7 +387,7 @@ async function refreshRow(pruneStore, objectPath) {
   return row;
 }
 
-async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
+async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps = {} }) {
   assertDurableRecoveryReady(durable);
   const recoveryDir = path.join(tempRoot, "recovery");
   restoreLocalRecovery(recoveryDir, durable);
@@ -388,6 +400,7 @@ async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql
     pruneStore,
     storageTarget,
     verifyBucket,
+    storageDeps,
     recoveryDir,
     downloadArchive: async () => ({ bytes: durable.archiveBytes, downloadMs: 0 }),
   });
@@ -397,11 +410,11 @@ async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql
   return result;
 }
 
-async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
-  const durableBefore = await inspectDurableRecovery(storageTarget, row);
+async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps = {} }) {
+  const durableBefore = await inspectDurableRecovery(storageTarget, row, storageDeps);
   assertResumeRecoveryState(row, durableBefore);
   if (!row.archive_proof_verified_at) {
-    await runPruneStep({ row, mode: "register-proof", env, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, downloadArchive: durableBefore ? async () => ({ bytes: durableBefore.archiveBytes, downloadMs: 0 }) : null });
+    await runPruneStep({ row, mode: "register-proof", env, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps, downloadArchive: durableBefore ? async () => ({ bytes: durableBefore.archiveBytes, downloadMs: 0 }) : null });
     row = await refreshRow(pruneStore, row.object_path);
   }
   const dry = await runPruneStep({
@@ -413,6 +426,7 @@ async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, s
     pruneStore,
     storageTarget,
     verifyBucket,
+    storageDeps,
     downloadArchive: durableBefore ? async () => ({ bytes: durableBefore.archiveBytes, downloadMs: 0 }) : null,
   });
   if (durableBefore) {
@@ -422,15 +436,15 @@ async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, s
     );
   }
   if (dry.state === "already_pruned") {
-    return executeVerifiedCycle({ row, identity, durable: durableBefore, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    return executeVerifiedCycle({ row, identity, durable: durableBefore, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps });
   }
   if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
   let durable = durableBefore;
   if (!durable) {
-    const main = await downloadPrivateArchiveObject(storageTarget, row.object_path);
-    durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes);
+    const main = await downloadPrivateArchiveObject(storageTarget, row.object_path, storageDeps);
+    durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, storageDeps);
   }
-  return executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+  return executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps });
 }
 
 export async function runStageAutomation({ env = process.env, now = new Date(), deps = {} } = {}) {
@@ -447,20 +461,23 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
   const storageTarget = deps.storageTarget || resolveStorageTarget("stage", moduleEnv, { singleTarget: true });
   const pruneStore = deps.pruneStore || createPruneStore(sql);
   const verifyBucket = deps.verifyBucket || ((target) => verifyArchiveBucket(target, deps));
-  let locked = false;
+  let lockSession = null;
   try {
-    locked = await acquireAdvisoryLock(sql);
-    if (!locked) {
+    lockSession = await acquireAdvisoryLock(sql);
+    if (!lockSession) {
       const result = { state: "no-op", reason: "advisory_lock_busy" };
       writeAggregateSummary(result);
       return result;
     }
     const identity = await assertIdentity(sql);
+    await assertAdvisoryLock(sql, lockSession);
     await verifyBucket(storageTarget);
     const ownRows = await loadOwnBatches(sql);
+    await assertAdvisoryLock(sql, lockSession);
     const ownCycle = findOwnCycle(ownRows);
     if (ownCycle.active) {
-      const result = await resumeOwnCycle({ row: await refreshRow(pruneStore, ownCycle.active.object_path), identity, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+      const result = await resumeOwnCycle({ row: await refreshRow(pruneStore, ownCycle.active.object_path), identity, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+      await assertAdvisoryLock(sql, lockSession);
       const output = {
         state: result.state,
         mode: "resume",
@@ -483,7 +500,9 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
         pruneStore,
         storageTarget,
         verifyBucket,
+        storageDeps: deps,
       });
+      await assertAdvisoryLock(sql, lockSession);
     }
 
     const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
@@ -508,26 +527,33 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
         emit: false,
       },
     });
+    await assertAdvisoryLock(sql, lockSession);
     if (exported.noCandidate) {
       const result = { state: "no-op", reason: "no_eligible_candidate" };
       writeAggregateSummary(result);
       return result;
     }
     await ensureArchiveBucket(storageTarget, deps);
+    await assertAdvisoryLock(sql, lockSession);
     const stored = await storeArchive({
       argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
       env: moduleEnv,
       cwd: tempRoot,
-      deps: { sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
+      deps: { ...deps, sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
     });
     let row = await refreshRow(pruneStore, stored.objectPath);
-    await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    await assertAdvisoryLock(sql, lockSession);
+    await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
     row = await refreshRow(pruneStore, row.object_path);
-    const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    await assertAdvisoryLock(sql, lockSession);
+    const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
     if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
+    await assertAdvisoryLock(sql, lockSession);
     const main = await downloadPrivateArchiveObject(storageTarget, row.object_path, deps);
     const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
-    const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    await assertAdvisoryLock(sql, lockSession);
+    const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+    await assertAdvisoryLock(sql, lockSession);
     const output = {
       state: executed.state,
       mode: "new",
@@ -551,7 +577,7 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
     writeAggregateSummary(result);
     throw error;
   } finally {
-    if (locked) {
+    if (lockSession) {
       try {
         await releaseAdvisoryLock(sql);
       } catch {

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -349,7 +349,8 @@ async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarge
   };
   if (downloadArchive) deps.downloadArchive = downloadArchive;
   if (verifyBucket) deps.verifyBucket = verifyBucket;
-  return pruneArchive({
+  const pruneRunner = storageDeps.pruneArchive || pruneArchive;
+  return pruneRunner({
     argv: pruneArgs(row, mode, mode === "execute" ? recoveryDir : null),
     env,
     cwd,

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -508,7 +508,8 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
 
     const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
     const manifestPath = path.join(tempRoot, "archive.manifest.json");
-    const exported = await runExport({
+    const exportArchive = deps.exportArchive || runExport;
+    const exported = await exportArchive({
       argv: [
         "--target", "stage",
         "--cutoff-days", String(STAGE_RETENTION_DAYS),
@@ -534,9 +535,11 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
       writeAggregateSummary(result);
       return result;
     }
-    await ensureArchiveBucket(storageTarget, deps);
+    const ensureBucket = deps.ensureArchiveBucket || ensureArchiveBucket;
+    await ensureBucket(storageTarget, deps);
     await assertAdvisoryLock(sql, lockSession);
-    const stored = await storeArchive({
+    const store = deps.storeArchive || storeArchive;
+    const stored = await store({
       argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
       env: moduleEnv,
       cwd: tempRoot,
@@ -550,7 +553,8 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
     const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
     if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
     await assertAdvisoryLock(sql, lockSession);
-    const main = await downloadPrivateArchiveObject(storageTarget, row.object_path, deps);
+    const downloadMain = deps.downloadPrivateArchive || downloadPrivateArchiveObject;
+    const main = await downloadMain(storageTarget, row.object_path, deps);
     const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
     await assertAdvisoryLock(sql, lockSession);
     const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -1,0 +1,574 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync, gzipSync } from "node:zlib";
+import postgres from "postgres";
+import {
+  runExport,
+  STAGE_AUTOMATION_POLICY_ID,
+  stringifyJson,
+} from "./chips-ledger-archive-export.mjs";
+import {
+  buildRecoveryArchiveObjectPath,
+  buildRecoveryManifestObjectPath,
+  downloadPrivateArchiveObject,
+  downloadPrivateObjectIfExists,
+  ensureArchiveBucket,
+  resolveStorageTarget,
+  storeArchive,
+  uploadOrVerifyPrivateObject,
+  verifyArchiveBucket,
+} from "./chips-ledger-archive-store.mjs";
+import {
+  buildRecoveryManifest,
+  createPruneStore,
+  pruneArchive,
+} from "./chips-ledger-archive-prune.mjs";
+import {
+  ensurePrivateDirectory,
+  writeExclusiveFiles,
+} from "./_shared/chips-ledger-archive-files.mjs";
+
+export const STAGE_PROJECT_REF = "krydukthwdvccggbyjfw";
+export const STAGE_SYSTEM_IDENTIFIER = "7656985631720456337";
+export const STAGE_MAX_BATCH_SIZE = 5000;
+export const STAGE_RETENTION_DAYS = 30;
+export const STAGE_AUTOMATION_LOCK_KEY = `chips-ledger-stage-automation-v1:${STAGE_PROJECT_REF}`;
+
+const SHA256_RE = /^[0-9a-f]{64}$/;
+const PRIVATE_FILE_MODE = 0o600;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function text(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+function sha256(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function redactedError(error) {
+  return text(error?.message || error)
+    .replace(/postgres(?:ql)?:\/\/[^\s]+/gi, "[redacted-db-url]")
+    .replace(/Bearer\s+[^\s]+/gi, "Bearer [redacted]")
+    .replace(/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[redacted-token]")
+    .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi, "[redacted-record-id]")
+    .replace(/\b(?:entry|transaction|account|table)[-_ ]?\d+\b/gi, "[redacted-record]");
+}
+
+function writeAggregateSummary(result) {
+  const safe = stringifyJson({
+    event: "chips_ledger_stage_automation",
+    target: "stage",
+    project_ref: STAGE_PROJECT_REF,
+    source_policy_id: STAGE_AUTOMATION_POLICY_ID,
+    state: result.state,
+    mode: result.mode || null,
+    transactions: result.transactions ?? null,
+    entries: result.entries ?? null,
+    tx_types: result.txTypes || null,
+    amounts: result.amounts || null,
+    raw_bytes: result.rawBytes ?? null,
+    compressed_bytes: result.compressedBytes ?? null,
+    compressed_sha256: result.compressedSha256 || null,
+    recovery_archive_sha256: result.recoveryArchiveSha256 || null,
+    recovery_manifest_sha256: result.recoveryManifestSha256 || null,
+    proof: result.proof || null,
+    receipt: result.receipt || null,
+    mappings: result.mappings ?? null,
+    reason: result.reason || null,
+  });
+  process.stdout.write(`${safe}\n`);
+  const summaryPath = text(process.env.GITHUB_STEP_SUMMARY);
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `\n\`\`\`json\n${safe}\n\`\`\`\n`, { mode: PRIVATE_FILE_MODE });
+  }
+}
+
+export function validateStageEnvironment(env = process.env) {
+  for (const key of Object.keys(env)) {
+    if (/^SUPABASE_PROD_|^PRODUCTION_/.test(key)) fail("Production credentials are not accepted by the Stage orchestrator");
+  }
+  const dbUrl = text(env.SUPABASE_STAGE_DB_URL);
+  const apiUrl = text(env.SUPABASE_STAGE_URL);
+  const serviceKey = text(env.SUPABASE_STAGE_SERVICE_ROLE_KEY);
+  if (!dbUrl || !apiUrl || !serviceKey) fail("Stage DB URL, Supabase URL and service key are required");
+  let parsedDb;
+  let parsedApi;
+  try {
+    parsedDb = new URL(dbUrl);
+    parsedApi = new URL(apiUrl);
+  } catch {
+    fail("Stage connection configuration is invalid");
+  }
+  if (parsedDb.protocol !== "postgres:" && parsedDb.protocol !== "postgresql:") fail("Stage DB URL must be PostgreSQL");
+  if (parsedApi.protocol !== "https:" || parsedApi.pathname !== "/" || parsedApi.search || parsedApi.hash) {
+    fail("Stage Supabase URL must be an HTTPS origin");
+  }
+  if (parsedApi.hostname.toLowerCase() !== `${STAGE_PROJECT_REF}.supabase.co`) {
+    fail("Stage Supabase URL does not match the canonical Stage project ref");
+  }
+  const direct = /^db\.([a-z0-9]{20})\.supabase\.co$/i.exec(parsedDb.hostname);
+  const pooler = /^[a-z0-9-]+\.pooler\.supabase\.com$/i.test(parsedDb.hostname);
+  const user = /^postgres\.([a-z0-9]{20})$/i.exec(decodeURIComponent(parsedDb.username || ""));
+  const dbProjectRef = (direct?.[1] || (pooler ? user?.[1] : ""))?.toLowerCase();
+  if (dbProjectRef !== STAGE_PROJECT_REF) fail("Stage DB URL does not match the canonical Stage project ref");
+  return {
+    dbUrl,
+    apiUrl: parsedApi.origin,
+    serviceKey,
+    moduleEnv: {
+      EXPECTED_SUPABASE_STAGE_PROJECT_REF: STAGE_PROJECT_REF,
+      SUPABASE_STAGE_DB_URL: dbUrl,
+      SUPABASE_URL: parsedApi.origin,
+      SUPABASE_SERVICE_ROLE_KEY: serviceKey,
+    },
+  };
+}
+
+async function acquireAdvisoryLock(sql) {
+  const rows = await sql.unsafe(
+    "select pg_catalog.pg_try_advisory_lock(pg_catalog.hashtextextended($1, 0)) as acquired;",
+    [STAGE_AUTOMATION_LOCK_KEY],
+  );
+  return rows[0]?.acquired === true || rows[0]?.acquired === "t";
+}
+
+async function releaseAdvisoryLock(sql) {
+  await sql.unsafe(
+    "select pg_catalog.pg_advisory_unlock(pg_catalog.hashtextextended($1, 0));",
+    [STAGE_AUTOMATION_LOCK_KEY],
+  );
+}
+
+async function assertIdentity(sql) {
+  const rows = await sql.unsafe("select system_identifier::text as system_identifier from pg_catalog.pg_control_system();");
+  const identity = text(rows[0]?.system_identifier);
+  if (identity !== STAGE_SYSTEM_IDENTIFIER) fail("database is not canonical Stage");
+  return identity;
+}
+
+async function loadOwnBatches(sql) {
+  return sql.unsafe(`select
+    object_path,
+    project_ref,
+    source_policy_id,
+    status,
+    committed_at::text as committed_at,
+    archive_proof_verified_at::text as archive_proof_verified_at,
+    archived_transaction_ids_sha256,
+    archived_entry_ids_sha256,
+    pruned_at::text as pruned_at,
+    pruned_transaction_count::text as pruned_transaction_count,
+    pruned_entry_count::text as pruned_entry_count,
+    pruned_transaction_ids_sha256,
+    pruned_entry_ids_sha256,
+    compressed_sha256
+  from public.chips_ledger_archive_batches
+  where project_ref = $1
+    and source_policy_id = $2
+  order by created_at desc, object_path desc;`, [STAGE_PROJECT_REF, STAGE_AUTOMATION_POLICY_ID]);
+}
+
+function receiptFieldCount(row) {
+  return [
+    row.pruned_at,
+    row.pruned_transaction_count,
+    row.pruned_entry_count,
+    row.pruned_transaction_ids_sha256,
+    row.pruned_entry_ids_sha256,
+  ].filter((value) => value != null).length;
+}
+
+function proofFieldCount(row) {
+  return [
+    row.archive_proof_verified_at,
+    row.archived_transaction_ids_sha256,
+    row.archived_entry_ids_sha256,
+  ].filter((value) => value != null).length;
+}
+
+export function findOwnCycle(rows) {
+  const active = rows.filter((row) => row.status === "pending"
+    || (row.status === "committed" && receiptFieldCount(row) !== 5));
+  if (active.length > 1) fail("multiple incomplete Stage automation manifests; refusing to choose one");
+  if (active[0]?.status === "pending") fail("Stage automation manifest is pending; refusing a blind resume");
+  if (active[0] && active[0].source_policy_id !== STAGE_AUTOMATION_POLICY_ID) {
+    fail("Stage automation manifest policy mismatch");
+  }
+  for (const row of rows) {
+    if (row.status !== "pending" && row.status !== "committed") fail("Stage automation manifest has an invalid state");
+    if (row.source_policy_id !== STAGE_AUTOMATION_POLICY_ID) fail("Stage automation manifest policy mismatch");
+    if (receiptFieldCount(row) !== 0 && receiptFieldCount(row) !== 5) fail("Stage automation receipt is partial");
+    if (proofFieldCount(row) !== 0 && proofFieldCount(row) !== 3) fail("Stage automation proof is partial");
+  }
+  return {
+    active: active[0] || null,
+    latestCompleted: rows.find((row) => row.status === "committed" && receiptFieldCount(row) === 5) || null,
+  };
+}
+
+function assertRecoveryManifestMatches(actual, expected) {
+  if (canonicalJson(actual) !== canonicalJson(expected)) fail("durable recovery manifest differs from verified evidence");
+}
+
+export function assertResumeRecoveryState(row, durable) {
+  if (row.pruned_at && !durable) fail("pruned Stage automation cycle has no durable recovery copies");
+  if (row.archive_proof_verified_at && !row.pruned_at && !durable) {
+    fail("proven Stage automation cycle has no durable recovery; refusing a blind Storage retry");
+  }
+  if (!row.archive_proof_verified_at && durable) {
+    fail("Stage automation recovery exists without an immutable proof; refusing an ambiguous resume");
+  }
+  return true;
+}
+
+async function inspectDurableRecovery(storageTarget, row, deps = {}) {
+  const archivePath = buildRecoveryArchiveObjectPath(row.compressed_sha256);
+  const manifestPath = buildRecoveryManifestObjectPath(row.compressed_sha256);
+  const [archiveBytes, manifestGzipBytes] = await Promise.all([
+    downloadPrivateObjectIfExists(storageTarget, archivePath, deps),
+    downloadPrivateObjectIfExists(storageTarget, manifestPath, deps),
+  ]);
+  if (archiveBytes == null && manifestGzipBytes == null) return null;
+  if (archiveBytes == null || manifestGzipBytes == null) fail("durable recovery copy is partial");
+  if (!SHA256_RE.test(row.compressed_sha256) || sha256(archiveBytes) !== row.compressed_sha256) {
+    fail("durable recovery archive copy checksum differs");
+  }
+  let manifestBytes;
+  try {
+    manifestBytes = gunzipSync(manifestGzipBytes);
+  } catch {
+    fail("durable recovery manifest is not valid gzip");
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestBytes.toString("utf8"));
+  } catch {
+    fail("durable recovery manifest is invalid JSON");
+  }
+  return {
+    archivePath,
+    manifestPath,
+    archiveBytes,
+    manifestGzipBytes,
+    manifestBytes,
+    manifest,
+    archiveSha256: sha256(archiveBytes),
+    manifestSha256: sha256(manifestGzipBytes),
+  };
+}
+
+export async function persistDurableRecovery(storageTarget, row, identity, evidence, archiveBytes, deps = {}) {
+  if (sha256(archiveBytes) !== row.compressed_sha256) fail("verified archive checksum differs before recovery copy");
+  const manifest = buildRecoveryManifest(row, identity, evidence, { target: "stage" });
+  const manifestBytes = Buffer.from(`${stringifyJson(manifest)}\n`, "utf8");
+  const manifestGzipBytes = gzipSync(manifestBytes, { level: 9, mtime: 0 });
+  const recoveryArchive = await uploadOrVerifyPrivateObject({
+    storageTarget,
+    objectPath: buildRecoveryArchiveObjectPath(row.compressed_sha256),
+    bytes: archiveBytes,
+    deps,
+  });
+  const recoveryManifest = await uploadOrVerifyPrivateObject({
+    storageTarget,
+    objectPath: buildRecoveryManifestObjectPath(row.compressed_sha256),
+    bytes: manifestGzipBytes,
+    deps,
+  });
+  const verified = await inspectDurableRecovery(storageTarget, row, deps);
+  if (!verified) fail("durable recovery copies disappeared after upload");
+  assertRecoveryManifestMatches(verified.manifest, manifest);
+  return {
+    ...verified,
+    recoveryArchive,
+    recoveryManifest,
+  };
+}
+
+function restoreLocalRecovery(directory, durable) {
+  ensurePrivateDirectory(directory);
+  const base = `chips-ledger-${sha256(durable.archiveBytes)}`;
+  const artifactPath = path.join(directory, `${base}.jsonl.gz`);
+  const manifestPath = path.join(directory, `${base}.recovery.json`);
+  writeExclusiveFiles([
+    { path: artifactPath, data: durable.archiveBytes },
+    { path: manifestPath, data: durable.manifestBytes },
+  ]);
+  return { directory, artifactPath, manifestPath };
+}
+
+export function assertDurableRecoveryReady(durable) {
+  if (!durable?.archiveBytes || !durable?.manifestGzipBytes || !durable?.manifestBytes) {
+    fail("execute requires both durable recovery copies");
+  }
+  return true;
+}
+
+function pruneArgs(row, mode, recoveryDir = null) {
+  const args = [
+    "--target", "stage",
+    "--object-path", row.object_path,
+    "--confirm-sha", row.compressed_sha256,
+  ];
+  if (mode === "register-proof") args.push("--register-proof");
+  if (mode === "execute") args.push("--execute", "--recovery-dir", recoveryDir);
+  return args;
+}
+
+async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarget, downloadArchive = null, recoveryDir = null, verifyBucket = null }) {
+  const deps = {
+    sql,
+    pruneStore,
+    storageTarget,
+    emit: false,
+  };
+  if (downloadArchive) deps.downloadArchive = downloadArchive;
+  if (verifyBucket) deps.verifyBucket = verifyBucket;
+  return pruneArchive({
+    argv: pruneArgs(row, mode, mode === "execute" ? recoveryDir : null),
+    env,
+    cwd,
+    deps,
+  });
+}
+
+async function verifyCompletedCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
+  const durable = await inspectDurableRecovery(storageTarget, row);
+  assertResumeRecoveryState(row, durable);
+  if (!durable) fail("completed Stage automation cycle has no durable recovery copies");
+  const dry = await runPruneStep({
+    row,
+    mode: "dry-run",
+    env,
+    cwd: tempRoot,
+    sql,
+    pruneStore,
+    storageTarget,
+    verifyBucket,
+    downloadArchive: async () => ({ bytes: durable.archiveBytes, downloadMs: 0 }),
+  });
+  if (dry.state !== "already_pruned") fail(`completed Stage automation cycle did not revalidate as already_pruned: ${dry.state}`);
+  assertRecoveryManifestMatches(
+    durable.manifest,
+    buildRecoveryManifest(row, identity, dry.evidence, { target: "stage" }),
+  );
+  return { durable, dry };
+}
+
+async function refreshRow(pruneStore, objectPath) {
+  const row = await pruneStore.getManifest(objectPath);
+  if (!row || row.source_policy_id !== STAGE_AUTOMATION_POLICY_ID) fail("Stage automation manifest policy mismatch");
+  return row;
+}
+
+async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
+  assertDurableRecoveryReady(durable);
+  const recoveryDir = path.join(tempRoot, "recovery");
+  restoreLocalRecovery(recoveryDir, durable);
+  const result = await runPruneStep({
+    row,
+    mode: "execute",
+    env,
+    cwd: tempRoot,
+    sql,
+    pruneStore,
+    storageTarget,
+    verifyBucket,
+    recoveryDir,
+    downloadArchive: async () => ({ bytes: durable.archiveBytes, downloadMs: 0 }),
+  });
+  if (result.state !== "pruned" && result.state !== "already_pruned") {
+    fail(`unexpected prune state: ${result.state}`);
+  }
+  return result;
+}
+
+async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket }) {
+  const durableBefore = await inspectDurableRecovery(storageTarget, row);
+  assertResumeRecoveryState(row, durableBefore);
+  if (!row.archive_proof_verified_at) {
+    await runPruneStep({ row, mode: "register-proof", env, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, downloadArchive: durableBefore ? async () => ({ bytes: durableBefore.archiveBytes, downloadMs: 0 }) : null });
+    row = await refreshRow(pruneStore, row.object_path);
+  }
+  const dry = await runPruneStep({
+    row,
+    mode: "dry-run",
+    env,
+    cwd: tempRoot,
+    sql,
+    pruneStore,
+    storageTarget,
+    verifyBucket,
+    downloadArchive: durableBefore ? async () => ({ bytes: durableBefore.archiveBytes, downloadMs: 0 }) : null,
+  });
+  if (durableBefore) {
+    assertRecoveryManifestMatches(
+      durableBefore.manifest,
+      buildRecoveryManifest(row, identity, dry.evidence, { target: "stage" }),
+    );
+  }
+  if (dry.state === "already_pruned") {
+    return executeVerifiedCycle({ row, identity, durable: durableBefore, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+  }
+  if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
+  let durable = durableBefore;
+  if (!durable) {
+    const main = await downloadPrivateArchiveObject(storageTarget, row.object_path);
+    durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes);
+  }
+  return executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+}
+
+export async function runStageAutomation({ env = process.env, now = new Date(), deps = {} } = {}) {
+  const config = validateStageEnvironment(env);
+  const moduleEnv = config.moduleEnv;
+  const sql = deps.sql || postgres(config.dbUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 10,
+    idle_timeout: 0,
+  });
+  const tempRoot = deps.tempRoot || fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-automation-"));
+  ensurePrivateDirectory(tempRoot);
+  const storageTarget = deps.storageTarget || resolveStorageTarget("stage", moduleEnv, { singleTarget: true });
+  const pruneStore = deps.pruneStore || createPruneStore(sql);
+  const verifyBucket = deps.verifyBucket || ((target) => verifyArchiveBucket(target, deps));
+  let locked = false;
+  try {
+    locked = await acquireAdvisoryLock(sql);
+    if (!locked) {
+      const result = { state: "no-op", reason: "advisory_lock_busy" };
+      writeAggregateSummary(result);
+      return result;
+    }
+    const identity = await assertIdentity(sql);
+    await verifyBucket(storageTarget);
+    const ownRows = await loadOwnBatches(sql);
+    const ownCycle = findOwnCycle(ownRows);
+    if (ownCycle.active) {
+      const result = await resumeOwnCycle({ row: await refreshRow(pruneStore, ownCycle.active.object_path), identity, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+      const output = {
+        state: result.state,
+        mode: "resume",
+        transactions: result.evidence.transactionCount,
+        entries: result.evidence.entryCount,
+        txTypes: result.evidence.txTypes,
+        amounts: { credits: result.evidence.credits, debits: result.evidence.debits, net: result.evidence.net },
+        compressedSha256: ownCycle.active.compressed_sha256,
+      };
+      writeAggregateSummary(output);
+      return output;
+    }
+    if (ownCycle.latestCompleted) {
+      await verifyCompletedCycle({
+        row: await refreshRow(pruneStore, ownCycle.latestCompleted.object_path),
+        identity,
+        env: moduleEnv,
+        tempRoot,
+        sql,
+        pruneStore,
+        storageTarget,
+        verifyBucket,
+      });
+    }
+
+    const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
+    const manifestPath = path.join(tempRoot, "archive.manifest.json");
+    const exported = await runExport({
+      argv: [
+        "--target", "stage",
+        "--cutoff-days", String(STAGE_RETENTION_DAYS),
+        "--batch-size", String(STAGE_MAX_BATCH_SIZE),
+        "--output", artifactPath,
+        "--manifest", manifestPath,
+      ],
+      env: moduleEnv,
+      cwd: tempRoot,
+      now,
+      deps: {
+        sql,
+        selector: "prunable",
+        sourcePolicyId: STAGE_AUTOMATION_POLICY_ID,
+        targetOptions: { singleTarget: true },
+        noCandidateIfEmpty: true,
+        emit: false,
+      },
+    });
+    if (exported.noCandidate) {
+      const result = { state: "no-op", reason: "no_eligible_candidate" };
+      writeAggregateSummary(result);
+      return result;
+    }
+    await ensureArchiveBucket(storageTarget, deps);
+    const stored = await storeArchive({
+      argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+      env: moduleEnv,
+      cwd: tempRoot,
+      deps: { sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
+    });
+    let row = await refreshRow(pruneStore, stored.objectPath);
+    await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    row = await refreshRow(pruneStore, row.object_path);
+    const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
+    const main = await downloadPrivateArchiveObject(storageTarget, row.object_path, deps);
+    const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
+    const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket });
+    const output = {
+      state: executed.state,
+      mode: "new",
+      transactions: executed.evidence.transactionCount,
+      entries: executed.evidence.entryCount,
+      txTypes: executed.evidence.txTypes,
+      amounts: { credits: executed.evidence.credits, debits: executed.evidence.debits, net: executed.evidence.net },
+      rawBytes: exported.bytes?.raw || null,
+      compressedBytes: row.compressed_bytes,
+      compressedSha256: row.compressed_sha256,
+      recoveryArchiveSha256: durable.recoveryArchive.sha256,
+      recoveryManifestSha256: durable.recoveryManifest.sha256,
+      proof: executed.state === "pruned" ? "verified" : null,
+      receipt: executed.state,
+      mappings: executed.evidence.transactionCount,
+    };
+    writeAggregateSummary(output);
+    return output;
+  } catch (error) {
+    const result = { state: "error", reason: redactedError(error) };
+    writeAggregateSummary(result);
+    throw error;
+  } finally {
+    if (locked) {
+      try {
+        await releaseAdvisoryLock(sql);
+      } catch {
+        // The session ending releases the lock; do not retry a failed unlock.
+      }
+    }
+    if (!deps.sql) await sql.end({ timeout: 5 });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  if (process.argv.slice(2).length !== 0) {
+    process.stderr.write("chips-ledger-stage-automation accepts no command-line options\n");
+    process.exitCode = 1;
+  } else {
+    runStageAutomation().catch(() => {
+      process.exitCode = 1;
+    });
+  }
+}

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -51,6 +51,8 @@ run("node", ["tests/chips-ledger-pagination.behavior.test.mjs"], "chips-ledger-p
 run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-archive-export");
 run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger-archive-storage");
 run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
+run("node", ["tests/chips/chips-ledger-stage-automation.test.mjs"], "chips-ledger-stage-automation");
+run("node", ["tests/chips/chips-ledger-stage-automation.workflow.guard.test.mjs"], "chips-ledger-stage-automation-workflow");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/bonus-campaigns-endpoint.behavior.test.mjs"], "bonus-campaigns-endpoint-behavior");
 run("node", ["tests/bonus-campaigns-scheduler.behavior.test.mjs"], "bonus-campaigns-scheduler-behavior");

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -51,7 +51,9 @@ run("node", ["tests/chips-ledger-pagination.behavior.test.mjs"], "chips-ledger-p
 run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-archive-export");
 run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger-archive-storage");
 run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
+run("node", ["tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs"], "chips-ledger-prunable-candidate-sql");
 run("node", ["tests/chips/chips-ledger-stage-automation.test.mjs"], "chips-ledger-stage-automation");
+run("node", ["tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs"], "chips-ledger-stage-automation-order");
 run("node", ["tests/chips/chips-ledger-stage-automation.workflow.guard.test.mjs"], "chips-ledger-stage-automation-workflow");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");
 run("node", ["tests/bonus-campaigns-endpoint.behavior.test.mjs"], "bonus-campaigns-endpoint-behavior");

--- a/supabase/migrations/20260813120000_chips_ledger_stage_automation.sql
+++ b/supabase/migrations/20260813120000_chips_ledger_stage_automation.sql
@@ -1,0 +1,80 @@
+begin;
+
+alter table public.chips_ledger_archive_batches
+  add column source_policy_id text;
+
+alter table public.chips_ledger_archive_batches
+  add constraint chips_ledger_archive_batches_source_policy_check
+  check (
+    source_policy_id is null
+    or source_policy_id = 'stage-ledger-auto-retention-30d-v1'
+  );
+
+create index chips_ledger_archive_batches_stage_automation_idx
+  on public.chips_ledger_archive_batches (project_ref, source_policy_id, status, pruned_at, created_at)
+  where source_policy_id = 'stage-ledger-auto-retention-30d-v1';
+
+create or replace function public.chips_guard_archive_source_policy_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'UPDATE'
+     and new.source_policy_id is distinct from old.source_policy_id then
+    raise exception 'Archive source policy is immutable';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger chips_ledger_archive_source_policy_guard
+before update on public.chips_ledger_archive_batches
+for each row execute function public.chips_guard_archive_source_policy_mutations();
+
+revoke all on function public.chips_guard_archive_source_policy_mutations()
+  from public, anon, authenticated, service_role;
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_catalog.pg_attribute
+     where attrelid = 'public.chips_ledger_archive_batches'::pg_catalog.regclass
+       and attname = 'source_policy_id'
+       and not attisdropped
+  ) then
+    raise exception 'Stage automation policy column is missing';
+  end if;
+
+  if not exists (
+    select 1
+      from pg_catalog.pg_trigger
+     where tgrelid = 'public.chips_ledger_archive_batches'::pg_catalog.regclass
+       and tgname = 'chips_ledger_archive_source_policy_guard'
+       and not tgisinternal
+  ) then
+    raise exception 'Stage automation policy immutability trigger is missing';
+  end if;
+
+  if pg_catalog.has_function_privilege(
+       'anon',
+       'public.chips_guard_archive_source_policy_mutations()',
+       'execute'
+     )
+     or pg_catalog.has_function_privilege(
+       'authenticated',
+       'public.chips_guard_archive_source_policy_mutations()',
+       'execute'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role',
+       'public.chips_guard_archive_source_policy_mutations()',
+       'execute'
+     ) then
+    raise exception 'Stage automation policy guard is executable by an API role';
+  end if;
+end;
+$$;
+
+commit;

--- a/tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs
+++ b/tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { PGlite } from "@electric-sql/pglite";
+import { PRUNABLE_CANDIDATE_SQL } from "../../scripts/ops/chips-ledger-archive-export.mjs";
+
+const CUTOFF = "2026-08-13T00:00:00.000000Z";
+const PAYLOAD_HASH = "a".repeat(64);
+const USER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function uuid(number) {
+  return `00000000-0000-4000-8000-${String(number).padStart(12, "0")}`;
+}
+
+async function createFixture() {
+  const db = new PGlite();
+  await db.exec(`
+    create table public.chips_transactions (
+      id uuid primary key,
+      sequence bigint not null,
+      tx_type text not null,
+      idempotency_key text not null,
+      payload_hash text not null,
+      user_id uuid,
+      reference text,
+      description text,
+      metadata jsonb not null default '{}'::jsonb,
+      created_by uuid,
+      created_at timestamptz not null
+    );
+    create table public.chips_accounts (
+      id uuid primary key,
+      user_id uuid,
+      system_key text,
+      account_type text not null,
+      status text not null,
+      balance bigint not null
+    );
+    create table public.chips_entries (
+      id bigint primary key,
+      transaction_id uuid not null references public.chips_transactions(id),
+      account_id uuid not null references public.chips_accounts(id),
+      entry_seq bigint not null,
+      amount bigint not null,
+      metadata jsonb not null default '{}'::jsonb,
+      created_at timestamptz not null
+    );
+    create table public.chips_transaction_idempotency (
+      idempotency_key text primary key,
+      transaction_id uuid not null,
+      payload_hash text not null,
+      tx_type text not null,
+      user_id uuid,
+      transaction_created_at timestamptz not null,
+      archive_batch_id text
+    );
+    create table public.poker_tables (
+      id uuid primary key,
+      status text not null
+    );
+  `);
+  return db;
+}
+
+async function insertCandidate(db, {
+  number,
+  txType = "TABLE_BUY_IN",
+  createdAt,
+  tableId = uuid(number + 1000),
+  tableStatus = "CLOSED",
+  escrowStatus = "active",
+  escrowBalance = 0,
+  userId = null,
+  marker = "metadata",
+  registry = "valid",
+  entries = "valid",
+  direction = "valid",
+}) {
+  const transactionId = uuid(number);
+  const idempotencyKey = `fixture-${number}`;
+  const systemAccountId = uuid(number + 10000);
+  const escrowAccountId = uuid(number + 20000);
+  const userAccountId = uuid(number + 30000);
+  const systemAmount = txType === "TABLE_BUY_IN" ? -10 : 10;
+  const escrowAmount = -systemAmount;
+  const effectiveSystemAmount = direction === "wrong" ? -systemAmount : systemAmount;
+  const effectiveEscrowAmount = direction === "wrong" ? -escrowAmount : escrowAmount;
+  const metadata = marker === "missing"
+    ? {}
+    : marker === "invalid"
+      ? { tableId: "not-a-uuid" }
+      : { tableId };
+  const reference = marker === "ambiguous" ? `table:${uuid(number + 40000)}` : null;
+
+  await db.query("insert into public.poker_tables (id, status) values ($1, $2)", [tableId, tableStatus]);
+  await db.query(
+    `insert into public.chips_accounts (id, user_id, system_key, account_type, status, balance)
+     values ($1, null, $2, 'SYSTEM', 'active', 0),
+            ($3, null, $4, 'ESCROW', $5, $6)`,
+    [systemAccountId, `SYSTEM_FIXTURE:${number}`, escrowAccountId, `POKER_TABLE:${tableId}`, escrowStatus, escrowBalance],
+  );
+  if (entries === "user") {
+    await db.query(
+      `insert into public.chips_accounts (id, user_id, system_key, account_type, status, balance)
+       values ($1, $2, null, 'USER', 'active', 0)`,
+      [userAccountId, USER_ID],
+    );
+  }
+  await db.query(
+    `insert into public.chips_transactions
+      (id, sequence, tx_type, idempotency_key, payload_hash, user_id, reference, metadata, created_at)
+     values ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)`,
+    [transactionId, number, txType, idempotencyKey, PAYLOAD_HASH, userId, reference, JSON.stringify(metadata), createdAt],
+  );
+
+  const entryRows = entries === "missing"
+    ? [[systemAccountId, effectiveSystemAmount]]
+    : entries === "conservation"
+      ? [[systemAccountId, effectiveSystemAmount], [escrowAccountId, effectiveEscrowAmount - 1]]
+      : entries === "user"
+        ? [[systemAccountId, effectiveSystemAmount], [escrowAccountId, effectiveEscrowAmount], [userAccountId, 1]]
+        : [[systemAccountId, effectiveSystemAmount], [escrowAccountId, effectiveEscrowAmount]];
+  for (const [index, [accountId, amount]] of entryRows.entries()) {
+    await db.query(
+      `insert into public.chips_entries
+        (id, transaction_id, account_id, entry_seq, amount, created_at)
+       values ($1, $2, $3, $4, $5, $6)`,
+      [number * 10 + index + 1, transactionId, accountId, index + 1, amount, createdAt],
+    );
+  }
+
+  if (registry !== "missing") {
+    await db.query(
+      `insert into public.chips_transaction_idempotency
+        (idempotency_key, transaction_id, payload_hash, tx_type, user_id, transaction_created_at, archive_batch_id)
+       values ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        idempotencyKey,
+        transactionId,
+        registry === "mismatched" ? "b".repeat(64) : PAYLOAD_HASH,
+        txType,
+        userId,
+        createdAt,
+        registry === "assigned" ? "batch-fixture" : null,
+      ],
+    );
+  }
+  return transactionId;
+}
+
+async function select(db, options = {}) {
+  const result = await db.query(PRUNABLE_CANDIDATE_SQL, [
+    options.cutoff || CUTOFF,
+    options.limit || 5000,
+    options.cursorCreatedAt || null,
+    options.cursorId || null,
+  ]);
+  return result.rows;
+}
+
+const db = await createFixture();
+try {
+  const validBuyIn = await insertCandidate(db, {
+    number: 1,
+    createdAt: "2026-08-01T00:00:00.000000Z",
+  });
+  const validCashOut = await insertCandidate(db, {
+    number: 2,
+    txType: "TABLE_CASH_OUT",
+    createdAt: "2026-08-02T00:00:00.000000Z",
+  });
+  const sameTimestampLow = await insertCandidate(db, {
+    number: 3,
+    createdAt: "2026-08-03T00:00:00.000000Z",
+  });
+  const sameTimestampHigh = await insertCandidate(db, {
+    number: 4,
+    createdAt: "2026-08-03T00:00:00.000000Z",
+  });
+
+  const rejected = [
+    ["USER transaction", { number: 10, txType: "USER", userId: USER_ID, createdAt: "2026-08-04T00:00:00.000000Z" }],
+    ["technical transaction with user_id", { number: 11, userId: USER_ID, createdAt: "2026-08-04T00:00:01.000000Z" }],
+    ["mismatched registry", { number: 12, registry: "mismatched", createdAt: "2026-08-05T00:00:00.000000Z" }],
+    ["missing registry", { number: 13, registry: "missing", createdAt: "2026-08-05T00:00:01.000000Z" }],
+    ["assigned registry", { number: 14, registry: "assigned", createdAt: "2026-08-06T00:00:00.000000Z" }],
+    ["ambiguous marker", { number: 15, marker: "ambiguous", createdAt: "2026-08-07T00:00:00.000000Z" }],
+    ["invalid marker", { number: 16, marker: "invalid", createdAt: "2026-08-08T00:00:00.000000Z" }],
+    ["open table", { number: 17, tableStatus: "OPEN", createdAt: "2026-08-09T00:00:00.000000Z" }],
+    ["inactive escrow", { number: 18, escrowStatus: "frozen", createdAt: "2026-08-10T00:00:00.000000Z" }],
+    ["non-zero escrow", { number: 19, escrowBalance: 1, createdAt: "2026-08-10T00:00:01.000000Z" }],
+    ["invalid entries", { number: 20, entries: "missing", createdAt: "2026-08-11T00:00:00.000000Z" }],
+    ["USER entry", { number: 21, entries: "user", createdAt: "2026-08-11T00:00:01.000000Z" }],
+    ["non-conserved entries", { number: 22, entries: "conservation", createdAt: "2026-08-12T00:00:00.000000Z" }],
+    ["wrong buy-in direction", { number: 23, direction: "wrong", createdAt: "2026-08-12T00:00:01.000000Z" }],
+    ["wrong cash-out direction", { number: 24, txType: "TABLE_CASH_OUT", direction: "wrong", createdAt: "2026-08-12T00:00:02.000000Z" }],
+  ];
+  for (const [, fixture] of rejected) await insertCandidate(db, fixture);
+
+  const rows = await select(db);
+  assert.deepEqual(rows.map((row) => row.id), [validBuyIn, validCashOut, sameTimestampLow, sameTimestampHigh]);
+  assert.deepEqual(rows.map((row) => row.tx_type), ["TABLE_BUY_IN", "TABLE_CASH_OUT", "TABLE_BUY_IN", "TABLE_BUY_IN"]);
+
+  const limited = await select(db, { limit: 2 });
+  assert.deepEqual(limited.map((row) => row.id), [validBuyIn, validCashOut]);
+
+  const afterTieLow = await select(db, {
+    cursorCreatedAt: "2026-08-03T00:00:00.000000Z",
+    cursorId: sameTimestampLow,
+  });
+  assert.deepEqual(afterTieLow.map((row) => row.id), [sameTimestampHigh]);
+} finally {
+  await db.close();
+}
+
+process.stdout.write("chips-ledger-prunable-candidate-sql behavior passed\n");

--- a/tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  runStageAutomation,
+  STAGE_PROJECT_REF,
+  STAGE_SYSTEM_IDENTIFIER,
+} from "../../scripts/ops/chips-ledger-stage-automation.mjs";
+import { STAGE_AUTOMATION_POLICY_ID } from "../../scripts/ops/chips-ledger-archive-export.mjs";
+import {
+  ARCHIVE_BUCKET,
+  buildRecoveryArchiveObjectPath,
+  buildRecoveryManifestObjectPath,
+} from "../../scripts/ops/chips-ledger-archive-store.mjs";
+
+const STAGE_URL = "https://krydukthwdvccggbyjfw.supabase.co";
+const ENV = {
+  SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
+  SUPABASE_STAGE_URL: STAGE_URL,
+  SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test-key",
+};
+
+function response(value, status = 200, headers = {}) {
+  if (Buffer.isBuffer(value)) {
+    return new Response(value, { status, headers: { "content-type": "application/gzip", ...headers } });
+  }
+  return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json", ...headers } });
+}
+
+function fakeSql() {
+  const calls = [];
+  const sql = {
+    calls,
+    unsafe: async (query, values = []) => {
+      calls.push({ query, values });
+      if (query.includes("pg_try_advisory_lock")) return [{ acquired: true, backend_pid: "stage-order-session" }];
+      if (query.includes("pg_control_system")) return [{ system_identifier: STAGE_SYSTEM_IDENTIFIER }];
+      if (query.includes("pg_backend_pid")) return [{ backend_pid: "stage-order-session" }];
+      if (query.includes("pg_advisory_unlock")) return [{ pg_advisory_unlock: true }];
+      if (query.includes("from public.chips_ledger_archive_batches")) return [];
+      throw new Error(`unexpected SQL: ${query}`);
+    },
+  };
+  return sql;
+}
+
+const archiveBytes = Buffer.from("verified gzip archive copy");
+const compressedSha = crypto.createHash("sha256").update(archiveBytes).digest("hex");
+const evidence = {
+  transactionIdsSha256: "d".repeat(64),
+  entryIdsSha256: "e".repeat(64),
+  transactionCount: 1,
+  entryCount: 2,
+  txTypes: { TABLE_BUY_IN: 1 },
+  credits: "10",
+  debits: "10",
+  net: "0",
+};
+const row = {
+  status: "pending",
+  batch_id: "7",
+  object_path: `v1/sha256/${compressedSha}.jsonl.gz`,
+  project_ref: STAGE_PROJECT_REF,
+  source_policy_id: STAGE_AUTOMATION_POLICY_ID,
+  format_version: 1,
+  cutoff: "2026-08-01T00:00:00.000000Z",
+  cursor_start_created_at: null,
+  cursor_start_id: null,
+  cursor_end_created_at: "2026-07-01T00:00:00.000000Z",
+  cursor_end_id: "00000000-0000-4000-8000-000000000001",
+  first_created_at: "2026-07-01T00:00:00.000000Z",
+  last_created_at: "2026-07-01T00:00:00.000000Z",
+  transaction_count: 1,
+  entry_count: 2,
+  tx_types: { TABLE_BUY_IN: 1 },
+  raw_bytes: 1,
+  compressed_bytes: archiveBytes.length,
+  raw_sha256: "c".repeat(64),
+  compressed_sha256: compressedSha,
+  credits: "10",
+  debits: "10",
+  net_amount: "0",
+};
+
+const events = [];
+const durableObjects = new Map();
+const storageTarget = {
+  target: "stage",
+  projectRef: STAGE_PROJECT_REF,
+  baseUrl: STAGE_URL,
+  serviceKey: "stage-test-key",
+};
+const recoveryPathFromUrl = (url) => {
+  const pathname = new URL(url).pathname;
+  const authenticatedPrefix = `/storage/v1/object/authenticated/${ARCHIVE_BUCKET}/`;
+  const uploadPrefix = `/storage/v1/object/${ARCHIVE_BUCKET}/`;
+  const prefix = pathname.startsWith(authenticatedPrefix) ? authenticatedPrefix : uploadPrefix;
+  return decodeURIComponent(pathname.slice(prefix.length));
+};
+const fetch = async (url, init = {}) => {
+  const method = init.method || "GET";
+  const objectPath = recoveryPathFromUrl(url);
+  if (method === "GET") {
+    events.push({ type: "recovery-download", objectPath, private: new URL(url).pathname.includes("/authenticated/") });
+    const value = durableObjects.get(objectPath);
+    return value ? response(value) : response({ message: "not found" }, 404);
+  }
+  if (method === "POST") {
+    const headers = new Headers(init.headers || {});
+    assert.equal(headers.get("x-upsert"), "false");
+    assert.equal(headers.get("content-type"), "application/gzip");
+    events.push({ type: "recovery-upload", objectPath });
+    durableObjects.set(objectPath, Buffer.from(init.body));
+    return response({ ok: true });
+  }
+  return response({ message: "unexpected method" }, 500);
+};
+
+let rowState = { ...row };
+const pruneModes = [];
+const result = await runStageAutomation({
+  env: ENV,
+  deps: {
+    sql: fakeSql(),
+    fetch,
+    storageTarget,
+    tempRoot: fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-order-")),
+    verifyBucket: async () => events.push({ type: "bucket-verified" }),
+    ensureArchiveBucket: async () => events.push({ type: "bucket-ensured" }),
+    exportArchive: async ({ argv }) => {
+      events.push({ type: "export" });
+      assert.equal(argv.includes("--batch-size"), true);
+      return { bytes: { raw: 1 } };
+    },
+    storeArchive: async () => {
+      events.push({ type: "archive-upload" });
+      return { objectPath: row.object_path };
+    },
+    pruneStore: {
+      getManifest: async () => rowState,
+    },
+    pruneArchive: async ({ argv }) => {
+      const mode = argv.includes("--execute") ? "execute" : argv.includes("--register-proof") ? "register-proof" : "dry-run";
+      pruneModes.push({ mode, argv });
+      events.push({ type: mode });
+      if (mode === "register-proof") {
+        rowState = {
+          ...rowState,
+          status: "committed",
+          archive_proof_verified_at: "2026-08-13T00:01:00.000000Z",
+          archived_transaction_ids_sha256: evidence.transactionIdsSha256,
+          archived_entry_ids_sha256: evidence.entryIdsSha256,
+        };
+        return { state: "proof_registered", evidence };
+      }
+      return { state: mode === "dry-run" ? "ready" : "pruned", evidence };
+    },
+    downloadPrivateArchive: async () => {
+      events.push({ type: "primary-download" });
+      return { bytes: archiveBytes, downloadMs: 0 };
+    },
+  },
+});
+
+assert.equal(result.state, "pruned");
+assert.deepEqual(pruneModes.map(({ mode }) => mode), ["register-proof", "dry-run", "execute"]);
+assert.equal(pruneModes.at(-1).argv.includes("--execute"), true);
+
+const executeIndex = events.findIndex(({ type }) => type === "execute");
+assert.notEqual(executeIndex, -1);
+assert.ok(events.findIndex(({ type }) => type === "primary-download") < executeIndex);
+const recoveryUploads = events.filter(({ type }) => type === "recovery-upload");
+const recoveryDownloads = events.filter(({ type }) => type === "recovery-download");
+const recoveryPaths = [
+  buildRecoveryArchiveObjectPath(compressedSha),
+  buildRecoveryManifestObjectPath(compressedSha),
+];
+assert.equal(recoveryUploads.length, 2);
+assert.deepEqual(recoveryUploads.map(({ objectPath }) => objectPath), recoveryPaths);
+assert.equal(recoveryDownloads.length, 6);
+assert.equal(recoveryDownloads.every(({ private: isPrivate }) => isPrivate), true);
+assert.equal(new Set(recoveryDownloads.map(({ objectPath }) => objectPath)).size, 2);
+for (const objectPath of recoveryPaths) {
+  const uploadIndex = events.findIndex(({ type, objectPath: pathValue }) => type === "recovery-upload" && pathValue === objectPath);
+  const downloadIndexes = events.flatMap((event, index) => event.type === "recovery-download" && event.objectPath === objectPath ? [index] : []);
+  assert.equal(downloadIndexes.length, 3);
+  assert.ok(uploadIndex >= 0);
+  assert.equal(downloadIndexes.some((index) => index > uploadIndex && index < executeIndex), true);
+  assert.equal(downloadIndexes.every((index) => index < executeIndex), true);
+}
+assert.equal(Math.max(...events.map((event, index) => event.type === "recovery-download" ? index : -1)) < executeIndex, true);
+
+process.stdout.write("chips-ledger-stage-automation order behavior passed\n");

--- a/tests/chips/chips-ledger-stage-automation.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.test.mjs
@@ -279,4 +279,61 @@ assert.equal(durable.manifestGzipBytes.length > 0, true);
 assert.equal(durable.recoveryArchive.sha256, compressedSha);
 assert.equal(durable.recoveryManifest.sha256, crypto.createHash("sha256").update(durable.manifestGzipBytes).digest("hex"));
 
+const resumeCycleRow = {
+  ...recoveryRow,
+  status: "committed",
+  committed_at: "2026-08-13T00:00:00.000000Z",
+  archive_proof_verified_at: "2026-08-13T00:01:00.000000Z",
+  archived_transaction_ids_sha256: evidence.transactionIdsSha256,
+  archived_entry_ids_sha256: evidence.entryIdsSha256,
+  pruned_at: null,
+  pruned_transaction_count: null,
+  pruned_entry_count: null,
+  pruned_transaction_ids_sha256: null,
+  pruned_entry_ids_sha256: null,
+};
+const resumeCalls = [];
+const resumeSql = fakeSql({ ownRows: [resumeCycleRow] });
+const resumeResult = await runStageAutomation({
+  env: ENV,
+  deps: {
+    sql: resumeSql,
+    fetch,
+    storageTarget,
+    pruneStore: { getManifest: async () => resumeCycleRow },
+    verifyBucket: async () => {},
+    tempRoot: fs.mkdtempSync("/tmp/chips-ledger-stage-automation-resume-"),
+    pruneArchive: async ({ argv }) => {
+      const mode = argv.includes("--execute") ? "execute" : argv.includes("--register-proof") ? "register-proof" : "dry-run";
+      resumeCalls.push(mode);
+      if (mode === "register-proof") throw new Error("proof must not be re-registered on a proven resume");
+      return { state: "already_pruned", evidence };
+    },
+  },
+});
+assert.equal(resumeResult.state, "already_pruned");
+assert.deepEqual(resumeCalls, ["dry-run", "execute"]);
+
+const noRecoveryCalls = [];
+const noRecoverySql = fakeSql({ ownRows: [resumeCycleRow] });
+await assert.rejects(
+  runStageAutomation({
+    env: ENV,
+    deps: {
+      sql: noRecoverySql,
+      fetch: async () => response({ message: "not found" }, 404),
+      storageTarget,
+      pruneStore: { getManifest: async () => resumeCycleRow },
+      verifyBucket: async () => {},
+      tempRoot: fs.mkdtempSync("/tmp/chips-ledger-stage-automation-no-recovery-"),
+      pruneArchive: async () => {
+        noRecoveryCalls.push(true);
+        return { state: "ready", evidence };
+      },
+    },
+  }),
+  /no durable recovery/,
+);
+assert.equal(noRecoveryCalls.length, 0);
+
 process.stdout.write("chips-ledger-stage-automation tests passed\n");

--- a/tests/chips/chips-ledger-stage-automation.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
+import fs from "node:fs";
 import { readSnapshot, STAGE_AUTOMATION_POLICY_ID } from "../../scripts/ops/chips-ledger-archive-export.mjs";
 import {
   assertDurableRecoveryReady,
@@ -25,19 +26,27 @@ const ENV = {
   SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test-key",
 };
 
+const stageOrchestratorSource = fs.readFileSync("scripts/ops/chips-ledger-stage-automation.mjs", "utf8");
+assert.doesNotMatch(stageOrchestratorSource, /--after-(?:created-at|id)/);
+
 function response(value, status = 200, headers = {}) {
   if (Buffer.isBuffer(value)) return new Response(value, { status, headers: { "content-type": "application/gzip", ...headers } });
   return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json", ...headers } });
 }
 
-function fakeSql({ acquired = true, ownRows = [] } = {}) {
+function fakeSql({ acquired = true, ownRows = [], loseSession = false } = {}) {
   const calls = [];
+  const session = { backendPid: "stage-test-session" };
   const sql = {
     calls,
     typed: (value, type) => ({ value, type }),
     unsafe: async (query, values = []) => {
       calls.push({ query, values });
-      if (query.includes("pg_try_advisory_lock")) return [{ acquired }];
+      if (query.includes("pg_try_advisory_lock")) return [{ acquired, backend_pid: session.backendPid }];
+      if (query.includes("pg_backend_pid")) {
+        if (loseSession) session.backendPid = "lost-stage-session";
+        return [{ backend_pid: session.backendPid }];
+      }
       if (query.includes("pg_advisory_unlock")) return [{ pg_advisory_unlock: true }];
       if (query.includes("pg_control_system")) return [{ system_identifier: STAGE_SYSTEM_IDENTIFIER }];
       if (query.includes("from public.chips_ledger_archive_batches")) return ownRows;
@@ -87,6 +96,20 @@ const noCandidate = await runStageAutomation({
 assert.equal(noCandidate.state, "no-op");
 assert.equal(noCandidate.reason, "no_eligible_candidate");
 assert.equal(noCandidateSql.calls.some(({ query }) => query.includes("pg_try_advisory_lock")), true);
+
+const lostSessionSql = fakeSql({ loseSession: true });
+await assert.rejects(
+  runStageAutomation({
+    env: ENV,
+    deps: {
+      sql: lostSessionSql,
+      storageTarget: { target: "stage", projectRef: STAGE_PROJECT_REF, baseUrl: STAGE_URL, serviceKey: "stage-test-key" },
+      pruneStore: {},
+      verifyBucket: async () => { throw new Error("bucket must not be queried after lock loss"); },
+    },
+  }),
+  /advisory lock session was lost/,
+);
 
 const selectorQueries = [];
 const selectorSql = {
@@ -253,5 +276,7 @@ assert.equal(durableObjects.has(buildRecoveryManifestObjectPath(compressedSha)),
 assert.equal(storageCalls.filter(({ method }) => method === "POST").length, 2);
 assert.equal(storageCalls.filter(({ method }) => method === "GET").length >= 6, true);
 assert.equal(durable.manifestGzipBytes.length > 0, true);
+assert.equal(durable.recoveryArchive.sha256, compressedSha);
+assert.equal(durable.recoveryManifest.sha256, crypto.createHash("sha256").update(durable.manifestGzipBytes).digest("hex"));
 
 process.stdout.write("chips-ledger-stage-automation tests passed\n");

--- a/tests/chips/chips-ledger-stage-automation.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { readSnapshot, STAGE_AUTOMATION_POLICY_ID } from "../../scripts/ops/chips-ledger-archive-export.mjs";
+import {
+  assertDurableRecoveryReady,
+  assertResumeRecoveryState,
+  findOwnCycle,
+  persistDurableRecovery,
+  runStageAutomation,
+  STAGE_PROJECT_REF,
+  STAGE_SYSTEM_IDENTIFIER,
+  validateStageEnvironment,
+} from "../../scripts/ops/chips-ledger-stage-automation.mjs";
+import {
+  ARCHIVE_BUCKET,
+  buildRecoveryArchiveObjectPath,
+  buildRecoveryManifestObjectPath,
+} from "../../scripts/ops/chips-ledger-archive-store.mjs";
+
+const STAGE_DB_URL = "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres";
+const STAGE_URL = "https://krydukthwdvccggbyjfw.supabase.co";
+const ENV = {
+  SUPABASE_STAGE_DB_URL: STAGE_DB_URL,
+  SUPABASE_STAGE_URL: STAGE_URL,
+  SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test-key",
+};
+
+function response(value, status = 200, headers = {}) {
+  if (Buffer.isBuffer(value)) return new Response(value, { status, headers: { "content-type": "application/gzip", ...headers } });
+  return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json", ...headers } });
+}
+
+function fakeSql({ acquired = true, ownRows = [] } = {}) {
+  const calls = [];
+  const sql = {
+    calls,
+    typed: (value, type) => ({ value, type }),
+    unsafe: async (query, values = []) => {
+      calls.push({ query, values });
+      if (query.includes("pg_try_advisory_lock")) return [{ acquired }];
+      if (query.includes("pg_advisory_unlock")) return [{ pg_advisory_unlock: true }];
+      if (query.includes("pg_control_system")) return [{ system_identifier: STAGE_SYSTEM_IDENTIFIER }];
+      if (query.includes("from public.chips_ledger_archive_batches")) return ownRows;
+      throw new Error(`unexpected SQL: ${query}`);
+    },
+    begin: async (callback) => callback({
+      unsafe: async (query, values = []) => {
+        calls.push({ query, values });
+        if (query.startsWith("set transaction")) return [];
+        return [];
+      },
+    }),
+  };
+  return sql;
+}
+
+assert.throws(
+  () => validateStageEnvironment({ ...ENV, SUPABASE_PROD_DB_URL: "forbidden" }),
+  /Production credentials are not accepted/,
+);
+
+const busySql = fakeSql({ acquired: false });
+const busy = await runStageAutomation({
+  env: ENV,
+  deps: {
+    sql: busySql,
+    storageTarget: { target: "stage", projectRef: STAGE_PROJECT_REF, baseUrl: STAGE_URL, serviceKey: "stage-test-key" },
+    pruneStore: {},
+    verifyBucket: async () => { throw new Error("bucket must not be queried while lock is busy"); },
+  },
+});
+assert.equal(busy.state, "no-op");
+assert.equal(busy.reason, "advisory_lock_busy");
+assert.equal(busySql.calls.filter(({ query }) => query.includes("pg_control_system")).length, 0);
+
+const noCandidateSql = fakeSql();
+const noCandidate = await runStageAutomation({
+  env: ENV,
+  deps: {
+    sql: noCandidateSql,
+    storageTarget: { target: "stage", projectRef: STAGE_PROJECT_REF, baseUrl: STAGE_URL, serviceKey: "stage-test-key" },
+    pruneStore: {},
+    verifyBucket: async () => {},
+    tempRoot: "/tmp/chips-ledger-stage-automation-test-noop",
+  },
+});
+assert.equal(noCandidate.state, "no-op");
+assert.equal(noCandidate.reason, "no_eligible_candidate");
+assert.equal(noCandidateSql.calls.some(({ query }) => query.includes("pg_try_advisory_lock")), true);
+
+const selectorQueries = [];
+const selectorSql = {
+  typed: (value, type) => ({ value, type }),
+  begin: async (callback) => callback({
+    unsafe: async (query, values = []) => {
+      selectorQueries.push({ query, values });
+      if (query.startsWith("set transaction")) return [];
+      if (query.includes("archive_batch_id is null")) return [{
+        id: "00000000-0000-4000-8000-000000000001",
+        tx_type: "TABLE_BUY_IN",
+      }];
+      return [];
+    },
+  }),
+};
+const selected = await readSnapshot(selectorSql, {
+  selector: "prunable",
+  cutoff: "2026-08-13T00:00:00.000000Z",
+  batchSize: 5000,
+  cursor: null,
+});
+const selectorPage = selectorQueries.find(({ values }) => values.length === 4);
+assert.match(selectorPage.query, /TABLE_BUY_IN/);
+assert.match(selectorPage.query, /TABLE_CASH_OUT/);
+assert.match(selectorPage.query, /c\.tx_type::text in \('TABLE_BUY_IN', 'TABLE_CASH_OUT'\)/);
+assert.match(selectorPage.query, /c\.user_id is null/);
+assert.match(selectorPage.query, /upper\(p\.status::text\) = 'CLOSED'/);
+assert.match(selectorPage.query, /ea\.status::text = 'active'/);
+assert.match(selectorPage.query, /ea\.balance = 0/);
+assert.match(selectorPage.query, /archive_batch_id is null/);
+assert.match(selectorPage.query, /not exists \(/);
+assert.match(selectorPage.query, /accounts\.system_key = 'POKER_TABLE:'/);
+assert.match(selectorPage.query, /accounts\.account_type::text = 'SYSTEM'/);
+assert.match(selectorPage.query, /count\(\*\) = 2/);
+assert.match(selectorPage.query, /count\(\*\) filter \(where accounts\.account_type::text = 'USER'\) = 0/);
+assert.match(selectorPage.query, /sum\(entries\.amount\) = 0/);
+assert.match(selectorPage.query, /order by e\.created_at asc, e\.id asc/);
+assert.match(selectorPage.query, /\$3::timestamptz is null/);
+assert.deepEqual(selectorPage.values, [
+  { value: "2026-08-13T00:00:00.000000Z", type: 25 },
+  5000,
+  null,
+  null,
+]);
+assert.equal(selected.candidates.length, 1);
+
+const completedRow = {
+  status: "committed",
+  source_policy_id: STAGE_AUTOMATION_POLICY_ID,
+  pruned_at: "2026-08-13T00:00:00Z",
+  pruned_transaction_count: "1",
+  pruned_entry_count: "2",
+  pruned_transaction_ids_sha256: "a".repeat(64),
+  pruned_entry_ids_sha256: "b".repeat(64),
+  archive_proof_verified_at: "2026-08-13T00:00:00Z",
+  archived_transaction_ids_sha256: "a".repeat(64),
+  archived_entry_ids_sha256: "b".repeat(64),
+};
+assert.equal(findOwnCycle([]).active, null);
+assert.equal(findOwnCycle([completedRow]).latestCompleted, completedRow);
+const resumableRow = {
+  ...completedRow,
+  pruned_at: null,
+  pruned_transaction_count: null,
+  pruned_entry_count: null,
+  pruned_transaction_ids_sha256: null,
+  pruned_entry_ids_sha256: null,
+};
+assert.equal(findOwnCycle([resumableRow]).active, resumableRow);
+assert.throws(
+  () => findOwnCycle([resumableRow, { ...resumableRow }]),
+  /multiple incomplete/,
+);
+assert.throws(
+  () => findOwnCycle([{ ...completedRow, pruned_entry_ids_sha256: null }]),
+  /receipt is partial/,
+);
+assert.throws(() => findOwnCycle([{ ...completedRow, status: "pending" }]), /pending/);
+assert.throws(() => assertDurableRecoveryReady({ archiveBytes: Buffer.from("archive") }), /both durable recovery copies/);
+assert.throws(
+  () => assertResumeRecoveryState({ archive_proof_verified_at: "now", pruned_at: null }, null),
+  /no durable recovery/,
+);
+assert.throws(
+  () => assertResumeRecoveryState({ archive_proof_verified_at: null, pruned_at: null }, { archiveBytes: Buffer.from("x") }),
+  /without an immutable proof/,
+);
+assert.equal(assertResumeRecoveryState({ archive_proof_verified_at: "now", pruned_at: null }, { archiveBytes: Buffer.from("x") }), true);
+assert.equal(assertResumeRecoveryState({ archive_proof_verified_at: "now", pruned_at: "now" }, { archiveBytes: Buffer.from("x") }), true);
+
+const archiveBytes = Buffer.from("verified gzip archive copy");
+const compressedSha = crypto.createHash("sha256").update(archiveBytes).digest("hex");
+const recoveryRow = {
+  object_path: `v1/sha256/${compressedSha}.jsonl.gz`,
+  batch_id: "7",
+  project_ref: STAGE_PROJECT_REF,
+  source_policy_id: STAGE_AUTOMATION_POLICY_ID,
+  format_version: 1,
+  cutoff: "2026-08-01T00:00:00.000000Z",
+  cursor_start_created_at: null,
+  cursor_start_id: null,
+  cursor_end_created_at: "2026-07-01T00:00:00.000000Z",
+  cursor_end_id: "00000000-0000-4000-8000-000000000001",
+  first_created_at: "2026-07-01T00:00:00.000000Z",
+  last_created_at: "2026-07-01T00:00:00.000000Z",
+  transaction_count: 1,
+  entry_count: 2,
+  tx_types: { TABLE_BUY_IN: 1 },
+  raw_bytes: 1,
+  compressed_bytes: archiveBytes.length,
+  raw_sha256: "c".repeat(64),
+  compressed_sha256: compressedSha,
+  credits: "10",
+  debits: "10",
+  net_amount: "0",
+};
+const evidence = {
+  transactionIdsSha256: "d".repeat(64),
+  entryIdsSha256: "e".repeat(64),
+  transactionCount: 1,
+  entryCount: 2,
+  txTypes: { TABLE_BUY_IN: 1 },
+  credits: "10",
+  debits: "10",
+  net: "0",
+};
+const durableObjects = new Map();
+const storageCalls = [];
+const storageTarget = {
+  target: "stage",
+  projectRef: STAGE_PROJECT_REF,
+  baseUrl: STAGE_URL,
+  serviceKey: "stage-test-key",
+};
+const fetch = async (url, init = {}) => {
+  const requestUrl = new URL(url);
+  const objectPath = decodeURIComponent(requestUrl.pathname.split(`/storage/v1/object/authenticated/${ARCHIVE_BUCKET}/`)[1] || requestUrl.pathname.split(`/storage/v1/object/${ARCHIVE_BUCKET}/`)[1] || "");
+  const method = init.method || "GET";
+  storageCalls.push({ method, objectPath, headers: new Headers(init.headers || {}) });
+  if (method === "GET") {
+    const value = durableObjects.get(objectPath);
+    return value ? response(value) : response({ message: "not found" }, 404);
+  }
+  if (method === "POST") {
+    assert.equal(new Headers(init.headers).get("x-upsert"), "false");
+    assert.equal(new Headers(init.headers).get("content-type"), "application/gzip");
+    durableObjects.set(objectPath, Buffer.from(init.body));
+    return response({ ok: true });
+  }
+  return response({ message: "unexpected" }, 500);
+};
+const durable = await persistDurableRecovery(
+  storageTarget,
+  recoveryRow,
+  STAGE_SYSTEM_IDENTIFIER,
+  evidence,
+  archiveBytes,
+  { fetch },
+);
+assert.equal(durable.archiveBytes.equals(archiveBytes), true);
+assert.equal(durableObjects.has(buildRecoveryArchiveObjectPath(compressedSha)), true);
+assert.equal(durableObjects.has(buildRecoveryManifestObjectPath(compressedSha)), true);
+assert.equal(storageCalls.filter(({ method }) => method === "POST").length, 2);
+assert.equal(storageCalls.filter(({ method }) => method === "GET").length >= 6, true);
+assert.equal(durable.manifestGzipBytes.length > 0, true);
+
+process.stdout.write("chips-ledger-stage-automation tests passed\n");

--- a/tests/chips/chips-ledger-stage-automation.workflow.guard.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.workflow.guard.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/chips-ledger-stage-automation.yml", "utf8");
+
+assert.match(workflow, /workflow_dispatch:/);
+assert.equal((workflow.match(/- cron:/g) || []).length, 1);
+assert.match(workflow, /cancel-in-progress:\s*false/);
+assert.match(workflow, /CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED == '1'/);
+assert.match(workflow, /SUPABASE_STAGE_DB_URL: \$\{\{ secrets\.SUPABASE_STAGE_DB_URL \}\}/);
+assert.match(workflow, /SUPABASE_STAGE_URL: \$\{\{ secrets\.SUPABASE_STAGE_URL \}\}/);
+assert.match(workflow, /SUPABASE_STAGE_SERVICE_ROLE_KEY: \$\{\{ secrets\.SUPABASE_STAGE_SERVICE_ROLE_KEY \}\}/);
+assert.doesNotMatch(workflow, /SUPABASE_PROD_|PRODUCTION|--target/);
+assert.match(workflow, /node scripts\/ops\/chips-ledger-stage-automation\.mjs/);
+
+process.stdout.write("chips-ledger-stage-automation workflow guard passed\n");


### PR DESCRIPTION
Relates to #886 and closed #874.

## Scope

Adds a Stage-only daily/manual automation path built on the existing exporter, Storage store, proof, dry-run and pruner. Production automation remains unreachable:

- the orchestrator accepts no CLI options and hardcodes Stage project ref `krydukthwdvccggbyjfw` and PostgreSQL system identifier `7656985631720456337`;
- the workflow passes only Stage credentials, has no Production secrets or target, and is disabled by default behind `vars.CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED == '1'`;
- one daily schedule plus `workflow_dispatch`, GitHub concurrency with `cancel-in-progress: false`, and a target-specific PostgreSQL session advisory lock.

## Safety contract

- One cycle selects the oldest currently eligible technical rows from the beginning of `(created_at,id)`; historical manual manifests without `source_policy_id` do not control selection.
- A dedicated prunable-only selector writes exactly the technical candidate set into JSONL; the existing manual exporter selector is unchanged.
- At most one batch of 5,000 transactions is attempted per run; no backlog-draining loop. Empty selection is a no-op.
- Pending, partial, mismatched and ambiguous owned state is fail-closed. Completed/proven/pruned state is resumed only after identity, policy, archive, durable recovery, proof, receipt and mapping revalidation.
- Before execute, the private bucket receives two deterministic no-overwrite (`x-upsert=false`) gzip objects: a full second archive copy and a gzip recovery manifest. Both are privately downloaded and byte/SHA verified; execute cannot proceed without both. Restore does not require the primary archive object.
- Existing pruner validation and row locks/retry policy remain authoritative; no scheduler, Production credentials, runtime/UI path or second archive system is introduced.

## Migration

Adds the nullable, immutable `source_policy_id` marker and a partial Stage automation index/guard without changing existing manual batches.

## Tests

- Stage automation guard/fundamental tests: Production hard-reject, lock/no-op, no-candidate no-op, exact technical selector and null cursor/no-gap behavior, resume/fail-closed state checks, durable two-copy recovery (MIME, no-overwrite, private download and bytes), and recovery readiness.
- Workflow and test-runner registration guards.
- Existing archive exporter/store/pruner tests.
- `npm run syntax`, migration-file validation and full `npm test` pass locally. The full suite required installing the existing `ws-server` workspace dependency; no database or cloud environment was contacted.

Kill switch remains disabled by default. No Stage/Production workflow or batch was run in this change.