### PR TITLE
Docs: record Stage ledger plateau follow-up for #889

### DIFF
--- a/docs/chips-ledger-stage-automation.md
+++ b/docs/chips-ledger-stage-automation.md
@@ -127,3 +127,190 @@ policy, archive, recovery, proof, receipt and mapping verification.
 Logs and Job Summary contain only aggregate counts, sizes, hashes and state. They
 never contain ledger records, credentials, DB URLs, service keys or recovery
 contents. No Actions artifact is used for recovery.
+
+## #889 Phase A audit (2026-08-14)
+
+This is the read-only Stage 2B.5 audit performed against `origin/main` at
+`8198e07ab79629aa9727e28b8969a3d3ac8c95f9`. The repository instructions and
+the current GitHub state for Issues #874, #886, #889, #890 and #891 were
+rechecked before the audit. Stage and Production were queried through the
+existing service configuration with repeatable-read, read-only transactions.
+No SQL mutation, Storage operation, archive export, proof, recovery write or
+prune was performed.
+
+The runtime fences observed in the audit were:
+
+- Stage project: `krydukthwdvccggbyjfw`.
+- Stage PostgreSQL system identifier: `7656985631720456337`.
+- Production project: `otbqfijerkieoxwpxjnm`.
+- Production PostgreSQL system identifier: `7575202818581710058`.
+- Read-only GitHub variable verification returned
+  `CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED=1`. No variable or workflow setting
+  was changed by this audit.
+- Stage was running from `/opt/arcade-ws-preview`; Production was inspected
+  read-only only. Secret values and database URLs were not printed.
+
+### Inventory snapshot
+
+The live snapshot was taken around 14:23 UTC. Stage is active, so its counts
+can increase between read-only statements. All observed transactions had two
+entries and every transaction and account aggregate was balanced.
+
+| tx_type | Stage transactions / entries | Stage older than 30d | Production transactions / entries | Production older than 30d |
+| --- | ---: | ---: | ---: | ---: |
+| `ADMIN_ADJUST` | 6 / 12 | 0 / 0 | 0 / 0 | 0 / 0 |
+| `BUY_IN` | 11 / 22 | 0 / 0 | 0 / 0 | 0 / 0 |
+| `CASH_OUT` | 11 / 22 | 0 / 0 | 0 / 0 | 0 / 0 |
+| `MINT` | 2 / 4 | 0 / 0 | 2 / 4 | 0 / 0 |
+| `PROMO_BONUS` | 6 / 12 | 0 / 0 | 1 / 2 | 0 / 0 |
+| `TABLE_BUY_IN` | 25,064 / 50,128 | 0 / 0 | 54 / 108 | 0 / 0 |
+| `TABLE_CASH_OUT` | 16,034 / 32,068 | 0 / 0 | 47 / 94 | 0 / 0 |
+| `WELCOME_BONUS` | 6 / 12 | 0 / 0 | 0 / 0 | 0 / 0 |
+| **total** | **41,140 / 82,280** | **0 / 0** | **104 / 208** | **0 / 0** |
+
+The exact physical relation sizes at the same audit point were:
+
+| relation | Stage heap / indexes / total bytes | Production heap / indexes / total bytes |
+| --- | ---: | ---: |
+| `chips_accounts` | 1,056,768 / 1,712,128 / 2,809,856 | 81,920 / 335,872 / 458,752 |
+| `chips_entries` | 10,944,512 / 17,907,712 / 28,893,184 | 327,680 / 974,848 / 1,343,488 |
+| `chips_ledger_archive_batches` | 8,192 / 49,152 / 65,536 | 8,192 / 32,768 / 49,152 |
+| `chips_transaction_idempotency` | 10,452,992 / 6,438,912 / 16,932,864 | 32,768 / 40,960 / 106,496 |
+| `chips_transactions` | 27,615,232 / 9,994,240 / 37,650,432 | 696,320 / 598,016 / 1,335,296 |
+| `poker_requests` | 417,792 / 237,568 / 753,664 | 81,920 / 319,488 / 442,368 |
+| `poker_state` | 3,915,776 / 163,840 / 4,120,576 | 245,760 / 65,536 / 352,256 |
+| `poker_tables` | 958,464 / 11,812,864 / 12,812,288 | 8,192 / 188,416 / 237,568 |
+
+The hot ledger relation total was 66,543,616 bytes on Stage and 2,678,784
+bytes on Production. The full database sizes were 259,804,307 and 20,966,547
+bytes respectively. These are measurements, not per-row byte estimates.
+
+Stage `TABLE_BUY_IN` and `TABLE_CASH_OUT` are the only material growth classes.
+The exact two-entry technical shape is present for 24,933 and 15,922 Stage
+transactions respectively; the remaining 131 and 112 transactions in those
+classes involve a USER entry. The corresponding Production split is 36/18
+and 32/15. The technical Stage classes produced 1,369.9 transactions/day over
+the 30-calendar-day window; the conservative sum of their observed daily
+peaks was 4,078 transactions/day (8,156 entries/day). The daily v1 limit of
+5,000 transactions is therefore above the observed conservative peak.
+
+Stage currently has 3,259 `CLOSED` and 5 `OPEN` poker tables. The table-marker
+ownership split was:
+
+- Stage `TABLE_BUY_IN`: 12,847 `CLOSED`, 12,202 missing table rows, 15
+  `OPEN`.
+- Stage `TABLE_CASH_OUT`: 9,675 `CLOSED`, 6,359 missing table rows.
+- Production `TABLE_BUY_IN`: 16 `CLOSED`, 38 missing table rows.
+- Production `TABLE_CASH_OUT`: 11 `CLOSED`, 36 missing table rows.
+
+All account rows observed on both environments were active; the total ledger
+entry amount and the sum of current account balances were both zero. There
+were no unbalanced transactions. This confirms conservation for the current
+hot state, not bounded growth for the whole database.
+
+The direct `PRUNABLE_CANDIDATE_SQL` count on Stage was zero. No transaction or
+entry in either environment was older than the 30-day cutoff, so there was no
+natural Stage candidate for a new evidence package.
+
+### Dependency and accounting decision
+
+The current consumers were traced through the shared ledger, the poker
+persistence/terminal-close paths, user/admin history, idempotency replay and
+the relevant migrations.
+
+- `TABLE_BUY_IN` and `TABLE_CASH_OUT` system-only rows are already the
+  `archive_safe_and_material` class of `stage-ledger-auto-retention-30d-v1`.
+  The v1 selector still requires the exact SYSTEM/ESCROW two-entry shape,
+  matching registry identity, active zero-balance escrow, and an absent or
+  `CLOSED` table. It remains unchanged.
+- USER-involved table transactions are `blocked_unproven` for archival and
+  negligible for this capacity decision. User history reads hot entries, and
+  terminal-close/bot provenance can require historical table funding rows.
+  No cold-read path or archive contract for those rows exists.
+- `BUY_IN`, `CASH_OUT`, `WELCOME_BONUS`, `PROMO_BONUS` and `ADMIN_ADJUST` are
+  user-facing or administrative classes with current history/replay
+  dependencies. `bonus_claims.transaction_id` is an `ON DELETE RESTRICT`
+  dependency for bonus transactions. They are currently
+  `negligible_for_capacity`, not newly archive-safe classes.
+- `MINT` is a two-row system seed in both inventories and is
+  `negligible_for_capacity`; no destructive extension is justified.
+- `HAND_SETTLEMENT`, `RAKE_FEE` and `PRIZE_PAYOUT` are represented by the
+  accounting contract/producers but had no rows in these live inventories.
+  They remain `blocked_unproven` for pruning until their replay, user-history,
+  provenance and recovery contracts are separately demonstrated.
+- `chips_transaction_idempotency` is durable by design and remains in the
+  scope of #890. This audit does not claim bounded growth for that registry,
+  orphan accounts, Storage, or the whole database.
+
+`FULL_REPLAY_TX_TYPES` covers `BUY_IN`, `CASH_OUT`, `WELCOME_BONUS`,
+`PROMO_BONUS` and `ADMIN_ADJUST`. `TABLE_BUY_IN` and `TABLE_CASH_OUT` are not
+full-replay types. The existing user-history and replay behavior therefore
+does not permit broadening v1 to the USER-involved subset.
+
+### Archive-schema audit
+
+Archive JSONL `schema_version=1` contains the transaction identity, sequence,
+type, idempotency and payload evidence, metadata/reference, table and escrow
+context, every entry, account snapshots and the immutable archive ID proof.
+The recovery manifest `recovery_schema_version=1` adds the target/policy and
+physical identity, archive SHA/count/amount evidence and both exact-ID hashes.
+That is sufficient for the existing technical system-only v1 rows. It is not
+sufficient to replace user history, bonus-claim references, or the full replay
+snapshots required by other classes. No new archive or recovery schema is
+needed because Phase B is not justified.
+
+### Archive state and capacity gate
+
+The Stage automation-owned state was one committed v1 batch with complete
+proof and receipt, already pruned, and no pending or incomplete v1 cycle. The
+Stage registry contained 43,144 rows: 2,004 mapped archive rows, 41,140
+unmapped rows, 40 complete replay snapshots and no partial snapshots. The
+zero missing-registry and identity-mismatch checks passed; the 2,004 registry
+references to absent hot transactions are the expected durable mappings for
+previously pruned rows.
+
+Historical manual manifests remain untouched and are not automation-owned:
+four committed rows with a null policy (three proven/pruned and one
+unproven/unpruned), plus one pending null-policy row. The orchestrator filters
+by the v1 policy ID, so these rows do not drive its cursor. Production has one
+committed, proven and pruned archive row and no `source_policy_id` column; it
+remains default-deny for Stage automation.
+
+Phase A does not justify Phase B. No new policy ID, selector, migration,
+workflow, authorization framework, archive schema or prepare-only path was
+added. The material technical classes already use the existing v1 pipeline,
+and all other currently growing classes are either negligible or lack a safe
+archive/recovery contract.
+
+The oldest currently remaining potentially v1-eligible system-only row is
+`2026-07-17 22:02:19.366Z`. Because the selector uses a strict 30-day cutoff,
+that cohort first becomes eligible immediately after
+`2026-08-16 22:02:19.366Z`. The first scheduled `17 2 * * *` run after that
+instant is `2026-08-17 02:17:00Z`.
+
+The observed conservative `4,078 transactions/day` peak is the sum of two
+class-specific peaks rather than one same-day cohort. The `TABLE_BUY_IN` peak
+of 2,673 occurred on 2026-08-04 and enters the retention window at
+`2026-09-03 00:00:00Z`; the `TABLE_CASH_OUT` peak of 1,405 occurred on
+2026-08-10 and enters it at `2026-09-09 00:00:00Z`. Thus the full conservative
+peak envelope is in the retention window by `2026-09-09 00:00:00Z`. The
+highest actual same-day combined count was 4,014.
+
+The concrete blocking follow-up is [#892 — Stage ledger plateau — verify v1
+drain after first 30-day eligibility window](https://github.com/krzysztofcal/arcadePlatform/issues/892).
+It must compare actual `PRUNABLE_CANDIDATE_SQL` backlog before and after the
+scheduled runs for both the first cohort and the two peak cohorts, and verify
+archive, proof, durable recovery, receipt, mappings and v1 throughput. Rows
+per day alone are not sufficient evidence.
+
+The capacity status is therefore:
+
+> hot `chips_transactions`/`chips_entries` plateau within #889 scope not yet
+> proven; verification is owned by #892. No `retained_hot_sustainable`
+> decision is made here.
+
+The follow-up must not broaden v1 or execute a new class. If a future Phase B
+does become necessary, it must first document the exact new tx types,
+eligibility predicates, archive/recovery evidence and capacity impact, create a
+new immutable policy ID, and stop before the first destructive Stage prune for
+human approval.


### PR DESCRIPTION
## Summary

- Document the exact first v1 eligibility timestamp and first scheduled run.
- Document the two class-specific peak-cohort retention dates.
- Record the read-only `CHIPS_LEDGER_STAGE_AUTOMATION_ENABLED=1` verification.
- Identify blocking follow-up #892 and require actual `PRUNABLE_CANDIDATE_SQL` before/after backlog evidence.
- Preserve the explicit conclusion that the hot ledger plateau is not yet proven.

Refs #889
Follow-up: #892

## Scope

Documentation only. No Phase B, v2, schema, migration, workflow, Stage data, Storage, database function, Production or destructive operation was changed.

## Checks

- `git diff --check`
- `npm test` (full suite, passed after installing dependencies from both lockfiles in the clean worktree)