### PR TITLE
Issue #886: improve Stage automation error observability

### DIFF
--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -121,7 +121,7 @@ function writeAggregateSummary(result) {
 
 function emitAggregateError(error) {
   try {
-    writeAggregateSummary({ state: "error", reason: redactedError(error) });
+    writeAggregateSummary({ state: "error", reason: error });
   } catch {
     // Preserve the original orchestration error if reporting itself fails.
   }
@@ -622,11 +622,8 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
     if (lockSession && sql) {
       try {
         await releaseAdvisoryLock(sql);
-      } catch (error) {
-        if (!failed) {
-          failed = true;
-          failure = error;
-        }
+      } catch {
+        // Closing an owned client below releases the session-scoped lock; preserve the cycle result.
       }
     }
     if (sql && ownsSql) {

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -60,22 +60,34 @@ function canonicalJson(value) {
   return JSON.stringify(value);
 }
 
-function redactedError(error) {
-  return text(error?.message || error)
-    .replace(/postgres(?:ql)?:\/\/[^\s]+/gi, "[redacted-db-url]")
-    .replace(/Bearer\s+[^\s]+/gi, "Bearer [redacted]")
-    .replace(/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[redacted-token]")
+export function redactedError(error) {
+  const message = text(error?.message || error);
+  return (message || "Stage automation failed")
+    .replace(/postgres(?:ql)?:\/\/[^\s"'`<>]+/gi, "[redacted-db-url]")
+    .replace(/\bBearer\s+[^\s,;)}\]"']+/gi, "Bearer [redacted]")
+    .replace(/\bsb_secret_[a-zA-Z0-9_-]+/gi, "[redacted-supabase-secret]")
+    .replace(/\beyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\b/g, "[redacted-token]")
+    .replace(/\b(?:password|passwd|secret|token|api[_-]?key|service[-_ ]?role[-_ ]?key)\s*[:=]\s*[^\s,;)}\]"']+/gi, "[redacted-secret]")
     .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi, "[redacted-record-id]")
     .replace(/\b(?:entry|transaction|account|table)[-_ ]?\d+\b/gi, "[redacted-record]");
 }
 
-function writeAggregateSummary(result) {
-  const safe = stringifyJson({
+function aggregatePayload(result) {
+  const base = {
     event: "chips_ledger_stage_automation",
     target: "stage",
     project_ref: STAGE_PROJECT_REF,
     source_policy_id: STAGE_AUTOMATION_POLICY_ID,
     state: result.state,
+  };
+  if (result.state === "error") {
+    return {
+      ...base,
+      reason: redactedError(result.reason),
+    };
+  }
+  return {
+    ...base,
     mode: result.mode || null,
     transactions: result.transactions ?? null,
     entries: result.entries ?? null,
@@ -90,11 +102,28 @@ function writeAggregateSummary(result) {
     receipt: result.receipt || null,
     mappings: result.mappings ?? null,
     reason: result.reason || null,
-  });
+  };
+}
+
+function writeAggregateSummary(result) {
+  const safe = stringifyJson(aggregatePayload(result));
   process.stdout.write(`${safe}\n`);
   const summaryPath = text(process.env.GITHUB_STEP_SUMMARY);
   if (summaryPath) {
-    fs.appendFileSync(summaryPath, `\n\`\`\`json\n${safe}\n\`\`\`\n`, { mode: PRIVATE_FILE_MODE });
+    try {
+      fs.appendFileSync(summaryPath, `\n\`\`\`json\n${safe}\n\`\`\`\n`, { mode: PRIVATE_FILE_MODE });
+    } catch {
+      // Job Summary is best-effort; stdout remains the authoritative report.
+    }
+  }
+  return safe;
+}
+
+function emitAggregateError(error) {
+  try {
+    writeAggregateSummary({ state: "error", reason: redactedError(error) });
+  } catch {
+    // Preserve the original orchestration error if reporting itself fails.
   }
 }
 
@@ -449,148 +478,174 @@ async function resumeOwnCycle({ row, identity, env, tempRoot, sql, pruneStore, s
 }
 
 export async function runStageAutomation({ env = process.env, now = new Date(), deps = {} } = {}) {
-  const config = validateStageEnvironment(env);
-  const moduleEnv = config.moduleEnv;
-  const sql = deps.sql || postgres(config.dbUrl, {
-    max: 1,
-    prepare: false,
-    connect_timeout: 10,
-    idle_timeout: 0,
-  });
-  const tempRoot = deps.tempRoot || fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-automation-"));
-  ensurePrivateDirectory(tempRoot);
-  const storageTarget = deps.storageTarget || resolveStorageTarget("stage", moduleEnv, { singleTarget: true });
-  const pruneStore = deps.pruneStore || createPruneStore(sql);
-  const verifyBucket = deps.verifyBucket || ((target) => verifyArchiveBucket(target, deps));
+  let sql = null;
   let lockSession = null;
+  let tempRoot = null;
+  let ownsSql = false;
+  let result = null;
+  let failed = false;
+  let failure = null;
+
   try {
+    const config = validateStageEnvironment(env);
+    const moduleEnv = config.moduleEnv;
+    const providedSql = deps.sql;
+    if (providedSql) {
+      sql = providedSql;
+    } else {
+      sql = postgres(config.dbUrl, {
+        max: 1,
+        prepare: false,
+        connect_timeout: 10,
+        idle_timeout: 0,
+      });
+      ownsSql = true;
+    }
+    tempRoot = deps.tempRoot || fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-automation-"));
+    ensurePrivateDirectory(tempRoot);
+    const storageTarget = deps.storageTarget || resolveStorageTarget("stage", moduleEnv, { singleTarget: true });
+    const pruneStore = deps.pruneStore || createPruneStore(sql);
+    const verifyBucket = deps.verifyBucket || ((target) => verifyArchiveBucket(target, deps));
+
     lockSession = await acquireAdvisoryLock(sql);
     if (!lockSession) {
-      const result = { state: "no-op", reason: "advisory_lock_busy" };
-      writeAggregateSummary(result);
-      return result;
-    }
-    const identity = await assertIdentity(sql);
-    await assertAdvisoryLock(sql, lockSession);
-    await verifyBucket(storageTarget);
-    const ownRows = await loadOwnBatches(sql);
-    await assertAdvisoryLock(sql, lockSession);
-    const ownCycle = findOwnCycle(ownRows);
-    if (ownCycle.active) {
-      const result = await resumeOwnCycle({ row: await refreshRow(pruneStore, ownCycle.active.object_path), identity, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+      result = { state: "no-op", reason: "advisory_lock_busy" };
+    } else {
+      const identity = await assertIdentity(sql);
       await assertAdvisoryLock(sql, lockSession);
-      const output = {
-        state: result.state,
-        mode: "resume",
-        transactions: result.evidence.transactionCount,
-        entries: result.evidence.entryCount,
-        txTypes: result.evidence.txTypes,
-        amounts: { credits: result.evidence.credits, debits: result.evidence.debits, net: result.evidence.net },
-        compressedSha256: ownCycle.active.compressed_sha256,
-      };
-      writeAggregateSummary(output);
-      return output;
-    }
-    if (ownCycle.latestCompleted) {
-      await verifyCompletedCycle({
-        row: await refreshRow(pruneStore, ownCycle.latestCompleted.object_path),
-        identity,
-        env: moduleEnv,
-        tempRoot,
-        sql,
-        pruneStore,
-        storageTarget,
-        verifyBucket,
-        storageDeps: deps,
-      });
+      await verifyBucket(storageTarget);
+      const ownRows = await loadOwnBatches(sql);
       await assertAdvisoryLock(sql, lockSession);
-    }
+      const ownCycle = findOwnCycle(ownRows);
+      if (ownCycle.active) {
+        const resumed = await resumeOwnCycle({ row: await refreshRow(pruneStore, ownCycle.active.object_path), identity, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+        await assertAdvisoryLock(sql, lockSession);
+        result = {
+          state: resumed.state,
+          mode: "resume",
+          transactions: resumed.evidence.transactionCount,
+          entries: resumed.evidence.entryCount,
+          txTypes: resumed.evidence.txTypes,
+          amounts: { credits: resumed.evidence.credits, debits: resumed.evidence.debits, net: resumed.evidence.net },
+          compressedSha256: ownCycle.active.compressed_sha256,
+        };
+      } else {
+        if (ownCycle.latestCompleted) {
+          await verifyCompletedCycle({
+            row: await refreshRow(pruneStore, ownCycle.latestCompleted.object_path),
+            identity,
+            env: moduleEnv,
+            tempRoot,
+            sql,
+            pruneStore,
+            storageTarget,
+            verifyBucket,
+            storageDeps: deps,
+          });
+          await assertAdvisoryLock(sql, lockSession);
+        }
 
-    const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
-    const manifestPath = path.join(tempRoot, "archive.manifest.json");
-    const exportArchive = deps.exportArchive || runExport;
-    const exported = await exportArchive({
-      argv: [
-        "--target", "stage",
-        "--cutoff-days", String(STAGE_RETENTION_DAYS),
-        "--batch-size", String(STAGE_MAX_BATCH_SIZE),
-        "--output", artifactPath,
-        "--manifest", manifestPath,
-      ],
-      env: moduleEnv,
-      cwd: tempRoot,
-      now,
-      deps: {
-        sql,
-        selector: "prunable",
-        sourcePolicyId: STAGE_AUTOMATION_POLICY_ID,
-        targetOptions: { singleTarget: true },
-        noCandidateIfEmpty: true,
-        emit: false,
-      },
-    });
-    await assertAdvisoryLock(sql, lockSession);
-    if (exported.noCandidate) {
-      const result = { state: "no-op", reason: "no_eligible_candidate" };
-      writeAggregateSummary(result);
-      return result;
-    }
-    const ensureBucket = deps.ensureArchiveBucket || ensureArchiveBucket;
-    await ensureBucket(storageTarget, deps);
-    await assertAdvisoryLock(sql, lockSession);
-    const store = deps.storeArchive || storeArchive;
-    const stored = await store({
-      argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
-      env: moduleEnv,
-      cwd: tempRoot,
-      deps: { ...deps, sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
-    });
-    let row = await refreshRow(pruneStore, stored.objectPath);
-    await assertAdvisoryLock(sql, lockSession);
-    await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
-    row = await refreshRow(pruneStore, row.object_path);
-    await assertAdvisoryLock(sql, lockSession);
-    const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
-    if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
-    await assertAdvisoryLock(sql, lockSession);
-    const downloadMain = deps.downloadPrivateArchive || downloadPrivateArchiveObject;
-    const main = await downloadMain(storageTarget, row.object_path, deps);
-    const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
-    await assertAdvisoryLock(sql, lockSession);
-    const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
-    await assertAdvisoryLock(sql, lockSession);
-    const output = {
-      state: executed.state,
-      mode: "new",
-      transactions: executed.evidence.transactionCount,
-      entries: executed.evidence.entryCount,
-      txTypes: executed.evidence.txTypes,
-      amounts: { credits: executed.evidence.credits, debits: executed.evidence.debits, net: executed.evidence.net },
-      rawBytes: exported.bytes?.raw || null,
-      compressedBytes: row.compressed_bytes,
-      compressedSha256: row.compressed_sha256,
-      recoveryArchiveSha256: durable.recoveryArchive.sha256,
-      recoveryManifestSha256: durable.recoveryManifest.sha256,
-      proof: executed.state === "pruned" ? "verified" : null,
-      receipt: executed.state,
-      mappings: executed.evidence.transactionCount,
-    };
-    writeAggregateSummary(output);
-    return output;
-  } catch (error) {
-    const result = { state: "error", reason: redactedError(error) };
-    writeAggregateSummary(result);
-    throw error;
-  } finally {
-    if (lockSession) {
-      try {
-        await releaseAdvisoryLock(sql);
-      } catch {
-        // The session ending releases the lock; do not retry a failed unlock.
+        const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
+        const manifestPath = path.join(tempRoot, "archive.manifest.json");
+        const exportArchive = deps.exportArchive || runExport;
+        const exported = await exportArchive({
+          argv: [
+            "--target", "stage",
+            "--cutoff-days", String(STAGE_RETENTION_DAYS),
+            "--batch-size", String(STAGE_MAX_BATCH_SIZE),
+            "--output", artifactPath,
+            "--manifest", manifestPath,
+          ],
+          env: moduleEnv,
+          cwd: tempRoot,
+          now,
+          deps: {
+            sql,
+            selector: "prunable",
+            sourcePolicyId: STAGE_AUTOMATION_POLICY_ID,
+            targetOptions: { singleTarget: true },
+            noCandidateIfEmpty: true,
+            emit: false,
+          },
+        });
+        await assertAdvisoryLock(sql, lockSession);
+        if (exported.noCandidate) {
+          result = { state: "no-op", reason: "no_eligible_candidate" };
+        } else {
+          const ensureBucket = deps.ensureArchiveBucket || ensureArchiveBucket;
+          await ensureBucket(storageTarget, deps);
+          await assertAdvisoryLock(sql, lockSession);
+          const store = deps.storeArchive || storeArchive;
+          const stored = await store({
+            argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+            env: moduleEnv,
+            cwd: tempRoot,
+            deps: { ...deps, sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
+          });
+          let row = await refreshRow(pruneStore, stored.objectPath);
+          await assertAdvisoryLock(sql, lockSession);
+          await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          row = await refreshRow(pruneStore, row.object_path);
+          await assertAdvisoryLock(sql, lockSession);
+          const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          if (dry.state !== "ready") fail(`Stage automation dry-run did not become ready: ${dry.state}`);
+          await assertAdvisoryLock(sql, lockSession);
+          const downloadMain = deps.downloadPrivateArchive || downloadPrivateArchiveObject;
+          const main = await downloadMain(storageTarget, row.object_path, deps);
+          const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
+          await assertAdvisoryLock(sql, lockSession);
+          const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          await assertAdvisoryLock(sql, lockSession);
+          result = {
+            state: executed.state,
+            mode: "new",
+            transactions: executed.evidence.transactionCount,
+            entries: executed.evidence.entryCount,
+            txTypes: executed.evidence.txTypes,
+            amounts: { credits: executed.evidence.credits, debits: executed.evidence.debits, net: executed.evidence.net },
+            rawBytes: exported.bytes?.raw || null,
+            compressedBytes: row.compressed_bytes,
+            compressedSha256: row.compressed_sha256,
+            recoveryArchiveSha256: durable.recoveryArchive.sha256,
+            recoveryManifestSha256: durable.recoveryManifest.sha256,
+            proof: executed.state === "pruned" ? "verified" : null,
+            receipt: executed.state,
+            mappings: executed.evidence.transactionCount,
+          };
+        }
       }
     }
-    if (!deps.sql) await sql.end({ timeout: 5 });
+  } catch (error) {
+    failed = true;
+    failure = error;
+  } finally {
+    if (lockSession && sql) {
+      try {
+        await releaseAdvisoryLock(sql);
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          failure = error;
+        }
+      }
+    }
+    if (sql && ownsSql) {
+      try {
+        await sql.end({ timeout: 5 });
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          failure = error;
+        }
+      }
+    }
   }
+  if (failed) {
+    emitAggregateError(failure);
+    throw failure;
+  }
+  writeAggregateSummary(result);
+  return result;
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -53,6 +53,7 @@ run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger
 run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
 run("node", ["tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs"], "chips-ledger-prunable-candidate-sql");
 run("node", ["tests/chips/chips-ledger-stage-automation.test.mjs"], "chips-ledger-stage-automation");
+run("node", ["tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs"], "chips-ledger-stage-automation-observability");
 run("node", ["tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs"], "chips-ledger-stage-automation-order");
 run("node", ["tests/chips/chips-ledger-stage-automation.workflow.guard.test.mjs"], "chips-ledger-stage-automation-workflow");
 run("node", ["tests/welcome-bonus.behavior.test.mjs"], "welcome-bonus-behavior");

--- a/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import tls from "node:tls";
+import {
+  redactedError,
+  runStageAutomation,
+  STAGE_PROJECT_REF,
+} from "../../scripts/ops/chips-ledger-stage-automation.mjs";
+import { STAGE_AUTOMATION_POLICY_ID } from "../../scripts/ops/chips-ledger-archive-export.mjs";
+
+const root = process.cwd();
+const cli = path.join(root, "scripts/ops/chips-ledger-stage-automation.mjs");
+const samplePassword = "P@ssw0rd-observability";
+const sampleDbUrl = `postgresql://postgres:${samplePassword}@db.${STAGE_PROJECT_REF}.supabase.co:5432/postgres?sslmode=require`;
+const sampleJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature";
+const sampleBearer = `Bearer ${sampleJwt}`;
+const sampleSecret = "sb_secret_observability-test_123";
+
+function cleanEnv(overrides = {}) {
+  return {
+    ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !/^SUPABASE_PROD_|^PRODUCTION_/.test(key))),
+    SUPABASE_STAGE_DB_URL: sampleDbUrl,
+    SUPABASE_STAGE_SERVICE_ROLE_KEY: sampleSecret,
+    ...overrides,
+  };
+}
+
+function parseSingleAggregate(stdout) {
+  const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+  assert.equal(lines.length, 1, "stdout must contain exactly one aggregate JSON line");
+  return { line: lines[0], report: JSON.parse(lines[0]) };
+}
+
+function parseSummary(summary) {
+  const match = summary.match(/```json\n([^\n]+)\n```/);
+  assert.ok(match, "Job Summary must contain one JSON code block");
+  return match[1];
+}
+
+function runInvalidConfigurationCli(summaryPath) {
+  return spawnSync(process.execPath, [cli], {
+    cwd: root,
+    env: cleanEnv({
+      SUPABASE_STAGE_URL: "",
+      GITHUB_STEP_SUMMARY: summaryPath,
+    }),
+    encoding: "utf8",
+  });
+}
+
+const cliTemp = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-observability-cli-"));
+try {
+  const summaryPath = path.join(cliTemp, "summary.md");
+  const child = runInvalidConfigurationCli(summaryPath);
+  assert.equal(child.status, 1);
+  assert.equal(child.signal, null);
+  assert.equal(child.stderr, "");
+  const { line, report } = parseSingleAggregate(child.stdout);
+  assert.deepEqual(Object.keys(report).sort(), [
+    "event",
+    "project_ref",
+    "reason",
+    "source_policy_id",
+    "state",
+    "target",
+  ]);
+  assert.equal(report.state, "error");
+  assert.equal(report.project_ref, STAGE_PROJECT_REF);
+  assert.equal(report.source_policy_id, STAGE_AUTOMATION_POLICY_ID);
+  assert.match(report.reason, /Stage DB URL, Supabase URL and service key are required/);
+  assert.equal(parseSummary(fs.readFileSync(summaryPath, "utf8")), line);
+  for (const secret of [sampleDbUrl, samplePassword, sampleJwt, sampleBearer, sampleSecret]) {
+    assert.equal(child.stdout.includes(secret), false, `stdout leaked ${secret}`);
+    assert.equal(fs.readFileSync(summaryPath, "utf8").includes(secret), false, `summary leaked ${secret}`);
+  }
+} finally {
+  fs.rmSync(cliTemp, { recursive: true, force: true });
+}
+
+const summaryFailureTemp = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-observability-summary-failure-"));
+try {
+  const summaryPath = path.join(summaryFailureTemp, "missing", "summary.md");
+  const child = runInvalidConfigurationCli(summaryPath);
+  assert.equal(child.status, 1);
+  const { report } = parseSingleAggregate(child.stdout);
+  assert.equal(report.state, "error");
+  assert.equal(fs.existsSync(summaryPath), false);
+  assert.equal(child.stdout.includes(sampleDbUrl), false);
+  assert.equal(child.stdout.includes(samplePassword), false);
+  assert.equal(child.stdout.includes(sampleJwt), false);
+  assert.equal(child.stdout.includes(sampleSecret), false);
+} finally {
+  fs.rmSync(summaryFailureTemp, { recursive: true, force: true });
+}
+
+const originalConnect = net.Socket.prototype.connect;
+const originalTlsConnect = tls.connect;
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+const originalSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+let tcpCalls = 0;
+let tlsCalls = 0;
+let fetchCalls = 0;
+let dbCalls = 0;
+let storageCalls = 0;
+let capturedStdout = "";
+net.Socket.prototype.connect = function blockedTcp(...args) {
+  tcpCalls += 1;
+  throw new Error("unexpected TCP call");
+};
+tls.connect = function blockedTls(...args) {
+  tlsCalls += 1;
+  throw new Error("unexpected TLS call");
+};
+globalThis.fetch = async function blockedFetch(...args) {
+  fetchCalls += 1;
+  throw new Error("unexpected fetch call");
+};
+process.stdout.write = (chunk) => {
+  capturedStdout += String(chunk);
+  return true;
+};
+const directTemp = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-observability-direct-"));
+process.env.GITHUB_STEP_SUMMARY = path.join(directTemp, "summary.md");
+try {
+  const invalidEnv = cleanEnv({ SUPABASE_STAGE_URL: "" });
+  const sql = {
+    unsafe: async () => {
+      dbCalls += 1;
+      throw new Error("unexpected DB call");
+    },
+    begin: async () => {
+      dbCalls += 1;
+      throw new Error("unexpected DB transaction");
+    },
+  };
+  await assert.rejects(
+    runStageAutomation({
+      env: invalidEnv,
+      deps: {
+        sql,
+        verifyBucket: async () => { storageCalls += 1; },
+        storageTarget: {},
+      },
+    }),
+    /Stage DB URL, Supabase URL and service key are required/,
+  );
+  const { report } = parseSingleAggregate(capturedStdout);
+  assert.equal(report.state, "error");
+  assert.equal(tcpCalls, 0);
+  assert.equal(tlsCalls, 0);
+  assert.equal(fetchCalls, 0);
+  assert.equal(dbCalls, 0);
+  assert.equal(storageCalls, 0);
+} finally {
+  fs.rmSync(directTemp, { recursive: true, force: true });
+  process.stdout.write = originalStdoutWrite;
+  if (originalSummaryPath === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+  else process.env.GITHUB_STEP_SUMMARY = originalSummaryPath;
+  net.Socket.prototype.connect = originalConnect;
+  tls.connect = originalTlsConnect;
+  globalThis.fetch = originalFetch;
+}
+
+const redacted = redactedError(new Error(
+  `failed with ${sampleDbUrl} password=${samplePassword} ${sampleBearer} ${sampleJwt} key=${sampleSecret} transaction-123`,
+));
+for (const secret of [sampleDbUrl, samplePassword, sampleJwt, sampleBearer, sampleSecret]) {
+  assert.equal(redacted.includes(secret), false, `redacted reason leaked ${secret}`);
+}
+assert.match(redacted, /\[redacted-db-url\]/);
+assert.match(redacted, /Bearer \[redacted\]/);
+assert.match(redacted, /\[redacted-supabase-secret\]/);
+assert.match(redacted, /\[redacted-token\]/);
+assert.match(redacted, /\[redacted-record\]/);
+
+const initFailureTemp = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-observability-init-"));
+try {
+  let capturedInitStdout = "";
+  process.stdout.write = (chunk) => {
+    capturedInitStdout += String(chunk);
+    return true;
+  };
+  process.env.GITHUB_STEP_SUMMARY = path.join(initFailureTemp, "summary.md");
+  const initError = new Error(
+    `initialization failed for ${sampleDbUrl} ${sampleBearer} ${sampleSecret} transaction-123`,
+  );
+  const deps = {};
+  Object.defineProperty(deps, "sql", {
+    get() {
+      throw initError;
+    },
+  });
+  await assert.rejects(
+    runStageAutomation({ env: cleanEnv({ SUPABASE_STAGE_URL: `https://${STAGE_PROJECT_REF}.supabase.co` }), deps }),
+    (error) => error === initError,
+  );
+  const { report } = parseSingleAggregate(capturedInitStdout);
+  assert.equal(report.state, "error");
+  assert.equal(parseSummary(fs.readFileSync(process.env.GITHUB_STEP_SUMMARY, "utf8")), capturedInitStdout.trim());
+  for (const secret of [sampleDbUrl, samplePassword, sampleJwt, sampleBearer, sampleSecret]) {
+    assert.equal(capturedInitStdout.includes(secret), false, `aggregate leaked ${secret}`);
+  }
+} finally {
+  fs.rmSync(initFailureTemp, { recursive: true, force: true });
+  process.stdout.write = originalStdoutWrite;
+  if (originalSummaryPath === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+  else process.env.GITHUB_STEP_SUMMARY = originalSummaryPath;
+}
+
+process.stdout.write("chips-ledger-stage-automation observability behavior passed\n");

--- a/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
@@ -178,6 +178,38 @@ assert.match(redacted, /\[redacted-supabase-secret\]/);
 assert.match(redacted, /\[redacted-token\]/);
 assert.match(redacted, /\[redacted-record\]/);
 
+const bearerStdout = [];
+const bearerOriginalStdoutWrite = process.stdout.write;
+const bearerOriginalSummaryPath = process.env.GITHUB_STEP_SUMMARY;
+process.stdout.write = (chunk) => {
+  bearerStdout.push(String(chunk));
+  return true;
+};
+delete process.env.GITHUB_STEP_SUMMARY;
+try {
+  const bearerSql = {
+    unsafe: async () => { throw new Error(sampleBearer); },
+    begin: async () => { throw new Error("unexpected DB transaction"); },
+  };
+  await assert.rejects(
+    runStageAutomation({
+      env: cleanEnv({ SUPABASE_STAGE_URL: `https://${STAGE_PROJECT_REF}.supabase.co` }),
+      deps: {
+        sql: bearerSql,
+        storageTarget: { target: "stage", projectRef: STAGE_PROJECT_REF, baseUrl: `https://${STAGE_PROJECT_REF}.supabase.co`, serviceKey: sampleSecret },
+        pruneStore: {},
+      },
+    }),
+    /Bearer/,
+  );
+} finally {
+  process.stdout.write = bearerOriginalStdoutWrite;
+  if (bearerOriginalSummaryPath === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+  else process.env.GITHUB_STEP_SUMMARY = bearerOriginalSummaryPath;
+}
+const bearerReport = parseSingleAggregate(bearerStdout.join("")).report;
+assert.equal(bearerReport.reason, "Bearer [redacted]");
+
 const initFailureTemp = fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-observability-init-"));
 try {
   let capturedInitStdout = "";

--- a/tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs
@@ -29,7 +29,7 @@ function response(value, status = 200, headers = {}) {
   return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json", ...headers } });
 }
 
-function fakeSql() {
+function fakeSql({ unlockError = null } = {}) {
   const calls = [];
   const sql = {
     calls,
@@ -38,7 +38,10 @@ function fakeSql() {
       if (query.includes("pg_try_advisory_lock")) return [{ acquired: true, backend_pid: "stage-order-session" }];
       if (query.includes("pg_control_system")) return [{ system_identifier: STAGE_SYSTEM_IDENTIFIER }];
       if (query.includes("pg_backend_pid")) return [{ backend_pid: "stage-order-session" }];
-      if (query.includes("pg_advisory_unlock")) return [{ pg_advisory_unlock: true }];
+      if (query.includes("pg_advisory_unlock")) {
+        if (unlockError) throw unlockError;
+        return [{ pg_advisory_unlock: true }];
+      }
       if (query.includes("from public.chips_ledger_archive_batches")) return [];
       throw new Error(`unexpected SQL: ${query}`);
     },
@@ -120,10 +123,12 @@ const fetch = async (url, init = {}) => {
 
 let rowState = { ...row };
 const pruneModes = [];
+const unlockError = new Error("advisory unlock failed after successful cycle");
+const cycleSql = fakeSql({ unlockError });
 const result = await runStageAutomation({
   env: ENV,
   deps: {
-    sql: fakeSql(),
+    sql: cycleSql,
     fetch,
     storageTarget,
     tempRoot: fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-order-")),
@@ -165,6 +170,7 @@ const result = await runStageAutomation({
 });
 
 assert.equal(result.state, "pruned");
+assert.equal(cycleSql.calls.filter(({ query }) => query.includes("pg_advisory_unlock")).length, 1);
 assert.deepEqual(pruneModes.map(({ mode }) => mode), ["register-proof", "dry-run", "execute"]);
 assert.equal(pruneModes.at(-1).argv.includes("--execute"), true);
 


### PR DESCRIPTION
## Summary

Refs #886.

This draft implements the approved observability-only correction for Chips Ledger Stage Automation:

- moves configuration/client/temp-directory/storage-target/prune-store initialization under the same error boundary as the orchestration cycle;
- emits one redacted aggregate JSON report for every orchestration error, including canonical Stage project and policy identifiers only;
- keeps Job Summary best-effort without replacing the original error;
- makes lock/client cleanup conditional on actual initialization;
- extends redaction coverage to PostgreSQL URLs, passwords, JWTs, Bearer tokens, and `sb_secret_*`;
- adds CLI behavior tests covering exit code 1, stdout/Job Summary parity, secret redaction, pre-connection zero DB/TCP/fetch/Storage calls, and summary-write failure.

No workflow, secret, variable, migration, Stage, or Production changes are included.

## Validation

- `node --check scripts/ops/chips-ledger-stage-automation.mjs`
- `node --check tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs`
- focused Stage automation, observability, no-op, recovery, execute, and order tests
- `npm run syntax` — 217 files
- `node scripts/check-db-migrations.mjs` — 55 migrations
- `npm test` — passed

The full local suite required a temporary no-save install of the existing `ws` runtime package in the clean worktree; no package manifest or lockfile changes are part of this PR.