### PR TITLE
[P1] Implement bot-only TABLE retention lifecycle (#890)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
           create table if not exists storage.objects (
             id bigint generated always as identity primary key
           );
+          create schema if not exists extensions;
           SQL
 
       - name: Apply migrations and run migration contracts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
             id bigint generated always as identity primary key
           );
           create schema if not exists extensions;
+          create extension if not exists pgcrypto with schema extensions;
           SQL
 
       - name: Apply migrations and run migration contracts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,16 @@ jobs:
         image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: contractpass
-          POSTGRES_DB: chips_test_db
+          POSTGRES_DB: chips_retention_test
         ports:
           - 5433:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d chips_test_db"
+          --health-cmd "pg_isready -U postgres -d chips_retention_test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
     env:
-      CHIPS_MIGRATIONS_TEST_DB_URL: postgresql://postgres:contractpass@127.0.0.1:5433/chips_test_db
+      CHIPS_MIGRATIONS_TEST_DB_URL: postgresql://postgres:contractpass@127.0.0.1:5433/chips_retention_test
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm i
 
-      - name: Bootstrap minimal Supabase auth schema
+      - name: Bootstrap minimal Supabase auth and storage schemas
         run: |
           psql "$CHIPS_MIGRATIONS_TEST_DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
           do $$
@@ -63,6 +63,17 @@ jobs:
           as $$
             select null::uuid;
           $$;
+          create schema if not exists storage;
+          create table if not exists storage.buckets (
+            id text primary key,
+            name text not null,
+            public boolean not null default false,
+            file_size_limit bigint,
+            allowed_mime_types text[]
+          );
+          create table if not exists storage.objects (
+            id bigint generated always as identity primary key
+          );
           SQL
 
       - name: Apply migrations and run migration contracts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Bootstrap minimal Supabase auth schema
         run: |
           psql "$CHIPS_MIGRATIONS_TEST_DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          do $$
+          begin
+            if not exists (select 1 from pg_roles where rolname = 'anon') then
+              create role anon noinherit;
+            end if;
+            if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+              create role authenticated noinherit;
+            end if;
+            if not exists (select 1 from pg_roles where rolname = 'service_role') then
+              create role service_role noinherit;
+            end if;
+          end
+          $$;
           create schema if not exists auth;
           create table if not exists auth.users (
             id uuid primary key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  chips-retention-integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: contractpass
+          POSTGRES_DB: chips_test_db
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d chips_test_db"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      CHIPS_MIGRATIONS_TEST_DB_URL: postgresql://postgres:contractpass@127.0.0.1:5433/chips_test_db
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci || npm i
+
+      - name: Apply migrations and run migration contracts
+        run: node tests/chips/chips.migration.test.mjs
+
+      - name: Run PostgreSQL bot-only retention contracts
+        run: node tests/chips/chips-ledger-bot-only-retention.test.mjs
+
   tests:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,12 @@ jobs:
           create table if not exists auth.users (
             id uuid primary key
           );
+          insert into auth.users (id) values
+            ('00000000-0000-4000-8000-000000000001'),
+            ('00000000-0000-4000-8000-000000000002'),
+            ('00000000-0000-4000-8000-000000000003'),
+            ('00000000-0000-4000-8000-000000000004')
+          on conflict (id) do nothing;
           create or replace function auth.uid()
           returns uuid
           language sql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Run PostgreSQL bot-only retention contracts
         run: node tests/chips/chips-ledger-bot-only-retention.test.mjs
 
+      - name: Run PostgreSQL TABLE metadata fence regressions
+        run: node tests/chips/chips-ledger-table-metadata-fence.test.mjs
+
   tests:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,22 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm i
 
+      - name: Bootstrap minimal Supabase auth schema
+        run: |
+          psql "$CHIPS_MIGRATIONS_TEST_DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          create schema if not exists auth;
+          create table if not exists auth.users (
+            id uuid primary key
+          );
+          create or replace function auth.uid()
+          returns uuid
+          language sql
+          stable
+          as $$
+            select null::uuid;
+          $$;
+          SQL
+
       - name: Apply migrations and run migration contracts
         run: node tests/chips/chips.migration.test.mjs
 

--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -134,6 +134,22 @@ const idempotencyError = (code, message, status = 503) => {
   return error;
 };
 
+const mapTableLifecycleError = (error) => {
+  if (error?.code === "P8901" || error?.code === "P8902") {
+    const mapped = new Error("TABLE idempotency key or binding is invalid");
+    mapped.code = "invalid_table_binding";
+    mapped.status = 400;
+    mapped.cause = error;
+    return mapped;
+  }
+  if (error?.code !== "P8903" && error?.code !== "P8904") return error;
+  const mapped = new Error(error.code === "P8903" ? "TABLE table is closed" : "TABLE idempotency binding is retired");
+  mapped.code = error.code === "P8903" ? "table_closed" : "idempotency_retired";
+  mapped.status = 409;
+  mapped.cause = error;
+  return mapped;
+};
+
 const normalizeIdempotencyUserId = (value) => {
   const normalized = value == null ? "" : String(value).trim();
   return normalized || null;
@@ -1190,7 +1206,11 @@ from inserted i;
     }
   };
 
-  result = tx ? await runInTx(tx) : await beginSql(async sqlTx => runInTx(sqlTx));
+  try {
+    result = tx ? await runInTx(tx) : await beginSql(async sqlTx => runInTx(sqlTx));
+  } catch (error) {
+    throw mapTableLifecycleError(error);
+  }
 
   if (!result?.transaction) {
     klog("chips_tx_missing_rows", { idempotencyKey });

--- a/netlify/functions/_shared/chips-ledger.mjs
+++ b/netlify/functions/_shared/chips-ledger.mjs
@@ -1044,7 +1044,7 @@ async function postTransaction({
 
       const txRows = await sqlTx`
       insert into public.chips_transactions (reference, description, metadata, idempotency_key, payload_hash, tx_type, user_id, created_by)
-      values (${reference}, ${description}, ${safeMetadataJson}::jsonb, ${idempotencyKey}, ${payloadHash}, ${txType}, ${payloadUserId || null}, ${createdBy})
+      values (${reference}, ${description}, (${safeMetadataJson}::text)::jsonb, ${idempotencyKey}, ${payloadHash}, ${txType}, ${payloadUserId || null}, ${createdBy})
       returning *;
     `;
 

--- a/scripts/ops/_shared/chips-table-idempotency.mjs
+++ b/scripts/ops/_shared/chips-table-idempotency.mjs
@@ -1,0 +1,100 @@
+// Versioned, server-verifiable TABLE_* idempotency-key bindings.
+//
+// The PostgreSQL implementation in the bot-only retention migration is the
+// authoritative write fence.  This small mirror is deliberately strict and
+// is used by exporter/operator code to reject an artifact before it reaches
+// Storage or the proof path.
+
+export const TABLE_TRANSACTION_TYPES = Object.freeze([
+  "TABLE_BUY_IN",
+  "TABLE_CASH_OUT",
+]);
+
+export const TABLE_IDEMPOTENCY_KEY_FORMAT_VERSION = 1;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const FORMATS = Object.freeze([
+  ["join-buyin", 1, "join-buyin"],
+  ["bot-seed-buyin", 1, "bot-seed-buyin"],
+  ["managed-bot-seed-buyin", 1, "managed-bot-seed-buyin"],
+  ["poker:leave", 2, "poker:leave"],
+  ["poker:inactive_cleanup", 2, "poker:inactive_cleanup"],
+  ["poker:rebuy:v1", 3, "poker:rebuy:v1"],
+  ["poker:deferred-leave:v1", 3, "poker:deferred-leave:v1"],
+  ["poker:bot-terminal-cashout:v1", 3, "poker:bot-terminal-cashout:v1"],
+  ["poker:human-terminal-cashout:v1", 3, "poker:human-terminal-cashout:v1"],
+  ["poker:bot-replacement-buyin:v1", 3, "poker:bot-replacement-buyin:v1"],
+  ["poker:managed-bot-top-up:v1", 3, "poker:managed-bot-top-up:v1"],
+]);
+
+function invalid(message) {
+  const error = new Error(message);
+  error.code = "invalid_table_idempotency_key";
+  return error;
+}
+
+function nonEmptySegments(parts, start) {
+  return parts.length > start && parts.slice(start).every((part) => part.length > 0);
+}
+
+export function parseTableIdempotencyKey(value) {
+  const key = typeof value === "string" ? value.trim() : "";
+  if (!key || key.length > 240) throw invalid("TABLE idempotency key is empty or too long");
+  const parts = key.split(":");
+  for (const [format, tableIndex, prefix] of FORMATS) {
+    if (!key.startsWith(`${prefix}:`)) continue;
+    if (!nonEmptySegments(parts, tableIndex + 1)) throw invalid(`TABLE idempotency key has an incomplete ${format} suffix`);
+    const tableId = parts[tableIndex]?.toLowerCase();
+    if (!UUID_RE.test(tableId)) throw invalid(`TABLE idempotency key has an invalid table id for ${format}`);
+    return Object.freeze({
+      version: TABLE_IDEMPOTENCY_KEY_FORMAT_VERSION,
+      format,
+      tableId,
+      key,
+    });
+  }
+  throw invalid("TABLE idempotency key format is not supported");
+}
+
+export function tryParseTableIdempotencyKey(value) {
+  try {
+    return parseTableIdempotencyKey(value);
+  } catch {
+    return null;
+  }
+}
+
+export function parseTableReference(value) {
+  const reference = typeof value === "string" ? value.trim() : "";
+  if (!reference) return null;
+  const match = /^(?:table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):([^:]+)(?::|$)/i.exec(reference);
+  if (!match) return null;
+  const tableId = match[1].toLowerCase();
+  if (!UUID_RE.test(tableId)) throw invalid("TABLE reference has an invalid table id");
+  return tableId;
+}
+
+export function tableBindingFromMetadata(metadata) {
+  if (metadata == null || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const value = metadata.tableId;
+  if (value == null || String(value).trim() === "") return null;
+  const tableId = String(value).trim().toLowerCase();
+  if (!UUID_RE.test(tableId)) throw invalid("TABLE metadata.tableId is invalid");
+  return tableId;
+}
+
+export function assertTableBinding({ idempotencyKey, metadata = null, reference = null } = {}) {
+  const parsed = parseTableIdempotencyKey(idempotencyKey);
+  const bindings = new Set([parsed.tableId]);
+  const metadataTableId = tableBindingFromMetadata(metadata);
+  if (metadataTableId) bindings.add(metadataTableId);
+  const referenceTableId = parseTableReference(reference);
+  if (referenceTableId) bindings.add(referenceTableId);
+  if (bindings.size !== 1) throw invalid("TABLE metadata/reference binding does not match idempotency key");
+  return parsed;
+}
+
+export function isTableTransactionType(value) {
+  return TABLE_TRANSACTION_TYPES.includes(String(value || "").trim().toUpperCase());
+}

--- a/scripts/ops/_shared/chips-table-idempotency.mjs
+++ b/scripts/ops/_shared/chips-table-idempotency.mjs
@@ -28,6 +28,14 @@ const FORMATS = Object.freeze([
   ["poker:managed-bot-top-up:v1", 3, "poker:managed-bot-top-up:v1"],
 ]);
 
+const REFERENCE_PREFIXES = Object.freeze([
+  "table",
+  "poker-rebuy",
+  "BOT_SEED_BUY_IN",
+  "BOT_REPLACEMENT_BUY_IN",
+  "MANAGED_BOT_TOP_UP",
+]);
+
 function invalid(message) {
   const error = new Error(message);
   error.code = "invalid_table_idempotency_key";
@@ -66,20 +74,24 @@ export function tryParseTableIdempotencyKey(value) {
 }
 
 export function parseTableReference(value) {
-  const reference = typeof value === "string" ? value.trim() : "";
-  if (!reference) return null;
-  const match = /^(?:table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):([^:]+)(?::|$)/i.exec(reference);
-  if (!match) return null;
-  const tableId = match[1].toLowerCase();
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") throw invalid("TABLE reference must be a string");
+  const reference = value.trim();
+  if (!reference) throw invalid("TABLE reference is empty");
+  const normalized = reference.toLowerCase();
+  const prefix = REFERENCE_PREFIXES.find((candidate) => normalized.startsWith(`${candidate.toLowerCase()}:`));
+  if (!prefix) throw invalid("TABLE reference format is not supported");
+  const tableId = reference.slice(prefix.length + 1).split(":", 1)[0].trim().toLowerCase();
   if (!UUID_RE.test(tableId)) throw invalid("TABLE reference has an invalid table id");
   return tableId;
 }
 
 export function tableBindingFromMetadata(metadata) {
   if (metadata == null || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  if (!Object.prototype.hasOwnProperty.call(metadata, "tableId")) return null;
   const value = metadata.tableId;
-  if (value == null || String(value).trim() === "") return null;
-  const tableId = String(value).trim().toLowerCase();
+  if (typeof value !== "string" || value.trim() === "") throw invalid("TABLE metadata.tableId is invalid");
+  const tableId = value.trim().toLowerCase();
   if (!UUID_RE.test(tableId)) throw invalid("TABLE metadata.tableId is invalid");
   return tableId;
 }
@@ -88,9 +100,9 @@ export function assertTableBinding({ idempotencyKey, metadata = null, reference 
   const parsed = parseTableIdempotencyKey(idempotencyKey);
   const bindings = new Set([parsed.tableId]);
   const metadataTableId = tableBindingFromMetadata(metadata);
-  if (metadataTableId) bindings.add(metadataTableId);
+  if (metadataTableId !== null) bindings.add(metadataTableId);
   const referenceTableId = parseTableReference(reference);
-  if (referenceTableId) bindings.add(referenceTableId);
+  if (referenceTableId !== null) bindings.add(referenceTableId);
   if (bindings.size !== 1) throw invalid("TABLE metadata/reference binding does not match idempotency key");
   return parsed;
 }

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -500,6 +500,213 @@ select eligible.id::text as id,
  limit $2::int;
 `;
 
+// A no-candidate result is not necessarily an empty database.  Keep the
+// diagnostic read-only and separate from the candidate selector so prepare-only
+// can explain which fail-closed condition prevented selection without relaxing
+// the selector itself.
+export const BOT_ONLY_BLOCKING_ANOMALY_SQL = `
+with table_rows as (
+  select registry.table_id,
+         max(registry.transaction_created_at) as newest_created_at,
+         count(*)::bigint as identity_count,
+         count(*) filter (
+           where registry.user_id is null
+             and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+             and registry.transaction_created_at < $1::timestamptz
+             and registry.archive_batch_id is null
+         )::bigint as eligible_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id is not null
+   group by registry.table_id
+), table_context as (
+  select stats.table_id,
+         stats.newest_created_at,
+         stats.identity_count,
+         stats.eligible_count,
+         tables.status::text as table_status,
+         tables.has_human_participant,
+         tables.bot_only_proof_eligible,
+         escrow.id as escrow_account_id,
+         escrow.status::text as escrow_status,
+         escrow.balance as escrow_balance
+    from table_rows stats
+    left join public.poker_tables tables on tables.id = stats.table_id
+    left join public.chips_accounts escrow
+      on escrow.account_type::text = 'ESCROW'
+     and escrow.system_key = 'POKER_TABLE:' || stats.table_id::text
+), marker_issues as (
+  select transactions.id,
+         registry.table_id
+    from public.chips_transactions transactions
+    left join public.chips_transaction_idempotency registry
+      on registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+   where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and (
+       (
+         transactions.metadata ? 'tableId'
+         and (
+           nullif(btrim(transactions.metadata->>'tableId'), '') is null
+           or nullif(btrim(transactions.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           or registry.table_id is null
+           or lower(btrim(transactions.metadata->>'tableId')) <> registry.table_id::text
+         )
+       )
+       or (
+         transactions.reference is not null
+         and (
+           transactions.reference !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+           or nullif(btrim(split_part(transactions.reference, ':', 2)), '') is null
+           or nullif(btrim(split_part(transactions.reference, ':', 2)), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9]{3}-[89ab][0-9]{3}-[0-9a-f]{12}$'
+           or registry.table_id is null
+           or lower(btrim(split_part(transactions.reference, ':', 2))) <> registry.table_id::text
+         )
+       )
+     )
+), entry_shapes as (
+  select transactions.id,
+         registry.table_id,
+         transactions.tx_type::text as tx_type,
+         count(entries.id)::bigint as entry_count,
+         count(*) filter (where accounts.account_type::text = 'USER')::bigint as user_entry_count,
+         count(*) filter (where accounts.account_type::text = 'SYSTEM')::bigint as system_entry_count,
+         count(*) filter (where accounts.account_type::text = 'ESCROW')::bigint as escrow_entry_count,
+         count(*) filter (
+           where accounts.account_type::text = 'ESCROW'
+             and accounts.system_key = 'POKER_TABLE:' || registry.table_id::text
+         )::bigint as matching_escrow_count,
+         coalesce(sum(entries.amount), 0)::numeric as net_amount
+    from public.chips_transactions transactions
+    left join public.chips_transaction_idempotency registry
+      on registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+    left join public.chips_entries entries on entries.transaction_id = transactions.id
+    left join public.chips_accounts accounts on accounts.id = entries.account_id
+   where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+   group by transactions.id, registry.table_id, transactions.tx_type
+), blockers as (
+  select 'unknown_table_identity'::text as blocker_code,
+         count(*)::bigint as transaction_count,
+         0::bigint as table_count
+    from public.chips_transaction_idempotency registry
+   where registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.table_id is null
+
+  union all
+
+  select 'missing_registry_identity',
+         count(*)::bigint,
+         0::bigint
+    from public.chips_transactions transactions
+    left join public.chips_transaction_idempotency registry
+      on registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+   where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.idempotency_key is null
+
+  union all
+
+  select 'invalid_marker',
+         count(distinct marker_issues.id)::bigint,
+         count(distinct marker_issues.table_id)::bigint
+    from marker_issues
+
+  union all
+
+  select 'deferred_entry_binding',
+         count(*)::bigint,
+         count(distinct entry_shapes.table_id)::bigint
+    from entry_shapes
+   where entry_shapes.entry_count <> 2
+      or entry_shapes.user_entry_count <> 0
+      or entry_shapes.system_entry_count <> 1
+      or entry_shapes.escrow_entry_count <> 1
+      or entry_shapes.matching_escrow_count <> 1
+      or entry_shapes.net_amount <> 0
+
+  union all
+
+  select 'younger_table_identity',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.newest_created_at >= $1::timestamptz
+
+  union all
+
+  select 'human_participant',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.has_human_participant is true
+
+  union all
+
+  select 'human_participant_unknown',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.has_human_participant is null
+
+  union all
+
+  select 'historically_uncertain',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.bot_only_proof_eligible is not true
+
+  union all
+
+  select 'table_not_closed',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.table_status is null
+      or upper(context.table_status) <> 'CLOSED'
+
+  union all
+
+  select 'escrow_not_active_or_zero',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.escrow_account_id is null
+      or context.escrow_status <> 'active'
+      or context.escrow_balance <> 0
+
+  union all
+
+  select 'identity_set_incomplete',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.eligible_count <> context.identity_count
+
+  union all
+
+  select 'no_eligible_identity',
+         coalesce(sum(context.identity_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.eligible_count = 0
+
+  union all
+
+  select 'batch_over_capacity',
+         coalesce(sum(context.eligible_count), 0)::bigint,
+         count(*)::bigint
+    from table_context context
+   where context.eligible_count > $2::int
+)
+select blocker_code,
+       transaction_count::text,
+       table_count::text
+  from blockers
+ where transaction_count > 0 or table_count > 0
+ order by blocker_code;
+`;
+
 const ENTRIES_SQL = `
 select
   e.id::text as id,
@@ -559,6 +766,14 @@ export function toBigIntString(value, label = "bigint") {
 
 function nullableText(value) {
   return value == null ? null : text(value) || null;
+}
+
+function normalizeBlockingAnomalies(rows) {
+  return (rows || []).map((row) => ({
+    code: text(row.blocker_code),
+    transaction_count: toBigIntString(row.transaction_count, "blocking anomaly transaction_count"),
+    table_count: toBigIntString(row.table_count, "blocking anomaly table_count"),
+  }));
 }
 
 function normalizeJson(value) {
@@ -1092,7 +1307,13 @@ export async function readSnapshot(sql, options) {
     ]);
     const ids = candidates.map((candidate) => text(candidate.id));
     const entries = ids.length ? await tx.unsafe(ENTRIES_SQL, [ids]) : [];
-    return { candidates, entries };
+    const blockingAnomalies = selector === "bot-only-7d" && candidates.length === 0
+      ? normalizeBlockingAnomalies(await tx.unsafe(BOT_ONLY_BLOCKING_ANOMALY_SQL, [
+        timestampParam(options.cutoff),
+        options.batchSize,
+      ]))
+      : [];
+    return { candidates, entries, blockingAnomalies };
   });
 }
 
@@ -1156,7 +1377,11 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
     const schemaVersion = deps.schemaVersion || (selector === "bot-only-7d" ? BOT_ONLY_EXPORT_SCHEMA_VERSION : EXPORT_SCHEMA_VERSION);
     const snapshot = await readSnapshot(sql, { ...options, selector });
     if (deps.noCandidateIfEmpty && snapshot.candidates.length === 0) {
-      return { noCandidate: true, options };
+      return {
+        noCandidate: true,
+        options,
+        blockingAnomalies: snapshot.blockingAnomalies,
+      };
     }
     const candidateIds = new Set(snapshot.candidates.map((candidate) => text(candidate.id)));
     const entriesByTransaction = groupEntries(snapshot.entries, candidateIds);

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -386,7 +386,11 @@ with table_rows as (
      and escrow.system_key = 'POKER_TABLE:' || registry.table_id::text
    join public.chips_entries entries on entries.transaction_id = transactions.id
    join public.chips_accounts accounts on accounts.id = entries.account_id
-   where $3::timestamptz is null
+   where (
+       $3::timestamptz is null
+       or transactions.created_at > $3::timestamptz
+       or (transactions.created_at = $3::timestamptz and transactions.id > $4::uuid)
+     )
      and transactions.created_at < $1::timestamptz
      and transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
      and transactions.user_id is null
@@ -435,6 +439,7 @@ with table_rows as (
             stats.newest_created_at, stats.identity_count, stats.eligible_count,
             stats.out_of_scope_keys_sha256
   having count(*) = 2
+     and count(distinct transactions.id) = stats.eligible_count
      and count(*) filter (where accounts.account_type::text = 'USER') = 0
      and count(*) filter (where accounts.account_type::text = 'SYSTEM') = 1
      and count(*) filter (where accounts.account_type::text = 'ESCROW') = 1

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -51,26 +51,49 @@ with base as (
     )
 ), markers as (
   select b.id as transaction_id,
-         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id
+         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id,
+         (
+           b.metadata ? 'tableId'
+           and (
+             nullif(btrim(b.metadata->>'tableId'), '') is null
+             or nullif(btrim(b.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           )
+         ) as invalid_marker
   from base b
-  where nullif(btrim(b.metadata->>'tableId'), '') is not null
+  where b.metadata ? 'tableId'
+    and (
+      nullif(btrim(b.metadata->>'tableId'), '') is not null
+      or b.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+    )
 
   union all
 
   select b.id,
          case
-           when lower(b.reference) like 'table:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
-           when lower(b.reference) like 'poker-rebuy:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           when b.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+             then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
            else null
-         end
+         end,
+         (
+           b.reference is not null
+           and (
+             b.reference !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+             or nullif(btrim(split_part(b.reference, ':', 2)), '') is null
+             or nullif(btrim(split_part(b.reference, ':', 2)), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           )
+         )
   from base b
-  where lower(b.reference) like 'table:%'
-     or lower(b.reference) like 'poker-rebuy:%'
+  where b.reference is not null
+    and (
+      b.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+      or b.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+    )
 
   union all
 
   select b.id,
-         lower(nullif(btrim(substring(a.system_key from 13)), ''))
+         lower(nullif(btrim(substring(a.system_key from 13)), '')),
+         false
   from base b
   join public.chips_entries e on e.transaction_id = b.id
   join public.chips_accounts a on a.id = e.account_id
@@ -79,7 +102,7 @@ with base as (
 ), marker_summary as (
   select transaction_id,
          array_agg(distinct table_id) filter (where table_id is not null) as table_ids,
-         bool_or(table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
+         bool_or(invalid_marker or table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
   from markers
   group by transaction_id
 ), classified as (
@@ -145,26 +168,49 @@ with base as (
     )
 ), markers as (
   select b.id as transaction_id,
-         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id
+         lower(nullif(btrim(b.metadata->>'tableId'), '')) as table_id,
+         (
+           b.metadata ? 'tableId'
+           and (
+             nullif(btrim(b.metadata->>'tableId'), '') is null
+             or nullif(btrim(b.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           )
+         ) as invalid_marker
   from base b
-  where nullif(btrim(b.metadata->>'tableId'), '') is not null
+  where b.metadata ? 'tableId'
+    and (
+      nullif(btrim(b.metadata->>'tableId'), '') is not null
+      or b.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+    )
 
   union all
 
   select b.id,
          case
-           when lower(b.reference) like 'table:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
-           when lower(b.reference) like 'poker-rebuy:%' then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
+           when b.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+             then lower(nullif(btrim(split_part(b.reference, ':', 2)), ''))
            else null
-         end
+         end,
+         (
+           b.reference is not null
+           and (
+             b.reference !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+             or nullif(btrim(split_part(b.reference, ':', 2)), '') is null
+             or nullif(btrim(split_part(b.reference, ':', 2)), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+           )
+         )
   from base b
-  where lower(b.reference) like 'table:%'
-     or lower(b.reference) like 'poker-rebuy:%'
+  where b.reference is not null
+    and (
+      b.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+      or b.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+    )
 
   union all
 
   select b.id,
-         lower(nullif(btrim(substring(a.system_key from 13)), ''))
+         lower(nullif(btrim(substring(a.system_key from 13)), '')),
+         false
   from base b
   join public.chips_entries e on e.transaction_id = b.id
   join public.chips_accounts a on a.id = e.account_id
@@ -173,7 +219,7 @@ with base as (
 ), marker_summary as (
   select transaction_id,
          array_agg(distinct table_id) filter (where table_id is not null) as table_ids,
-         bool_or(table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
+         bool_or(invalid_marker or table_id is null or table_id !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$') as invalid_table_marker
   from markers
   group by transaction_id
 ), classified as (
@@ -344,6 +390,23 @@ with table_rows as (
      and transactions.created_at < $1::timestamptz
      and transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
      and transactions.user_id is null
+     and (
+       transactions.metadata is null
+       or not (transactions.metadata ? 'tableId')
+       or (
+         nullif(btrim(transactions.metadata->>'tableId'), '') is not null
+         and nullif(btrim(transactions.metadata->>'tableId'), '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+         and lower(btrim(transactions.metadata->>'tableId')) = registry.table_id::text
+       )
+     )
+     and (
+       transactions.reference is null
+       or (
+         transactions.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+         and nullif(btrim(split_part(transactions.reference, ':', 2)), '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+         and lower(btrim(split_part(transactions.reference, ':', 2))) = registry.table_id::text
+       )
+     )
      and tables.status::text = 'CLOSED'
      and tables.has_human_participant is false
      and tables.bot_only_proof_eligible is true

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -557,7 +557,7 @@ with table_rows as (
          and (
            transactions.reference !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
            or nullif(btrim(split_part(transactions.reference, ':', 2)), '') is null
-           or nullif(btrim(split_part(transactions.reference, ':', 2)), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9]{3}-[89ab][0-9]{3}-[0-9a-f]{12}$'
+           or nullif(btrim(split_part(transactions.reference, ':', 2)), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
            or registry.table_id is null
            or lower(btrim(split_part(transactions.reference, ':', 2))) <> registry.table_id::text
          )
@@ -575,6 +575,9 @@ with table_rows as (
            where accounts.account_type::text = 'ESCROW'
              and accounts.system_key = 'POKER_TABLE:' || registry.table_id::text
          )::bigint as matching_escrow_count,
+         count(*) filter (where accounts.status::text = 'active')::bigint as active_entry_count,
+         coalesce(sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM'), 0)::numeric as system_amount,
+         coalesce(sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW'), 0)::numeric as escrow_amount,
          coalesce(sum(entries.amount), 0)::numeric as net_amount
     from public.chips_transactions transactions
     left join public.chips_transaction_idempotency registry
@@ -622,7 +625,16 @@ with table_rows as (
       or entry_shapes.system_entry_count <> 1
       or entry_shapes.escrow_entry_count <> 1
       or entry_shapes.matching_escrow_count <> 1
+      or entry_shapes.active_entry_count <> 2
       or entry_shapes.net_amount <> 0
+      or (
+        entry_shapes.tx_type = 'TABLE_BUY_IN'
+        and (entry_shapes.system_amount >= 0 or entry_shapes.escrow_amount <= 0)
+      )
+      or (
+        entry_shapes.tx_type = 'TABLE_CASH_OUT'
+        and (entry_shapes.escrow_amount >= 0 or entry_shapes.system_amount <= 0)
+      )
 
   union all
 

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
 import postgres from "postgres";
 import { writeExclusiveFiles } from "./_shared/chips-ledger-archive-files.mjs";
+import { assertTableBinding } from "./_shared/chips-table-idempotency.mjs";
 
 export const EXPORT_SCHEMA_VERSION = 1;
 export const DEFAULT_CUTOFF_DAYS = 30;
@@ -12,6 +13,9 @@ export const DEFAULT_BATCH_SIZE = 5000;
 export const MAX_BATCH_SIZE = 5000;
 export const PRODUCTION_MAX_BATCH_SIZE = 2;
 export const STAGE_AUTOMATION_POLICY_ID = "stage-ledger-auto-retention-30d-v1";
+export const BOT_ONLY_RETENTION_POLICY_ID = "stage-ledger-bot-only-retention-7d-v1";
+export const BOT_ONLY_EXPORT_SCHEMA_VERSION = 2;
+export const BOT_ONLY_RETENTION_DAYS = 7;
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const INTEGER_RE = /^-?(?:0|[1-9][0-9]*)$/;
@@ -268,6 +272,166 @@ order by e.created_at asc, e.id asc
 limit $2::int;
 `;
 
+// Schema-v2 selection is table-complete.  A batch contains one table only;
+// this makes the lifecycle receipt and the final table marker independently
+// auditable and leaves an over-capacity table untouched.
+export const BOT_ONLY_CANDIDATE_SQL = `
+with table_rows as (
+  select registry.table_id,
+         max(registry.transaction_created_at) as newest_created_at,
+         count(*)::bigint as identity_count,
+         count(*) filter (
+           where registry.user_id is null
+             and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+             and registry.transaction_created_at < $1::timestamptz
+             and registry.archive_batch_id is null
+         )::bigint as eligible_count,
+         public.chips_archive_text_ids_sha256(
+           coalesce(array_agg(registry.idempotency_key order by registry.idempotency_key)
+             filter (where registry.user_id is not null), array[]::text[])
+         ) as out_of_scope_keys_sha256
+    from public.chips_transaction_idempotency registry
+   where registry.table_id is not null
+   group by registry.table_id
+), eligible_transactions as (
+  select transactions.id,
+         transactions.sequence,
+         transactions.tx_type,
+         transactions.idempotency_key,
+         transactions.payload_hash,
+         transactions.user_id,
+         transactions.reference,
+         transactions.description,
+         transactions.metadata,
+         transactions.created_by,
+         transactions.created_at,
+         registry.table_id as key_table_id,
+         registry.key_format_version,
+         registry.key_format,
+         tables.id as table_row_id,
+         tables.status::text as table_status,
+         tables.has_human_participant,
+         tables.bot_only_proof_eligible,
+         escrow.id::text as escrow_account_id,
+         escrow.status::text as escrow_status,
+         escrow.balance::text as escrow_balance,
+         stats.newest_created_at as table_newest_created_at,
+         stats.identity_count as table_identity_count,
+         stats.eligible_count as table_eligible_count,
+         stats.out_of_scope_keys_sha256 as table_out_of_scope_keys_sha256,
+         count(entries.id)::text as entry_count
+    from public.chips_transactions transactions
+    join public.chips_transaction_idempotency registry
+      on registry.idempotency_key = transactions.idempotency_key
+     and registry.transaction_id = transactions.id
+     and registry.payload_hash = transactions.payload_hash
+     and registry.tx_type = transactions.tx_type
+     and registry.user_id is not distinct from transactions.user_id
+     and registry.transaction_created_at = transactions.created_at
+     and registry.table_id is not null
+     and registry.key_format_version = 1
+     and registry.key_format is not null
+     and registry.key_format = public.chips_parse_table_idempotency_key(transactions.idempotency_key)->>'format'
+     and registry.archive_batch_id is null
+    join table_rows stats on stats.table_id = registry.table_id
+    join public.poker_tables tables on tables.id = registry.table_id
+    join public.chips_accounts escrow
+      on escrow.account_type::text = 'ESCROW'
+     and escrow.system_key = 'POKER_TABLE:' || registry.table_id::text
+   join public.chips_entries entries on entries.transaction_id = transactions.id
+   join public.chips_accounts accounts on accounts.id = entries.account_id
+   where $3::timestamptz is null
+     and transactions.created_at < $1::timestamptz
+     and transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and transactions.user_id is null
+     and tables.status::text = 'CLOSED'
+     and tables.has_human_participant is false
+     and tables.bot_only_proof_eligible is true
+     and escrow.status::text = 'active'
+     and escrow.balance = 0
+     and stats.newest_created_at < $1::timestamptz
+     and stats.eligible_count > 0
+     and stats.eligible_count <= $2::int
+     and not exists (
+       select 1 from public.chips_transaction_idempotency unknown
+        where unknown.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+          and unknown.table_id is null
+     )
+     and not exists (
+       select 1 from table_rows blocked
+        where blocked.table_id = registry.table_id
+          and blocked.eligible_count <> blocked.identity_count
+     )
+   group by transactions.id, transactions.sequence, transactions.tx_type,
+            transactions.idempotency_key, transactions.payload_hash,
+            transactions.user_id, transactions.reference, transactions.description,
+            transactions.metadata, transactions.created_by, transactions.created_at,
+            registry.table_id, registry.key_format_version, registry.key_format,
+            tables.id, tables.status, tables.has_human_participant,
+            tables.bot_only_proof_eligible, escrow.id, escrow.status, escrow.balance,
+            stats.newest_created_at, stats.identity_count, stats.eligible_count,
+            stats.out_of_scope_keys_sha256
+  having count(*) = 2
+     and count(*) filter (where accounts.account_type::text = 'USER') = 0
+     and count(*) filter (where accounts.account_type::text = 'SYSTEM') = 1
+     and count(*) filter (where accounts.account_type::text = 'ESCROW') = 1
+     and count(*) filter (
+       where accounts.account_type::text = 'ESCROW'
+         and accounts.system_key = 'POKER_TABLE:' || registry.table_id::text
+     ) = 1
+     and bool_and(accounts.status::text = 'active')
+     and sum(entries.amount) = 0
+     and (
+       (transactions.tx_type::text = 'TABLE_BUY_IN'
+        and sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') < 0
+        and sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') > 0)
+       or
+       (transactions.tx_type::text = 'TABLE_CASH_OUT'
+        and sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') < 0
+        and sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') > 0)
+     )
+), selected_table as (
+  select key_table_id
+    from eligible_transactions
+   group by key_table_id
+   order by key_table_id
+   limit 1
+)
+select eligible.id::text as id,
+       eligible.sequence::text as sequence,
+       eligible.tx_type::text as tx_type,
+       eligible.idempotency_key,
+       eligible.payload_hash,
+       eligible.user_id::text as user_id,
+       eligible.reference,
+       eligible.description,
+       eligible.metadata,
+       eligible.created_by::text as created_by,
+       eligible.created_at::text as created_at,
+       true as table_related,
+       eligible.key_table_id::text as table_id,
+       false as invalid_table_marker,
+       true as table_exists,
+       eligible.table_status,
+       eligible.escrow_account_id,
+       eligible.escrow_status,
+       eligible.escrow_balance,
+       eligible.entry_count,
+       eligible.has_human_participant,
+       eligible.bot_only_proof_eligible,
+       eligible.key_table_id::text,
+       eligible.key_format_version,
+       eligible.key_format,
+       eligible.table_newest_created_at::text,
+       eligible.table_identity_count,
+       eligible.table_eligible_count,
+       eligible.table_out_of_scope_keys_sha256
+  from eligible_transactions eligible
+  join selected_table on selected_table.key_table_id = eligible.key_table_id
+ order by eligible.created_at asc, eligible.id asc
+ limit $2::int;
+`;
+
 const ENTRIES_SQL = `
 select
   e.id::text as id,
@@ -441,9 +605,9 @@ export function evaluateTableEligibility(candidate) {
   return { eligible: true, reason: tableExists ? "closed_table" : "retained_escrow_after_table_retention" };
 }
 
-function buildTableContext(candidate) {
+function buildTableContext(candidate, schemaVersion = EXPORT_SCHEMA_VERSION) {
   if (!candidate?.table_related && !candidate?.tableRelated && !candidate?.table_id && !candidate?.tableId) return null;
-  return {
+  const context = {
     table_id: text(candidate.table_id ?? candidate.tableId),
     table_exists: candidate.table_exists === true || candidate.tableExists === true,
     table_status: nullableText(candidate.table_status ?? candidate.tableStatus)?.toUpperCase() || null,
@@ -451,9 +615,29 @@ function buildTableContext(candidate) {
     escrow_status: nullableText(candidate.escrow_status ?? candidate.escrowStatus)?.toLowerCase() || null,
     escrow_balance: toBigIntString(candidate.escrow_balance ?? candidate.escrowBalance, "escrow.balance"),
   };
+  if (schemaVersion === BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+    context.bot_only_proof = {
+      has_human_participant: candidate.has_human_participant === false
+        ? false
+        : candidate.has_human_participant === true ? true : null,
+      proof_eligible: candidate.bot_only_proof_eligible === true
+        ? true
+        : candidate.bot_only_proof_eligible === false ? false : null,
+      table_id_from_key: text(candidate.key_table_id ?? candidate.table_id ?? candidate.tableId),
+      key_format_version: Number(candidate.key_format_version),
+      key_format: text(candidate.key_format),
+    };
+    context.table_identity_summary = {
+      newest_created_at: normalizeTimestamp(candidate.table_newest_created_at, "table.newest_created_at"),
+      identity_count: toBigIntString(candidate.table_identity_count, "table.identity_count"),
+      eligible_count: toBigIntString(candidate.table_eligible_count, "table.eligible_count"),
+      out_of_scope_keys_sha256: text(candidate.table_out_of_scope_keys_sha256),
+    };
+  }
+  return context;
 }
 
-export function buildExportRecord(candidate, rawEntries) {
+export function buildExportRecord(candidate, rawEntries, { schemaVersion = EXPORT_SCHEMA_VERSION } = {}) {
   const transactionId = text(candidate?.id);
   if (!UUID_RE.test(transactionId)) fail("transaction.id is not a UUID");
   const entries = [...rawEntries].sort(compareEntries).map((entry) => ({
@@ -475,7 +659,7 @@ export function buildExportRecord(candidate, rawEntries) {
   }));
 
   return {
-    schema_version: EXPORT_SCHEMA_VERSION,
+    schema_version: schemaVersion,
     record_type: "chips_transaction",
     transaction: {
       id: transactionId,
@@ -490,7 +674,7 @@ export function buildExportRecord(candidate, rawEntries) {
       created_by: nullableText(candidate.created_by),
       created_at: normalizeTimestamp(candidate.created_at, "transaction.created_at"),
     },
-    table_context: buildTableContext(candidate),
+    table_context: buildTableContext(candidate, schemaVersion),
     entries,
   };
 }
@@ -499,7 +683,44 @@ function candidateId(candidate) {
   return text(candidate?.id);
 }
 
-export function validateBatch({ candidates, records, cutoff }) {
+function validateBotOnlyRecord(candidate, record) {
+  const transaction = record?.transaction;
+  const context = record?.table_context;
+  const proof = context?.bot_only_proof;
+  const summary = context?.table_identity_summary;
+  if (transaction?.tx_type !== "TABLE_BUY_IN" && transaction?.tx_type !== "TABLE_CASH_OUT") fail("bot-only archive contains a non-TABLE transaction");
+  if (transaction.user_id != null) fail("bot-only archive contains a USER transaction");
+  if (!context || context.table_exists !== true || context.table_status !== "CLOSED"
+    || !context.escrow_account_id || context.escrow_status !== "active" || context.escrow_balance !== "0") {
+    fail("bot-only archive table lifecycle evidence is incomplete");
+  }
+  if (candidate?.has_human_participant !== false || candidate?.bot_only_proof_eligible !== true) {
+    fail("bot-only candidate human-participant proof is not authoritative");
+  }
+  if (!proof || proof.has_human_participant !== false || proof.proof_eligible !== true) fail("bot-only archive human-participant proof is not authoritative");
+  if (proof.table_id_from_key !== context.table_id || proof.key_format_version !== 1 || !proof.key_format) fail("bot-only idempotency key binding evidence is incomplete");
+  if (!summary || BigInt(summary.identity_count) < 1n || BigInt(summary.eligible_count) < 1n || !/^[0-9a-f]{64}$/.test(summary.out_of_scope_keys_sha256)) fail("bot-only table completeness evidence is incomplete");
+  const parsedBinding = assertTableBinding({
+    idempotencyKey: transaction.idempotency_key,
+    metadata: transaction.metadata,
+    reference: transaction.reference,
+  });
+  if (parsedBinding.tableId !== context.table_id || parsedBinding.format !== proof.key_format) fail("bot-only idempotency key binding differs from the table context");
+  const tableEntries = record.entries || [];
+  if (tableEntries.length !== 2 || tableEntries.some((entry) => entry.account?.account_type === "USER")) fail("bot-only archive entry shape contains a USER entry");
+  const escrowEntries = tableEntries.filter((entry) => entry.account?.account_type === "ESCROW");
+  const systemEntries = tableEntries.filter((entry) => entry.account?.account_type === "SYSTEM");
+  if (escrowEntries.length !== 1 || systemEntries.length !== 1 || escrowEntries[0].account.system_key !== `POKER_TABLE:${context.table_id}`) {
+    fail("bot-only archive ESCROW binding is incomplete");
+  }
+  const escrowAmount = BigInt(escrowEntries[0].amount);
+  const systemAmount = BigInt(systemEntries[0].amount);
+  if (transaction.tx_type === "TABLE_BUY_IN" && !(escrowAmount > 0n && systemAmount < 0n)) fail("bot-only TABLE_BUY_IN direction is invalid");
+  if (transaction.tx_type === "TABLE_CASH_OUT" && !(escrowAmount < 0n && systemAmount > 0n)) fail("bot-only TABLE_CASH_OUT direction is invalid");
+  if (candidate?.key_table_id && text(candidate.key_table_id) !== context.table_id) fail("bot-only key-derived table id differs from metadata/ESCROW");
+}
+
+export function validateBatch({ candidates, records, cutoff, schemaVersion = EXPORT_SCHEMA_VERSION }) {
   if (!Array.isArray(candidates) || !Array.isArray(records)) fail("batch must contain arrays");
   if (candidates.length !== records.length) fail("batch transaction count mismatch");
 
@@ -522,7 +743,7 @@ export function validateBatch({ candidates, records, cutoff }) {
   records.forEach((record, index) => {
     const transaction = record?.transaction;
     const id = text(transaction?.id);
-    if (record?.schema_version !== EXPORT_SCHEMA_VERSION || record?.record_type !== "chips_transaction") {
+    if (record?.schema_version !== schemaVersion || record?.record_type !== "chips_transaction") {
       fail("unsupported or malformed export record");
     }
     if (id !== expectedOrder[index]) fail("transaction order is not deterministic");
@@ -536,6 +757,7 @@ export function validateBatch({ candidates, records, cutoff }) {
     }
     const eligibility = evaluateTableEligibility(candidate);
     if (!eligibility.eligible) fail(`ineligible poker transaction: ${eligibility.reason}`);
+    if (schemaVersion === BOT_ONLY_EXPORT_SCHEMA_VERSION) validateBotOnlyRecord(candidate, record);
 
     const expectedEntries = BigInt(toBigIntString(candidate.entry_count, "database entry count"));
     if (!Array.isArray(record.entries) || BigInt(record.entries.length) !== expectedEntries) {
@@ -578,7 +800,7 @@ export function validateBatch({ candidates, records, cutoff }) {
   };
 }
 
-export function buildManifest({ target, cutoff, batchSize, cursor, records, archive, outputPath, sourcePolicyId = null }) {
+export function buildManifest({ target, cutoff, batchSize, cursor, records, archive, outputPath, sourcePolicyId = null, schemaVersion = EXPORT_SCHEMA_VERSION }) {
   const validation = validateBatch({ candidates: records.map((record) => ({
     id: record.transaction.id,
     created_at: record.transaction.created_at,
@@ -589,20 +811,47 @@ export function buildManifest({ target, cutoff, batchSize, cursor, records, arch
     table_status: record.table_context?.table_status,
     escrow_account_id: record.table_context?.escrow_account_id,
     escrow_balance: record.table_context?.escrow_balance,
-  })), records, cutoff: null });
+    has_human_participant: record.table_context?.bot_only_proof?.has_human_participant,
+    bot_only_proof_eligible: record.table_context?.bot_only_proof?.proof_eligible,
+    key_table_id: record.table_context?.bot_only_proof?.table_id_from_key,
+    key_format_version: record.table_context?.bot_only_proof?.key_format_version,
+    key_format: record.table_context?.bot_only_proof?.key_format,
+    table_newest_created_at: record.table_context?.table_identity_summary?.newest_created_at,
+    table_identity_count: record.table_context?.table_identity_summary?.identity_count,
+    table_eligible_count: record.table_context?.table_identity_summary?.eligible_count,
+    table_out_of_scope_keys_sha256: record.table_context?.table_identity_summary?.out_of_scope_keys_sha256,
+  })), records, cutoff: null, schemaVersion });
   const first = records[0]?.transaction || null;
   const last = records.at(-1)?.transaction || null;
   const compressionRatio = archive.rawBytes.length === 0
     ? null
     : Number((archive.compressedBytes.length / archive.rawBytes.length).toFixed(6));
   const endCursor = last ? { created_at: last.created_at, id: last.id } : null;
+  const registryKeysSha256 = schemaVersion === BOT_ONLY_EXPORT_SCHEMA_VERSION
+    ? crypto.createHash("sha256").update(`${records.map((record) => text(record.transaction.idempotency_key)).sort().join("\n")}\n`).digest("hex")
+    : null;
 
   return {
-    schema_version: EXPORT_SCHEMA_VERSION,
+    schema_version: schemaVersion,
     artifact_type: "chips_ledger_archive",
     format: "jsonl.gz",
     target,
     ...(sourcePolicyId == null ? {} : { source_policy_id: sourcePolicyId }),
+    ...(schemaVersion === BOT_ONLY_EXPORT_SCHEMA_VERSION ? {
+      bot_only: {
+        table_id: records[0]?.table_context?.table_id || null,
+        table_count: 1,
+        newest_created_at: records[0]?.table_context?.table_identity_summary?.newest_created_at || null,
+        registry_keys_sha256: registryKeysSha256,
+        out_of_scope_keys_sha256: records[0]?.table_context?.table_identity_summary?.out_of_scope_keys_sha256 || null,
+        identity_count: records[0]?.table_context?.table_identity_summary?.identity_count == null
+          ? null
+          : Number(records[0].table_context.table_identity_summary.identity_count),
+        eligible_count: records[0]?.table_context?.table_identity_summary?.eligible_count == null
+          ? null
+          : Number(records[0].table_context.table_identity_summary.eligible_count),
+      },
+    } : {}),
     cutoff: {
       created_at: cutoff,
       rule: "transaction.created_at < cutoff",
@@ -764,7 +1013,9 @@ export async function readSnapshot(sql, options) {
       ? CANDIDATE_SQL
       : selector === "prunable"
         ? PRUNABLE_CANDIDATE_SQL
-        : fail("snapshot selector must be standard or prunable");
+        : selector === "bot-only-7d"
+          ? BOT_ONLY_CANDIDATE_SQL
+          : fail("snapshot selector must be standard, prunable, or bot-only-7d");
     const candidates = await tx.unsafe(candidateSql, [
       timestampParam(options.cutoff),
       options.batchSize,
@@ -833,7 +1084,9 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
   });
 
   try {
-    const snapshot = await readSnapshot(sql, { ...options, selector: deps.selector || "standard" });
+    const selector = deps.selector || "standard";
+    const schemaVersion = deps.schemaVersion || (selector === "bot-only-7d" ? BOT_ONLY_EXPORT_SCHEMA_VERSION : EXPORT_SCHEMA_VERSION);
+    const snapshot = await readSnapshot(sql, { ...options, selector });
     if (deps.noCandidateIfEmpty && snapshot.candidates.length === 0) {
       return { noCandidate: true, options };
     }
@@ -842,14 +1095,15 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
     const records = sortRecords(snapshot.candidates.map((candidate) => buildExportRecord(
       candidate,
       entriesByTransaction.get(text(candidate.id)) || [],
+      { schemaVersion },
     )));
-    validateBatch({ candidates: snapshot.candidates, records, cutoff: options.cutoff });
+    validateBatch({ candidates: snapshot.candidates, records, cutoff: options.cutoff, schemaVersion });
 
     const archive = buildArchiveBytes(records);
     const roundTripRaw = gunzipSync(archive.compressedBytes);
     if (!roundTripRaw.equals(archive.rawBytes)) fail("gzip round-trip verification failed");
     const roundTripRecords = parseJsonl(roundTripRaw.toString("utf8"));
-    validateBatch({ candidates: snapshot.candidates, records: roundTripRecords, cutoff: options.cutoff });
+    validateBatch({ candidates: snapshot.candidates, records: roundTripRecords, cutoff: options.cutoff, schemaVersion });
     if (serializeRecords(roundTripRecords) !== archive.rawText) fail("JSONL round-trip verification failed");
 
     const manifest = buildManifest({
@@ -861,6 +1115,7 @@ export async function runExport({ argv = process.argv.slice(2), env = process.en
       archive,
       outputPath: options.outputPath,
       sourcePolicyId: deps.sourcePolicyId || null,
+      schemaVersion,
     });
     if (manifest.sha256.compressed_artifact !== crypto.createHash("sha256").update(archive.compressedBytes).digest("hex")) {
       fail("manifest checksum verification failed");

--- a/scripts/ops/chips-ledger-archive-export.mjs
+++ b/scripts/ops/chips-ledger-archive-export.mjs
@@ -439,7 +439,6 @@ with table_rows as (
             stats.newest_created_at, stats.identity_count, stats.eligible_count,
             stats.out_of_scope_keys_sha256
   having count(*) = 2
-     and count(distinct transactions.id) = stats.eligible_count
      and count(*) filter (where accounts.account_type::text = 'USER') = 0
      and count(*) filter (where accounts.account_type::text = 'SYSTEM') = 1
      and count(*) filter (where accounts.account_type::text = 'ESCROW') = 1
@@ -462,6 +461,7 @@ with table_rows as (
   select key_table_id
     from eligible_transactions
    group by key_table_id
+   having count(*) = max(table_eligible_count)
    order by key_table_id
    limit 1
 )

--- a/scripts/ops/chips-ledger-archive-prune.mjs
+++ b/scripts/ops/chips-ledger-archive-prune.mjs
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { maxBatchSizeForTarget, stringifyJson } from "./chips-ledger-archive-export.mjs";
+import {
+  BOT_ONLY_EXPORT_SCHEMA_VERSION,
+  BOT_ONLY_RETENTION_POLICY_ID,
+  maxBatchSizeForTarget,
+  stringifyJson,
+} from "./chips-ledger-archive-export.mjs";
 import {
   ARCHIVE_BUCKET,
   buildObjectPath,
@@ -17,6 +22,7 @@ import {
   ensurePrivateDirectory,
   writeExclusiveFiles,
 } from "./_shared/chips-ledger-archive-files.mjs";
+import { assertTableBinding } from "./_shared/chips-table-idempotency.mjs";
 
 export const STAGE_SYSTEM_IDENTIFIER = "7656985631720456337";
 export const PRODUCTION_SYSTEM_IDENTIFIER = "7575202818581710058";
@@ -39,6 +45,7 @@ Modes (mutually exclusive):
   default                        Validate Storage and run a database dry-run.
   --register-proof               Persist immutable ordered transaction/entry ID proof.
   --execute                      Prune exact proof-bound IDs after all checks.
+  --approved-batch-id <integer> Exact schema-v2 bot-only GO batch (execute only).
 
 Execute-only:
   --recovery-dir <path>          Required private 0700 recovery directory.
@@ -141,6 +148,8 @@ export function buildPruneEvidence(localArchive, { maxBatchSize = MAX_BATCH_SIZE
   const tables = new Set();
   let userTransactions = 0;
   let userEntries = 0;
+  const registryKeys = [];
+  const tableIds = new Set();
 
   for (const record of localArchive.records) {
     const transaction = record.transaction;
@@ -149,6 +158,22 @@ export function buildPruneEvidence(localArchive, { maxBatchSize = MAX_BATCH_SIZE
     if (transaction.user_id !== null) userTransactions += 1;
     const tableId = tableIdForRecord(record);
     tables.add(tableId);
+    if (localArchive.manifest.schema_version === BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+      const parsedBinding = assertTableBinding({
+        idempotencyKey: transaction.idempotency_key,
+        metadata: transaction.metadata,
+        reference: transaction.reference,
+      });
+      if (transaction.user_id !== null || record.table_context?.bot_only_proof?.has_human_participant !== false
+        || record.table_context?.bot_only_proof?.proof_eligible !== true
+        || record.table_context?.bot_only_proof?.table_id_from_key !== tableId
+        || parsedBinding.tableId !== tableId
+        || record.table_context?.bot_only_proof?.key_format !== parsedBinding.format) {
+        fail("schema-v2 archive is not proven bot-only");
+      }
+      registryKeys.push(text(transaction.idempotency_key));
+      tableIds.add(tableId);
+    }
     if (record.entries.length !== 2) fail("technical archive transaction must contain exactly two entries");
 
     const systemEntries = record.entries.filter((entry) => text(entry?.account?.account_type).toUpperCase() === "SYSTEM");
@@ -189,6 +214,12 @@ export function buildPruneEvidence(localArchive, { maxBatchSize = MAX_BATCH_SIZE
     credits: localArchive.summary.credits,
     debits: localArchive.summary.debits,
     net: localArchive.summary.netAmount,
+    ...(localArchive.manifest.schema_version === BOT_ONLY_EXPORT_SCHEMA_VERSION ? {
+      registryKeys: [...registryKeys].sort(),
+      registryKeysSha256: hashCanonicalLines([...registryKeys].sort()),
+      tableId: tableIds.size === 1 ? [...tableIds][0] : null,
+      outOfScopeKeysSha256: text(localArchive.manifest.bot_only?.out_of_scope_keys_sha256),
+    } : {}),
   };
 }
 
@@ -198,6 +229,7 @@ function parseArgs(argv) {
     ["--object-path", "objectPath"],
     ["--confirm-sha", "confirmSha"],
     ["--recovery-dir", "recoveryDir"],
+    ["--approved-batch-id", "approvedBatchId"],
   ]);
   const args = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -264,6 +296,11 @@ function parseManifestRow(row) {
     debits: String(row.debits),
     net_amount: String(row.net_amount),
     batch_id: String(row.batch_id),
+    bot_only_table_count: row.bot_only_table_count == null ? null : Number(row.bot_only_table_count),
+    bot_only_identity_count: row.bot_only_identity_count == null ? null : Number(row.bot_only_identity_count),
+    bot_only_eligible_count: row.bot_only_eligible_count == null ? null : Number(row.bot_only_eligible_count),
+    registry_cleaned_key_count: row.registry_cleaned_key_count == null ? null : Number(row.registry_cleaned_key_count),
+    destructive_go_batch_id: row.destructive_go_batch_id == null ? null : Number(row.destructive_go_batch_id),
   };
 }
 
@@ -299,6 +336,17 @@ function exporterManifestFromDatabase(row, target) {
     sha256: { raw_jsonl: row.raw_sha256, compressed_artifact: row.compressed_sha256 },
     artifact: path.basename(row.object_path),
     ...(row.source_policy_id ? { source_policy_id: row.source_policy_id } : {}),
+    ...(row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION ? {
+      bot_only: {
+        table_id: row.bot_only_table_id,
+        table_count: Number(row.bot_only_table_count),
+        newest_created_at: row.bot_only_newest_created_at,
+        registry_keys_sha256: row.bot_only_registry_keys_sha256,
+        out_of_scope_keys_sha256: row.bot_only_out_of_scope_keys_sha256,
+        identity_count: Number(row.bot_only_identity_count),
+        eligible_count: Number(row.bot_only_eligible_count),
+      },
+    } : {}),
   };
 }
 
@@ -337,6 +385,15 @@ export function buildRecoveryManifest(row, identity, evidence, target) {
       transaction_ids_sha256: evidence.transactionIdsSha256,
       entry_ids_sha256: evidence.entryIdsSha256,
     },
+    ...(row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION ? {
+      bot_only: {
+        table_id: row.bot_only_table_id || evidence.tableId,
+        table_count: row.bot_only_table_count || 1,
+        registry_keys_sha256: row.bot_only_registry_keys_sha256 || evidence.registryKeysSha256,
+        registry_key_count: evidence.registryKeys?.length || 0,
+        out_of_scope_keys_sha256: row.bot_only_out_of_scope_keys_sha256 || evidence.outOfScopeKeysSha256,
+      },
+    } : {}),
   };
 }
 
@@ -406,7 +463,19 @@ function manifestSelectSql() {
     archive_proof_verified_at::text as archive_proof_verified_at,
     pruned_at::text as pruned_at, pruned_transaction_count::text as pruned_transaction_count,
     pruned_entry_count::text as pruned_entry_count, pruned_transaction_ids_sha256,
-    pruned_entry_ids_sha256
+    pruned_entry_ids_sha256,
+    bot_only_table_id::text as bot_only_table_id,
+    bot_only_table_count::text as bot_only_table_count,
+    bot_only_newest_created_at::text as bot_only_newest_created_at,
+    bot_only_registry_keys_sha256,
+    bot_only_out_of_scope_keys_sha256,
+    bot_only_identity_count::text as bot_only_identity_count,
+    bot_only_eligible_count::text as bot_only_eligible_count,
+    registry_cleaned_at::text as registry_cleaned_at,
+    registry_cleaned_key_count::text as registry_cleaned_key_count,
+    registry_cleaned_keys_sha256,
+    destructive_go_at::text as destructive_go_at,
+    destructive_go_batch_id::text as destructive_go_batch_id
   from public.chips_ledger_archive_batches where object_path = $1;`;
 }
 
@@ -440,6 +509,21 @@ export function createPruneStore(sql) {
         return rows[0]?.result;
       });
     },
+    async registerBotOnlyProof(row, evidence) {
+      return sql.begin(async (tx) => {
+        await tx.unsafe("set transaction isolation level repeatable read;");
+        const rows = await tx.unsafe(`select public.chips_register_bot_only_archive_proof(
+          $1, $2::uuid[], $3::bigint[], $4::uuid, $5::text[]
+        ) as result;`, [
+          row.object_path,
+          evidence.transactionIds,
+          evidence.entryIds,
+          evidence.tableId,
+          evidence.registryKeys,
+        ]);
+        return rows[0]?.result;
+      });
+    },
     async prune(objectPath, evidence, execute) {
       return sql.begin(async (tx) => {
         await tx.unsafe("set transaction isolation level serializable;");
@@ -448,6 +532,25 @@ export function createPruneStore(sql) {
         const rows = await tx.unsafe(`select public.chips_prune_committed_archive_batch(
           $1, $2::uuid[], $3::bigint[], $4::boolean
         ) as result;`, [objectPath, evidence.transactionIds, evidence.entryIds, execute]);
+        return rows[0]?.result;
+      });
+    },
+    async cleanupBotOnly(objectPath, evidence, execute, approvedBatchId = null) {
+      return sql.begin(async (tx) => {
+        await tx.unsafe("set transaction isolation level serializable;");
+        await tx.unsafe("set local lock_timeout = '5s';");
+        await tx.unsafe("set local statement_timeout = '120s';");
+        const rows = await tx.unsafe(`select public.chips_prune_and_cleanup_bot_only_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::text[], $5::uuid, $6::boolean, $7::bigint
+        ) as result;`, [
+          objectPath,
+          evidence.transactionIds,
+          evidence.entryIds,
+          evidence.registryKeys,
+          evidence.tableId,
+          execute,
+          approvedBatchId,
+        ]);
         return rows[0]?.result;
       });
     },
@@ -462,6 +565,26 @@ export function createPruneStore(sql) {
           where registry.transaction_id = any($2::uuid[]) and registry.archive_batch_id = batches.batch_id) as mapping_count,
         (select count(*)::text from public.chips_transaction_idempotency registry
           where registry.archive_batch_id = batches.batch_id and not (registry.transaction_id = any($2::uuid[]))) as extra_mapping_count,
+        (select count(*)::text from public.chips_transactions transactions where transactions.id = any($2::uuid[])) as hot_transaction_count,
+        (select count(*)::text from public.chips_entries entries
+          where entries.transaction_id = any($2::uuid[]) or entries.id = any($3::bigint[])) as hot_entry_count
+      from public.chips_ledger_archive_batches batches where batches.object_path = $1;`, [
+        row.object_path, evidence.transactionIds, evidence.entryIds,
+      ]);
+      return rows[0] || null;
+    },
+    async verifyBotOnlyCommitted(row, evidence) {
+      const rows = await sql.unsafe(`select
+        batches.pruned_at::text as pruned_at,
+        batches.pruned_transaction_count::text as pruned_transaction_count,
+        batches.pruned_entry_count::text as pruned_entry_count,
+        batches.pruned_transaction_ids_sha256,
+        batches.pruned_entry_ids_sha256,
+        batches.registry_cleaned_at::text as registry_cleaned_at,
+        batches.registry_cleaned_key_count::text as registry_cleaned_key_count,
+        batches.registry_cleaned_keys_sha256,
+        (select count(*)::text from public.chips_transaction_idempotency registry
+          where registry.archive_batch_id = batches.batch_id) as remaining_mapping_count,
         (select count(*)::text from public.chips_transactions transactions where transactions.id = any($2::uuid[])) as hot_transaction_count,
         (select count(*)::text from public.chips_entries entries
           where entries.transaction_id = any($2::uuid[]) or entries.id = any($3::bigint[])) as hot_entry_count
@@ -547,6 +670,8 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
   if (args.objectPath !== buildObjectPath(args.confirmSha)) fail("--object-path does not match --confirm-sha");
   if (args.execute && !args.recoveryDir) fail("--recovery-dir is required with --execute");
   if (!args.execute && args.recoveryDir) fail("--recovery-dir is only valid with --execute");
+  if (args.approvedBatchId != null && !args.execute) fail("--approved-batch-id is only valid with --execute");
+  if (args.approvedBatchId != null && !/^[1-9][0-9]*$/.test(args.approvedBatchId)) fail("--approved-batch-id must be a positive integer");
 
   const target = deps.storageTarget || resolveStorageTarget(args.target, env, deps.targetOptions || {});
   const sql = deps.sql || (deps.pruneStore ? null : postgres(target.dbUrl, {
@@ -580,9 +705,12 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
     const evidence = buildPruneEvidence(localArchive, { maxBatchSize: targetPolicy(target.target).maxBatchSize });
 
     if (args.registerProof) {
-      const proof = await store.registerProof(row, evidence);
+      const proof = row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION
+        ? await store.registerBotOnlyProof(row, evidence)
+        : await store.registerProof(row, evidence);
+      const refreshedRow = await store.getManifest(row.object_path);
       const result = {
-        row,
+        row: refreshedRow,
         identity,
         evidence,
         target,
@@ -594,7 +722,7 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
       return result;
     }
 
-    if (args.execute) assertProofMatches(row, evidence);
+    if (args.execute) assertProofMatches(await store.getManifest(row.object_path), evidence);
     let recoveryBundle = null;
     if (args.execute) {
       recoveryBundle = writeRecoveryBundle({
@@ -607,15 +735,17 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
       });
     }
 
-    const pruneResult = await executeArchivePrune({
-      store,
-      objectPath: row.object_path,
-      evidence,
-      execute: Boolean(args.execute),
-      beforeAttempt: recoveryBundle
-        ? () => verifyRecoveryBundle({ bundle: recoveryBundle, row, target, identity, expectedEvidence: evidence })
-        : null,
-    });
+    const pruneResult = row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION
+      ? await store.cleanupBotOnly(row.object_path, evidence, Boolean(args.execute), args.approvedBatchId == null ? null : Number(args.approvedBatchId))
+      : await executeArchivePrune({
+        store,
+        objectPath: row.object_path,
+        evidence,
+        execute: Boolean(args.execute),
+        beforeAttempt: recoveryBundle
+          ? () => verifyRecoveryBundle({ bundle: recoveryBundle, row, target, identity, expectedEvidence: evidence })
+          : null,
+      });
 
     let postCommitDownloadMs = null;
     if (args.execute) {
@@ -631,7 +761,26 @@ export async function pruneArchive({ argv = process.argv.slice(2), env = process
           target,
           artifactName: path.basename(row.object_path),
         });
-        assertPostCommitVerification(await store.verifyCommitted(row, evidence), evidence);
+        const verification = row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION
+          ? await store.verifyBotOnlyCommitted(row, evidence)
+          : await store.verifyCommitted(row, evidence);
+        if (row.format_version === BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+          if (!verification?.pruned_at
+            || Number(verification.pruned_transaction_count) !== evidence.transactionCount
+            || Number(verification.pruned_entry_count) !== evidence.entryCount
+            || verification.pruned_transaction_ids_sha256 !== evidence.transactionIdsSha256
+            || verification.pruned_entry_ids_sha256 !== evidence.entryIdsSha256
+            || !verification.registry_cleaned_at
+            || Number(verification.registry_cleaned_key_count) !== evidence.registryKeys.length
+            || verification.registry_cleaned_keys_sha256 !== evidence.registryKeysSha256
+            || Number(verification.remaining_mapping_count) !== 0
+            || Number(verification.hot_transaction_count) !== 0
+            || Number(verification.hot_entry_count) !== 0) {
+            fail("post-commit bot-only cleanup verification failed", "post_commit_verification_failed");
+          }
+        } else {
+          assertPostCommitVerification(verification, evidence);
+        }
       } catch (error) {
         if (error?.code === "post_commit_verification_failed") throw error;
         fail(`post-commit verification failed: ${error?.message || error}`, "post_commit_verification_failed");

--- a/scripts/ops/chips-ledger-archive-store.mjs
+++ b/scripts/ops/chips-ledger-archive-store.mjs
@@ -6,6 +6,8 @@ import { gunzipSync } from "node:zlib";
 import postgres from "postgres";
 import {
   EXPORT_SCHEMA_VERSION,
+  BOT_ONLY_EXPORT_SCHEMA_VERSION,
+  BOT_ONLY_RETENTION_POLICY_ID,
   compareTransactions,
   maxBatchSizeForTarget,
   parseJsonl,
@@ -15,6 +17,7 @@ import {
   stringifyJson,
   timestampToMicros,
 } from "./chips-ledger-archive-export.mjs";
+import { assertTableBinding } from "./_shared/chips-table-idempotency.mjs";
 
 export const ARCHIVE_BUCKET = "chips-ledger-archive";
 export const ARCHIVE_MIME_TYPE = "application/gzip";
@@ -147,17 +150,26 @@ function verifyCursor(cursor, label) {
 
 function verifyManifestShape(manifest, artifactName, target) {
   if (!manifest || typeof manifest !== "object") fail("local manifest must be an object");
-  if (manifest.schema_version !== EXPORT_SCHEMA_VERSION || manifest.artifact_type !== "chips_ledger_archive" || manifest.format !== "jsonl.gz") {
+  if (![EXPORT_SCHEMA_VERSION, BOT_ONLY_EXPORT_SCHEMA_VERSION].includes(manifest.schema_version)
+    || manifest.artifact_type !== "chips_ledger_archive" || manifest.format !== "jsonl.gz") {
     fail("local manifest has an unsupported archive format");
   }
   if (manifest.target !== target.target) fail("local manifest target does not match --target");
   if (manifest.source_policy_id !== undefined
     && manifest.source_policy_id !== null
-    && manifest.source_policy_id !== STAGE_AUTOMATION_POLICY_ID) {
+    && manifest.source_policy_id !== STAGE_AUTOMATION_POLICY_ID
+    && manifest.source_policy_id !== BOT_ONLY_RETENTION_POLICY_ID) {
     fail("local manifest source policy is unsupported");
   }
   if (manifest.source_policy_id === STAGE_AUTOMATION_POLICY_ID && target.target !== "stage") {
     fail("Stage automation policy cannot be stored for a non-Stage target");
+  }
+  if (manifest.schema_version === BOT_ONLY_EXPORT_SCHEMA_VERSION
+    && (manifest.source_policy_id !== BOT_ONLY_RETENTION_POLICY_ID || target.target !== "stage")) {
+    fail("schema-v2 archive requires the Stage bot-only retention policy");
+  }
+  if (manifest.source_policy_id === BOT_ONLY_RETENTION_POLICY_ID && manifest.schema_version !== BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+    fail("bot-only retention policy requires schema-v2 archive evidence");
   }
   if (manifest.artifact !== artifactName) fail("local manifest artifact name does not match the archive");
   if (!manifest.cutoff || typeof manifest.cutoff.created_at !== "string") fail("local manifest cutoff is missing");
@@ -177,6 +189,19 @@ function verifyManifestShape(manifest, artifactName, target) {
     txTypeTotal += count;
   }
   if (txTypeTotal !== batch.transactions) fail("local manifest tx_types count mismatch");
+
+  if (manifest.schema_version === BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+    const botOnly = manifest.bot_only;
+    if (!botOnly || !UUID_RE.test(text(botOnly.table_id)) || botOnly.table_count !== 1
+      || !timestampValue(botOnly.newest_created_at)
+      || !SHA256_RE.test(text(botOnly.registry_keys_sha256))
+      || !SHA256_RE.test(text(botOnly.out_of_scope_keys_sha256))
+      || !Number.isSafeInteger(botOnly.identity_count) || botOnly.identity_count < 1
+      || botOnly.identity_count !== batch.transactions
+      || botOnly.eligible_count !== batch.transactions) {
+      fail("schema-v2 bot-only manifest evidence is incomplete");
+    }
+  }
 
   const amounts = manifest.amounts;
   if (!amounts) fail("local manifest amounts are missing");
@@ -202,6 +227,16 @@ function verifyManifestShape(manifest, artifactName, target) {
   return { cursorStart, cursorEnd };
 }
 
+function timestampValue(value) {
+  if (typeof value !== "string") return false;
+  try {
+    timestampToMicros(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function summarizeRecords(records, manifest) {
   if (!Array.isArray(records)) fail("JSONL artifact must contain records");
   const sorted = [...records].sort(compareTransactions);
@@ -218,7 +253,7 @@ function summarizeRecords(records, manifest) {
     if (record !== sorted[recordIndex]) fail("JSONL transaction order is not deterministic");
     const transaction = record?.transaction;
     const transactionId = text(transaction?.id).toLowerCase();
-    if (record?.schema_version !== EXPORT_SCHEMA_VERSION || record?.record_type !== "chips_transaction" || !UUID_RE.test(transactionId)) {
+    if (record?.schema_version !== manifest.schema_version || record?.record_type !== "chips_transaction" || !UUID_RE.test(transactionId)) {
       fail("JSONL artifact contains a malformed transaction");
     }
     if (seenTransactions.has(transactionId)) fail("JSONL artifact contains duplicate transactions");
@@ -230,6 +265,42 @@ function summarizeRecords(records, manifest) {
     txTypes[txType] = (txTypes[txType] || 0) + 1;
 
     if (!Array.isArray(record.entries)) fail(`JSONL artifact has no entries array for ${transactionId}`);
+    if (manifest.schema_version === BOT_ONLY_EXPORT_SCHEMA_VERSION) {
+      const context = record.table_context;
+      const proof = context?.bot_only_proof;
+      const summary = context?.table_identity_summary;
+      if (transaction.tx_type !== "TABLE_BUY_IN" && transaction.tx_type !== "TABLE_CASH_OUT") fail("schema-v2 artifact contains a non-TABLE transaction");
+      if (transaction.user_id != null || context?.table_exists !== true || context?.table_status !== "CLOSED"
+        || !context?.escrow_account_id || context?.escrow_status !== "active" || context?.escrow_balance !== "0"
+        || context?.table_id !== manifest.bot_only?.table_id) fail("schema-v2 artifact lifecycle evidence is invalid");
+      if (!proof || proof.has_human_participant !== false || proof.proof_eligible !== true
+        || proof.table_id_from_key !== context.table_id || proof.key_format_version !== 1 || !text(proof.key_format)) {
+        fail("schema-v2 artifact bot-only proof is invalid");
+      }
+      if (!summary || !timestampValue(summary.newest_created_at)
+        || !/^[0-9]+$/.test(text(summary.identity_count))
+        || !/^[0-9]+$/.test(text(summary.eligible_count))
+        || text(summary.identity_count) !== String(manifest.bot_only?.identity_count)
+        || text(summary.eligible_count) !== String(manifest.bot_only?.eligible_count)
+        || !SHA256_RE.test(text(summary.out_of_scope_keys_sha256))
+        || summary.newest_created_at !== manifest.bot_only?.newest_created_at) {
+        fail("schema-v2 artifact table summary is invalid");
+      }
+      const parsedBinding = assertTableBinding({
+        idempotencyKey: transaction.idempotency_key,
+        metadata: transaction.metadata,
+        reference: transaction.reference,
+      });
+      if (parsedBinding.tableId !== context.table_id || parsedBinding.format !== proof.key_format) fail("schema-v2 artifact idempotency binding is invalid");
+      const escrowEntries = record.entries.filter((entry) => entry.account?.account_type === "ESCROW");
+      const systemEntries = record.entries.filter((entry) => entry.account?.account_type === "SYSTEM");
+      if (escrowEntries.length !== 1 || systemEntries.length !== 1 || record.entries.some((entry) => entry.account?.account_type === "USER")
+        || escrowEntries[0]?.account?.system_key !== `POKER_TABLE:${context.table_id}`
+        || (transaction.tx_type === "TABLE_BUY_IN" && !(BigInt(escrowEntries[0].amount) > 0n && BigInt(systemEntries[0].amount) < 0n))
+        || (transaction.tx_type === "TABLE_CASH_OUT" && !(BigInt(escrowEntries[0].amount) < 0n && BigInt(systemEntries[0].amount) > 0n))) {
+        fail("schema-v2 artifact entry binding is invalid");
+      }
+    }
     const sortedEntries = [...record.entries].sort((left, right) => {
       const leftId = BigInt(assertIntegerString(left?.id, "entry.id", { nonNegative: true }));
       const rightId = BigInt(assertIntegerString(right?.id, "entry.id", { nonNegative: true }));
@@ -455,6 +526,13 @@ function manifestRow(manifest, storageTarget, objectPath) {
     debits: manifest.amounts.debits,
     net_amount: manifest.amounts.net,
     source_policy_id: manifest.source_policy_id || null,
+    bot_only_table_id: manifest.bot_only?.table_id || null,
+    bot_only_table_count: manifest.bot_only?.table_count == null ? null : String(manifest.bot_only.table_count),
+    bot_only_newest_created_at: manifest.bot_only?.newest_created_at || null,
+    bot_only_registry_keys_sha256: manifest.bot_only?.registry_keys_sha256 || null,
+    bot_only_out_of_scope_keys_sha256: manifest.bot_only?.out_of_scope_keys_sha256 || null,
+    bot_only_identity_count: manifest.bot_only?.identity_count == null ? null : String(manifest.bot_only.identity_count),
+    bot_only_eligible_count: manifest.bot_only?.eligible_count == null ? null : String(manifest.bot_only.eligible_count),
     status: "pending",
   };
 }
@@ -463,6 +541,8 @@ const IMMUTABLE_FIELDS = [
   "object_path", "project_ref", "format_version", "cutoff", "cursor_start_created_at", "cursor_start_id",
   "cursor_end_created_at", "cursor_end_id", "first_created_at", "last_created_at", "transaction_count",
   "entry_count", "tx_types", "raw_bytes", "compressed_bytes", "raw_sha256", "compressed_sha256", "credits", "debits", "net_amount", "source_policy_id",
+  "bot_only_table_id", "bot_only_table_count", "bot_only_newest_created_at", "bot_only_registry_keys_sha256",
+  "bot_only_out_of_scope_keys_sha256", "bot_only_identity_count", "bot_only_eligible_count",
 ];
 
 function assertSameManifest(existing, expected) {
@@ -629,6 +709,27 @@ function selectManifestSql() {
     debits::text as debits,
     net_amount::text as net_amount,
     source_policy_id,
+    batch_id::text as batch_id,
+    archived_transaction_ids_sha256,
+    archived_entry_ids_sha256,
+    archive_proof_verified_at::text as archive_proof_verified_at,
+    pruned_at::text as pruned_at,
+    pruned_transaction_count::text as pruned_transaction_count,
+    pruned_entry_count::text as pruned_entry_count,
+    pruned_transaction_ids_sha256,
+    pruned_entry_ids_sha256,
+    bot_only_table_id::text as bot_only_table_id,
+    bot_only_table_count::text as bot_only_table_count,
+    bot_only_newest_created_at::text as bot_only_newest_created_at,
+    bot_only_registry_keys_sha256,
+    bot_only_out_of_scope_keys_sha256,
+    bot_only_identity_count::text as bot_only_identity_count,
+    bot_only_eligible_count::text as bot_only_eligible_count,
+    registry_cleaned_at::text as registry_cleaned_at,
+    registry_cleaned_key_count::text as registry_cleaned_key_count,
+    registry_cleaned_keys_sha256,
+    destructive_go_at::text as destructive_go_at,
+    destructive_go_batch_id::text as destructive_go_batch_id,
     status
   from public.chips_ledger_archive_batches
   where object_path = $1;`;
@@ -648,6 +749,12 @@ function normalizeManifestRow(row) {
     debits: String(row.debits),
     net_amount: String(row.net_amount),
     source_policy_id: row.source_policy_id || null,
+    batch_id: row.batch_id == null ? null : String(row.batch_id),
+    bot_only_table_count: row.bot_only_table_count == null ? null : String(row.bot_only_table_count),
+    bot_only_identity_count: row.bot_only_identity_count == null ? null : String(row.bot_only_identity_count),
+    bot_only_eligible_count: row.bot_only_eligible_count == null ? null : String(row.bot_only_eligible_count),
+    registry_cleaned_key_count: row.registry_cleaned_key_count == null ? null : String(row.registry_cleaned_key_count),
+    destructive_go_batch_id: row.destructive_go_batch_id == null ? null : String(row.destructive_go_batch_id),
   };
 }
 
@@ -665,16 +772,23 @@ export function createManifestStore(sql) {
         (object_path, project_ref, format_version, cutoff, cursor_start_created_at, cursor_start_id,
          cursor_end_created_at, cursor_end_id, first_created_at, last_created_at, transaction_count,
          entry_count, tx_types, raw_bytes, compressed_bytes, raw_sha256, compressed_sha256,
-         credits, debits, net_amount, source_policy_id, status)
+         credits, debits, net_amount, source_policy_id,
+         bot_only_table_id, bot_only_table_count, bot_only_newest_created_at,
+         bot_only_registry_keys_sha256, bot_only_out_of_scope_keys_sha256,
+         bot_only_identity_count, bot_only_eligible_count, status)
         values ($1, $2, $3::integer, $4::timestamptz, $5::timestamptz, $6::uuid,
                 $7::timestamptz, $8::uuid, $9::timestamptz, $10::timestamptz, $11::bigint,
                 $12::bigint, $13::jsonb, $14::bigint, $15::bigint, $16, $17,
-                $18::numeric, $19::numeric, $20::numeric, $21, 'pending')
+                $18::numeric, $19::numeric, $20::numeric, $21,
+                $22::uuid, $23::bigint, $24::timestamptz, $25, $26, $27::bigint, $28::bigint, 'pending')
         on conflict (object_path) do nothing;`, [
         row.object_path, row.project_ref, row.format_version, timestampParam(row.cutoff), timestampParam(row.cursor_start_created_at), row.cursor_start_id,
         timestampParam(row.cursor_end_created_at), row.cursor_end_id, timestampParam(row.first_created_at), timestampParam(row.last_created_at), row.transaction_count,
         row.entry_count, row.tx_types, row.raw_bytes, row.compressed_bytes, row.raw_sha256, row.compressed_sha256,
         row.credits, row.debits, row.net_amount, row.source_policy_id,
+        row.bot_only_table_id, row.bot_only_table_count, timestampParam(row.bot_only_newest_created_at),
+        row.bot_only_registry_keys_sha256, row.bot_only_out_of_scope_keys_sha256,
+        row.bot_only_identity_count, row.bot_only_eligible_count,
       ]);
     },
     async markCommitted(objectPath) {

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -6,6 +6,9 @@ import { fileURLToPath } from "node:url";
 import { gunzipSync, gzipSync } from "node:zlib";
 import postgres from "postgres";
 import {
+  BOT_ONLY_EXPORT_SCHEMA_VERSION,
+  BOT_ONLY_RETENTION_DAYS,
+  BOT_ONLY_RETENTION_POLICY_ID,
   runExport,
   STAGE_AUTOMATION_POLICY_ID,
   stringifyJson,
@@ -77,7 +80,7 @@ function aggregatePayload(result) {
     event: "chips_ledger_stage_automation",
     target: "stage",
     project_ref: STAGE_PROJECT_REF,
-    source_policy_id: STAGE_AUTOMATION_POLICY_ID,
+    source_policy_id: result.sourcePolicyId || STAGE_AUTOMATION_POLICY_ID,
     state: result.state,
   };
   if (result.state === "error") {
@@ -200,7 +203,7 @@ async function assertIdentity(sql) {
   return identity;
 }
 
-async function loadOwnBatches(sql) {
+async function loadOwnBatches(sql, sourcePolicyId = STAGE_AUTOMATION_POLICY_ID) {
   return sql.unsafe(`select
     object_path,
     project_ref,
@@ -215,11 +218,23 @@ async function loadOwnBatches(sql) {
     pruned_entry_count::text as pruned_entry_count,
     pruned_transaction_ids_sha256,
     pruned_entry_ids_sha256,
+    bot_only_table_id,
+    bot_only_table_count::text as bot_only_table_count,
+    bot_only_newest_created_at::text as bot_only_newest_created_at,
+    bot_only_registry_keys_sha256,
+    bot_only_out_of_scope_keys_sha256,
+    bot_only_identity_count::text as bot_only_identity_count,
+    bot_only_eligible_count::text as bot_only_eligible_count,
+    registry_cleaned_at::text as registry_cleaned_at,
+    registry_cleaned_key_count::text as registry_cleaned_key_count,
+    registry_cleaned_keys_sha256,
+    destructive_go_at::text as destructive_go_at,
+    destructive_go_batch_id::text as destructive_go_batch_id,
     compressed_sha256
   from public.chips_ledger_archive_batches
   where project_ref = $1
     and source_policy_id = $2
-  order by created_at desc, object_path desc;`, [STAGE_PROJECT_REF, STAGE_AUTOMATION_POLICY_ID]);
+  order by created_at desc, object_path desc;`, [STAGE_PROJECT_REF, sourcePolicyId]);
 }
 
 function receiptFieldCount(row) {
@@ -357,7 +372,7 @@ export function assertDurableRecoveryReady(durable) {
   return true;
 }
 
-function pruneArgs(row, mode, recoveryDir = null) {
+function pruneArgs(row, mode, recoveryDir = null, approvedBatchId = null) {
   const args = [
     "--target", "stage",
     "--object-path", row.object_path,
@@ -365,10 +380,11 @@ function pruneArgs(row, mode, recoveryDir = null) {
   ];
   if (mode === "register-proof") args.push("--register-proof");
   if (mode === "execute") args.push("--execute", "--recovery-dir", recoveryDir);
+  if (approvedBatchId != null) args.push("--approved-batch-id", String(approvedBatchId));
   return args;
 }
 
-async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarget, downloadArchive = null, recoveryDir = null, verifyBucket = null, storageDeps = {} }) {
+async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarget, downloadArchive = null, recoveryDir = null, approvedBatchId = null, verifyBucket = null, storageDeps = {} }) {
   const deps = {
     ...storageDeps,
     sql,
@@ -380,7 +396,7 @@ async function runPruneStep({ row, mode, env, cwd, sql, pruneStore, storageTarge
   if (verifyBucket) deps.verifyBucket = verifyBucket;
   const pruneRunner = storageDeps.pruneArchive || pruneArchive;
   return pruneRunner({
-    argv: pruneArgs(row, mode, mode === "execute" ? recoveryDir : null),
+    argv: pruneArgs(row, mode, mode === "execute" ? recoveryDir : null, approvedBatchId),
     env,
     cwd,
     deps,
@@ -411,13 +427,17 @@ async function verifyCompletedCycle({ row, identity, env, tempRoot, sql, pruneSt
   return { durable, dry };
 }
 
-async function refreshRow(pruneStore, objectPath) {
+async function refreshPolicyRow(pruneStore, objectPath, sourcePolicyId = STAGE_AUTOMATION_POLICY_ID) {
   const row = await pruneStore.getManifest(objectPath);
-  if (!row || row.source_policy_id !== STAGE_AUTOMATION_POLICY_ID) fail("Stage automation manifest policy mismatch");
+  if (!row || row.source_policy_id !== sourcePolicyId) fail("Stage automation manifest policy mismatch");
   return row;
 }
 
-async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps = {} }) {
+async function refreshRow(pruneStore, objectPath) {
+  return refreshPolicyRow(pruneStore, objectPath, STAGE_AUTOMATION_POLICY_ID);
+}
+
+async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql, pruneStore, storageTarget, approvedBatchId = null, verifyBucket, storageDeps = {} }) {
   assertDurableRecoveryReady(durable);
   const recoveryDir = path.join(tempRoot, "recovery");
   restoreLocalRecovery(recoveryDir, durable);
@@ -432,9 +452,10 @@ async function executeVerifiedCycle({ row, identity, durable, env, tempRoot, sql
     verifyBucket,
     storageDeps,
     recoveryDir,
+    approvedBatchId,
     downloadArchive: async () => ({ bytes: durable.archiveBytes, downloadMs: 0 }),
   });
-  if (result.state !== "pruned" && result.state !== "already_pruned") {
+  if (result.state !== "pruned" && result.state !== "already_pruned" && result.state !== "cleaned" && result.state !== "already_cleaned") {
     fail(`unexpected prune state: ${result.state}`);
   }
   return result;
@@ -645,13 +666,223 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
   return result;
 }
 
+// Issue #890 uses the same Stage runner, Storage bucket, proof store, prune
+// store, recovery copies, and advisory lock.  Its default is deliberately
+// prepare-only: no call reaches the destructive DB operator unless the caller
+// explicitly supplies one exact approved batch id and opts into execution.
+export async function runBotOnlyStageAutomation({
+  env = process.env,
+  now = new Date(),
+  deps = {},
+  prepareOnly = true,
+  approvedBatchId = null,
+} = {}) {
+  if (prepareOnly !== true && (approvedBatchId == null || !/^[1-9][0-9]*$/.test(String(approvedBatchId)))) {
+    fail("bot-only destructive execution requires one exact approved batch id");
+  }
+  if (prepareOnly !== true && text(env.CHIPS_LEDGER_BOT_ONLY_EXECUTE) !== "1") {
+    fail("bot-only destructive execution requires the explicit default-off execution gate");
+  }
+  if (prepareOnly === true && approvedBatchId != null) {
+    fail("approved bot-only batch id is only valid with destructive execution");
+  }
+  let sql = null;
+  let lockSession = null;
+  let tempRoot = null;
+  let ownsSql = false;
+  let result = null;
+  let failed = false;
+  let failure = null;
+  try {
+    const config = validateStageEnvironment(env);
+    const moduleEnv = config.moduleEnv;
+    if (deps.sql) sql = deps.sql;
+    else {
+      sql = postgres(config.dbUrl, { max: 1, prepare: false, connect_timeout: 10, idle_timeout: 0 });
+      ownsSql = true;
+    }
+    tempRoot = deps.tempRoot || fs.mkdtempSync(path.join(os.tmpdir(), "chips-ledger-stage-bot-only-"));
+    ensurePrivateDirectory(tempRoot);
+    const storageTarget = deps.storageTarget || resolveStorageTarget("stage", moduleEnv, { singleTarget: true });
+    const pruneStore = deps.pruneStore || createPruneStore(sql);
+    const verifyBucket = deps.verifyBucket || ((target) => verifyArchiveBucket(target, deps));
+    lockSession = await acquireAdvisoryLock(sql);
+    if (!lockSession) result = { state: "no-op", reason: "advisory_lock_busy", sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID };
+    else {
+      const identity = await assertIdentity(sql);
+      await assertAdvisoryLock(sql, lockSession);
+      await verifyBucket(storageTarget);
+      const ownRows = await loadOwnBatches(sql, BOT_ONLY_RETENTION_POLICY_ID);
+      const activeRows = ownRows.filter((row) => row.status === "pending" || (row.status === "committed" && !row.registry_cleaned_at));
+      if (activeRows.length > 1) fail("multiple incomplete bot-only Stage manifests; refusing to choose one");
+      if (activeRows[0]?.status === "pending") fail("bot-only Stage manifest is pending; refusing a blind resume");
+
+      const prepareExisting = async (row) => {
+        row = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
+        if (!row.archive_proof_verified_at) {
+          await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          row = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
+        }
+        const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+        if (dry.state === "already_cleaned") return { row, dry, durable: null };
+        if (dry.state !== "ready") fail(`bot-only Stage dry-run did not become ready: ${dry.state}`);
+        const existing = await inspectDurableRecovery(storageTarget, row, deps);
+        assertResumeRecoveryState(row, existing);
+        let durable = existing;
+        if (!durable) {
+          const mainArchive = await (deps.downloadPrivateArchive || downloadPrivateArchiveObject)(storageTarget, row.object_path, deps);
+          durable = await persistDurableRecovery(
+            storageTarget,
+            row,
+            identity,
+            dry.evidence,
+            mainArchive.bytes,
+            deps,
+          );
+        }
+        if (!prepareOnly) {
+          if (String(approvedBatchId) !== String(row.batch_id)) fail("approved bot-only batch id does not match the active manifest");
+          const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, approvedBatchId, storageDeps: deps });
+          return { row, dry, durable, executed };
+        }
+        return { row, dry, durable, executed: null };
+      };
+
+      if (activeRows[0]) {
+        const cycle = await prepareExisting(activeRows[0]);
+        result = {
+          state: cycle.executed?.state || (cycle.dry.state === "already_cleaned" ? "already_cleaned" : "prepared"),
+          mode: prepareOnly ? "prepare-only" : "execute",
+          sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+          transactions: cycle.dry.evidence?.transactionCount ?? null,
+          entries: cycle.dry.evidence?.entryCount ?? null,
+          txTypes: cycle.dry.evidence?.txTypes ?? null,
+          amounts: cycle.dry.evidence ? { credits: cycle.dry.evidence.credits, debits: cycle.dry.evidence.debits, net: cycle.dry.evidence.net } : null,
+          compressedSha256: cycle.row.compressed_sha256,
+        };
+      } else {
+        const latestCompleted = ownRows.find((row) => row.status === "committed" && row.registry_cleaned_at);
+        if (latestCompleted) {
+          const completed = await runPruneStep({
+            row: await refreshPolicyRow(pruneStore, latestCompleted.object_path, BOT_ONLY_RETENTION_POLICY_ID),
+            mode: "dry-run",
+            env: moduleEnv,
+            cwd: tempRoot,
+            sql,
+            pruneStore,
+            storageTarget,
+            verifyBucket,
+            storageDeps: deps,
+          });
+          if (completed.state !== "already_cleaned") fail(`completed bot-only Stage cycle did not revalidate as already_cleaned: ${completed.state}`);
+        }
+        const artifactPath = path.join(tempRoot, "archive.jsonl.gz");
+        const manifestPath = path.join(tempRoot, "archive.manifest.json");
+        const exported = await (deps.exportArchive || runExport)({
+          argv: ["--target", "stage", "--cutoff-days", String(BOT_ONLY_RETENTION_DAYS), "--batch-size", String(STAGE_MAX_BATCH_SIZE), "--output", artifactPath, "--manifest", manifestPath],
+          env: moduleEnv,
+          cwd: tempRoot,
+          now,
+          deps: {
+            sql,
+            selector: "bot-only-7d",
+            schemaVersion: BOT_ONLY_EXPORT_SCHEMA_VERSION,
+            sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+            targetOptions: { singleTarget: true },
+            noCandidateIfEmpty: true,
+            emit: false,
+          },
+        });
+        if (exported.noCandidate) result = { state: "no-op", reason: "no_eligible_bot_only_table", sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID };
+        else {
+          await (deps.ensureArchiveBucket || ensureArchiveBucket)(storageTarget, deps);
+          const stored = await (deps.storeArchive || storeArchive)({
+            argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+            env: moduleEnv,
+            cwd: tempRoot,
+            deps: { ...deps, sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
+          });
+          let row = await refreshPolicyRow(pruneStore, stored.objectPath, BOT_ONLY_RETENTION_POLICY_ID);
+          await runPruneStep({ row, mode: "register-proof", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          row = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
+          const dry = await runPruneStep({ row, mode: "dry-run", env: moduleEnv, cwd: tempRoot, sql, pruneStore, storageTarget, verifyBucket, storageDeps: deps });
+          if (dry.state !== "ready") fail(`new bot-only Stage dry-run did not become ready: ${dry.state}`);
+          const main = await (deps.downloadPrivateArchive || downloadPrivateArchiveObject)(storageTarget, row.object_path, deps);
+          const durable = await persistDurableRecovery(storageTarget, row, identity, dry.evidence, main.bytes, deps);
+          let executed = null;
+          if (!prepareOnly) {
+            if (String(approvedBatchId) !== String(row.batch_id)) fail("approved bot-only batch id does not match the new manifest");
+            executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, approvedBatchId, storageDeps: deps });
+          }
+          result = {
+            state: executed?.state || "prepared",
+            mode: prepareOnly ? "prepare-only" : "execute",
+            sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+            transactions: dry.evidence.transactionCount,
+            entries: dry.evidence.entryCount,
+            txTypes: dry.evidence.txTypes,
+            amounts: { credits: dry.evidence.credits, debits: dry.evidence.debits, net: dry.evidence.net },
+            compressedSha256: row.compressed_sha256,
+            proof: "verified",
+            receipt: executed?.state || "prepare-only",
+          };
+        }
+      }
+    }
+  } catch (error) {
+    failed = true;
+    failure = error;
+  } finally {
+    if (lockSession && sql) {
+      try { await releaseAdvisoryLock(sql); } catch { /* owned session close releases it */ }
+    }
+    if (sql && ownsSql) {
+      try { await sql.end({ timeout: 5 }); } catch (error) { if (!failed) { failed = true; failure = error; } }
+    }
+  }
+  if (failed) {
+    emitAggregateError(failure);
+    throw failure;
+  }
+  writeAggregateSummary(result);
+  return result;
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  if (process.argv.slice(2).length !== 0) {
-    process.stderr.write("chips-ledger-stage-automation accepts no command-line options\n");
-    process.exitCode = 1;
-  } else {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0) {
     runStageAutomation().catch(() => {
       process.exitCode = 1;
     });
+  } else if (argv[0] === "--policy" && argv[1] === "bot-only-7d") {
+    let prepareOnly = true;
+    let prepareOnlyRequested = false;
+    let executeRequested = false;
+    let approvedBatchId = null;
+    for (let index = 2; index < argv.length; index += 1) {
+      if (argv[index] === "--prepare-only") {
+        if (prepareOnlyRequested || executeRequested) throw new Error("--prepare-only and --execute are mutually exclusive or duplicated");
+        prepareOnlyRequested = true;
+        prepareOnly = true;
+      } else if (argv[index] === "--execute") {
+        if (executeRequested || prepareOnlyRequested) throw new Error("--prepare-only and --execute are mutually exclusive or duplicated");
+        executeRequested = true;
+        prepareOnly = false;
+      } else if (argv[index] === "--approved-batch-id") {
+        const value = argv[index + 1];
+        if (!value || value.startsWith("--")) throw new Error("--approved-batch-id requires a value");
+        if (approvedBatchId !== null) throw new Error("--approved-batch-id was supplied more than once");
+        approvedBatchId = value;
+        index += 1;
+      } else {
+        throw new Error(`unknown Stage bot-only option: ${argv[index]}`);
+      }
+    }
+    runBotOnlyStageAutomation({ prepareOnly, approvedBatchId }).catch(() => {
+      process.exitCode = 1;
+    });
+  } else {
+    process.stderr.write("usage: node scripts/ops/chips-ledger-stage-automation.mjs [--policy bot-only-7d [--prepare-only|--execute --approved-batch-id <id>]]\n");
+    process.exitCode = 1;
   }
 }

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -41,6 +41,7 @@ export const STAGE_RETENTION_DAYS = 30;
 export const STAGE_AUTOMATION_LOCK_KEY = `chips-ledger-stage-automation-v1:${STAGE_PROJECT_REF}`;
 
 const SHA256_RE = /^[0-9a-f]{64}$/;
+const COMMIT_SHA_RE = /^[0-9a-f]{40}$/i;
 const PRIVATE_FILE_MODE = 0o600;
 
 function fail(message) {
@@ -49,6 +50,14 @@ function fail(message) {
 
 function text(value) {
   return value == null ? "" : String(value).trim();
+}
+
+export function resolveDeployedCommitSha(env = process.env, { required = true } = {}) {
+  const rawCommitSha = text(env.DEPLOYED_COMMIT_SHA || env.GITHUB_SHA);
+  if (!rawCommitSha && !required) return null;
+  const commitSha = rawCommitSha.toLowerCase();
+  if (!COMMIT_SHA_RE.test(commitSha)) fail("a 40-character deployed commit SHA is required");
+  return commitSha;
 }
 
 function sha256(bytes) {
@@ -82,6 +91,7 @@ function aggregatePayload(result) {
     project_ref: STAGE_PROJECT_REF,
     source_policy_id: result.sourcePolicyId || STAGE_AUTOMATION_POLICY_ID,
     state: result.state,
+    deployed_commit_sha: result.deployedCommitSha || null,
   };
   if (result.state === "error") {
     return {
@@ -125,6 +135,7 @@ function aggregatePayload(result) {
     proof: result.proof || null,
     receipt: result.receipt || null,
     mappings: result.mappings ?? null,
+    blocking_anomalies: result.blockingAnomalies || null,
     destructive_go_batch_id: result.destructiveGoBatchId ?? null,
     destructive_go_at: result.destructiveGoAt || null,
     reason: result.reason || null,
@@ -145,15 +156,15 @@ function writeAggregateSummary(result) {
   return safe;
 }
 
-function emitAggregateError(error) {
+function emitAggregateError(error, context = {}) {
   try {
-    writeAggregateSummary({ state: "error", reason: error });
+    writeAggregateSummary({ state: "error", reason: error, ...context });
   } catch {
     // Preserve the original orchestration error if reporting itself fails.
   }
 }
 
-export function validateStageEnvironment(env = process.env) {
+export function validateStageEnvironment(env = process.env, { requireCommitSha = false } = {}) {
   for (const key of Object.keys(env)) {
     if (/^SUPABASE_PROD_|^PRODUCTION_/.test(key)) fail("Production credentials are not accepted by the Stage orchestrator");
   }
@@ -161,6 +172,7 @@ export function validateStageEnvironment(env = process.env) {
   const apiUrl = text(env.SUPABASE_STAGE_URL);
   const serviceKey = text(env.SUPABASE_STAGE_SERVICE_ROLE_KEY);
   if (!dbUrl || !apiUrl || !serviceKey) fail("Stage DB URL, Supabase URL and service key are required");
+  const deployedCommitSha = resolveDeployedCommitSha(env, { required: requireCommitSha });
   let parsedDb;
   let parsedApi;
   try {
@@ -185,11 +197,13 @@ export function validateStageEnvironment(env = process.env) {
     dbUrl,
     apiUrl: parsedApi.origin,
     serviceKey,
+    deployedCommitSha,
     moduleEnv: {
       EXPECTED_SUPABASE_STAGE_PROJECT_REF: STAGE_PROJECT_REF,
       SUPABASE_STAGE_DB_URL: dbUrl,
       SUPABASE_URL: parsedApi.origin,
       SUPABASE_SERVICE_ROLE_KEY: serviceKey,
+      ...(deployedCommitSha ? { DEPLOYED_COMMIT_SHA: deployedCommitSha } : {}),
     },
   };
 }
@@ -289,7 +303,7 @@ export function botOnlyExportArgs(row, artifactPath, manifestPath) {
   return args;
 }
 
-export function botOnlyReport({ row, identity, dry, durable, state, mode }) {
+export function botOnlyReport({ row, identity, dry, durable, state, mode, deployedCommitSha = null, blockingAnomalies = [] }) {
   const evidence = dry?.evidence || null;
   const recoveryArchiveSha256 = durable?.recoveryArchive?.sha256 || durable?.archiveSha256 || null;
   const recoveryManifestSha256 = durable?.recoveryManifest?.sha256 || durable?.manifestSha256 || null;
@@ -298,6 +312,7 @@ export function botOnlyReport({ row, identity, dry, durable, state, mode }) {
     mode,
     sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
     projectRef: row?.project_ref || STAGE_PROJECT_REF,
+    deployedCommitSha,
     formatVersion: row?.format_version == null ? null : Number(row.format_version),
     stageSystemIdentifier: identity,
     batchId: row?.batch_id || null,
@@ -347,6 +362,27 @@ export function botOnlyReport({ row, identity, dry, durable, state, mode }) {
     destructiveGoBatchId: row?.destructive_go_batch_id || null,
     destructiveGoAt: row?.destructive_go_at || null,
     mappings: evidence?.transactionCount ?? null,
+    blockingAnomalies,
+  };
+}
+
+function botOnlyNoCandidateReport({ exported, identity, deployedCommitSha }) {
+  const blockingAnomalies = exported.blockingAnomalies || [];
+  return {
+    state: "no-op",
+    mode: "prepare-only",
+    sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+    projectRef: exported.options?.projectRef || STAGE_PROJECT_REF,
+    deployedCommitSha,
+    formatVersion: BOT_ONLY_EXPORT_SCHEMA_VERSION,
+    stageSystemIdentifier: identity,
+    batchId: null,
+    objectPath: null,
+    cutoff: exported.options?.cutoff || null,
+    cursorStart: exported.options?.cursor || null,
+    cursorEnd: null,
+    blockingAnomalies,
+    reason: blockingAnomalies.length ? "blocking_anomalies" : "no_eligible_bot_only_table",
   };
 }
 
@@ -617,11 +653,13 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
   let tempRoot = null;
   let ownsSql = false;
   let result = null;
+  let deployedCommitSha = null;
   let failed = false;
   let failure = null;
 
   try {
     const config = validateStageEnvironment(env);
+    deployedCommitSha = config.deployedCommitSha;
     const moduleEnv = config.moduleEnv;
     const providedSql = deps.sql;
     if (providedSql) {
@@ -772,9 +810,10 @@ export async function runStageAutomation({ env = process.env, now = new Date(), 
     }
   }
   if (failed) {
-    emitAggregateError(failure);
+    emitAggregateError(failure, { deployedCommitSha });
     throw failure;
   }
+  if (result && deployedCommitSha) result = { ...result, deployedCommitSha };
   writeAggregateSummary(result);
   return result;
 }
@@ -804,10 +843,12 @@ export async function runBotOnlyStageAutomation({
   let tempRoot = null;
   let ownsSql = false;
   let result = null;
+  let deployedCommitSha = null;
   let failed = false;
   let failure = null;
   try {
-    const config = validateStageEnvironment(env);
+    const config = validateStageEnvironment(env, { requireCommitSha: true });
+    deployedCommitSha = config.deployedCommitSha;
     const moduleEnv = config.moduleEnv;
     if (deps.sql) sql = deps.sql;
     else {
@@ -906,6 +947,7 @@ export async function runBotOnlyStageAutomation({
           durable: cycle.durable,
           state: cycle.executed?.state || (cycle.dry.state === "already_cleaned" ? "already_cleaned" : "prepared"),
           mode: prepareOnly ? "prepare-only" : "execute",
+          deployedCommitSha,
         });
       } else {
         const latestCompleted = ownRows.find((row) => row.status === "committed" && row.registry_cleaned_at);
@@ -940,7 +982,9 @@ export async function runBotOnlyStageAutomation({
             emit: false,
           },
         });
-        if (exported.noCandidate) result = { state: "no-op", reason: "no_eligible_bot_only_table", sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID };
+        if (exported.noCandidate) {
+          result = botOnlyNoCandidateReport({ exported, identity, deployedCommitSha });
+        }
         else {
           await (deps.ensureArchiveBucket || ensureArchiveBucket)(storageTarget, deps);
           const stored = await (deps.storeArchive || storeArchive)({
@@ -969,6 +1013,7 @@ export async function runBotOnlyStageAutomation({
             durable,
             state: executed?.state || "prepared",
             mode: prepareOnly ? "prepare-only" : "execute",
+            deployedCommitSha,
           });
         }
       }
@@ -985,9 +1030,10 @@ export async function runBotOnlyStageAutomation({
     }
   }
   if (failed) {
-    emitAggregateError(failure);
+    emitAggregateError(failure, { deployedCommitSha });
     throw failure;
   }
+  if (result && deployedCommitSha) result = { ...result, deployedCommitSha };
   writeAggregateSummary(result);
   return result;
 }

--- a/scripts/ops/chips-ledger-stage-automation.mjs
+++ b/scripts/ops/chips-ledger-stage-automation.mjs
@@ -92,18 +92,41 @@ function aggregatePayload(result) {
   return {
     ...base,
     mode: result.mode || null,
+    batch_id: result.batchId ?? null,
+    format_version: result.formatVersion ?? null,
+    object_path: result.objectPath || null,
+    cutoff: result.cutoff || null,
+    cursor_start: result.cursorStart || null,
+    cursor_end: result.cursorEnd || null,
+    stage_system_identifier: result.stageSystemIdentifier || null,
+    table_id: result.tableId || null,
+    table_count: result.tableCount ?? null,
+    registry_key_count: result.registryKeyCount ?? null,
+    registry_keys_sha256: result.registryKeysSha256 || null,
+    out_of_scope_keys_sha256: result.outOfScopeKeysSha256 || null,
+    identity_count: result.identityCount ?? null,
+    eligible_count: result.eligibleCount ?? null,
     transactions: result.transactions ?? null,
     entries: result.entries ?? null,
     tx_types: result.txTypes || null,
     amounts: result.amounts || null,
     raw_bytes: result.rawBytes ?? null,
     compressed_bytes: result.compressedBytes ?? null,
+    raw_sha256: result.rawSha256 || null,
     compressed_sha256: result.compressedSha256 || null,
+    archive_proof_transaction_ids_sha256: result.archiveProofTransactionIdsSha256 || null,
+    archive_proof_entry_ids_sha256: result.archiveProofEntryIdsSha256 || null,
+    prune_receipt: result.pruneReceipt || null,
+    cleanup_receipt: result.cleanupReceipt || null,
     recovery_archive_sha256: result.recoveryArchiveSha256 || null,
     recovery_manifest_sha256: result.recoveryManifestSha256 || null,
+    recovery_archive_path: result.recoveryArchivePath || null,
+    recovery_manifest_path: result.recoveryManifestPath || null,
     proof: result.proof || null,
     receipt: result.receipt || null,
     mappings: result.mappings ?? null,
+    destructive_go_batch_id: result.destructiveGoBatchId ?? null,
+    destructive_go_at: result.destructiveGoAt || null,
     reason: result.reason || null,
   };
 }
@@ -209,6 +232,20 @@ async function loadOwnBatches(sql, sourcePolicyId = STAGE_AUTOMATION_POLICY_ID) 
     project_ref,
     source_policy_id,
     status,
+    batch_id::text as batch_id,
+    format_version::text as format_version,
+    cutoff::text as cutoff,
+    cursor_start_created_at::text as cursor_start_created_at,
+    cursor_start_id,
+    transaction_count::text as transaction_count,
+    entry_count::text as entry_count,
+    raw_bytes::text as raw_bytes,
+    compressed_bytes::text as compressed_bytes,
+    raw_sha256,
+    compressed_sha256,
+    credits::text as credits,
+    debits::text as debits,
+    net_amount::text as net_amount,
     committed_at::text as committed_at,
     archive_proof_verified_at::text as archive_proof_verified_at,
     archived_transaction_ids_sha256,
@@ -229,12 +266,88 @@ async function loadOwnBatches(sql, sourcePolicyId = STAGE_AUTOMATION_POLICY_ID) 
     registry_cleaned_key_count::text as registry_cleaned_key_count,
     registry_cleaned_keys_sha256,
     destructive_go_at::text as destructive_go_at,
-    destructive_go_batch_id::text as destructive_go_batch_id,
-    compressed_sha256
+    destructive_go_batch_id::text as destructive_go_batch_id
   from public.chips_ledger_archive_batches
   where project_ref = $1
     and source_policy_id = $2
   order by created_at desc, object_path desc;`, [STAGE_PROJECT_REF, sourcePolicyId]);
+}
+
+export function botOnlyExportArgs(row, artifactPath, manifestPath) {
+  if (!row?.cutoff) fail("pending bot-only manifest has no immutable cutoff");
+  const args = [
+    "--target", "stage",
+    "--cutoff", row.cutoff,
+    "--batch-size", String(STAGE_MAX_BATCH_SIZE),
+    "--output", artifactPath,
+    "--manifest", manifestPath,
+  ];
+  if (row.cursor_start_created_at || row.cursor_start_id) {
+    if (!row.cursor_start_created_at || !row.cursor_start_id) fail("pending bot-only manifest has a partial cursor");
+    args.splice(6, 0, "--after-created-at", row.cursor_start_created_at, "--after-id", row.cursor_start_id);
+  }
+  return args;
+}
+
+export function botOnlyReport({ row, identity, dry, durable, state, mode }) {
+  const evidence = dry?.evidence || null;
+  const recoveryArchiveSha256 = durable?.recoveryArchive?.sha256 || durable?.archiveSha256 || null;
+  const recoveryManifestSha256 = durable?.recoveryManifest?.sha256 || durable?.manifestSha256 || null;
+  return {
+    state,
+    mode,
+    sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+    projectRef: row?.project_ref || STAGE_PROJECT_REF,
+    formatVersion: row?.format_version == null ? null : Number(row.format_version),
+    stageSystemIdentifier: identity,
+    batchId: row?.batch_id || null,
+    objectPath: row?.object_path || null,
+    cutoff: row?.cutoff || null,
+    cursorStart: row?.cursor_start_created_at || row?.cursor_start_id
+      ? { created_at: row.cursor_start_created_at || null, id: row.cursor_start_id || null }
+      : null,
+    cursorEnd: row?.cursor_end_created_at || row?.cursor_end_id
+      ? { created_at: row.cursor_end_created_at || null, id: row.cursor_end_id || null }
+      : null,
+    tableId: row?.bot_only_table_id || evidence?.tableId || null,
+    tableCount: row?.bot_only_table_count || (evidence?.tableId ? 1 : null),
+    transactions: evidence?.transactionCount ?? (row?.transaction_count == null ? null : Number(row.transaction_count)),
+    entries: evidence?.entryCount ?? (row?.entry_count == null ? null : Number(row.entry_count)),
+    txTypes: evidence?.txTypes || null,
+    amounts: evidence ? { credits: evidence.credits, debits: evidence.debits, net: evidence.net } : null,
+    identityCount: row?.bot_only_identity_count || null,
+    eligibleCount: row?.bot_only_eligible_count || null,
+    registryKeyCount: evidence?.registryKeys?.length ?? row?.bot_only_identity_count ?? null,
+    registryKeysSha256: row?.bot_only_registry_keys_sha256 || evidence?.registryKeysSha256 || null,
+    outOfScopeKeysSha256: row?.bot_only_out_of_scope_keys_sha256 || evidence?.outOfScopeKeysSha256 || null,
+    rawBytes: row?.raw_bytes == null ? null : Number(row.raw_bytes),
+    rawSha256: row?.raw_sha256 || null,
+    compressedBytes: row?.compressed_bytes == null ? null : Number(row.compressed_bytes),
+    compressedSha256: row?.compressed_sha256 || null,
+    archiveProofTransactionIdsSha256: row?.archived_transaction_ids_sha256 || null,
+    archiveProofEntryIdsSha256: row?.archived_entry_ids_sha256 || null,
+    pruneReceipt: row?.pruned_at ? {
+      at: row.pruned_at,
+      transaction_count: row.pruned_transaction_count,
+      entry_count: row.pruned_entry_count,
+      transaction_ids_sha256: row.pruned_transaction_ids_sha256,
+      entry_ids_sha256: row.pruned_entry_ids_sha256,
+    } : null,
+    cleanupReceipt: row?.registry_cleaned_at ? {
+      at: row.registry_cleaned_at,
+      key_count: row.registry_cleaned_key_count,
+      keys_sha256: row.registry_cleaned_keys_sha256,
+    } : null,
+    recoveryArchiveSha256,
+    recoveryManifestSha256,
+    recoveryArchivePath: durable?.archivePath || null,
+    recoveryManifestPath: durable?.manifestPath || null,
+    proof: row?.archive_proof_verified_at ? "verified" : null,
+    receipt: row?.registry_cleaned_at ? "cleaned" : state === "prepared" ? "prepare-only" : null,
+    destructiveGoBatchId: row?.destructive_go_batch_id || null,
+    destructiveGoAt: row?.destructive_go_at || null,
+    mappings: evidence?.transactionCount ?? null,
+  };
 }
 
 function receiptFieldCount(row) {
@@ -715,7 +828,43 @@ export async function runBotOnlyStageAutomation({
       const ownRows = await loadOwnBatches(sql, BOT_ONLY_RETENTION_POLICY_ID);
       const activeRows = ownRows.filter((row) => row.status === "pending" || (row.status === "committed" && !row.registry_cleaned_at));
       if (activeRows.length > 1) fail("multiple incomplete bot-only Stage manifests; refusing to choose one");
-      if (activeRows[0]?.status === "pending") fail("bot-only Stage manifest is pending; refusing a blind resume");
+
+      const resumePending = async (row) => {
+        const artifactPath = path.join(tempRoot, "pending-bot-only.archive.jsonl.gz");
+        const manifestPath = path.join(tempRoot, "pending-bot-only.archive.manifest.json");
+        const exported = await (deps.exportArchive || runExport)({
+          argv: botOnlyExportArgs(row, artifactPath, manifestPath),
+          env: moduleEnv,
+          cwd: tempRoot,
+          now,
+          deps: {
+            sql,
+            selector: "bot-only-7d",
+            schemaVersion: BOT_ONLY_EXPORT_SCHEMA_VERSION,
+            sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
+            targetOptions: { singleTarget: true },
+            noCandidateIfEmpty: true,
+            emit: false,
+          },
+        });
+        if (exported.noCandidate) fail("pending bot-only Stage manifest cannot be reproduced at its immutable cutoff");
+        const stored = await (deps.storeArchive || storeArchive)({
+          argv: ["--target", "stage", "--artifact", artifactPath, "--manifest", manifestPath],
+          env: moduleEnv,
+          cwd: tempRoot,
+          deps: { ...deps, sql, storageTarget, targetOptions: { singleTarget: true }, emit: false },
+        });
+        if (stored.objectPath !== row.object_path) fail("pending bot-only manifest object path differs from the reproduced artifact");
+        const refreshed = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
+        if (refreshed.status !== "committed") fail("pending bot-only Stage manifest was not committed during retry");
+        return refreshed;
+      };
+
+      let activeRow = activeRows[0] || null;
+      if (activeRow?.status === "pending") {
+        activeRow = await resumePending(activeRow);
+        await assertAdvisoryLock(sql, lockSession);
+      }
 
       const prepareExisting = async (row) => {
         row = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
@@ -743,23 +892,21 @@ export async function runBotOnlyStageAutomation({
         if (!prepareOnly) {
           if (String(approvedBatchId) !== String(row.batch_id)) fail("approved bot-only batch id does not match the active manifest");
           const executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, approvedBatchId, storageDeps: deps });
-          return { row, dry, durable, executed };
+          return { row: await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID), dry, durable, executed };
         }
         return { row, dry, durable, executed: null };
       };
 
-      if (activeRows[0]) {
-        const cycle = await prepareExisting(activeRows[0]);
-        result = {
+      if (activeRow) {
+        const cycle = await prepareExisting(activeRow);
+        result = botOnlyReport({
+          row: cycle.row,
+          identity,
+          dry: cycle.dry,
+          durable: cycle.durable,
           state: cycle.executed?.state || (cycle.dry.state === "already_cleaned" ? "already_cleaned" : "prepared"),
           mode: prepareOnly ? "prepare-only" : "execute",
-          sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
-          transactions: cycle.dry.evidence?.transactionCount ?? null,
-          entries: cycle.dry.evidence?.entryCount ?? null,
-          txTypes: cycle.dry.evidence?.txTypes ?? null,
-          amounts: cycle.dry.evidence ? { credits: cycle.dry.evidence.credits, debits: cycle.dry.evidence.debits, net: cycle.dry.evidence.net } : null,
-          compressedSha256: cycle.row.compressed_sha256,
-        };
+        });
       } else {
         const latestCompleted = ownRows.find((row) => row.status === "committed" && row.registry_cleaned_at);
         if (latestCompleted) {
@@ -813,19 +960,16 @@ export async function runBotOnlyStageAutomation({
           if (!prepareOnly) {
             if (String(approvedBatchId) !== String(row.batch_id)) fail("approved bot-only batch id does not match the new manifest");
             executed = await executeVerifiedCycle({ row, identity, durable, env: moduleEnv, tempRoot, sql, pruneStore, storageTarget, verifyBucket, approvedBatchId, storageDeps: deps });
+            row = await refreshPolicyRow(pruneStore, row.object_path, BOT_ONLY_RETENTION_POLICY_ID);
           }
-          result = {
+          result = botOnlyReport({
+            row,
+            identity,
+            dry,
+            durable,
             state: executed?.state || "prepared",
             mode: prepareOnly ? "prepare-only" : "execute",
-            sourcePolicyId: BOT_ONLY_RETENTION_POLICY_ID,
-            transactions: dry.evidence.transactionCount,
-            entries: dry.evidence.entryCount,
-            txTypes: dry.evidence.txTypes,
-            amounts: { credits: dry.evidence.credits, debits: dry.evidence.debits, net: dry.evidence.net },
-            compressedSha256: row.compressed_sha256,
-            proof: "verified",
-            receipt: executed?.state || "prepare-only",
-          };
+          });
         }
       }
     }

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -53,6 +53,7 @@ run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger
 run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
 run("node", ["tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs"], "chips-ledger-prunable-candidate-sql");
 run("node", ["tests/chips/chips-ledger-bot-only-retention.test.mjs"], "chips-ledger-bot-only-retention");
+run("node", ["tests/chips/chips-ledger-table-metadata-fence.test.mjs"], "chips-ledger-table-metadata-fence");
 run("node", ["tests/chips/chips-ledger-stage-automation.test.mjs"], "chips-ledger-stage-automation");
 run("node", ["tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs"], "chips-ledger-stage-automation-observability");
 run("node", ["tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs"], "chips-ledger-stage-automation-order");

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -52,6 +52,7 @@ run("node", ["tests/chips/chips-ledger-archive-export.test.mjs"], "chips-ledger-
 run("node", ["tests/chips/chips-ledger-archive-storage.test.mjs"], "chips-ledger-archive-storage");
 run("node", ["tests/chips/chips-ledger-archive-pruning.test.mjs"], "chips-ledger-archive-pruning");
 run("node", ["tests/chips/chips-ledger-prunable-candidate-sql.behavior.test.mjs"], "chips-ledger-prunable-candidate-sql");
+run("node", ["tests/chips/chips-ledger-bot-only-retention.test.mjs"], "chips-ledger-bot-only-retention");
 run("node", ["tests/chips/chips-ledger-stage-automation.test.mjs"], "chips-ledger-stage-automation");
 run("node", ["tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs"], "chips-ledger-stage-automation-observability");
 run("node", ["tests/chips/chips-ledger-stage-automation.order.behavior.test.mjs"], "chips-ledger-stage-automation-order");

--- a/shared/poker-domain/bots.mjs
+++ b/shared/poker-domain/bots.mjs
@@ -287,6 +287,7 @@ returning seat_no;
         userId: null,
         txType: "TABLE_BUY_IN",
         idempotencyKey: `${idempotencyPrefix}:${tableId}:${seatNo}`,
+        reference: `BOT_SEED_BUY_IN:${tableId}:${seatNo}`,
         metadata: {
           actor: "BOT",
           botUserId,

--- a/shared/poker-domain/leave.mjs
+++ b/shared/poker-domain/leave.mjs
@@ -173,6 +173,8 @@ const postHumanLeaveCashoutInTx = async ({
     userId,
     txType: "TABLE_CASH_OUT",
     idempotencyKey,
+    reference: `table:${tableId}`,
+    metadata: { tableId },
     entries: [
       { accountType: "ESCROW", systemKey: `POKER_TABLE:${tableId}`, amount: -amount },
       { accountType: "USER", amount },

--- a/shared/poker-domain/table-buy-in.mjs
+++ b/shared/poker-domain/table-buy-in.mjs
@@ -20,12 +20,16 @@ export async function postUserTableBuyIn({
   if (!tableId || !userId || !idempotencyKey) throw makeError("invalid_buy_in");
   if (!Number.isInteger(normalizedAmount) || normalizedAmount <= 0) throw makeError("invalid_buy_in");
 
+  const normalizedTableId = String(tableId).trim();
+  const normalizedMetadata = metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? { ...metadata, tableId: metadata.tableId ?? normalizedTableId }
+    : { tableId: normalizedTableId };
   return postTransaction({
     userId,
     txType: "TABLE_BUY_IN",
     idempotencyKey,
-    reference,
-    metadata,
+    reference: reference ?? `table:${normalizedTableId}`,
+    metadata: normalizedMetadata,
     entries: [
       { accountType: "USER", amount: -normalizedAmount },
       { accountType: "ESCROW", systemKey: `POKER_TABLE:${tableId}`, amount: normalizedAmount }

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -938,6 +938,7 @@ $$;
 
 -- Recreate the public wrapper so the unchanged 30-day pruner cannot be used
 -- to execute a schema-v2 bot-only batch without the lifecycle operator.
+set role chips_ledger_archive_pruner;
 create or replace function public.chips_prune_committed_archive_batch(
   p_object_path text,
   p_transaction_ids uuid[],
@@ -967,6 +968,7 @@ begin
   return public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, p_execute is true);
 end;
 $$;
+reset role;
 
 -- This gate is intentionally never called by automation in this change.  A
 -- future owner action must name the exact batch and use the exact confirmation

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -849,6 +849,9 @@ begin
   go_changed := new.destructive_go_at is distinct from old.destructive_go_at
     or new.destructive_go_batch_id is distinct from old.destructive_go_batch_id;
 
+  if proof_changed and receipt_changed then
+    raise exception 'Archive proof and prune receipt require separate transitions';
+  end if;
   if receipt_changed and cleanup_changed then
     raise exception 'Archive prune receipt and registry cleanup receipt require separate transitions';
   end if;

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -294,6 +294,34 @@ $$;
 
 alter function public.chips_parse_table_idempotency_key(text) owner to postgres;
 
+create or replace function public.chips_parse_table_reference(p_reference text)
+returns uuid
+language plpgsql
+immutable
+strict
+security definer
+set search_path = ''
+as $$
+declare
+  reference_value text := pg_catalog.btrim(p_reference);
+  marker text;
+begin
+  if reference_value = ''
+     or reference_value !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
+    raise exception using errcode = 'P8902', message = 'TABLE reference format is not supported';
+  end if;
+  marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.split_part(reference_value, ':', 2)));
+  if marker is null
+     or marker = ''
+     or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+    raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
+  end if;
+  return marker::uuid;
+end;
+$$;
+
+alter function public.chips_parse_table_reference(text) owner to postgres;
+
 create or replace function public.chips_table_transaction_before_insert()
 returns trigger
 language plpgsql
@@ -319,7 +347,9 @@ begin
 
   if new.metadata ? 'tableId' then
     marker := pg_catalog.lower(pg_catalog.btrim(new.metadata->>'tableId'));
-    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+    if marker is null
+       or marker = ''
+       or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
        or marker::uuid <> key_table_id then
       raise exception using
         errcode = 'P8902',
@@ -327,13 +357,8 @@ begin
     end if;
   end if;
 
-  if new.reference is not null
-     and new.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(new.reference, '^[^:]+:([^:]+)')));
-    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-      raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
-    end if;
-    reference_table_id := marker::uuid;
+  if new.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(new.reference);
     if reference_table_id <> key_table_id then
       raise exception using errcode = 'P8902', message = 'TABLE reference does not match the idempotency key';
     end if;
@@ -410,7 +435,8 @@ begin
 
   if transaction_row.metadata ? 'tableId' then
     transaction_marker := pg_catalog.lower(pg_catalog.btrim(transaction_row.metadata->>'tableId'));
-    if transaction_marker = ''
+    if transaction_marker is null
+       or transaction_marker = ''
        or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
        or transaction_marker::uuid <> key_table_id then
       raise exception using
@@ -419,14 +445,8 @@ begin
     end if;
   end if;
 
-  if transaction_row.reference is not null
-     and transaction_row.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    transaction_marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(transaction_row.reference, '^[^:]+:([^:]+)')));
-    if transaction_marker = ''
-       or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-      raise exception using errcode = 'P8904', message = 'TABLE transaction reference marker is invalid';
-    end if;
-    reference_table_id := transaction_marker::uuid;
+  if transaction_row.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(transaction_row.reference);
     if reference_table_id <> key_table_id then
       raise exception using errcode = 'P8904', message = 'TABLE transaction reference does not bind to its idempotency key';
     end if;
@@ -1252,10 +1272,18 @@ begin
       having transactions.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
           or transactions.user_id is not null
           or transactions.created_at >= batch.cutoff
-          or (transactions.metadata ? 'tableId'
-              and pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text)
-          or (transactions.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
-              and pg_catalog.lower(pg_catalog.substring(transactions.reference, '^[^:]+:([^:]+)')) <> p_table_id::text)
+          or (
+            transactions.metadata ? 'tableId'
+            and (
+              pg_catalog.nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') is null
+              or pg_catalog.nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+              or pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text
+            )
+          )
+          or (
+            transactions.reference is not null
+            and public.chips_parse_table_reference(transactions.reference) <> p_table_id
+          )
           or count(*) <> 2
           or count(*) filter (where accounts.account_type::text = 'USER') <> 0
           or count(*) filter (where accounts.account_type::text = 'SYSTEM') <> 1
@@ -1431,6 +1459,7 @@ begin
      and batches.registry_cleaned_at is null;
   if not found then raise exception using errcode = 'P8924', message = 'Bot-only cleanup receipt transition was not unique'; end if;
 
+  perform pg_catalog.set_config('chips_bot_only_lifecycle', '1', true);
   update public.poker_tables tables
      set bot_only_retention_complete_at = coalesce(tables.bot_only_retention_complete_at, pg_catalog.timezone('utc', pg_catalog.now()))
    where tables.id = batch.bot_only_table_id
@@ -1490,5 +1519,7 @@ revoke all on function public.chips_archive_text_ids_sha256(text[]) from public,
 grant execute on function public.chips_archive_text_ids_sha256(text[]) to postgres, chips_ledger_archive_pruner;
 revoke all on function public.chips_parse_table_idempotency_key(text) from public, anon, authenticated, service_role;
 grant execute on function public.chips_parse_table_idempotency_key(text) to postgres, chips_ledger_archive_pruner;
+revoke all on function public.chips_parse_table_reference(text) from public, anon, authenticated, service_role;
+grant execute on function public.chips_parse_table_reference(text) to postgres;
 
 commit;

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -387,7 +387,7 @@ security definer
 set search_path = ''
 as $$
 declare
-  transaction_id uuid;
+  target_transaction_id uuid;
   transaction_row record;
   parsed jsonb;
   key_table_id uuid;
@@ -413,16 +413,16 @@ begin
     return new;
   end if;
   if tg_table_name = 'chips_transactions' then
-    transaction_id := new.id;
+    target_transaction_id := new.id;
   elsif tg_op = 'DELETE' then
-    transaction_id := old.transaction_id;
+    target_transaction_id := old.transaction_id;
   else
-    transaction_id := new.transaction_id;
+    target_transaction_id := new.transaction_id;
   end if;
   select transactions.*
     into transaction_row
     from public.chips_transactions as transactions
-   where transactions.id = transaction_id;
+   where transactions.id = target_transaction_id;
   if not found or transaction_row.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
     if tg_op = 'DELETE' then
       return old;
@@ -479,12 +479,12 @@ begin
          user_identity_count, user_identity_mismatch_count
     from public.chips_entries as entries
     join public.chips_accounts as accounts on accounts.id = entries.account_id
-   where entries.transaction_id = transaction_id;
+   where entries.transaction_id = target_transaction_id;
 
   select count(*)
     into invalid_entry_marker_count
     from public.chips_entries as entries
-   where entries.transaction_id = transaction_id
+   where entries.transaction_id = target_transaction_id
      and (
        entries.metadata ? 'tableId'
        and (
@@ -501,14 +501,14 @@ begin
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text = 'ESCROW'
         and entries.amount > 0
     )
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text in ('USER', 'SYSTEM')
         and entries.amount < 0
     );
@@ -520,14 +520,14 @@ begin
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text = 'ESCROW'
         and entries.amount < 0
     )
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text in ('USER', 'SYSTEM')
         and entries.amount > 0
     );

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -153,7 +153,7 @@ begin
   if tg_op <> 'UPDATE'
      or old.control_id is distinct from new.control_id
      or current_user <> 'postgres'
-     or pg_catalog.current_setting('chips_table_fence_control', true) <> '1' then
+     or coalesce(pg_catalog.current_setting('chips_table_fence_control', true), '') <> '1' then
     raise exception 'TABLE fence activation must use the owner-controlled gate';
   end if;
   return new;
@@ -725,7 +725,7 @@ begin
        or new.has_human_participant is true
        or new.bot_only_proof_eligible is not true
        or current_user <> 'chips_ledger_archive_pruner'
-       or pg_catalog.current_setting('chips_bot_only_lifecycle', true) <> '1'
+       or coalesce(pg_catalog.current_setting('chips_bot_only_lifecycle', true), '') <> '1'
        or not exists (
          select 1
            from public.chips_ledger_archive_batches batches
@@ -832,23 +832,34 @@ begin
   if receipt_changed and cleanup_changed then
     raise exception 'Archive prune receipt and registry cleanup receipt require separate transitions';
   end if;
+  if receipt_changed
+     and new.format_version = 2
+     and (
+       coalesce(pg_catalog.current_setting('chips_bot_only_prune', true), '') <> '1'
+       or new.destructive_go_at is null
+       or new.destructive_go_batch_id is distinct from new.batch_id
+     ) then
+    raise exception using
+      errcode = 'P8911',
+      message = 'Schema-v2 bot-only batches require the exact lifecycle operator and batch GO';
+  end if;
   if (proof_changed or bot_proof_changed) and current_user <> 'chips_ledger_archive_pruner' then
     raise exception 'Archive proof may only be written by the archive pruner';
   end if;
   if bot_proof_changed
-     and pg_catalog.current_setting('chips_bot_only_proof', true) <> '1' then
+     and coalesce(pg_catalog.current_setting('chips_bot_only_proof', true), '') <> '1' then
     raise exception 'Bot-only proof may only be written by the lifecycle proof operator';
   end if;
   if (receipt_changed or cleanup_changed) and current_user <> 'chips_ledger_archive_pruner' then
     raise exception 'Archive receipt may only be written by the archive pruner';
   end if;
   if cleanup_changed
-     and pg_catalog.current_setting('chips_bot_cleanup_receipt', true) <> '1' then
+     and coalesce(pg_catalog.current_setting('chips_bot_cleanup_receipt', true), '') <> '1' then
     raise exception 'Bot-only cleanup receipt may only be written by the lifecycle cleanup operator';
   end if;
   if go_changed and not (
     current_user = 'postgres'
-    and pg_catalog.current_setting('chips_bot_only_go', true) = '1'
+    and coalesce(pg_catalog.current_setting('chips_bot_only_go', true), '') = '1'
   ) then
     raise exception 'Bot-only destructive GO may only be written by the exact authorization function';
   end if;
@@ -938,37 +949,9 @@ $$;
 
 -- Recreate the public wrapper so the unchanged 30-day pruner cannot be used
 -- to execute a schema-v2 bot-only batch without the lifecycle operator.
-set role chips_ledger_archive_pruner;
-create or replace function public.chips_prune_committed_archive_batch(
-  p_object_path text,
-  p_transaction_ids uuid[],
-  p_entry_ids bigint[],
-  p_execute boolean default false
-)
-returns jsonb
-language plpgsql
-security definer
-set search_path = ''
-as $$
-declare
-  target_project_ref text;
-  target_format_version integer;
-begin
-  if p_execute is null then raise exception 'Ledger archive pruning execute flag must not be NULL'; end if;
-  select batches.project_ref, batches.format_version
-    into target_project_ref, target_format_version
-    from public.chips_ledger_archive_batches batches
-   where batches.object_path = p_object_path
-   for update;
-  if not found then raise exception 'Committed archive manifest was not found'; end if;
-  if target_format_version = 2 then
-    raise exception using errcode = 'P8911', message = 'Schema-v2 bot-only batches require the bot-only lifecycle operator';
-  end if;
-  perform public.chips_assert_archive_prune_target(target_project_ref, pg_catalog.cardinality(p_transaction_ids));
-  return public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, p_execute is true);
-end;
-$$;
-reset role;
+-- The existing wrapper remains owned by the established pruner role.  The
+-- archive-batch guard above blocks its destructive schema-v2 path by code
+-- P8911; the existing 30-day path is unchanged.
 
 -- This gate is intentionally never called by automation in this change.  A
 -- future owner action must name the exact batch and use the exact confirmation
@@ -1415,6 +1398,7 @@ begin
     raise exception using errcode = 'P8923', message = 'Exact bot-only batch GO is required before destructive cleanup';
   end if;
 
+  perform pg_catalog.set_config('chips_bot_only_prune', '1', true);
   prune_result := public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, true);
   perform public.chips_assert_bot_only_table_lifecycle_gate(batch.bot_only_table_id, batch.batch_id, batch.cutoff, p_registry_keys);
   select count(*) into deleted_registry_count

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -153,7 +153,7 @@ begin
   if tg_op <> 'UPDATE'
      or old.control_id is distinct from new.control_id
      or current_user <> 'postgres'
-     or coalesce(pg_catalog.current_setting('chips_table_fence_control', true), '') <> '1' then
+     or coalesce(pg_catalog.current_setting('chips.table_fence_control', true), '') <> '1' then
     raise exception 'TABLE fence activation must use the owner-controlled gate';
   end if;
   return new;
@@ -190,7 +190,7 @@ begin
   ) then
     raise exception using errcode = 'P8900', message = 'TABLE fence cannot be deactivated after bot-only cleanup begins';
   end if;
-  perform pg_catalog.set_config('chips_table_fence_control', '1', true);
+  perform pg_catalog.set_config('chips.table_fence_control', '1', true);
   update public.chips_table_fence_control
      set enforcement_active = next_active,
          activated_at = case when next_active then coalesce(activated_at, pg_catalog.timezone('utc', pg_catalog.now())) else activated_at end,
@@ -661,7 +661,7 @@ as $$
 begin
   if tg_op = 'DELETE' then
     if current_user = 'chips_ledger_archive_pruner'
-       and pg_catalog.current_setting('chips_bot_registry_cleanup', true) = '1' then
+       and pg_catalog.current_setting('chips.bot_registry_cleanup', true) = '1' then
       return old;
     end if;
     raise exception 'Idempotency registry rows are durable; DELETE is not permitted';
@@ -745,7 +745,7 @@ begin
        or new.has_human_participant is true
        or new.bot_only_proof_eligible is not true
        or current_user <> 'chips_ledger_archive_pruner'
-       or coalesce(pg_catalog.current_setting('chips_bot_only_lifecycle', true), '') <> '1'
+       or coalesce(pg_catalog.current_setting('chips.bot_only_lifecycle', true), '') <> '1'
        or not exists (
          select 1
            from public.chips_ledger_archive_batches batches
@@ -858,7 +858,7 @@ begin
   if receipt_changed
      and new.format_version = 2
      and (
-       coalesce(pg_catalog.current_setting('chips_bot_only_prune', true), '') <> '1'
+       coalesce(pg_catalog.current_setting('chips.bot_only_prune', true), '') <> '1'
        or new.destructive_go_at is null
        or new.destructive_go_batch_id is distinct from new.batch_id
      ) then
@@ -870,19 +870,19 @@ begin
     raise exception 'Archive proof may only be written by the archive pruner';
   end if;
   if bot_proof_changed
-     and coalesce(pg_catalog.current_setting('chips_bot_only_proof', true), '') <> '1' then
+     and coalesce(pg_catalog.current_setting('chips.bot_only_proof', true), '') <> '1' then
     raise exception 'Bot-only proof may only be written by the lifecycle proof operator';
   end if;
   if (receipt_changed or cleanup_changed) and current_user <> 'chips_ledger_archive_pruner' then
     raise exception 'Archive receipt may only be written by the archive pruner';
   end if;
   if cleanup_changed
-     and coalesce(pg_catalog.current_setting('chips_bot_cleanup_receipt', true), '') <> '1' then
+     and coalesce(pg_catalog.current_setting('chips.bot_cleanup_receipt', true), '') <> '1' then
     raise exception 'Bot-only cleanup receipt may only be written by the lifecycle cleanup operator';
   end if;
   if go_changed and not (
     current_user = 'postgres'
-    and coalesce(pg_catalog.current_setting('chips_bot_only_go', true), '') = '1'
+    and coalesce(pg_catalog.current_setting('chips.bot_only_go', true), '') = '1'
   ) then
     raise exception 'Bot-only destructive GO may only be written by the exact authorization function';
   end if;
@@ -1015,7 +1015,7 @@ begin
     raise exception using errcode = 'P8912', message = 'Only one exact committed Stage bot-only batch may be authorized';
   end if;
   perform public.chips_assert_archive_prune_target(batch.project_ref, batch.transaction_count);
-  perform pg_catalog.set_config('chips_bot_only_go', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_go', '1', true);
   update public.chips_ledger_archive_batches
      set destructive_go_at = pg_catalog.timezone('utc', pg_catalog.now()),
          destructive_go_batch_id = batch.batch_id
@@ -1355,7 +1355,7 @@ begin
     return pg_catalog.jsonb_build_object('state', 'proof_exists', 'transactions', batch.transaction_count, 'entries', batch.entry_count);
   end if;
 
-  perform pg_catalog.set_config('chips_bot_only_proof', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_proof', '1', true);
   update public.chips_ledger_archive_batches batches
      set archived_transaction_ids_sha256 = transaction_ids_sha256,
          archived_entry_ids_sha256 = entry_ids_sha256,
@@ -1437,7 +1437,7 @@ begin
     raise exception using errcode = 'P8923', message = 'Exact bot-only batch GO is required before destructive cleanup';
   end if;
 
-  perform pg_catalog.set_config('chips_bot_only_prune', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_prune', '1', true);
   prune_result := public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, true);
   perform public.chips_assert_bot_only_table_lifecycle_gate(batch.bot_only_table_id, batch.batch_id, batch.cutoff, p_registry_keys);
   select count(*) into deleted_registry_count
@@ -1446,14 +1446,14 @@ begin
      and registry.idempotency_key = any(p_registry_keys);
   if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry cleanup set is incomplete'; end if;
 
-  perform pg_catalog.set_config('chips_bot_registry_cleanup', '1', true);
+  perform pg_catalog.set_config('chips.bot_registry_cleanup', '1', true);
   delete from public.chips_transaction_idempotency registry
    where registry.archive_batch_id = batch.batch_id
      and registry.idempotency_key = any(p_registry_keys);
   get diagnostics deleted_registry_count = row_count;
   if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry DELETE count mismatch'; end if;
 
-  perform pg_catalog.set_config('chips_bot_cleanup_receipt', '1', true);
+  perform pg_catalog.set_config('chips.bot_cleanup_receipt', '1', true);
   update public.chips_ledger_archive_batches batches
      set registry_cleaned_at = pg_catalog.timezone('utc', pg_catalog.now()),
          registry_cleaned_key_count = pg_catalog.cardinality(p_registry_keys),
@@ -1462,7 +1462,7 @@ begin
      and batches.registry_cleaned_at is null;
   if not found then raise exception using errcode = 'P8924', message = 'Bot-only cleanup receipt transition was not unique'; end if;
 
-  perform pg_catalog.set_config('chips_bot_only_lifecycle', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_lifecycle', '1', true);
   update public.poker_tables tables
      set bot_only_retention_complete_at = coalesce(tables.bot_only_retention_complete_at, pg_catalog.timezone('utc', pg_catalog.now()))
    where tables.id = batch.bot_only_table_id

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -1278,8 +1278,8 @@ begin
           or (
             transactions.metadata ? 'tableId'
             and (
-              pg_catalog.nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') is null
-              or pg_catalog.nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+              nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') is null
+              or nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
               or pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text
             )
           )

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -329,7 +329,7 @@ begin
 
   if new.reference is not null
      and new.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(new.reference from '^[^:]+:([^:]+)')));
+    marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(new.reference, '^[^:]+:([^:]+)')));
     if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
       raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
     end if;
@@ -421,7 +421,7 @@ begin
 
   if transaction_row.reference is not null
      and transaction_row.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    transaction_marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(transaction_row.reference from '^[^:]+:([^:]+)')));
+    transaction_marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(transaction_row.reference, '^[^:]+:([^:]+)')));
     if transaction_marker = ''
        or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
       raise exception using errcode = 'P8904', message = 'TABLE transaction reference marker is invalid';
@@ -1262,7 +1262,7 @@ begin
           or (transactions.metadata ? 'tableId'
               and pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text)
           or (transactions.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
-              and pg_catalog.lower(pg_catalog.substring(transactions.reference from '^[^:]+:([^:]+)')) <> p_table_id::text)
+              and pg_catalog.lower(pg_catalog.substring(transactions.reference, '^[^:]+:([^:]+)')) <> p_table_id::text)
           or count(*) <> 2
           or count(*) filter (where accounts.account_type::text = 'USER') <> 0
           or count(*) filter (where accounts.account_type::text = 'SYSTEM') <> 1

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -1523,6 +1523,6 @@ grant execute on function public.chips_archive_text_ids_sha256(text[]) to postgr
 revoke all on function public.chips_parse_table_idempotency_key(text) from public, anon, authenticated, service_role;
 grant execute on function public.chips_parse_table_idempotency_key(text) to postgres, chips_ledger_archive_pruner;
 revoke all on function public.chips_parse_table_reference(text) from public, anon, authenticated, service_role;
-grant execute on function public.chips_parse_table_reference(text) to postgres;
+grant execute on function public.chips_parse_table_reference(text) to postgres, chips_ledger_archive_pruner;
 
 commit;

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -1,0 +1,1508 @@
+begin;
+
+-- Issue #890 is deliberately additive.  Existing archive batches, the v1
+-- object namespace, and stage-ledger-auto-retention-30d-v1 remain valid.
+alter table public.chips_ledger_archive_batches
+  drop constraint if exists chips_ledger_archive_batches_source_policy_check;
+
+alter table public.chips_ledger_archive_batches
+  add column bot_only_table_id uuid,
+  add column bot_only_table_count bigint,
+  add column bot_only_newest_created_at timestamptz,
+  add column bot_only_registry_keys_sha256 text,
+  add column bot_only_out_of_scope_keys_sha256 text,
+  add column bot_only_identity_count bigint,
+  add column bot_only_eligible_count bigint,
+  add column registry_cleaned_at timestamptz,
+  add column registry_cleaned_key_count bigint,
+  add column registry_cleaned_keys_sha256 text,
+  add column destructive_go_at timestamptz,
+  add column destructive_go_batch_id bigint;
+
+alter table public.chips_ledger_archive_batches
+  add constraint chips_ledger_archive_batches_source_policy_check
+  check (
+    source_policy_id is null
+    or source_policy_id in (
+      'stage-ledger-auto-retention-30d-v1',
+      'stage-ledger-bot-only-retention-7d-v1'
+    )
+  ),
+  add constraint chips_ledger_archive_batches_bot_only_policy_check
+    check (
+      format_version <> 2
+      or source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
+    ),
+  add constraint chips_ledger_archive_batches_bot_only_evidence_check
+    check (
+      (
+        format_version <> 2
+        and bot_only_table_id is null
+        and bot_only_table_count is null
+        and bot_only_newest_created_at is null
+        and bot_only_registry_keys_sha256 is null
+        and bot_only_out_of_scope_keys_sha256 is null
+        and bot_only_identity_count is null
+        and bot_only_eligible_count is null
+      ) or (
+        format_version = 2
+        and bot_only_table_id is not null
+        and bot_only_table_count = 1
+        and bot_only_newest_created_at is not null
+        and bot_only_registry_keys_sha256 ~ '^[0-9a-f]{64}$'
+        and bot_only_out_of_scope_keys_sha256 ~ '^[0-9a-f]{64}$'
+        and bot_only_identity_count >= 1
+        and bot_only_identity_count = transaction_count
+        and bot_only_eligible_count = transaction_count
+      )
+    ),
+  add constraint chips_ledger_archive_batches_cleanup_receipt_check
+    check (
+      (
+        registry_cleaned_at is null
+        and registry_cleaned_key_count is null
+        and registry_cleaned_keys_sha256 is null
+      ) or (
+        format_version = 2
+        and archive_proof_verified_at is not null
+        and pruned_at is not null
+        and bot_only_registry_keys_sha256 is not null
+        and registry_cleaned_at is not null
+        and registry_cleaned_key_count = transaction_count
+        and registry_cleaned_key_count > 0
+        and registry_cleaned_keys_sha256 = bot_only_registry_keys_sha256
+      )
+    ),
+  add constraint chips_ledger_archive_batches_go_check
+    check (
+      (destructive_go_at is null and destructive_go_batch_id is null)
+      or (destructive_go_at is not null and destructive_go_batch_id = batch_id)
+    );
+
+create index chips_ledger_archive_batches_bot_only_stage_idx
+  on public.chips_ledger_archive_batches (
+    project_ref,
+    source_policy_id,
+    status,
+    pruned_at,
+    registry_cleaned_at,
+    created_at
+  )
+  where source_policy_id = 'stage-ledger-bot-only-retention-7d-v1';
+
+alter table public.chips_transaction_idempotency
+  add column table_id uuid,
+  add column key_format_version integer,
+  add column key_format text;
+
+alter table public.chips_transaction_idempotency
+  add constraint chips_transaction_idempotency_key_format_version_check
+    check (key_format_version is null or key_format_version = 1),
+  add constraint chips_transaction_idempotency_key_format_check
+    check (key_format is null or length(trim(key_format)) > 0);
+
+alter table public.poker_tables
+  add column bot_only_proof_eligible boolean not null default false,
+  add column bot_only_retention_complete_at timestamptz;
+
+-- Existing false values are historical/uncertain and remain permanently
+-- unqualified.  Only tables created after this migration receive the new
+-- authoritative default.
+alter table public.poker_tables
+  alter column bot_only_proof_eligible set default true;
+
+-- The additive migration installs both fences before runtime activation.  The
+-- singleton control row is the only reversible switch; it is deliberately
+-- OFF until all compatible producers have been deployed and verified.
+create table public.chips_table_fence_control (
+  control_id boolean primary key default true check (control_id is true),
+  enforcement_active boolean not null default false,
+  activated_at timestamptz,
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+insert into public.chips_table_fence_control (control_id, enforcement_active)
+values (true, false);
+
+alter table public.chips_table_fence_control enable row level security;
+revoke all on table public.chips_table_fence_control from public, anon, authenticated, service_role;
+
+create or replace function public.chips_table_fence_is_active()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(
+    (select control.enforcement_active
+       from public.chips_table_fence_control control
+      where control.control_id is true),
+    false
+  )
+$$;
+
+alter function public.chips_table_fence_is_active() owner to postgres;
+
+create or replace function public.chips_guard_table_fence_control()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op <> 'UPDATE'
+     or old.control_id is distinct from new.control_id
+     or current_user <> 'postgres'
+     or pg_catalog.current_setting('chips_table_fence_control', true) <> '1' then
+    raise exception 'TABLE fence activation must use the owner-controlled gate';
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.chips_guard_table_fence_control() owner to postgres;
+
+drop trigger if exists chips_table_fence_control_guard on public.chips_table_fence_control;
+create trigger chips_table_fence_control_guard
+before update or delete on public.chips_table_fence_control
+for each row execute function public.chips_guard_table_fence_control();
+
+create or replace function public.chips_set_table_fence_active(p_active boolean)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  next_active boolean := p_active;
+begin
+  if next_active is null then
+    raise exception using errcode = 'P8900', message = 'TABLE fence activation cannot be NULL';
+  end if;
+  if not next_active and (
+    exists (
+      select 1 from public.chips_ledger_archive_batches batches
+       where batches.registry_cleaned_at is not null
+    ) or exists (
+      select 1 from public.poker_tables tables
+       where tables.bot_only_retention_complete_at is not null
+    )
+  ) then
+    raise exception using errcode = 'P8900', message = 'TABLE fence cannot be deactivated after bot-only cleanup begins';
+  end if;
+  perform pg_catalog.set_config('chips_table_fence_control', '1', true);
+  update public.chips_table_fence_control
+     set enforcement_active = next_active,
+         activated_at = case when next_active then coalesce(activated_at, pg_catalog.timezone('utc', pg_catalog.now())) else activated_at end,
+         updated_at = pg_catalog.timezone('utc', pg_catalog.now())
+   where control_id is true;
+  return pg_catalog.jsonb_build_object(
+    'state', case when next_active then 'active' else 'inactive' end,
+    'enforcement_active', next_active
+  );
+end;
+$$;
+
+alter function public.chips_set_table_fence_active(boolean) owner to postgres;
+
+create or replace function public.chips_parse_table_idempotency_key(p_key text)
+returns jsonb
+language plpgsql
+immutable
+strict
+security definer
+set search_path = ''
+as $$
+declare
+  key_value text := pg_catalog.btrim(p_key);
+  parts text[];
+  format_name text;
+  table_position integer;
+  table_value text;
+begin
+  if key_value = '' or pg_catalog.length(key_value) > 240 then
+    raise exception using
+      errcode = 'P8901',
+      message = 'TABLE idempotency key is empty or too long';
+  end if;
+
+  parts := pg_catalog.regexp_split_to_array(key_value, ':');
+  if exists (select 1 from pg_catalog.unnest(parts) as values(value) where value = '') then
+    raise exception using errcode = 'P8901', message = 'TABLE idempotency key contains an empty marker';
+  end if;
+
+  if key_value like 'join-buyin:%' then
+    format_name := 'join-buyin';
+    table_position := 2;
+  elsif key_value like 'bot-seed-buyin:%' then
+    format_name := 'bot-seed-buyin';
+    table_position := 2;
+  elsif key_value like 'managed-bot-seed-buyin:%' then
+    format_name := 'managed-bot-seed-buyin';
+    table_position := 2;
+  elsif key_value like 'poker:leave:%' then
+    format_name := 'poker:leave';
+    table_position := 3;
+  elsif key_value like 'poker:inactive_cleanup:%' then
+    format_name := 'poker:inactive_cleanup';
+    table_position := 3;
+  elsif key_value like 'poker:rebuy:v1:%' then
+    format_name := 'poker:rebuy:v1';
+    table_position := 4;
+  elsif key_value like 'poker:deferred-leave:v1:%' then
+    format_name := 'poker:deferred-leave:v1';
+    table_position := 4;
+  elsif key_value like 'poker:bot-terminal-cashout:v1:%' then
+    format_name := 'poker:bot-terminal-cashout:v1';
+    table_position := 4;
+  elsif key_value like 'poker:human-terminal-cashout:v1:%' then
+    format_name := 'poker:human-terminal-cashout:v1';
+    table_position := 4;
+  elsif key_value like 'poker:bot-replacement-buyin:v1:%' then
+    format_name := 'poker:bot-replacement-buyin:v1';
+    table_position := 4;
+  elsif key_value like 'poker:managed-bot-top-up:v1:%' then
+    format_name := 'poker:managed-bot-top-up:v1';
+    table_position := 4;
+  else
+    raise exception using errcode = 'P8901', message = 'TABLE idempotency key format is not supported';
+  end if;
+
+  if pg_catalog.cardinality(parts) <= table_position
+     or exists (
+       select 1
+       from pg_catalog.generate_subscripts(parts, 1) as positions(position)
+       where positions.position > table_position
+         and parts[positions.position] = ''
+     ) then
+    raise exception using errcode = 'P8901', message = 'TABLE idempotency key suffix is incomplete';
+  end if;
+
+  table_value := pg_catalog.lower(pg_catalog.btrim(parts[table_position]));
+  if table_value !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+    raise exception using errcode = 'P8901', message = 'TABLE idempotency key table id is invalid';
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'version', 1,
+    'format', format_name,
+    'table_id', table_value,
+    'key', key_value
+  );
+end;
+$$;
+
+alter function public.chips_parse_table_idempotency_key(text) owner to postgres;
+
+create or replace function public.chips_table_transaction_before_insert()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  parsed jsonb;
+  key_table_id uuid;
+  marker text;
+  reference_table_id uuid;
+  table_status text;
+begin
+  if new.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
+    return new;
+  end if;
+  if not public.chips_table_fence_is_active() then
+    return new;
+  end if;
+
+  parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
+  key_table_id := (parsed->>'table_id')::uuid;
+
+  if new.metadata ? 'tableId' then
+    marker := pg_catalog.lower(pg_catalog.btrim(new.metadata->>'tableId'));
+    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       or marker::uuid <> key_table_id then
+      raise exception using
+        errcode = 'P8902',
+        message = 'TABLE metadata.tableId does not match the idempotency key';
+    end if;
+  end if;
+
+  if new.reference is not null
+     and new.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
+    marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(new.reference from '^[^:]+:([^:]+)')));
+    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
+    end if;
+    reference_table_id := marker::uuid;
+    if reference_table_id <> key_table_id then
+      raise exception using errcode = 'P8902', message = 'TABLE reference does not match the idempotency key';
+    end if;
+  end if;
+
+  select tables.status
+    into table_status
+    from public.poker_tables as tables
+   where tables.id = key_table_id
+   for update;
+  if not found or pg_catalog.upper(coalesce(table_status, '')) <> 'OPEN' then
+    raise exception using
+      errcode = 'P8903',
+      message = 'TABLE transaction is rejected because the table is closed or missing';
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.chips_table_transaction_before_insert() owner to postgres;
+
+create or replace function public.chips_validate_table_transaction_binding()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  transaction_id uuid;
+  transaction_row record;
+  parsed jsonb;
+  key_table_id uuid;
+  transaction_marker text;
+  reference_table_id uuid;
+  entry_count bigint;
+  user_entry_count bigint;
+  system_entry_count bigint;
+  escrow_entry_count bigint;
+  matching_escrow_count bigint;
+  invalid_account_count bigint;
+  invalid_entry_marker_count bigint;
+  total_amount numeric;
+  user_identity_count bigint;
+  user_identity_mismatch_count bigint;
+  buy_in_shape boolean;
+  cash_out_shape boolean;
+begin
+  if not public.chips_table_fence_is_active() then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+    return new;
+  end if;
+  if tg_table_name = 'chips_transactions' then
+    transaction_id := new.id;
+  elsif tg_op = 'DELETE' then
+    transaction_id := old.transaction_id;
+  else
+    transaction_id := new.transaction_id;
+  end if;
+  select transactions.*
+    into transaction_row
+    from public.chips_transactions as transactions
+   where transactions.id = transaction_id;
+  if not found or transaction_row.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+    return new;
+  end if;
+
+  parsed := public.chips_parse_table_idempotency_key(transaction_row.idempotency_key);
+  key_table_id := (parsed->>'table_id')::uuid;
+
+  if transaction_row.metadata ? 'tableId' then
+    transaction_marker := pg_catalog.lower(pg_catalog.btrim(transaction_row.metadata->>'tableId'));
+    if transaction_marker = ''
+       or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       or transaction_marker::uuid <> key_table_id then
+      raise exception using
+        errcode = 'P8904',
+        message = 'TABLE transaction metadata does not bind to its idempotency key';
+    end if;
+  end if;
+
+  if transaction_row.reference is not null
+     and transaction_row.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
+    transaction_marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(transaction_row.reference from '^[^:]+:([^:]+)')));
+    if transaction_marker = ''
+       or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      raise exception using errcode = 'P8904', message = 'TABLE transaction reference marker is invalid';
+    end if;
+    reference_table_id := transaction_marker::uuid;
+    if reference_table_id <> key_table_id then
+      raise exception using errcode = 'P8904', message = 'TABLE transaction reference does not bind to its idempotency key';
+    end if;
+  end if;
+
+  if not exists (
+    select 1 from public.poker_tables tables where tables.id = key_table_id
+  ) then
+    raise exception using errcode = 'P8904', message = 'TABLE transaction table identity is missing';
+  end if;
+
+  select
+    count(*),
+    count(*) filter (where accounts.account_type::text = 'USER'),
+    count(*) filter (where accounts.account_type::text = 'SYSTEM'),
+    count(*) filter (where accounts.account_type::text = 'ESCROW'),
+    count(*) filter (
+      where accounts.account_type::text = 'ESCROW'
+        and accounts.system_key = 'POKER_TABLE:' || key_table_id::text
+    ),
+    count(*) filter (where accounts.status::text <> 'active'),
+    coalesce(sum(entries.amount), 0),
+    count(*) filter (where accounts.account_type::text = 'USER' and accounts.user_id is not null),
+    count(*) filter (
+      where accounts.account_type::text = 'USER'
+        and accounts.user_id is distinct from transaction_row.user_id
+    )
+    into entry_count, user_entry_count, system_entry_count, escrow_entry_count,
+         matching_escrow_count, invalid_account_count, total_amount,
+         user_identity_count, user_identity_mismatch_count
+    from public.chips_entries as entries
+    join public.chips_accounts as accounts on accounts.id = entries.account_id
+   where entries.transaction_id = transaction_id;
+
+  select count(*)
+    into invalid_entry_marker_count
+    from public.chips_entries as entries
+   where entries.transaction_id = transaction_id
+     and (
+       entries.metadata ? 'tableId'
+       and (
+         entries.metadata->>'tableId' is null
+         or pg_catalog.lower(pg_catalog.btrim(entries.metadata->>'tableId')) <> key_table_id::text
+       )
+     );
+
+  buy_in_shape := transaction_row.tx_type::text = 'TABLE_BUY_IN'
+    and (
+      (user_entry_count = 1 and system_entry_count = 0 and escrow_entry_count = 1)
+      or (user_entry_count = 0 and system_entry_count = 1 and escrow_entry_count = 1)
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = transaction_id
+        and accounts.account_type::text = 'ESCROW'
+        and entries.amount > 0
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = transaction_id
+        and accounts.account_type::text in ('USER', 'SYSTEM')
+        and entries.amount < 0
+    );
+  cash_out_shape := transaction_row.tx_type::text = 'TABLE_CASH_OUT'
+    and (
+      (user_entry_count = 1 and system_entry_count = 0 and escrow_entry_count = 1)
+      or (user_entry_count = 0 and system_entry_count = 1 and escrow_entry_count = 1)
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = transaction_id
+        and accounts.account_type::text = 'ESCROW'
+        and entries.amount < 0
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = transaction_id
+        and accounts.account_type::text in ('USER', 'SYSTEM')
+        and entries.amount > 0
+    );
+
+  if entry_count <> 2
+     or matching_escrow_count <> 1
+     or invalid_account_count <> 0
+     or invalid_entry_marker_count <> 0
+     or total_amount <> 0
+     or user_identity_mismatch_count <> 0
+     or (transaction_row.user_id is null and user_entry_count <> 0)
+     or (transaction_row.user_id is not null and (user_entry_count <> 1 or user_identity_count <> 1))
+     or not (buy_in_shape or cash_out_shape) then
+    raise exception using
+      errcode = 'P8904',
+      message = 'TABLE transaction entries do not bind to one authoritative ESCROW table';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.chips_validate_table_transaction_binding() owner to postgres;
+
+drop trigger if exists chips_table_transaction_fence on public.chips_transactions;
+create trigger chips_table_transaction_fence
+before insert on public.chips_transactions
+for each row execute function public.chips_table_transaction_before_insert();
+
+drop trigger if exists chips_table_transaction_binding on public.chips_transactions;
+create constraint trigger chips_table_transaction_binding
+after insert on public.chips_transactions
+deferrable initially deferred
+for each row execute function public.chips_validate_table_transaction_binding();
+
+drop trigger if exists chips_entries_table_transaction_binding on public.chips_entries;
+create constraint trigger chips_entries_table_transaction_binding
+after insert or update or delete on public.chips_entries
+deferrable initially deferred
+for each row execute function public.chips_validate_table_transaction_binding();
+
+create or replace function public.chips_capture_transaction_idempotency()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  parsed jsonb;
+  parsed_table_id uuid;
+  fence_active boolean;
+begin
+  fence_active := public.chips_table_fence_is_active();
+  if new.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
+    if fence_active then
+      parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
+    else
+      begin
+        parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
+      exception when sqlstate 'P8901' then
+        parsed := null;
+      end;
+    end if;
+    parsed_table_id := (parsed->>'table_id')::uuid;
+  end if;
+
+  insert into public.chips_transaction_idempotency (
+    idempotency_key,
+    transaction_id,
+    payload_hash,
+    tx_type,
+    user_id,
+    transaction_created_at,
+    table_id,
+    key_format_version,
+    key_format
+  ) values (
+    new.idempotency_key,
+    new.id,
+    new.payload_hash,
+    new.tx_type,
+    new.user_id,
+    new.created_at,
+    parsed_table_id,
+    case when parsed is null then null else (parsed->>'version')::integer end,
+    case when parsed is null then null else parsed->>'format' end
+  );
+  return new;
+end;
+$$;
+
+alter function public.chips_capture_transaction_idempotency() owner to postgres;
+
+-- Backfill only hot rows for which the authoritative transaction is still
+-- available.  Unsupported historical keys intentionally remain NULL.
+do $$
+declare
+  row_data record;
+  parsed jsonb;
+begin
+  for row_data in
+    select registry.idempotency_key, transactions.id, transactions.idempotency_key as tx_key
+      from public.chips_transaction_idempotency registry
+      join public.chips_transactions transactions on transactions.id = registry.transaction_id
+     where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+       and registry.table_id is null
+  loop
+    begin
+      parsed := public.chips_parse_table_idempotency_key(row_data.tx_key);
+      update public.chips_transaction_idempotency
+         set table_id = (parsed->>'table_id')::uuid,
+             key_format_version = (parsed->>'version')::integer,
+             key_format = parsed->>'format'
+       where idempotency_key = row_data.idempotency_key;
+    exception when others then
+      -- Historical uncertainty is a deliberate fail-closed state.
+      null;
+    end;
+  end loop;
+end;
+$$;
+
+create or replace function public.chips_guard_idempotency_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    if current_user = 'chips_ledger_archive_pruner'
+       and pg_catalog.current_setting('chips_bot_registry_cleanup', true) = '1' then
+      return old;
+    end if;
+    raise exception 'Idempotency registry rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.idempotency_key is distinct from old.idempotency_key
+    or new.transaction_id is distinct from old.transaction_id
+    or new.payload_hash is distinct from old.payload_hash
+    or new.tx_type is distinct from old.tx_type
+    or new.user_id is distinct from old.user_id
+    or new.transaction_created_at is distinct from old.transaction_created_at
+    or new.created_at is distinct from old.created_at then
+    raise exception 'Idempotency registry identity is immutable';
+  end if;
+
+  if old.table_id is not null
+     or old.key_format_version is not null
+     or old.key_format is not null then
+    if new.table_id is distinct from old.table_id
+       or new.key_format_version is distinct from old.key_format_version
+       or new.key_format is distinct from old.key_format then
+      raise exception 'Idempotency table binding cannot be replaced or cleared';
+    end if;
+  elsif new.table_id is not null
+     or new.key_format_version is not null
+     or new.key_format is not null then
+    if current_user <> 'postgres' then
+      raise exception 'Historical idempotency table binding may only be backfilled by migration';
+    end if;
+  end if;
+
+  if old.replay_transaction is not null
+    or old.replay_entries is not null
+    or old.replay_completed_at is not null then
+    if new.replay_transaction is distinct from old.replay_transaction
+      or new.replay_entries is distinct from old.replay_entries
+      or new.replay_completed_at is distinct from old.replay_completed_at then
+      raise exception 'Completed idempotency replay cannot be replaced or cleared';
+    end if;
+  elsif not (
+    new.replay_transaction is null
+    and new.replay_entries is null
+    and new.replay_completed_at is null
+  ) and not (
+    new.replay_transaction is not null
+    and new.replay_entries is not null
+    and new.replay_completed_at is not null
+  ) then
+    raise exception 'Idempotency replay must transition from empty to complete';
+  end if;
+
+  if new.archive_batch_id is distinct from old.archive_batch_id then
+    if current_user <> 'chips_ledger_archive_pruner' then
+      raise exception 'Idempotency archive mapping may only be written by the archive pruner';
+    end if;
+    if old.archive_batch_id is not null then
+      raise exception 'Idempotency archive mapping cannot be replaced or cleared';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.chips_guard_poker_table_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if old.has_human_participant is true and new.has_human_participant is not true then
+    raise exception using errcode = 'P8905', message = 'has_human_participant is one-way';
+  end if;
+
+  if new.bot_only_proof_eligible is distinct from old.bot_only_proof_eligible then
+    raise exception using errcode = 'P8906', message = 'bot-only proof eligibility is immutable';
+  end if;
+
+  if new.bot_only_retention_complete_at is distinct from old.bot_only_retention_complete_at then
+    if old.bot_only_retention_complete_at is not null
+       or new.bot_only_retention_complete_at is null
+       or new.has_human_participant is true
+       or new.bot_only_proof_eligible is not true
+       or current_user <> 'chips_ledger_archive_pruner'
+       or pg_catalog.current_setting('chips_bot_only_lifecycle', true) <> '1'
+       or not exists (
+         select 1
+           from public.chips_ledger_archive_batches batches
+          where batches.bot_only_table_id = new.id
+            and batches.format_version = 2
+            and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
+            and batches.archive_proof_verified_at is not null
+            and batches.pruned_at is not null
+            and batches.registry_cleaned_at is not null
+            and batches.registry_cleaned_key_count = batches.transaction_count
+            and batches.registry_cleaned_keys_sha256 = batches.bot_only_registry_keys_sha256
+            and not exists (
+              select 1
+                from public.chips_transaction_idempotency registry
+               where registry.table_id = new.id
+            )
+       ) then
+      raise exception using errcode = 'P8907', message = 'bot-only table lifecycle marker transition is not authorized';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists poker_tables_guard_human_participant on public.poker_tables;
+create trigger poker_tables_guard_human_participant
+before update of has_human_participant, bot_only_proof_eligible, bot_only_retention_complete_at
+on public.poker_tables
+for each row execute function public.chips_guard_poker_table_mutations();
+
+-- The existing v1 proof/prune guard remains in place, but now also protects
+-- v2 evidence, the cleanup receipt, and the exact-batch GO latch.
+create or replace function public.chips_guard_archive_batch_mutations()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  old_proof_count integer;
+  new_proof_count integer;
+  old_receipt_count integer;
+  new_receipt_count integer;
+  old_bot_proof_count integer;
+  new_bot_proof_count integer;
+  old_cleanup_count integer;
+  new_cleanup_count integer;
+  proof_changed boolean;
+  receipt_changed boolean;
+  bot_proof_changed boolean;
+  cleanup_changed boolean;
+  go_changed boolean;
+begin
+  if tg_op = 'DELETE' then
+    raise exception 'Archive batch rows are durable; DELETE is not permitted';
+  end if;
+
+  if new.object_path is distinct from old.object_path
+    or new.batch_id is distinct from old.batch_id
+    or new.project_ref is distinct from old.project_ref
+    or new.format_version is distinct from old.format_version
+    or new.cutoff is distinct from old.cutoff
+    or new.cursor_start_created_at is distinct from old.cursor_start_created_at
+    or new.cursor_start_id is distinct from old.cursor_start_id
+    or new.cursor_end_created_at is distinct from old.cursor_end_created_at
+    or new.cursor_end_id is distinct from old.cursor_end_id
+    or new.first_created_at is distinct from old.first_created_at
+    or new.last_created_at is distinct from old.last_created_at
+    or new.transaction_count is distinct from old.transaction_count
+    or new.entry_count is distinct from old.entry_count
+    or new.tx_types is distinct from old.tx_types
+    or new.raw_bytes is distinct from old.raw_bytes
+    or new.compressed_bytes is distinct from old.compressed_bytes
+    or new.raw_sha256 is distinct from old.raw_sha256
+    or new.compressed_sha256 is distinct from old.compressed_sha256
+    or new.credits is distinct from old.credits
+    or new.debits is distinct from old.debits
+    or new.net_amount is distinct from old.net_amount
+    or new.created_at is distinct from old.created_at
+    or new.source_policy_id is distinct from old.source_policy_id then
+    raise exception 'Archive batch proof fields are immutable';
+  end if;
+
+  proof_changed := new.archived_transaction_ids_sha256 is distinct from old.archived_transaction_ids_sha256
+    or new.archived_entry_ids_sha256 is distinct from old.archived_entry_ids_sha256
+    or new.archive_proof_verified_at is distinct from old.archive_proof_verified_at;
+  receipt_changed := new.pruned_at is distinct from old.pruned_at
+    or new.pruned_transaction_count is distinct from old.pruned_transaction_count
+    or new.pruned_entry_count is distinct from old.pruned_entry_count
+    or new.pruned_transaction_ids_sha256 is distinct from old.pruned_transaction_ids_sha256
+    or new.pruned_entry_ids_sha256 is distinct from old.pruned_entry_ids_sha256;
+  bot_proof_changed := new.bot_only_table_id is distinct from old.bot_only_table_id
+    or new.bot_only_table_count is distinct from old.bot_only_table_count
+    or new.bot_only_newest_created_at is distinct from old.bot_only_newest_created_at
+    or new.bot_only_registry_keys_sha256 is distinct from old.bot_only_registry_keys_sha256
+    or new.bot_only_out_of_scope_keys_sha256 is distinct from old.bot_only_out_of_scope_keys_sha256
+    or new.bot_only_identity_count is distinct from old.bot_only_identity_count
+    or new.bot_only_eligible_count is distinct from old.bot_only_eligible_count;
+  cleanup_changed := new.registry_cleaned_at is distinct from old.registry_cleaned_at
+    or new.registry_cleaned_key_count is distinct from old.registry_cleaned_key_count
+    or new.registry_cleaned_keys_sha256 is distinct from old.registry_cleaned_keys_sha256;
+  go_changed := new.destructive_go_at is distinct from old.destructive_go_at
+    or new.destructive_go_batch_id is distinct from old.destructive_go_batch_id;
+
+  if receipt_changed and cleanup_changed then
+    raise exception 'Archive prune receipt and registry cleanup receipt require separate transitions';
+  end if;
+  if (proof_changed or bot_proof_changed) and current_user <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive proof may only be written by the archive pruner';
+  end if;
+  if bot_proof_changed
+     and pg_catalog.current_setting('chips_bot_only_proof', true) <> '1' then
+    raise exception 'Bot-only proof may only be written by the lifecycle proof operator';
+  end if;
+  if (receipt_changed or cleanup_changed) and current_user <> 'chips_ledger_archive_pruner' then
+    raise exception 'Archive receipt may only be written by the archive pruner';
+  end if;
+  if cleanup_changed
+     and pg_catalog.current_setting('chips_bot_cleanup_receipt', true) <> '1' then
+    raise exception 'Bot-only cleanup receipt may only be written by the lifecycle cleanup operator';
+  end if;
+  if go_changed and not (
+    current_user = 'postgres'
+    and pg_catalog.current_setting('chips_bot_only_go', true) = '1'
+  ) then
+    raise exception 'Bot-only destructive GO may only be written by the exact authorization function';
+  end if;
+
+  if new.status is distinct from old.status then
+    if old.status <> 'pending' or new.status <> 'committed'
+      or old.committed_at is not null or new.committed_at is null then
+      raise exception 'Archive batch status may only transition pending to committed';
+    end if;
+  elsif new.committed_at is distinct from old.committed_at then
+    raise exception 'Archive batch committed_at is immutable';
+  end if;
+
+  old_proof_count := pg_catalog.num_nonnulls(old.archived_transaction_ids_sha256, old.archived_entry_ids_sha256, old.archive_proof_verified_at);
+  new_proof_count := pg_catalog.num_nonnulls(new.archived_transaction_ids_sha256, new.archived_entry_ids_sha256, new.archive_proof_verified_at);
+  if old_proof_count = 0 then
+    if new_proof_count not in (0, 3) then raise exception 'Archive ID proof must transition from empty to complete'; end if;
+    if new_proof_count = 3 and new.status <> 'committed' then raise exception 'Archive ID proof requires a committed batch'; end if;
+  elsif proof_changed then
+    raise exception 'Archive ID proof cannot be replaced or cleared';
+  end if;
+
+  old_receipt_count := pg_catalog.num_nonnulls(old.pruned_at, old.pruned_transaction_count, old.pruned_entry_count, old.pruned_transaction_ids_sha256, old.pruned_entry_ids_sha256);
+  new_receipt_count := pg_catalog.num_nonnulls(new.pruned_at, new.pruned_transaction_count, new.pruned_entry_count, new.pruned_transaction_ids_sha256, new.pruned_entry_ids_sha256);
+  if old_receipt_count = 0 then
+    if new_receipt_count not in (0, 5) then raise exception 'Archive prune receipt must transition from empty to complete'; end if;
+    if new_receipt_count = 5 and new_proof_count <> 3 then raise exception 'Archive prune receipt requires an immutable ID proof'; end if;
+  elsif receipt_changed then
+    raise exception 'Archive prune receipt cannot be replaced or cleared';
+  end if;
+
+  old_bot_proof_count := pg_catalog.num_nonnulls(old.bot_only_table_id, old.bot_only_table_count, old.bot_only_newest_created_at, old.bot_only_registry_keys_sha256, old.bot_only_out_of_scope_keys_sha256, old.bot_only_identity_count, old.bot_only_eligible_count);
+  new_bot_proof_count := pg_catalog.num_nonnulls(new.bot_only_table_id, new.bot_only_table_count, new.bot_only_newest_created_at, new.bot_only_registry_keys_sha256, new.bot_only_out_of_scope_keys_sha256, new.bot_only_identity_count, new.bot_only_eligible_count);
+  if old_bot_proof_count = 0 then
+    if new_bot_proof_count not in (0, 7) then raise exception 'Bot-only proof must transition from empty to complete'; end if;
+    if new_bot_proof_count = 7 and (new.status <> 'committed' or new.format_version <> 2) then raise exception 'Bot-only proof requires a committed schema-v2 batch'; end if;
+  elsif bot_proof_changed then
+    raise exception 'Bot-only proof cannot be replaced or cleared';
+  end if;
+
+  old_cleanup_count := pg_catalog.num_nonnulls(old.registry_cleaned_at, old.registry_cleaned_key_count, old.registry_cleaned_keys_sha256);
+  new_cleanup_count := pg_catalog.num_nonnulls(new.registry_cleaned_at, new.registry_cleaned_key_count, new.registry_cleaned_keys_sha256);
+  if old_cleanup_count = 0 then
+    if new_cleanup_count not in (0, 3) then raise exception 'Registry cleanup receipt must transition from empty to complete'; end if;
+    if new_cleanup_count = 3 and (new_bot_proof_count <> 7 or new_receipt_count <> 5) then raise exception 'Registry cleanup receipt requires bot-only proof and ledger prune receipt'; end if;
+  elsif cleanup_changed then
+    raise exception 'Registry cleanup receipt cannot be replaced or cleared';
+  end if;
+
+  if old.destructive_go_at is not null and go_changed then
+    raise exception 'Bot-only destructive GO cannot be replaced or cleared';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists poker_tables_guard_human_participant on public.poker_tables;
+create trigger poker_tables_guard_human_participant
+before update of has_human_participant, bot_only_proof_eligible, bot_only_retention_complete_at
+on public.poker_tables
+for each row execute function public.chips_guard_poker_table_mutations();
+
+drop trigger if exists chips_ledger_archive_batches_guard on public.chips_ledger_archive_batches;
+create trigger chips_ledger_archive_batches_guard
+before update or delete on public.chips_ledger_archive_batches
+for each row execute function public.chips_guard_archive_batch_mutations();
+
+create or replace function public.chips_archive_text_ids_sha256(p_ids text[])
+returns text
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  payload text;
+begin
+  if p_ids is null or (pg_catalog.array_ndims(p_ids) is not null and pg_catalog.array_ndims(p_ids) <> 1)
+     or pg_catalog.array_position(p_ids, null) is not null then
+    raise exception 'Text ID proof requires a one-dimensional non-null text array';
+  end if;
+  select coalesce(pg_catalog.string_agg(value || E'\n', '' order by value), '')
+    into payload
+    from pg_catalog.unnest(p_ids) as values(value);
+  return pg_catalog.encode(extensions.digest(pg_catalog.convert_to(payload, 'UTF8'), 'sha256'), 'hex');
+end;
+$$;
+
+-- Recreate the public wrapper so the unchanged 30-day pruner cannot be used
+-- to execute a schema-v2 bot-only batch without the lifecycle operator.
+create or replace function public.chips_prune_committed_archive_batch(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_execute boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_project_ref text;
+  target_format_version integer;
+begin
+  if p_execute is null then raise exception 'Ledger archive pruning execute flag must not be NULL'; end if;
+  select batches.project_ref, batches.format_version
+    into target_project_ref, target_format_version
+    from public.chips_ledger_archive_batches batches
+   where batches.object_path = p_object_path
+   for update;
+  if not found then raise exception 'Committed archive manifest was not found'; end if;
+  if target_format_version = 2 then
+    raise exception using errcode = 'P8911', message = 'Schema-v2 bot-only batches require the bot-only lifecycle operator';
+  end if;
+  perform public.chips_assert_archive_prune_target(target_project_ref, pg_catalog.cardinality(p_transaction_ids));
+  return public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, p_execute is true);
+end;
+$$;
+
+-- This gate is intentionally never called by automation in this change.  A
+-- future owner action must name the exact batch and use the exact confirmation
+-- string, so GO cannot roll forward to a different object.
+create or replace function public.chips_authorize_bot_only_archive_batch(
+  p_batch_id bigint,
+  p_confirmation text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch public.chips_ledger_archive_batches%rowtype;
+begin
+  if p_confirmation is distinct from ('GO ' || p_batch_id::text) then
+    raise exception using errcode = 'P8912', message = 'Exact bot-only batch GO confirmation is required';
+  end if;
+  select batches.* into batch
+    from public.chips_ledger_archive_batches batches
+   where batches.batch_id = p_batch_id
+   for update;
+  if not found or batch.status <> 'committed'
+     or batch.format_version <> 2
+     or batch.source_policy_id <> 'stage-ledger-bot-only-retention-7d-v1'
+     or batch.project_ref <> 'krydukthwdvccggbyjfw'
+     or batch.archive_proof_verified_at is null
+     or batch.bot_only_table_id is null
+     or batch.pruned_at is not null
+     or batch.registry_cleaned_at is not null then
+    raise exception using errcode = 'P8912', message = 'Only one exact committed Stage bot-only batch may be authorized';
+  end if;
+  perform public.chips_assert_archive_prune_target(batch.project_ref, batch.transaction_count);
+  perform pg_catalog.set_config('chips_bot_only_go', '1', true);
+  update public.chips_ledger_archive_batches
+     set destructive_go_at = pg_catalog.timezone('utc', pg_catalog.now()),
+         destructive_go_batch_id = batch.batch_id
+   where chips_ledger_archive_batches.batch_id = batch.batch_id
+     and destructive_go_at is null;
+  return pg_catalog.jsonb_build_object('state', 'authorized', 'batch_id', batch.batch_id);
+end;
+$$;
+
+create or replace function public.chips_assert_bot_only_table_lifecycle_gate(
+  p_table_id uuid,
+  p_batch_id bigint,
+  p_cutoff timestamptz,
+  p_registry_keys text[]
+)
+returns jsonb
+language plpgsql
+set search_path = ''
+as $$
+declare
+  table_row record;
+  escrow_count bigint;
+  unknown_registry_count bigint;
+  unknown_hot_count bigint;
+  human_registry_count bigint;
+  young_registry_count bigint;
+  incomplete_old_count bigint;
+  newest_created_at timestamptz;
+begin
+  if not public.chips_table_fence_is_active() then
+    raise exception using errcode = 'P8913', message = 'Bot-only lifecycle gate requires the active TABLE fence';
+  end if;
+  if p_batch_id is null or not exists (
+    select 1
+      from public.chips_ledger_archive_batches batches
+     where batches.batch_id = p_batch_id
+       and batches.status = 'committed'
+       and batches.format_version = 2
+       and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
+       and batches.cutoff = p_cutoff
+  ) then
+    raise exception using errcode = 'P8913', message = 'Bot-only lifecycle gate requires the exact committed schema-v2 batch';
+  end if;
+  select tables.id, tables.status, tables.has_human_participant, tables.bot_only_proof_eligible, tables.bot_only_retention_complete_at
+    into table_row
+    from public.poker_tables tables
+   where tables.id = p_table_id
+   for update;
+  if not found then raise exception using errcode = 'P8913', message = 'Bot-only table is missing'; end if;
+  if pg_catalog.upper(table_row.status::text) <> 'CLOSED' then raise exception using errcode = 'P8913', message = 'Bot-only table is not CLOSED'; end if;
+  if table_row.has_human_participant is true then raise exception using errcode = 'P8913', message = 'Human-participant table is outside bot-only retention'; end if;
+  if table_row.bot_only_proof_eligible is not true then raise exception using errcode = 'P8913', message = 'Historical bot-only proof is uncertain'; end if;
+
+  select count(*) into escrow_count
+    from public.chips_accounts accounts
+   where accounts.account_type::text = 'ESCROW'
+     and accounts.system_key = 'POKER_TABLE:' || p_table_id::text
+     and accounts.status::text = 'active'
+     and accounts.balance = 0;
+  if escrow_count <> 1 then raise exception using errcode = 'P8913', message = 'Bot-only table escrow is not active and zero'; end if;
+
+  select count(*) into unknown_registry_count
+    from public.chips_transaction_idempotency registry
+   where registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.table_id is null;
+  select count(*) into unknown_hot_count
+    from public.chips_transactions transactions
+    left join public.chips_transaction_idempotency registry on registry.transaction_id = transactions.id
+   where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.table_id is null;
+  if unknown_registry_count <> 0 or unknown_hot_count <> 0 then
+    raise exception using errcode = 'P8914', message = 'Unknown TABLE identity blocks bot-only lifecycle completion';
+  end if;
+
+  select count(*) into human_registry_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id
+     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.user_id is not null;
+  if human_registry_count <> 0 then raise exception using errcode = 'P8914', message = 'USER TABLE identity blocks bot-only lifecycle completion'; end if;
+
+  select count(*) into young_registry_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id
+     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.user_id is null
+     and registry.transaction_created_at >= p_cutoff;
+  if young_registry_count <> 0 then raise exception using errcode = 'P8915', message = 'Young TABLE identity blocks bot-only lifecycle completion'; end if;
+
+  select count(*) into incomplete_old_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id
+     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+     and registry.user_id is null
+     and registry.transaction_created_at < p_cutoff
+     and not (
+       registry.idempotency_key = any(coalesce(p_registry_keys, array[]::text[]))
+       or exists (
+         select 1
+           from public.chips_ledger_archive_batches batches
+          where batches.batch_id = registry.archive_batch_id
+            and batches.format_version = 2
+            and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
+            and batches.pruned_at is not null
+            and batches.registry_cleaned_at is not null
+       )
+     );
+  if incomplete_old_count <> 0 then raise exception using errcode = 'P8916', message = 'Old TABLE identity is not fully archived, pruned, and cleaned'; end if;
+
+  select max(value) into newest_created_at
+    from (
+      select max(registry.transaction_created_at) as value
+        from public.chips_transaction_idempotency registry
+       where registry.table_id = p_table_id
+      union all
+      select max(batches.bot_only_newest_created_at)
+        from public.chips_ledger_archive_batches batches
+       where batches.bot_only_table_id = p_table_id
+         and batches.format_version = 2
+         and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
+         and batches.registry_cleaned_at is not null
+    ) known;
+  if newest_created_at is null or newest_created_at >= p_cutoff then
+    raise exception using errcode = 'P8915', message = 'Newest known TABLE identity is not older than the bot-only cutoff';
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'state', 'table_complete',
+    'table_id', p_table_id,
+    'newest_created_at', newest_created_at,
+    'unknown_registry', unknown_registry_count,
+    'unknown_hot', unknown_hot_count,
+    'protected_registry', human_registry_count
+  );
+end;
+$$;
+
+create or replace function public.chips_register_bot_only_archive_proof(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_table_id uuid,
+  p_registry_keys text[]
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch public.chips_ledger_archive_batches%rowtype;
+  actual_transaction_ids uuid[];
+  actual_entry_ids bigint[];
+  actual_registry_keys text[];
+  sorted_registry_keys text[];
+  out_of_scope_keys text[];
+  transaction_ids_sha256 text;
+  entry_ids_sha256 text;
+  registry_keys_sha256 text;
+  out_of_scope_keys_sha256 text;
+  expected_transaction_count bigint;
+  expected_entry_count bigint;
+  actual_table_count bigint;
+  actual_identity_count bigint;
+  actual_eligible_count bigint;
+  invalid_registry_binding_count bigint;
+  newest_created_at timestamptz;
+  table_row record;
+  invalid_shape_count bigint;
+  updated_count bigint;
+begin
+  perform public.chips_assert_archive_prune_target('krydukthwdvccggbyjfw', pg_catalog.cardinality(p_transaction_ids));
+  if p_transaction_ids is null or p_entry_ids is null or p_registry_keys is null
+     or pg_catalog.cardinality(p_transaction_ids) < 1
+     or pg_catalog.cardinality(p_transaction_ids) > 5000
+     or pg_catalog.cardinality(p_entry_ids) < 1
+     or pg_catalog.cardinality(p_registry_keys) <> pg_catalog.cardinality(p_transaction_ids) then
+    raise exception using errcode = 'P8917', message = 'Bot-only proof batch arrays are invalid';
+  end if;
+  if (select count(*) from pg_catalog.unnest(p_transaction_ids) as values(value)) <> (select count(distinct value) from pg_catalog.unnest(p_transaction_ids) as values(value))
+     or (select count(*) from pg_catalog.unnest(p_entry_ids) as values(value)) <> (select count(distinct value) from pg_catalog.unnest(p_entry_ids) as values(value))
+     or (select count(*) from pg_catalog.unnest(p_registry_keys) as values(value)) <> (select count(distinct value) from pg_catalog.unnest(p_registry_keys) as values(value)) then
+    raise exception using errcode = 'P8917', message = 'Bot-only proof batch arrays contain duplicates';
+  end if;
+
+  transaction_ids_sha256 := public.chips_archive_uuid_ids_sha256(p_transaction_ids);
+  entry_ids_sha256 := public.chips_archive_bigint_ids_sha256(p_entry_ids);
+
+  select batches.* into batch
+    from public.chips_ledger_archive_batches batches
+   where batches.object_path = p_object_path
+   for update;
+  if not found then raise exception using errcode = 'P8917', message = 'Committed bot-only archive manifest was not found'; end if;
+  if batch.status <> 'committed'
+     or batch.project_ref <> 'krydukthwdvccggbyjfw'
+     or batch.format_version <> 2
+     or batch.source_policy_id <> 'stage-ledger-bot-only-retention-7d-v1' then
+    raise exception using errcode = 'P8917', message = 'Bot-only proof requires a committed canonical Stage schema-v2 batch';
+  end if;
+  if batch.object_path <> ('v1/sha256/' || batch.compressed_sha256 || '.jsonl.gz') then
+    raise exception using errcode = 'P8917', message = 'Bot-only object path does not match compressed SHA-256';
+  end if;
+  if batch.transaction_count <> pg_catalog.cardinality(p_transaction_ids)
+     or batch.entry_count <> pg_catalog.cardinality(p_entry_ids) then
+    raise exception using errcode = 'P8917', message = 'Bot-only proof counts do not match the manifest';
+  end if;
+
+  select pg_catalog.array_agg(transactions.id order by transactions.created_at, transactions.id)
+    into actual_transaction_ids
+    from public.chips_transactions transactions
+   where transactions.id = any(p_transaction_ids);
+  if actual_transaction_ids is distinct from p_transaction_ids then raise exception using errcode = 'P8917', message = 'Bot-only transaction order does not match the hot ledger'; end if;
+
+  with wanted as (
+    select ids.id, ids.ordinality from pg_catalog.unnest(p_transaction_ids) with ordinality ids(id, ordinality)
+  )
+  select pg_catalog.array_agg(entries.id order by wanted.ordinality, entries.id)
+    into actual_entry_ids
+    from wanted join public.chips_entries entries on entries.transaction_id = wanted.id;
+  if actual_entry_ids is distinct from p_entry_ids then raise exception using errcode = 'P8917', message = 'Bot-only entry order does not match the hot ledger'; end if;
+
+  select tables.id, tables.status, tables.has_human_participant, tables.bot_only_proof_eligible
+    into table_row
+    from public.poker_tables tables
+   where tables.id = p_table_id
+   for update;
+  if not found or pg_catalog.upper(coalesce(table_row.status::text, '')) <> 'CLOSED' or table_row.has_human_participant is true or table_row.bot_only_proof_eligible is not true then
+    raise exception using errcode = 'P8918', message = 'Bot-only proof requires an authoritative closed bot-only table';
+  end if;
+
+  select count(*) into actual_table_count
+    from (
+      select distinct (public.chips_parse_table_idempotency_key(transactions.idempotency_key)->>'table_id')::uuid as table_id
+        from public.chips_transactions transactions
+       where transactions.id = any(p_transaction_ids)
+    ) tables;
+  if actual_table_count <> 1 or exists (
+    select 1
+      from public.chips_transactions transactions
+     where transactions.id = any(p_transaction_ids)
+       and (public.chips_parse_table_idempotency_key(transactions.idempotency_key)->>'table_id')::uuid <> p_table_id
+  ) then
+    raise exception using errcode = 'P8918', message = 'Bot-only proof has more than one table identity';
+  end if;
+
+  select count(*) into invalid_shape_count
+    from (
+      select transactions.id
+        from public.chips_transactions transactions
+        join public.chips_entries entries on entries.transaction_id = transactions.id
+        join public.chips_accounts accounts on accounts.id = entries.account_id
+       where transactions.id = any(p_transaction_ids)
+       group by transactions.id, transactions.tx_type, transactions.user_id, transactions.created_at,
+                transactions.metadata, transactions.reference
+      having transactions.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
+          or transactions.user_id is not null
+          or transactions.created_at >= batch.cutoff
+          or (transactions.metadata ? 'tableId'
+              and pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text)
+          or (transactions.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
+              and pg_catalog.lower(pg_catalog.substring(transactions.reference from '^[^:]+:([^:]+)')) <> p_table_id::text)
+          or count(*) <> 2
+          or count(*) filter (where accounts.account_type::text = 'USER') <> 0
+          or count(*) filter (where accounts.account_type::text = 'SYSTEM') <> 1
+          or count(*) filter (where accounts.account_type::text = 'ESCROW') <> 1
+          or count(*) filter (where accounts.account_type::text = 'ESCROW' and accounts.system_key = 'POKER_TABLE:' || p_table_id::text) <> 1
+          or not bool_and(accounts.status::text = 'active')
+          or sum(entries.amount) <> 0
+          or (transactions.tx_type::text = 'TABLE_BUY_IN' and (sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') >= 0 or sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') <= 0))
+          or (transactions.tx_type::text = 'TABLE_CASH_OUT' and (sum(entries.amount) filter (where accounts.account_type::text = 'ESCROW') >= 0 or sum(entries.amount) filter (where accounts.account_type::text = 'SYSTEM') <= 0))
+    ) invalid;
+  if invalid_shape_count <> 0 then raise exception using errcode = 'P8918', message = 'Bot-only proof is outside the technical TABLE whitelist'; end if;
+
+  select pg_catalog.array_agg(registry.idempotency_key order by registry.idempotency_key)
+    into actual_registry_keys
+    from public.chips_transaction_idempotency registry
+   where registry.transaction_id = any(p_transaction_ids)
+     and registry.table_id = p_table_id
+     and registry.archive_batch_id is null;
+  select pg_catalog.array_agg(value order by value)
+    into sorted_registry_keys
+    from pg_catalog.unnest(p_registry_keys) as values(value);
+  if actual_registry_keys is distinct from sorted_registry_keys then raise exception using errcode = 'P8919', message = 'Bot-only registry key proof does not match the hot registry'; end if;
+  select count(*)
+    into invalid_registry_binding_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id
+     and (
+       registry.key_format_version is distinct from 1
+       or registry.key_format is distinct from (
+         public.chips_parse_table_idempotency_key(registry.idempotency_key)->>'format'
+       )
+     );
+  if invalid_registry_binding_count <> 0 then
+    raise exception using errcode = 'P8919', message = 'Bot-only registry format does not match the server-verifiable key';
+  end if;
+  registry_keys_sha256 := public.chips_archive_text_ids_sha256(sorted_registry_keys);
+
+  select pg_catalog.array_agg(registry.idempotency_key order by registry.idempotency_key)
+    into out_of_scope_keys
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id
+     and not (registry.idempotency_key = any(sorted_registry_keys));
+  out_of_scope_keys := coalesce(out_of_scope_keys, array[]::text[]);
+  out_of_scope_keys_sha256 := public.chips_archive_text_ids_sha256(out_of_scope_keys);
+  select count(*) into actual_identity_count
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id;
+  actual_eligible_count := pg_catalog.cardinality(p_transaction_ids);
+  if actual_identity_count <> actual_eligible_count then
+    raise exception using errcode = 'P8919', message = 'Bot-only registry identity count does not match the complete eligible set';
+  end if;
+  select max(registry.transaction_created_at) into newest_created_at
+    from public.chips_transaction_idempotency registry
+   where registry.table_id = p_table_id;
+  if newest_created_at is null or newest_created_at >= batch.cutoff then raise exception using errcode = 'P8915', message = 'Bot-only proof newest identity has not crossed the seven-day cutoff'; end if;
+
+  perform public.chips_assert_bot_only_table_lifecycle_gate(p_table_id, batch.batch_id, batch.cutoff, sorted_registry_keys);
+
+  if batch.archive_proof_verified_at is not null then
+    if batch.archived_transaction_ids_sha256 is distinct from transaction_ids_sha256
+       or batch.archived_entry_ids_sha256 is distinct from entry_ids_sha256
+       or batch.bot_only_table_id is distinct from p_table_id
+       or batch.bot_only_registry_keys_sha256 is distinct from registry_keys_sha256 then
+      raise exception using errcode = 'P8920', message = 'Existing bot-only proof differs from the requested evidence';
+    end if;
+    return pg_catalog.jsonb_build_object('state', 'proof_exists', 'transactions', batch.transaction_count, 'entries', batch.entry_count);
+  end if;
+
+  perform pg_catalog.set_config('chips_bot_only_proof', '1', true);
+  update public.chips_ledger_archive_batches batches
+     set archived_transaction_ids_sha256 = transaction_ids_sha256,
+         archived_entry_ids_sha256 = entry_ids_sha256,
+         archive_proof_verified_at = pg_catalog.timezone('utc', pg_catalog.now()),
+         bot_only_table_id = p_table_id,
+         bot_only_table_count = 1,
+         bot_only_newest_created_at = newest_created_at,
+         bot_only_registry_keys_sha256 = registry_keys_sha256,
+         bot_only_out_of_scope_keys_sha256 = out_of_scope_keys_sha256,
+         bot_only_identity_count = actual_identity_count,
+         bot_only_eligible_count = actual_eligible_count
+   where batches.batch_id = batch.batch_id
+     and batches.archive_proof_verified_at is null;
+  get diagnostics updated_count = row_count;
+  if updated_count <> 1 then raise exception using errcode = 'P8920', message = 'Bot-only proof transition was not unique'; end if;
+  return pg_catalog.jsonb_build_object('state', 'proof_registered', 'transactions', batch.transaction_count, 'entries', batch.entry_count, 'table_id', p_table_id, 'registry_keys_sha256', registry_keys_sha256);
+end;
+$$;
+
+create or replace function public.chips_prune_and_cleanup_bot_only_archive_batch(
+  p_object_path text,
+  p_transaction_ids uuid[],
+  p_entry_ids bigint[],
+  p_registry_keys text[],
+  p_table_id uuid,
+  p_execute boolean default false,
+  p_approved_batch_id bigint default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  batch public.chips_ledger_archive_batches%rowtype;
+  registry_keys_sha256 text;
+  prune_result jsonb;
+  deleted_registry_count bigint;
+begin
+  if p_execute is null then raise exception using errcode = 'P8921', message = 'Bot-only execute flag must not be NULL'; end if;
+  if p_registry_keys is null
+     or pg_catalog.cardinality(p_registry_keys) < 1
+     or pg_catalog.cardinality(p_registry_keys) <> pg_catalog.cardinality(p_transaction_ids) then
+    raise exception using errcode = 'P8921', message = 'Bot-only cleanup registry key set is invalid';
+  end if;
+  select batches.* into batch
+    from public.chips_ledger_archive_batches batches
+   where batches.object_path = p_object_path
+   for update;
+  if not found or batch.project_ref <> 'krydukthwdvccggbyjfw' or batch.format_version <> 2 or batch.source_policy_id <> 'stage-ledger-bot-only-retention-7d-v1' then
+    raise exception using errcode = 'P8921', message = 'Bot-only cleanup requires a canonical Stage schema-v2 batch';
+  end if;
+  perform public.chips_assert_archive_prune_target(batch.project_ref, pg_catalog.cardinality(p_transaction_ids));
+  if batch.bot_only_table_id is distinct from p_table_id
+     or batch.transaction_count <> pg_catalog.cardinality(p_transaction_ids)
+     or batch.entry_count <> pg_catalog.cardinality(p_entry_ids)
+     or batch.archive_proof_verified_at is null
+     or batch.archived_transaction_ids_sha256 <> public.chips_archive_uuid_ids_sha256(p_transaction_ids)
+     or batch.archived_entry_ids_sha256 <> public.chips_archive_bigint_ids_sha256(p_entry_ids) then
+    raise exception using errcode = 'P8921', message = 'Bot-only cleanup arguments do not match immutable proof';
+  end if;
+  registry_keys_sha256 := public.chips_archive_text_ids_sha256(p_registry_keys);
+  if registry_keys_sha256 <> batch.bot_only_registry_keys_sha256 then raise exception using errcode = 'P8921', message = 'Bot-only cleanup keys do not match immutable proof'; end if;
+
+  if batch.registry_cleaned_at is not null then
+    if batch.registry_cleaned_key_count <> pg_catalog.cardinality(p_registry_keys)
+       or batch.registry_cleaned_keys_sha256 <> registry_keys_sha256 then
+      raise exception using errcode = 'P8922', message = 'Existing bot-only cleanup receipt differs from the retry';
+    end if;
+    return pg_catalog.jsonb_build_object('state', 'already_cleaned', 'transactions', batch.transaction_count, 'registry_keys', batch.registry_cleaned_key_count);
+  end if;
+
+  perform public.chips_assert_bot_only_table_lifecycle_gate(batch.bot_only_table_id, batch.batch_id, batch.cutoff, p_registry_keys);
+  if not p_execute then
+    prune_result := public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, false);
+    return prune_result || pg_catalog.jsonb_build_object('cleanup', 'prepare_only', 'table_id', batch.bot_only_table_id);
+  end if;
+  if p_approved_batch_id is distinct from batch.batch_id or batch.destructive_go_batch_id is distinct from batch.batch_id or batch.destructive_go_at is null then
+    raise exception using errcode = 'P8923', message = 'Exact bot-only batch GO is required before destructive cleanup';
+  end if;
+
+  prune_result := public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, true);
+  perform public.chips_assert_bot_only_table_lifecycle_gate(batch.bot_only_table_id, batch.batch_id, batch.cutoff, p_registry_keys);
+  select count(*) into deleted_registry_count
+    from public.chips_transaction_idempotency registry
+   where registry.archive_batch_id = batch.batch_id
+     and registry.idempotency_key = any(p_registry_keys);
+  if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry cleanup set is incomplete'; end if;
+
+  perform pg_catalog.set_config('chips_bot_registry_cleanup', '1', true);
+  delete from public.chips_transaction_idempotency registry
+   where registry.archive_batch_id = batch.batch_id
+     and registry.idempotency_key = any(p_registry_keys);
+  get diagnostics deleted_registry_count = row_count;
+  if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry DELETE count mismatch'; end if;
+
+  perform pg_catalog.set_config('chips_bot_cleanup_receipt', '1', true);
+  update public.chips_ledger_archive_batches batches
+     set registry_cleaned_at = pg_catalog.timezone('utc', pg_catalog.now()),
+         registry_cleaned_key_count = pg_catalog.cardinality(p_registry_keys),
+         registry_cleaned_keys_sha256 = registry_keys_sha256
+   where batches.batch_id = batch.batch_id
+     and batches.registry_cleaned_at is null;
+  if not found then raise exception using errcode = 'P8924', message = 'Bot-only cleanup receipt transition was not unique'; end if;
+
+  update public.poker_tables tables
+     set bot_only_retention_complete_at = coalesce(tables.bot_only_retention_complete_at, pg_catalog.timezone('utc', pg_catalog.now()))
+   where tables.id = batch.bot_only_table_id
+     and tables.bot_only_retention_complete_at is null;
+  return prune_result || pg_catalog.jsonb_build_object('state', 'cleaned', 'registry_keys', deleted_registry_count, 'table_id', batch.bot_only_table_id);
+end;
+$$;
+
+-- The existing archive-pruner role is reused; no second destructive role is
+-- introduced.  Column grants and RLS policies keep the new path narrow.
+grant select on public.chips_ledger_archive_batches, public.chips_transaction_idempotency, public.poker_tables to chips_ledger_archive_pruner;
+grant update (
+  bot_only_table_id,
+  bot_only_table_count,
+  bot_only_newest_created_at,
+  bot_only_registry_keys_sha256,
+  bot_only_out_of_scope_keys_sha256,
+  bot_only_identity_count,
+  bot_only_eligible_count,
+  registry_cleaned_at,
+  registry_cleaned_key_count,
+  registry_cleaned_keys_sha256
+) on public.chips_ledger_archive_batches to chips_ledger_archive_pruner;
+grant delete on public.chips_transaction_idempotency to chips_ledger_archive_pruner;
+grant update (bot_only_retention_complete_at) on public.poker_tables to chips_ledger_archive_pruner;
+
+drop policy if exists chips_archive_pruner_tables_marker_update on public.poker_tables;
+create policy chips_archive_pruner_tables_marker_update
+  on public.poker_tables
+  for update to chips_ledger_archive_pruner
+  using (true)
+  with check (has_human_participant is not true and bot_only_retention_complete_at is not null);
+
+drop policy if exists chips_archive_pruner_registry_delete on public.chips_transaction_idempotency;
+create policy chips_archive_pruner_registry_delete
+  on public.chips_transaction_idempotency
+  for delete to chips_ledger_archive_pruner
+  using (true);
+
+grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
+set role chips_ledger_archive_pruner;
+
+alter function public.chips_archive_text_ids_sha256(text[]) owner to chips_ledger_archive_pruner;
+alter function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) owner to chips_ledger_archive_pruner;
+alter function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) owner to chips_ledger_archive_pruner;
+alter function public.chips_assert_bot_only_table_lifecycle_gate(uuid, bigint, timestamptz, text[]) owner to chips_ledger_archive_pruner;
+
+reset role;
+revoke create on schema public from chips_ledger_archive_pruner;
+revoke chips_ledger_archive_pruner from postgres;
+
+revoke all on function public.chips_authorize_bot_only_archive_batch(bigint, text) from public, anon, authenticated, service_role;
+grant execute on function public.chips_authorize_bot_only_archive_batch(bigint, text) to postgres;
+revoke all on function public.chips_table_fence_is_active() from public, anon, authenticated, service_role;
+grant execute on function public.chips_table_fence_is_active() to postgres, chips_ledger_archive_pruner;
+revoke all on function public.chips_set_table_fence_active(boolean) from public, anon, authenticated, service_role;
+grant execute on function public.chips_set_table_fence_active(boolean) to postgres;
+revoke all on function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) from public, anon, authenticated, service_role;
+grant execute on function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) to postgres;
+revoke all on function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) from public, anon, authenticated, service_role;
+grant execute on function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) to postgres;
+revoke all on function public.chips_assert_bot_only_table_lifecycle_gate(uuid, bigint, timestamptz, text[]) from public, anon, authenticated, service_role;
+revoke all on function public.chips_archive_text_ids_sha256(text[]) from public, anon, authenticated, service_role;
+grant execute on function public.chips_archive_text_ids_sha256(text[]) to postgres, chips_ledger_archive_pruner;
+revoke all on function public.chips_parse_table_idempotency_key(text) from public, anon, authenticated, service_role;
+grant execute on function public.chips_parse_table_idempotency_key(text) to postgres, chips_ledger_archive_pruner;
+
+commit;

--- a/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
+++ b/supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql
@@ -927,6 +927,10 @@ create trigger chips_ledger_archive_batches_guard
 before update or delete on public.chips_ledger_archive_batches
 for each row execute function public.chips_guard_archive_batch_mutations();
 
+grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
+set role chips_ledger_archive_pruner;
+
 create or replace function public.chips_archive_text_ids_sha256(p_ids text[])
 returns text
 language plpgsql
@@ -946,6 +950,8 @@ begin
   return pg_catalog.encode(extensions.digest(pg_catalog.convert_to(payload, 'UTF8'), 'sha256'), 'hex');
 end;
 $$;
+
+reset role;
 
 -- Recreate the public wrapper so the unchanged 30-day pruner cannot be used
 -- to execute a schema-v2 bot-only batch without the lifecycle operator.
@@ -995,6 +1001,8 @@ begin
   return pg_catalog.jsonb_build_object('state', 'authorized', 'batch_id', batch.batch_id);
 end;
 $$;
+
+set role chips_ledger_archive_pruner;
 
 create or replace function public.chips_assert_bot_only_table_lifecycle_gate(
   p_table_id uuid,
@@ -1431,6 +1439,8 @@ begin
 end;
 $$;
 
+reset role;
+
 -- The existing archive-pruner role is reused; no second destructive role is
 -- introduced.  Column grants and RLS policies keep the new path narrow.
 grant select on public.chips_ledger_archive_batches, public.chips_transaction_idempotency, public.poker_tables to chips_ledger_archive_pruner;
@@ -1462,16 +1472,6 @@ create policy chips_archive_pruner_registry_delete
   for delete to chips_ledger_archive_pruner
   using (true);
 
-grant chips_ledger_archive_pruner to postgres;
-grant create on schema public to chips_ledger_archive_pruner;
-set role chips_ledger_archive_pruner;
-
-alter function public.chips_archive_text_ids_sha256(text[]) owner to chips_ledger_archive_pruner;
-alter function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) owner to chips_ledger_archive_pruner;
-alter function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) owner to chips_ledger_archive_pruner;
-alter function public.chips_assert_bot_only_table_lifecycle_gate(uuid, bigint, timestamptz, text[]) owner to chips_ledger_archive_pruner;
-
-reset role;
 revoke create on schema public from chips_ledger_archive_pruner;
 revoke chips_ledger_archive_pruner from postgres;
 

--- a/supabase/migrations/20260819220000_chips_ledger_bot_only_retention_hardening.sql
+++ b/supabase/migrations/20260819220000_chips_ledger_bot_only_retention_hardening.sql
@@ -620,6 +620,7 @@ begin
 end;
 $$;
 grant chips_ledger_archive_pruner to postgres;
+grant create on schema public to chips_ledger_archive_pruner;
 set role chips_ledger_archive_pruner;
 create or replace function public.chips_register_bot_only_archive_proof(
   p_object_path text,
@@ -936,9 +937,9 @@ begin
 end;
 $$;
 reset role;
+revoke create on schema public from chips_ledger_archive_pruner;
 revoke chips_ledger_archive_pruner from postgres;
 revoke all on function public.chips_parse_table_reference(text) from public, anon, authenticated, service_role;
 grant execute on function public.chips_parse_table_reference(text) to postgres, chips_ledger_archive_pruner;
 
 commit;
-

--- a/supabase/migrations/20260819220000_chips_ledger_bot_only_retention_hardening.sql
+++ b/supabase/migrations/20260819220000_chips_ledger_bot_only_retention_hardening.sql
@@ -1,149 +1,7 @@
 begin;
 
--- Issue #890 is deliberately additive.  Existing archive batches, the v1
--- object namespace, and stage-ledger-auto-retention-30d-v1 remain valid.
-alter table public.chips_ledger_archive_batches
-  drop constraint if exists chips_ledger_archive_batches_source_policy_check;
-
-alter table public.chips_ledger_archive_batches
-  add column bot_only_table_id uuid,
-  add column bot_only_table_count bigint,
-  add column bot_only_newest_created_at timestamptz,
-  add column bot_only_registry_keys_sha256 text,
-  add column bot_only_out_of_scope_keys_sha256 text,
-  add column bot_only_identity_count bigint,
-  add column bot_only_eligible_count bigint,
-  add column registry_cleaned_at timestamptz,
-  add column registry_cleaned_key_count bigint,
-  add column registry_cleaned_keys_sha256 text,
-  add column destructive_go_at timestamptz,
-  add column destructive_go_batch_id bigint;
-
-alter table public.chips_ledger_archive_batches
-  add constraint chips_ledger_archive_batches_source_policy_check
-  check (
-    source_policy_id is null
-    or source_policy_id in (
-      'stage-ledger-auto-retention-30d-v1',
-      'stage-ledger-bot-only-retention-7d-v1'
-    )
-  ),
-  add constraint chips_ledger_archive_batches_bot_only_policy_check
-    check (
-      format_version <> 2
-      or source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
-    ),
-  add constraint chips_ledger_archive_batches_bot_only_evidence_check
-    check (
-      (
-        format_version <> 2
-        and bot_only_table_id is null
-        and bot_only_table_count is null
-        and bot_only_newest_created_at is null
-        and bot_only_registry_keys_sha256 is null
-        and bot_only_out_of_scope_keys_sha256 is null
-        and bot_only_identity_count is null
-        and bot_only_eligible_count is null
-      ) or (
-        format_version = 2
-        and bot_only_table_id is not null
-        and bot_only_table_count = 1
-        and bot_only_newest_created_at is not null
-        and bot_only_registry_keys_sha256 ~ '^[0-9a-f]{64}$'
-        and bot_only_out_of_scope_keys_sha256 ~ '^[0-9a-f]{64}$'
-        and bot_only_identity_count >= 1
-        and bot_only_identity_count = transaction_count
-        and bot_only_eligible_count = transaction_count
-      )
-    ),
-  add constraint chips_ledger_archive_batches_cleanup_receipt_check
-    check (
-      (
-        registry_cleaned_at is null
-        and registry_cleaned_key_count is null
-        and registry_cleaned_keys_sha256 is null
-      ) or (
-        format_version = 2
-        and archive_proof_verified_at is not null
-        and pruned_at is not null
-        and bot_only_registry_keys_sha256 is not null
-        and registry_cleaned_at is not null
-        and registry_cleaned_key_count = transaction_count
-        and registry_cleaned_key_count > 0
-        and registry_cleaned_keys_sha256 = bot_only_registry_keys_sha256
-      )
-    ),
-  add constraint chips_ledger_archive_batches_go_check
-    check (
-      (destructive_go_at is null and destructive_go_batch_id is null)
-      or (destructive_go_at is not null and destructive_go_batch_id = batch_id)
-    );
-
-create index chips_ledger_archive_batches_bot_only_stage_idx
-  on public.chips_ledger_archive_batches (
-    project_ref,
-    source_policy_id,
-    status,
-    pruned_at,
-    registry_cleaned_at,
-    created_at
-  )
-  where source_policy_id = 'stage-ledger-bot-only-retention-7d-v1';
-
-alter table public.chips_transaction_idempotency
-  add column table_id uuid,
-  add column key_format_version integer,
-  add column key_format text;
-
-alter table public.chips_transaction_idempotency
-  add constraint chips_transaction_idempotency_key_format_version_check
-    check (key_format_version is null or key_format_version = 1),
-  add constraint chips_transaction_idempotency_key_format_check
-    check (key_format is null or length(trim(key_format)) > 0);
-
-alter table public.poker_tables
-  add column bot_only_proof_eligible boolean not null default false,
-  add column bot_only_retention_complete_at timestamptz;
-
--- Existing false values are historical/uncertain and remain permanently
--- unqualified.  Only tables created after this migration receive the new
--- authoritative default.
-alter table public.poker_tables
-  alter column bot_only_proof_eligible set default true;
-
--- The additive migration installs both fences before runtime activation.  The
--- singleton control row is the only reversible switch; it is deliberately
--- OFF until all compatible producers have been deployed and verified.
-create table public.chips_table_fence_control (
-  control_id boolean primary key default true check (control_id is true),
-  enforcement_active boolean not null default false,
-  activated_at timestamptz,
-  updated_at timestamptz not null default timezone('utc', now())
-);
-
-insert into public.chips_table_fence_control (control_id, enforcement_active)
-values (true, false);
-
-alter table public.chips_table_fence_control enable row level security;
-revoke all on table public.chips_table_fence_control from public, anon, authenticated, service_role;
-
-create or replace function public.chips_table_fence_is_active()
-returns boolean
-language sql
-stable
-security definer
-set search_path = ''
-as $$
-  select coalesce(
-    (select control.enforcement_active
-       from public.chips_table_fence_control control
-      where control.control_id is true),
-    false
-  )
-$$;
-
-alter function public.chips_table_fence_is_active() owner to postgres;
-
+-- The original 20260818100000 migration is already recorded on shared Stage.
+-- This follow-up applies only the post-Stage hardening without rewriting history.
 create or replace function public.chips_guard_table_fence_control()
 returns trigger
 language plpgsql
@@ -153,20 +11,12 @@ begin
   if tg_op <> 'UPDATE'
      or old.control_id is distinct from new.control_id
      or current_user <> 'postgres'
-     or coalesce(pg_catalog.current_setting('chips_table_fence_control', true), '') <> '1' then
+     or coalesce(pg_catalog.current_setting('chips.table_fence_control', true), '') <> '1' then
     raise exception 'TABLE fence activation must use the owner-controlled gate';
   end if;
   return new;
 end;
 $$;
-
-alter function public.chips_guard_table_fence_control() owner to postgres;
-
-drop trigger if exists chips_table_fence_control_guard on public.chips_table_fence_control;
-create trigger chips_table_fence_control_guard
-before update or delete on public.chips_table_fence_control
-for each row execute function public.chips_guard_table_fence_control();
-
 create or replace function public.chips_set_table_fence_active(p_active boolean)
 returns jsonb
 language plpgsql
@@ -190,7 +40,7 @@ begin
   ) then
     raise exception using errcode = 'P8900', message = 'TABLE fence cannot be deactivated after bot-only cleanup begins';
   end if;
-  perform pg_catalog.set_config('chips_table_fence_control', '1', true);
+  perform pg_catalog.set_config('chips.table_fence_control', '1', true);
   update public.chips_table_fence_control
      set enforcement_active = next_active,
          activated_at = case when next_active then coalesce(activated_at, pg_catalog.timezone('utc', pg_catalog.now())) else activated_at end,
@@ -202,11 +52,8 @@ begin
   );
 end;
 $$;
-
-alter function public.chips_set_table_fence_active(boolean) owner to postgres;
-
-create or replace function public.chips_parse_table_idempotency_key(p_key text)
-returns jsonb
+create or replace function public.chips_parse_table_reference(p_reference text)
+returns uuid
 language plpgsql
 immutable
 strict
@@ -214,86 +61,23 @@ security definer
 set search_path = ''
 as $$
 declare
-  key_value text := pg_catalog.btrim(p_key);
-  parts text[];
-  format_name text;
-  table_position integer;
-  table_value text;
+  reference_value text := pg_catalog.btrim(p_reference);
+  marker text;
 begin
-  if key_value = '' or pg_catalog.length(key_value) > 240 then
-    raise exception using
-      errcode = 'P8901',
-      message = 'TABLE idempotency key is empty or too long';
+  if reference_value = ''
+     or reference_value !~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
+    raise exception using errcode = 'P8902', message = 'TABLE reference format is not supported';
   end if;
-
-  parts := pg_catalog.regexp_split_to_array(key_value, ':');
-  if exists (select 1 from pg_catalog.unnest(parts) as values(value) where value = '') then
-    raise exception using errcode = 'P8901', message = 'TABLE idempotency key contains an empty marker';
+  marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.split_part(reference_value, ':', 2)));
+  if marker is null
+     or marker = ''
+     or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+    raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
   end if;
-
-  if key_value like 'join-buyin:%' then
-    format_name := 'join-buyin';
-    table_position := 2;
-  elsif key_value like 'bot-seed-buyin:%' then
-    format_name := 'bot-seed-buyin';
-    table_position := 2;
-  elsif key_value like 'managed-bot-seed-buyin:%' then
-    format_name := 'managed-bot-seed-buyin';
-    table_position := 2;
-  elsif key_value like 'poker:leave:%' then
-    format_name := 'poker:leave';
-    table_position := 3;
-  elsif key_value like 'poker:inactive_cleanup:%' then
-    format_name := 'poker:inactive_cleanup';
-    table_position := 3;
-  elsif key_value like 'poker:rebuy:v1:%' then
-    format_name := 'poker:rebuy:v1';
-    table_position := 4;
-  elsif key_value like 'poker:deferred-leave:v1:%' then
-    format_name := 'poker:deferred-leave:v1';
-    table_position := 4;
-  elsif key_value like 'poker:bot-terminal-cashout:v1:%' then
-    format_name := 'poker:bot-terminal-cashout:v1';
-    table_position := 4;
-  elsif key_value like 'poker:human-terminal-cashout:v1:%' then
-    format_name := 'poker:human-terminal-cashout:v1';
-    table_position := 4;
-  elsif key_value like 'poker:bot-replacement-buyin:v1:%' then
-    format_name := 'poker:bot-replacement-buyin:v1';
-    table_position := 4;
-  elsif key_value like 'poker:managed-bot-top-up:v1:%' then
-    format_name := 'poker:managed-bot-top-up:v1';
-    table_position := 4;
-  else
-    raise exception using errcode = 'P8901', message = 'TABLE idempotency key format is not supported';
-  end if;
-
-  if pg_catalog.cardinality(parts) <= table_position
-     or exists (
-       select 1
-       from pg_catalog.generate_subscripts(parts, 1) as positions(position)
-       where positions.position > table_position
-         and parts[positions.position] = ''
-     ) then
-    raise exception using errcode = 'P8901', message = 'TABLE idempotency key suffix is incomplete';
-  end if;
-
-  table_value := pg_catalog.lower(pg_catalog.btrim(parts[table_position]));
-  if table_value !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-    raise exception using errcode = 'P8901', message = 'TABLE idempotency key table id is invalid';
-  end if;
-
-  return pg_catalog.jsonb_build_object(
-    'version', 1,
-    'format', format_name,
-    'table_id', table_value,
-    'key', key_value
-  );
+  return marker::uuid;
 end;
 $$;
-
-alter function public.chips_parse_table_idempotency_key(text) owner to postgres;
-
+alter function public.chips_parse_table_reference(text) owner to postgres;
 create or replace function public.chips_table_transaction_before_insert()
 returns trigger
 language plpgsql
@@ -319,7 +103,9 @@ begin
 
   if new.metadata ? 'tableId' then
     marker := pg_catalog.lower(pg_catalog.btrim(new.metadata->>'tableId'));
-    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+    if marker is null
+       or marker = ''
+       or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
        or marker::uuid <> key_table_id then
       raise exception using
         errcode = 'P8902',
@@ -327,13 +113,8 @@ begin
     end if;
   end if;
 
-  if new.reference is not null
-     and new.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(new.reference, '^[^:]+:([^:]+)')));
-    if marker = '' or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-      raise exception using errcode = 'P8902', message = 'TABLE reference marker is invalid';
-    end if;
-    reference_table_id := marker::uuid;
+  if new.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(new.reference);
     if reference_table_id <> key_table_id then
       raise exception using errcode = 'P8902', message = 'TABLE reference does not match the idempotency key';
     end if;
@@ -352,9 +133,6 @@ begin
   return new;
 end;
 $$;
-
-alter function public.chips_table_transaction_before_insert() owner to postgres;
-
 create or replace function public.chips_validate_table_transaction_binding()
 returns trigger
 language plpgsql
@@ -362,7 +140,7 @@ security definer
 set search_path = ''
 as $$
 declare
-  transaction_id uuid;
+  target_transaction_id uuid;
   transaction_row record;
   parsed jsonb;
   key_table_id uuid;
@@ -388,16 +166,16 @@ begin
     return new;
   end if;
   if tg_table_name = 'chips_transactions' then
-    transaction_id := new.id;
+    target_transaction_id := new.id;
   elsif tg_op = 'DELETE' then
-    transaction_id := old.transaction_id;
+    target_transaction_id := old.transaction_id;
   else
-    transaction_id := new.transaction_id;
+    target_transaction_id := new.transaction_id;
   end if;
   select transactions.*
     into transaction_row
     from public.chips_transactions as transactions
-   where transactions.id = transaction_id;
+   where transactions.id = target_transaction_id;
   if not found or transaction_row.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
     if tg_op = 'DELETE' then
       return old;
@@ -410,7 +188,8 @@ begin
 
   if transaction_row.metadata ? 'tableId' then
     transaction_marker := pg_catalog.lower(pg_catalog.btrim(transaction_row.metadata->>'tableId'));
-    if transaction_marker = ''
+    if transaction_marker is null
+       or transaction_marker = ''
        or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
        or transaction_marker::uuid <> key_table_id then
       raise exception using
@@ -419,14 +198,8 @@ begin
     end if;
   end if;
 
-  if transaction_row.reference is not null
-     and transaction_row.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):' then
-    transaction_marker := pg_catalog.lower(pg_catalog.btrim(pg_catalog.substring(transaction_row.reference, '^[^:]+:([^:]+)')));
-    if transaction_marker = ''
-       or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-      raise exception using errcode = 'P8904', message = 'TABLE transaction reference marker is invalid';
-    end if;
-    reference_table_id := transaction_marker::uuid;
+  if transaction_row.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(transaction_row.reference);
     if reference_table_id <> key_table_id then
       raise exception using errcode = 'P8904', message = 'TABLE transaction reference does not bind to its idempotency key';
     end if;
@@ -459,12 +232,12 @@ begin
          user_identity_count, user_identity_mismatch_count
     from public.chips_entries as entries
     join public.chips_accounts as accounts on accounts.id = entries.account_id
-   where entries.transaction_id = transaction_id;
+   where entries.transaction_id = target_transaction_id;
 
   select count(*)
     into invalid_entry_marker_count
     from public.chips_entries as entries
-   where entries.transaction_id = transaction_id
+   where entries.transaction_id = target_transaction_id
      and (
        entries.metadata ? 'tableId'
        and (
@@ -481,14 +254,14 @@ begin
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text = 'ESCROW'
         and entries.amount > 0
     )
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text in ('USER', 'SYSTEM')
         and entries.amount < 0
     );
@@ -500,14 +273,14 @@ begin
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text = 'ESCROW'
         and entries.amount < 0
     )
     and exists (
       select 1 from public.chips_entries entries
       join public.chips_accounts accounts on accounts.id = entries.account_id
-      where entries.transaction_id = transaction_id
+      where entries.transaction_id = target_transaction_id
         and accounts.account_type::text in ('USER', 'SYSTEM')
         and entries.amount > 0
     );
@@ -532,107 +305,6 @@ begin
   return new;
 end;
 $$;
-
-alter function public.chips_validate_table_transaction_binding() owner to postgres;
-
-drop trigger if exists chips_table_transaction_fence on public.chips_transactions;
-create trigger chips_table_transaction_fence
-before insert on public.chips_transactions
-for each row execute function public.chips_table_transaction_before_insert();
-
-drop trigger if exists chips_table_transaction_binding on public.chips_transactions;
-create constraint trigger chips_table_transaction_binding
-after insert on public.chips_transactions
-deferrable initially deferred
-for each row execute function public.chips_validate_table_transaction_binding();
-
-drop trigger if exists chips_entries_table_transaction_binding on public.chips_entries;
-create constraint trigger chips_entries_table_transaction_binding
-after insert or update or delete on public.chips_entries
-deferrable initially deferred
-for each row execute function public.chips_validate_table_transaction_binding();
-
-create or replace function public.chips_capture_transaction_idempotency()
-returns trigger
-language plpgsql
-security definer
-set search_path = ''
-as $$
-declare
-  parsed jsonb;
-  parsed_table_id uuid;
-  fence_active boolean;
-begin
-  fence_active := public.chips_table_fence_is_active();
-  if new.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
-    if fence_active then
-      parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
-    else
-      begin
-        parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
-      exception when sqlstate 'P8901' then
-        parsed := null;
-      end;
-    end if;
-    parsed_table_id := (parsed->>'table_id')::uuid;
-  end if;
-
-  insert into public.chips_transaction_idempotency (
-    idempotency_key,
-    transaction_id,
-    payload_hash,
-    tx_type,
-    user_id,
-    transaction_created_at,
-    table_id,
-    key_format_version,
-    key_format
-  ) values (
-    new.idempotency_key,
-    new.id,
-    new.payload_hash,
-    new.tx_type,
-    new.user_id,
-    new.created_at,
-    parsed_table_id,
-    case when parsed is null then null else (parsed->>'version')::integer end,
-    case when parsed is null then null else parsed->>'format' end
-  );
-  return new;
-end;
-$$;
-
-alter function public.chips_capture_transaction_idempotency() owner to postgres;
-
--- Backfill only hot rows for which the authoritative transaction is still
--- available.  Unsupported historical keys intentionally remain NULL.
-do $$
-declare
-  row_data record;
-  parsed jsonb;
-begin
-  for row_data in
-    select registry.idempotency_key, transactions.id, transactions.idempotency_key as tx_key
-      from public.chips_transaction_idempotency registry
-      join public.chips_transactions transactions on transactions.id = registry.transaction_id
-     where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-       and registry.table_id is null
-  loop
-    begin
-      parsed := public.chips_parse_table_idempotency_key(row_data.tx_key);
-      update public.chips_transaction_idempotency
-         set table_id = (parsed->>'table_id')::uuid,
-             key_format_version = (parsed->>'version')::integer,
-             key_format = parsed->>'format'
-       where idempotency_key = row_data.idempotency_key;
-    exception when others then
-      -- Historical uncertainty is a deliberate fail-closed state.
-      null;
-    end;
-  end loop;
-end;
-$$;
-
 create or replace function public.chips_guard_idempotency_mutations()
 returns trigger
 language plpgsql
@@ -641,7 +313,7 @@ as $$
 begin
   if tg_op = 'DELETE' then
     if current_user = 'chips_ledger_archive_pruner'
-       and pg_catalog.current_setting('chips_bot_registry_cleanup', true) = '1' then
+       and pg_catalog.current_setting('chips.bot_registry_cleanup', true) = '1' then
       return old;
     end if;
     raise exception 'Idempotency registry rows are durable; DELETE is not permitted';
@@ -704,7 +376,6 @@ begin
   return new;
 end;
 $$;
-
 create or replace function public.chips_guard_poker_table_mutations()
 returns trigger
 language plpgsql
@@ -725,7 +396,7 @@ begin
        or new.has_human_participant is true
        or new.bot_only_proof_eligible is not true
        or current_user <> 'chips_ledger_archive_pruner'
-       or coalesce(pg_catalog.current_setting('chips_bot_only_lifecycle', true), '') <> '1'
+       or coalesce(pg_catalog.current_setting('chips.bot_only_lifecycle', true), '') <> '1'
        or not exists (
          select 1
            from public.chips_ledger_archive_batches batches
@@ -749,15 +420,6 @@ begin
   return new;
 end;
 $$;
-
-drop trigger if exists poker_tables_guard_human_participant on public.poker_tables;
-create trigger poker_tables_guard_human_participant
-before update of has_human_participant, bot_only_proof_eligible, bot_only_retention_complete_at
-on public.poker_tables
-for each row execute function public.chips_guard_poker_table_mutations();
-
--- The existing v1 proof/prune guard remains in place, but now also protects
--- v2 evidence, the cleanup receipt, and the exact-batch GO latch.
 create or replace function public.chips_guard_archive_batch_mutations()
 returns trigger
 language plpgsql
@@ -829,13 +491,16 @@ begin
   go_changed := new.destructive_go_at is distinct from old.destructive_go_at
     or new.destructive_go_batch_id is distinct from old.destructive_go_batch_id;
 
+  if proof_changed and receipt_changed then
+    raise exception 'Archive proof and prune receipt require separate transitions';
+  end if;
   if receipt_changed and cleanup_changed then
     raise exception 'Archive prune receipt and registry cleanup receipt require separate transitions';
   end if;
   if receipt_changed
      and new.format_version = 2
      and (
-       coalesce(pg_catalog.current_setting('chips_bot_only_prune', true), '') <> '1'
+       coalesce(pg_catalog.current_setting('chips.bot_only_prune', true), '') <> '1'
        or new.destructive_go_at is null
        or new.destructive_go_batch_id is distinct from new.batch_id
      ) then
@@ -847,19 +512,19 @@ begin
     raise exception 'Archive proof may only be written by the archive pruner';
   end if;
   if bot_proof_changed
-     and coalesce(pg_catalog.current_setting('chips_bot_only_proof', true), '') <> '1' then
+     and coalesce(pg_catalog.current_setting('chips.bot_only_proof', true), '') <> '1' then
     raise exception 'Bot-only proof may only be written by the lifecycle proof operator';
   end if;
   if (receipt_changed or cleanup_changed) and current_user <> 'chips_ledger_archive_pruner' then
     raise exception 'Archive receipt may only be written by the archive pruner';
   end if;
   if cleanup_changed
-     and coalesce(pg_catalog.current_setting('chips_bot_cleanup_receipt', true), '') <> '1' then
+     and coalesce(pg_catalog.current_setting('chips.bot_cleanup_receipt', true), '') <> '1' then
     raise exception 'Bot-only cleanup receipt may only be written by the lifecycle cleanup operator';
   end if;
   if go_changed and not (
     current_user = 'postgres'
-    and coalesce(pg_catalog.current_setting('chips_bot_only_go', true), '') = '1'
+    and coalesce(pg_catalog.current_setting('chips.bot_only_go', true), '') = '1'
   ) then
     raise exception 'Bot-only destructive GO may only be written by the exact authorization function';
   end if;
@@ -915,53 +580,6 @@ begin
   return new;
 end;
 $$;
-
-drop trigger if exists poker_tables_guard_human_participant on public.poker_tables;
-create trigger poker_tables_guard_human_participant
-before update of has_human_participant, bot_only_proof_eligible, bot_only_retention_complete_at
-on public.poker_tables
-for each row execute function public.chips_guard_poker_table_mutations();
-
-drop trigger if exists chips_ledger_archive_batches_guard on public.chips_ledger_archive_batches;
-create trigger chips_ledger_archive_batches_guard
-before update or delete on public.chips_ledger_archive_batches
-for each row execute function public.chips_guard_archive_batch_mutations();
-
-grant chips_ledger_archive_pruner to postgres;
-grant create on schema public to chips_ledger_archive_pruner;
-set role chips_ledger_archive_pruner;
-
-create or replace function public.chips_archive_text_ids_sha256(p_ids text[])
-returns text
-language plpgsql
-immutable
-set search_path = ''
-as $$
-declare
-  payload text;
-begin
-  if p_ids is null or (pg_catalog.array_ndims(p_ids) is not null and pg_catalog.array_ndims(p_ids) <> 1)
-     or pg_catalog.array_position(p_ids, null) is not null then
-    raise exception 'Text ID proof requires a one-dimensional non-null text array';
-  end if;
-  select coalesce(pg_catalog.string_agg(value || E'\n', '' order by value), '')
-    into payload
-    from pg_catalog.unnest(p_ids) as values(value);
-  return pg_catalog.encode(extensions.digest(pg_catalog.convert_to(payload, 'UTF8'), 'sha256'), 'hex');
-end;
-$$;
-
-reset role;
-
--- Recreate the public wrapper so the unchanged 30-day pruner cannot be used
--- to execute a schema-v2 bot-only batch without the lifecycle operator.
--- The existing wrapper remains owned by the established pruner role.  The
--- archive-batch guard above blocks its destructive schema-v2 path by code
--- P8911; the existing 30-day path is unchanged.
-
--- This gate is intentionally never called by automation in this change.  A
--- future owner action must name the exact batch and use the exact confirmation
--- string, so GO cannot roll forward to a different object.
 create or replace function public.chips_authorize_bot_only_archive_batch(
   p_batch_id bigint,
   p_confirmation text
@@ -992,7 +610,7 @@ begin
     raise exception using errcode = 'P8912', message = 'Only one exact committed Stage bot-only batch may be authorized';
   end if;
   perform public.chips_assert_archive_prune_target(batch.project_ref, batch.transaction_count);
-  perform pg_catalog.set_config('chips_bot_only_go', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_go', '1', true);
   update public.chips_ledger_archive_batches
      set destructive_go_at = pg_catalog.timezone('utc', pg_catalog.now()),
          destructive_go_batch_id = batch.batch_id
@@ -1001,137 +619,8 @@ begin
   return pg_catalog.jsonb_build_object('state', 'authorized', 'batch_id', batch.batch_id);
 end;
 $$;
-
+grant chips_ledger_archive_pruner to postgres;
 set role chips_ledger_archive_pruner;
-
-create or replace function public.chips_assert_bot_only_table_lifecycle_gate(
-  p_table_id uuid,
-  p_batch_id bigint,
-  p_cutoff timestamptz,
-  p_registry_keys text[]
-)
-returns jsonb
-language plpgsql
-set search_path = ''
-as $$
-declare
-  table_row record;
-  escrow_count bigint;
-  unknown_registry_count bigint;
-  unknown_hot_count bigint;
-  human_registry_count bigint;
-  young_registry_count bigint;
-  incomplete_old_count bigint;
-  newest_created_at timestamptz;
-begin
-  if not public.chips_table_fence_is_active() then
-    raise exception using errcode = 'P8913', message = 'Bot-only lifecycle gate requires the active TABLE fence';
-  end if;
-  if p_batch_id is null or not exists (
-    select 1
-      from public.chips_ledger_archive_batches batches
-     where batches.batch_id = p_batch_id
-       and batches.status = 'committed'
-       and batches.format_version = 2
-       and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
-       and batches.cutoff = p_cutoff
-  ) then
-    raise exception using errcode = 'P8913', message = 'Bot-only lifecycle gate requires the exact committed schema-v2 batch';
-  end if;
-  select tables.id, tables.status, tables.has_human_participant, tables.bot_only_proof_eligible, tables.bot_only_retention_complete_at
-    into table_row
-    from public.poker_tables tables
-   where tables.id = p_table_id
-   for update;
-  if not found then raise exception using errcode = 'P8913', message = 'Bot-only table is missing'; end if;
-  if pg_catalog.upper(table_row.status::text) <> 'CLOSED' then raise exception using errcode = 'P8913', message = 'Bot-only table is not CLOSED'; end if;
-  if table_row.has_human_participant is true then raise exception using errcode = 'P8913', message = 'Human-participant table is outside bot-only retention'; end if;
-  if table_row.bot_only_proof_eligible is not true then raise exception using errcode = 'P8913', message = 'Historical bot-only proof is uncertain'; end if;
-
-  select count(*) into escrow_count
-    from public.chips_accounts accounts
-   where accounts.account_type::text = 'ESCROW'
-     and accounts.system_key = 'POKER_TABLE:' || p_table_id::text
-     and accounts.status::text = 'active'
-     and accounts.balance = 0;
-  if escrow_count <> 1 then raise exception using errcode = 'P8913', message = 'Bot-only table escrow is not active and zero'; end if;
-
-  select count(*) into unknown_registry_count
-    from public.chips_transaction_idempotency registry
-   where registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-     and registry.table_id is null;
-  select count(*) into unknown_hot_count
-    from public.chips_transactions transactions
-    left join public.chips_transaction_idempotency registry on registry.transaction_id = transactions.id
-   where transactions.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-     and registry.table_id is null;
-  if unknown_registry_count <> 0 or unknown_hot_count <> 0 then
-    raise exception using errcode = 'P8914', message = 'Unknown TABLE identity blocks bot-only lifecycle completion';
-  end if;
-
-  select count(*) into human_registry_count
-    from public.chips_transaction_idempotency registry
-   where registry.table_id = p_table_id
-     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-     and registry.user_id is not null;
-  if human_registry_count <> 0 then raise exception using errcode = 'P8914', message = 'USER TABLE identity blocks bot-only lifecycle completion'; end if;
-
-  select count(*) into young_registry_count
-    from public.chips_transaction_idempotency registry
-   where registry.table_id = p_table_id
-     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-     and registry.user_id is null
-     and registry.transaction_created_at >= p_cutoff;
-  if young_registry_count <> 0 then raise exception using errcode = 'P8915', message = 'Young TABLE identity blocks bot-only lifecycle completion'; end if;
-
-  select count(*) into incomplete_old_count
-    from public.chips_transaction_idempotency registry
-   where registry.table_id = p_table_id
-     and registry.tx_type::text in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
-     and registry.user_id is null
-     and registry.transaction_created_at < p_cutoff
-     and not (
-       registry.idempotency_key = any(coalesce(p_registry_keys, array[]::text[]))
-       or exists (
-         select 1
-           from public.chips_ledger_archive_batches batches
-          where batches.batch_id = registry.archive_batch_id
-            and batches.format_version = 2
-            and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
-            and batches.pruned_at is not null
-            and batches.registry_cleaned_at is not null
-       )
-     );
-  if incomplete_old_count <> 0 then raise exception using errcode = 'P8916', message = 'Old TABLE identity is not fully archived, pruned, and cleaned'; end if;
-
-  select max(value) into newest_created_at
-    from (
-      select max(registry.transaction_created_at) as value
-        from public.chips_transaction_idempotency registry
-       where registry.table_id = p_table_id
-      union all
-      select max(batches.bot_only_newest_created_at)
-        from public.chips_ledger_archive_batches batches
-       where batches.bot_only_table_id = p_table_id
-         and batches.format_version = 2
-         and batches.source_policy_id = 'stage-ledger-bot-only-retention-7d-v1'
-         and batches.registry_cleaned_at is not null
-    ) known;
-  if newest_created_at is null or newest_created_at >= p_cutoff then
-    raise exception using errcode = 'P8915', message = 'Newest known TABLE identity is not older than the bot-only cutoff';
-  end if;
-
-  return pg_catalog.jsonb_build_object(
-    'state', 'table_complete',
-    'table_id', p_table_id,
-    'newest_created_at', newest_created_at,
-    'unknown_registry', unknown_registry_count,
-    'unknown_hot', unknown_hot_count,
-    'protected_registry', human_registry_count
-  );
-end;
-$$;
-
 create or replace function public.chips_register_bot_only_archive_proof(
   p_object_path text,
   p_transaction_ids uuid[],
@@ -1252,10 +741,18 @@ begin
       having transactions.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT')
           or transactions.user_id is not null
           or transactions.created_at >= batch.cutoff
-          or (transactions.metadata ? 'tableId'
-              and pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text)
-          or (transactions.reference ~* '^(table|poker-rebuy|BOT_SEED_BUY_IN|BOT_REPLACEMENT_BUY_IN|MANAGED_BOT_TOP_UP):'
-              and pg_catalog.lower(pg_catalog.substring(transactions.reference, '^[^:]+:([^:]+)')) <> p_table_id::text)
+          or (
+            transactions.metadata ? 'tableId'
+            and (
+              nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') is null
+              or nullif(pg_catalog.btrim(transactions.metadata->>'tableId'), '') !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+              or pg_catalog.lower(pg_catalog.btrim(transactions.metadata->>'tableId')) <> p_table_id::text
+            )
+          )
+          or (
+            transactions.reference is not null
+            and public.chips_parse_table_reference(transactions.reference) <> p_table_id
+          )
           or count(*) <> 2
           or count(*) filter (where accounts.account_type::text = 'USER') <> 0
           or count(*) filter (where accounts.account_type::text = 'SYSTEM') <> 1
@@ -1324,7 +821,7 @@ begin
     return pg_catalog.jsonb_build_object('state', 'proof_exists', 'transactions', batch.transaction_count, 'entries', batch.entry_count);
   end if;
 
-  perform pg_catalog.set_config('chips_bot_only_proof', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_proof', '1', true);
   update public.chips_ledger_archive_batches batches
      set archived_transaction_ids_sha256 = transaction_ids_sha256,
          archived_entry_ids_sha256 = entry_ids_sha256,
@@ -1343,7 +840,6 @@ begin
   return pg_catalog.jsonb_build_object('state', 'proof_registered', 'transactions', batch.transaction_count, 'entries', batch.entry_count, 'table_id', p_table_id, 'registry_keys_sha256', registry_keys_sha256);
 end;
 $$;
-
 create or replace function public.chips_prune_and_cleanup_bot_only_archive_batch(
   p_object_path text,
   p_transaction_ids uuid[],
@@ -1406,7 +902,7 @@ begin
     raise exception using errcode = 'P8923', message = 'Exact bot-only batch GO is required before destructive cleanup';
   end if;
 
-  perform pg_catalog.set_config('chips_bot_only_prune', '1', true);
+  perform pg_catalog.set_config('chips.bot_only_prune', '1', true);
   prune_result := public.chips_prune_committed_archive_batch_internal(p_object_path, p_transaction_ids, p_entry_ids, true);
   perform public.chips_assert_bot_only_table_lifecycle_gate(batch.bot_only_table_id, batch.batch_id, batch.cutoff, p_registry_keys);
   select count(*) into deleted_registry_count
@@ -1415,14 +911,14 @@ begin
      and registry.idempotency_key = any(p_registry_keys);
   if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry cleanup set is incomplete'; end if;
 
-  perform pg_catalog.set_config('chips_bot_registry_cleanup', '1', true);
+  perform pg_catalog.set_config('chips.bot_registry_cleanup', '1', true);
   delete from public.chips_transaction_idempotency registry
    where registry.archive_batch_id = batch.batch_id
      and registry.idempotency_key = any(p_registry_keys);
   get diagnostics deleted_registry_count = row_count;
   if deleted_registry_count <> pg_catalog.cardinality(p_registry_keys) then raise exception using errcode = 'P8924', message = 'Bot-only registry DELETE count mismatch'; end if;
 
-  perform pg_catalog.set_config('chips_bot_cleanup_receipt', '1', true);
+  perform pg_catalog.set_config('chips.bot_cleanup_receipt', '1', true);
   update public.chips_ledger_archive_batches batches
      set registry_cleaned_at = pg_catalog.timezone('utc', pg_catalog.now()),
          registry_cleaned_key_count = pg_catalog.cardinality(p_registry_keys),
@@ -1431,6 +927,7 @@ begin
      and batches.registry_cleaned_at is null;
   if not found then raise exception using errcode = 'P8924', message = 'Bot-only cleanup receipt transition was not unique'; end if;
 
+  perform pg_catalog.set_config('chips.bot_only_lifecycle', '1', true);
   update public.poker_tables tables
      set bot_only_retention_complete_at = coalesce(tables.bot_only_retention_complete_at, pg_catalog.timezone('utc', pg_catalog.now()))
    where tables.id = batch.bot_only_table_id
@@ -1438,57 +935,10 @@ begin
   return prune_result || pg_catalog.jsonb_build_object('state', 'cleaned', 'registry_keys', deleted_registry_count, 'table_id', batch.bot_only_table_id);
 end;
 $$;
-
 reset role;
-
--- The existing archive-pruner role is reused; no second destructive role is
--- introduced.  Column grants and RLS policies keep the new path narrow.
-grant select on public.chips_ledger_archive_batches, public.chips_transaction_idempotency, public.poker_tables to chips_ledger_archive_pruner;
-grant update (
-  bot_only_table_id,
-  bot_only_table_count,
-  bot_only_newest_created_at,
-  bot_only_registry_keys_sha256,
-  bot_only_out_of_scope_keys_sha256,
-  bot_only_identity_count,
-  bot_only_eligible_count,
-  registry_cleaned_at,
-  registry_cleaned_key_count,
-  registry_cleaned_keys_sha256
-) on public.chips_ledger_archive_batches to chips_ledger_archive_pruner;
-grant delete on public.chips_transaction_idempotency to chips_ledger_archive_pruner;
-grant update (bot_only_retention_complete_at) on public.poker_tables to chips_ledger_archive_pruner;
-
-drop policy if exists chips_archive_pruner_tables_marker_update on public.poker_tables;
-create policy chips_archive_pruner_tables_marker_update
-  on public.poker_tables
-  for update to chips_ledger_archive_pruner
-  using (true)
-  with check (has_human_participant is not true and bot_only_retention_complete_at is not null);
-
-drop policy if exists chips_archive_pruner_registry_delete on public.chips_transaction_idempotency;
-create policy chips_archive_pruner_registry_delete
-  on public.chips_transaction_idempotency
-  for delete to chips_ledger_archive_pruner
-  using (true);
-
-revoke create on schema public from chips_ledger_archive_pruner;
 revoke chips_ledger_archive_pruner from postgres;
-
-revoke all on function public.chips_authorize_bot_only_archive_batch(bigint, text) from public, anon, authenticated, service_role;
-grant execute on function public.chips_authorize_bot_only_archive_batch(bigint, text) to postgres;
-revoke all on function public.chips_table_fence_is_active() from public, anon, authenticated, service_role;
-grant execute on function public.chips_table_fence_is_active() to postgres, chips_ledger_archive_pruner;
-revoke all on function public.chips_set_table_fence_active(boolean) from public, anon, authenticated, service_role;
-grant execute on function public.chips_set_table_fence_active(boolean) to postgres;
-revoke all on function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) from public, anon, authenticated, service_role;
-grant execute on function public.chips_register_bot_only_archive_proof(text, uuid[], bigint[], uuid, text[]) to postgres;
-revoke all on function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) from public, anon, authenticated, service_role;
-grant execute on function public.chips_prune_and_cleanup_bot_only_archive_batch(text, uuid[], bigint[], text[], uuid, boolean, bigint) to postgres;
-revoke all on function public.chips_assert_bot_only_table_lifecycle_gate(uuid, bigint, timestamptz, text[]) from public, anon, authenticated, service_role;
-revoke all on function public.chips_archive_text_ids_sha256(text[]) from public, anon, authenticated, service_role;
-grant execute on function public.chips_archive_text_ids_sha256(text[]) to postgres, chips_ledger_archive_pruner;
-revoke all on function public.chips_parse_table_idempotency_key(text) from public, anon, authenticated, service_role;
-grant execute on function public.chips_parse_table_idempotency_key(text) to postgres, chips_ledger_archive_pruner;
+revoke all on function public.chips_parse_table_reference(text) from public, anon, authenticated, service_role;
+grant execute on function public.chips_parse_table_reference(text) to postgres, chips_ledger_archive_pruner;
 
 commit;
+

--- a/supabase/migrations/20260823090000_chips_ledger_table_metadata_fence_hardening.sql
+++ b/supabase/migrations/20260823090000_chips_ledger_table_metadata_fence_hardening.sql
@@ -1,0 +1,286 @@
+begin;
+
+-- The TABLE fence must understand both native JSONB objects and the legacy
+-- JSONB strings written by the old Netlify interpolation.  Keep the stored
+-- value unchanged for compatibility; normalize only inside the fence.
+create or replace function public.chips_normalize_table_metadata(p_metadata jsonb)
+returns jsonb
+language plpgsql
+immutable
+security definer
+set search_path = ''
+as $$
+declare
+  normalized jsonb := p_metadata;
+begin
+  if normalized is null then
+    raise exception using
+      errcode = 'P8902',
+      message = 'TABLE metadata must be a JSON object';
+  end if;
+
+  if pg_catalog.jsonb_typeof(normalized) = 'string' then
+    begin
+      normalized := (normalized #>> '{}')::jsonb;
+    exception when others then
+      raise exception using
+        errcode = 'P8902',
+        message = 'TABLE metadata legacy JSON string is invalid';
+    end;
+  end if;
+
+  if pg_catalog.jsonb_typeof(normalized) is distinct from 'object' then
+    raise exception using
+      errcode = 'P8902',
+      message = 'TABLE metadata must be a JSON object';
+  end if;
+
+  return normalized;
+end;
+$$;
+
+alter function public.chips_normalize_table_metadata(jsonb) owner to postgres;
+revoke all on function public.chips_normalize_table_metadata(jsonb) from public, anon, authenticated, service_role;
+grant execute on function public.chips_normalize_table_metadata(jsonb) to postgres;
+
+create or replace function public.chips_table_transaction_before_insert()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  parsed jsonb;
+  normalized_metadata jsonb;
+  key_table_id uuid;
+  marker text;
+  reference_table_id uuid;
+  table_status text;
+begin
+  if new.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
+    return new;
+  end if;
+  if not public.chips_table_fence_is_active() then
+    return new;
+  end if;
+
+  normalized_metadata := public.chips_normalize_table_metadata(new.metadata);
+  parsed := public.chips_parse_table_idempotency_key(new.idempotency_key);
+  key_table_id := (parsed->>'table_id')::uuid;
+
+  if normalized_metadata ? 'tableId' then
+    marker := pg_catalog.lower(pg_catalog.btrim(normalized_metadata->>'tableId'));
+    if marker is null
+       or marker = ''
+       or marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       or marker::uuid <> key_table_id then
+      raise exception using
+        errcode = 'P8902',
+        message = 'TABLE metadata.tableId does not match the idempotency key';
+    end if;
+  end if;
+
+  if new.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(new.reference);
+    if reference_table_id <> key_table_id then
+      raise exception using errcode = 'P8902', message = 'TABLE reference does not match the idempotency key';
+    end if;
+  end if;
+
+  select tables.status
+    into table_status
+    from public.poker_tables as tables
+   where tables.id = key_table_id
+   for update;
+  if not found or pg_catalog.upper(coalesce(table_status, '')) <> 'OPEN' then
+    raise exception using
+      errcode = 'P8903',
+      message = 'TABLE transaction is rejected because the table is closed or missing';
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.chips_table_transaction_before_insert() owner to postgres;
+
+create or replace function public.chips_validate_table_transaction_binding()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  target_transaction_id uuid;
+  transaction_row record;
+  normalized_transaction_metadata jsonb;
+  parsed jsonb;
+  key_table_id uuid;
+  transaction_marker text;
+  reference_table_id uuid;
+  entry_count bigint;
+  user_entry_count bigint;
+  system_entry_count bigint;
+  escrow_entry_count bigint;
+  matching_escrow_count bigint;
+  invalid_account_count bigint;
+  invalid_entry_marker_count bigint;
+  total_amount numeric;
+  user_identity_count bigint;
+  user_identity_mismatch_count bigint;
+  buy_in_shape boolean;
+  cash_out_shape boolean;
+begin
+  if not public.chips_table_fence_is_active() then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+    return new;
+  end if;
+  if tg_table_name = 'chips_transactions' then
+    target_transaction_id := new.id;
+  elsif tg_op = 'DELETE' then
+    target_transaction_id := old.transaction_id;
+  else
+    target_transaction_id := new.transaction_id;
+  end if;
+  select transactions.*
+    into transaction_row
+    from public.chips_transactions as transactions
+   where transactions.id = target_transaction_id;
+  if not found or transaction_row.tx_type::text not in ('TABLE_BUY_IN', 'TABLE_CASH_OUT') then
+    if tg_op = 'DELETE' then
+      return old;
+    end if;
+    return new;
+  end if;
+
+  normalized_transaction_metadata := public.chips_normalize_table_metadata(transaction_row.metadata);
+  parsed := public.chips_parse_table_idempotency_key(transaction_row.idempotency_key);
+  key_table_id := (parsed->>'table_id')::uuid;
+
+  if normalized_transaction_metadata ? 'tableId' then
+    transaction_marker := pg_catalog.lower(pg_catalog.btrim(normalized_transaction_metadata->>'tableId'));
+    if transaction_marker is null
+       or transaction_marker = ''
+       or transaction_marker !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       or transaction_marker::uuid <> key_table_id then
+      raise exception using
+        errcode = 'P8904',
+        message = 'TABLE transaction metadata does not bind to its idempotency key';
+    end if;
+  end if;
+
+  if transaction_row.reference is not null then
+    reference_table_id := public.chips_parse_table_reference(transaction_row.reference);
+    if reference_table_id <> key_table_id then
+      raise exception using errcode = 'P8904', message = 'TABLE transaction reference does not bind to its idempotency key';
+    end if;
+  end if;
+
+  if not exists (
+    select 1 from public.poker_tables tables where tables.id = key_table_id
+  ) then
+    raise exception using errcode = 'P8904', message = 'TABLE transaction table identity is missing';
+  end if;
+
+  select
+    count(*),
+    count(*) filter (where accounts.account_type::text = 'USER'),
+    count(*) filter (where accounts.account_type::text = 'SYSTEM'),
+    count(*) filter (where accounts.account_type::text = 'ESCROW'),
+    count(*) filter (
+      where accounts.account_type::text = 'ESCROW'
+        and accounts.system_key = 'POKER_TABLE:' || key_table_id::text
+    ),
+    count(*) filter (where accounts.status::text <> 'active'),
+    coalesce(sum(entries.amount), 0),
+    count(*) filter (where accounts.account_type::text = 'USER' and accounts.user_id is not null),
+    count(*) filter (
+      where accounts.account_type::text = 'USER'
+        and accounts.user_id is distinct from transaction_row.user_id
+    )
+    into entry_count, user_entry_count, system_entry_count, escrow_entry_count,
+         matching_escrow_count, invalid_account_count, total_amount,
+         user_identity_count, user_identity_mismatch_count
+    from public.chips_entries as entries
+    join public.chips_accounts as accounts on accounts.id = entries.account_id
+   where entries.transaction_id = target_transaction_id;
+
+  select count(*)
+    into invalid_entry_marker_count
+    from public.chips_entries as entries
+    cross join lateral (
+      select public.chips_normalize_table_metadata(entries.metadata) as metadata
+    ) as normalized
+   where entries.transaction_id = target_transaction_id
+     and (
+       normalized.metadata ? 'tableId'
+       and (
+         normalized.metadata->>'tableId' is null
+         or pg_catalog.lower(pg_catalog.btrim(normalized.metadata->>'tableId')) <> key_table_id::text
+       )
+     );
+
+  buy_in_shape := transaction_row.tx_type::text = 'TABLE_BUY_IN'
+    and (
+      (user_entry_count = 1 and system_entry_count = 0 and escrow_entry_count = 1)
+      or (user_entry_count = 0 and system_entry_count = 1 and escrow_entry_count = 1)
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = target_transaction_id
+        and accounts.account_type::text = 'ESCROW'
+        and entries.amount > 0
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = target_transaction_id
+        and accounts.account_type::text in ('USER', 'SYSTEM')
+        and entries.amount < 0
+    );
+  cash_out_shape := transaction_row.tx_type::text = 'TABLE_CASH_OUT'
+    and (
+      (user_entry_count = 1 and system_entry_count = 0 and escrow_entry_count = 1)
+      or (user_entry_count = 0 and system_entry_count = 1 and escrow_entry_count = 1)
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = target_transaction_id
+        and accounts.account_type::text = 'ESCROW'
+        and entries.amount < 0
+    )
+    and exists (
+      select 1 from public.chips_entries entries
+      join public.chips_accounts accounts on accounts.id = entries.account_id
+      where entries.transaction_id = target_transaction_id
+        and accounts.account_type::text in ('USER', 'SYSTEM')
+        and entries.amount > 0
+    );
+
+  if entry_count <> 2
+     or matching_escrow_count <> 1
+     or invalid_account_count <> 0
+     or invalid_entry_marker_count <> 0
+     or total_amount <> 0
+     or user_identity_mismatch_count <> 0
+     or (transaction_row.user_id is null and user_entry_count <> 0)
+     or (transaction_row.user_id is not null and (user_entry_count <> 1 or user_identity_count <> 1))
+     or not (buy_in_shape or cash_out_shape) then
+    raise exception using
+      errcode = 'P8904',
+      message = 'TABLE transaction entries do not bind to one authoritative ESCROW table';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+alter function public.chips_validate_table_transaction_binding() owner to postgres;
+
+commit;

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -759,7 +759,7 @@ async function retryDestructiveOperatorPostgresContract(sql) {
           fixture.transaction.key,
           "e".repeat(64),
         ]);
-      }, "P8903", /closed or missing/);
+      }, "P8902", /does not match the idempotency key/);
       const afterReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
       assert.deepEqual(afterReuse.accounts, beforeReuse.accounts, "failed key reuse must not change balances or next_entry_seq");
       assert.equal(afterReuse.accountBalanceTotal, beforeReuse.accountBalanceTotal);

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import postgres from "postgres";
 
 import {
+  BOT_ONLY_BLOCKING_ANOMALY_SQL,
   BOT_ONLY_CANDIDATE_SQL,
   buildArchiveBytes,
   buildExportRecord,
@@ -167,6 +168,7 @@ function failClosedLifecycleContract() {
     SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
     SUPABASE_STAGE_URL: "https://krydukthwdvccggbyjfw.supabase.co",
     SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test",
+    GITHUB_SHA: "f".repeat(40),
     SUPABASE_PROD_DB_URL: "forbidden",
   }), /Production credentials/);
 }
@@ -347,6 +349,30 @@ async function historicalKeyAndEntryBindingPostgresContract(sql) {
       key_format_version: 1,
       key_format: "bot-seed-buyin",
     });
+    const baselineAccounting = await readAccountingSnapshot(
+      tx,
+      [fixture.systemAccountId, fixture.escrowAccountId],
+      [valid.transactionId],
+    );
+    const assertNoBindingEffects = async (label) => {
+      const counts = await tx.unsafe(`
+        select
+          (select count(*) from public.chips_transactions where id = $1::uuid) as transactions,
+          (select count(*) from public.chips_entries where transaction_id = $1::uuid) as entries,
+          (select count(*) from public.chips_transaction_idempotency where idempotency_key = $2) as registry_rows;
+      `, [valid.transactionId, valid.key]);
+      assert.equal(Number(counts[0].transactions), 1, `${label}: valid transaction must remain the only committed fixture transaction`);
+      assert.equal(Number(counts[0].entries), 2, `${label}: invalid binding must not add entries`);
+      assert.equal(Number(counts[0].registry_rows), 1, `${label}: invalid binding must not add registry rows`);
+      const accounting = await readAccountingSnapshot(
+        tx,
+        [fixture.systemAccountId, fixture.escrowAccountId],
+        [valid.transactionId],
+      );
+      assert.deepEqual(accounting.accounts, baselineAccounting.accounts, `${label}: balances and next_entry_seq must be unchanged`);
+      assert.equal(accounting.accountBalanceTotal, baselineAccounting.accountBalanceTotal, `${label}: account total must be unchanged`);
+      assert.equal(accounting.conservation, baselineAccounting.conservation, `${label}: conservation must be unchanged`);
+    };
 
     await expectDatabaseError(tx, "null_metadata_marker", async () => {
       await tx.unsafe(`
@@ -355,6 +381,7 @@ async function historicalKeyAndEntryBindingPostgresContract(sql) {
         values ($1::uuid, $2, '{"tableId":null}'::jsonb, $3, $4, 'TABLE_BUY_IN', null);
       `, [randomUUID(), `BOT_SEED_BUY_IN:${fixture.tableId}:1`, `bot-seed-buyin:${fixture.tableId}:bad-meta-${randomUUID()}`, "b".repeat(64)]);
     }, "P8902", /metadata\.tableId|metadata/);
+    await assertNoBindingEffects("null metadata marker");
 
     await expectDatabaseError(tx, "unknown_reference_marker", async () => {
       await tx.unsafe(`
@@ -369,6 +396,7 @@ async function historicalKeyAndEntryBindingPostgresContract(sql) {
         "c".repeat(64),
       ]);
     }, "P8902", /reference/);
+    await assertNoBindingEffects("unknown reference marker");
 
     const wrongEscrowId = randomUUID();
     await tx.unsafe(`
@@ -384,6 +412,7 @@ async function historicalKeyAndEntryBindingPostgresContract(sql) {
       });
       await tx.unsafe("set constraints all immediate;");
     }, "P8904", /ESCROW table|authoritative ESCROW/);
+    await assertNoBindingEffects("deferred ESCROW binding");
 
     throw DB_ROLLBACK;
   }).catch((error) => {
@@ -437,11 +466,11 @@ async function concurrencyInsertVersusClosePostgresContract(dbUrl) {
   }
 }
 
-async function createTimedBotTable(sql, createdAt) {
+async function createTimedBotTable(sql, createdAt, secondCreatedAt = createdAt) {
   return sql.begin(async (tx) => {
     const fixture = await createDatabaseTable(tx);
     await insertDatabaseTableTransaction(tx, fixture, { kind: "buyin", createdAt, keySuffix: "buyin" });
-    await insertDatabaseTableTransaction(tx, fixture, { kind: "cashout", createdAt, keySuffix: "cashout" });
+    await insertDatabaseTableTransaction(tx, fixture, { kind: "cashout", createdAt: secondCreatedAt, keySuffix: "cashout" });
     await tx.unsafe("set constraints all immediate;");
     await tx.unsafe("update public.poker_tables set status = 'CLOSED' where id = $1::uuid;", [fixture.tableId]);
     return fixture;
@@ -452,12 +481,65 @@ async function ageBoundaryPostgresContract(sql) {
   await enableTableFence(sql, true);
   const now = Date.now();
   const cutoff = new Date(now - (7 * DAY_MS)).toISOString();
-  const oldTable = await createTimedBotTable(sql, new Date(now - (10 * DAY_MS)).toISOString());
-  const recentTable = await createTimedBotTable(sql, new Date(now - (6 * DAY_MS)).toISOString());
+  const mixedTable = await createTimedBotTable(
+    sql,
+    new Date(now - (10 * DAY_MS)).toISOString(),
+    new Date(now - (6 * DAY_MS)).toISOString(),
+  );
   const rows = await sql.unsafe(BOT_ONLY_CANDIDATE_SQL, [cutoff, 5000, null, null]);
-  assert.equal(rows.length, 2, "the 10-day table should contribute its complete two-transaction batch");
-  assert.deepEqual(new Set(rows.map((row) => row.table_id)), new Set([oldTable.tableId]));
-  assert.equal(rows.some((row) => row.table_id === recentTable.tableId), false, "the 6-day table must remain untouched");
+  assert.equal(rows.length, 0, "a table with 10-day and 6-day identities must remain untouched");
+  const blockers = await sql.unsafe(BOT_ONLY_BLOCKING_ANOMALY_SQL, [cutoff, 5000]);
+  assert.ok(
+    blockers.some((row) => row.blocker_code === "younger_table_identity" && Number(row.table_count) === 1),
+    "the mixed-age table must report the younger identity as a blocking anomaly",
+  );
+
+  const youngerCrossedCutoff = new Date(now - (5 * DAY_MS)).toISOString();
+  const eligibleAfterCrossing = await sql.unsafe(BOT_ONLY_CANDIDATE_SQL, [youngerCrossedCutoff, 5000, null, null]);
+  assert.equal(eligibleAfterCrossing.length, 2, "the complete table becomes eligible only after the younger identity crosses seven days");
+  assert.deepEqual(new Set(eligibleAfterCrossing.map((row) => row.table_id)), new Set([mixedTable.tableId]));
+}
+
+async function readAccountingSnapshot(db, accountIds, transactionIds) {
+  const accounts = await db.unsafe(`
+    select id::text, balance::text, next_entry_seq::text
+      from public.chips_accounts
+     where id = any($1::uuid[])
+     order by id;
+  `, [accountIds]);
+  const totals = await db.unsafe(`
+    select
+      coalesce((select sum(balance) from public.chips_accounts), 0)::text as account_balance_total,
+      coalesce((select sum(amount) from public.chips_entries), 0)::text as conservation,
+      coalesce((select sum(amount) from public.chips_entries where transaction_id = any($1::uuid[])), 0)::text as selected_transaction_net;
+  `, [transactionIds]);
+  return {
+    accounts,
+    accountBalanceTotal: totals[0].account_balance_total,
+    conservation: totals[0].conservation,
+    selectedTransactionNet: totals[0].selected_transaction_net,
+  };
+}
+
+async function readTransactionIdentity(db, transactionId) {
+  const rows = await db.unsafe(`
+    select
+      transactions.id::text,
+      transactions.sequence::text,
+      transactions.idempotency_key,
+      transactions.payload_hash,
+      transactions.tx_type::text,
+      transactions.user_id::text,
+      transactions.created_at::text,
+      registry.table_id::text as table_id,
+      registry.key_format_version,
+      registry.key_format
+    from public.chips_transactions transactions
+    left join public.chips_transaction_idempotency registry
+      on registry.idempotency_key = transactions.idempotency_key
+   where transactions.id = $1::uuid;
+  `, [transactionId]);
+  return rows[0] || null;
 }
 
 async function retryDestructiveOperatorPostgresContract(sql) {
@@ -474,6 +556,12 @@ async function retryDestructiveOperatorPostgresContract(sql) {
   const transactionIds = [fixture.transaction.transactionId];
   const entryIds = fixture.transaction.entryIds;
   const registryKeys = [fixture.transaction.key];
+  const accountIds = [fixture.systemAccountId, fixture.escrowAccountId];
+  const accountingBefore = await readAccountingSnapshot(sql, accountIds, transactionIds);
+  const transactionIdentityBefore = await readTransactionIdentity(sql, fixture.transaction.transactionId);
+  assert.ok(transactionIdentityBefore, "the hot transaction identity must exist before cleanup");
+  assert.equal(accountingBefore.selectedTransactionNet, "0", "the hot transaction must conserve its entries");
+  assert.equal(accountingBefore.conservation, "0", "the ledger must conserve entries before cleanup");
   const hashes = await sql.unsafe(`
     select
       public.chips_archive_uuid_ids_sha256($1::uuid[]) as transaction_hash,
@@ -584,6 +672,10 @@ async function retryDestructiveOperatorPostgresContract(sql) {
       assert.equal(Number(inTransaction[0].hot_entries), 0);
       assert.equal(Number(inTransaction[0].registry_rows), 0);
       assert.ok(inTransaction[0].receipt_at);
+      const accountingInTransaction = await readAccountingSnapshot(tx, accountIds, transactionIds);
+      assert.deepEqual(accountingInTransaction.accounts, accountingBefore.accounts, "cleanup must not change balances or next_entry_seq");
+      assert.equal(accountingInTransaction.accountBalanceTotal, accountingBefore.accountBalanceTotal);
+      assert.equal(accountingInTransaction.conservation, accountingBefore.conservation);
       throw DB_ROLLBACK;
     }).catch((error) => {
       if (error !== DB_ROLLBACK) throw error;
@@ -602,6 +694,12 @@ async function retryDestructiveOperatorPostgresContract(sql) {
     assert.equal(Number(afterRollback[0].registry_rows), 1, "rollback must restore the registry row");
     assert.equal(afterRollback[0].pruned_at, null, "rollback must restore the prune receipt");
     assert.equal(afterRollback[0].cleaned_at, null, "rollback must restore the cleanup receipt");
+    assert.deepEqual(await readTransactionIdentity(sql, fixture.transaction.transactionId), transactionIdentityBefore, "rollback must restore transaction identity");
+    const accountingAfterRollback = await readAccountingSnapshot(sql, accountIds, transactionIds);
+    assert.deepEqual(accountingAfterRollback.accounts, accountingBefore.accounts, "rollback must restore balances and next_entry_seq");
+    assert.equal(accountingAfterRollback.accountBalanceTotal, accountingBefore.accountBalanceTotal);
+    assert.equal(accountingAfterRollback.conservation, accountingBefore.conservation);
+    assert.equal(accountingAfterRollback.selectedTransactionNet, accountingBefore.selectedTransactionNet);
 
     const execute = await sql.begin(async (tx) => {
       await tx.unsafe("set transaction isolation level serializable;");
@@ -621,6 +719,48 @@ async function retryDestructiveOperatorPostgresContract(sql) {
       `, [objectPath, transactionIds, entryIds, registryKeys, fixture.tableId, batchId]);
     });
     assert.equal(retry[0].result.state, "already_cleaned", "a retry must be idempotent after cleanup receipt commit");
+
+    const accountingAfterCleanup = await readAccountingSnapshot(sql, accountIds, transactionIds);
+    assert.deepEqual(accountingAfterCleanup.accounts, accountingBefore.accounts, "destructive cleanup must preserve balances and next_entry_seq");
+    assert.equal(accountingAfterCleanup.accountBalanceTotal, accountingBefore.accountBalanceTotal);
+    assert.equal(accountingAfterCleanup.conservation, accountingBefore.conservation);
+    assert.equal(accountingAfterCleanup.selectedTransactionNet, "0");
+    assert.equal(await readTransactionIdentity(sql, fixture.transaction.transactionId), null, "cleanup must remove only the hot transaction identity");
+
+    await sql.begin(async (tx) => {
+      const substituted = await createDatabaseTable(tx, "OPEN");
+      const reusedTransactionId = randomUUID();
+      const beforeReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
+      await expectDatabaseError(tx, "deleted_key_reuse", async () => {
+        await tx.unsafe(`
+          insert into public.chips_transactions
+            (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
+          values ($1::uuid, $2, $3::jsonb, $4, $5, 'TABLE_BUY_IN', null);
+        `, [
+          reusedTransactionId,
+          `BOT_SEED_BUY_IN:${substituted.tableId}:reuse`,
+          JSON.stringify({ tableId: substituted.tableId }),
+          fixture.transaction.key,
+          "e".repeat(64),
+        ]);
+      }, "P8903", /closed or missing/);
+      const afterReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
+      assert.deepEqual(afterReuse.accounts, beforeReuse.accounts, "failed key reuse must not change balances or next_entry_seq");
+      assert.equal(afterReuse.accountBalanceTotal, beforeReuse.accountBalanceTotal);
+      assert.equal(afterReuse.conservation, beforeReuse.conservation);
+      const reuseRows = await tx.unsafe(`
+        select
+          (select count(*) from public.chips_transactions where id = $1::uuid) as transactions,
+          (select count(*) from public.chips_transaction_idempotency where idempotency_key = $2) as registry_rows,
+          (select count(*) from public.chips_entries where transaction_id = $1::uuid) as entries;
+      `, [reusedTransactionId, fixture.transaction.key]);
+      assert.equal(Number(reuseRows[0].transactions), 0, "deleted key reuse must not create a transaction");
+      assert.equal(Number(reuseRows[0].entries), 0, "deleted key reuse must not create entries");
+      assert.equal(Number(reuseRows[0].registry_rows), 0, "deleted key reuse must not recreate the registry identity");
+      throw DB_ROLLBACK;
+    }).catch((error) => {
+      if (error !== DB_ROLLBACK) throw error;
+    });
   } finally {
     await sql.unsafe(gateDefinitions[0].stage_definition);
     await sql.unsafe(gateDefinitions[0].target_definition);

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import postgres from "postgres";
 
 import {
+  BOT_ONLY_CANDIDATE_SQL,
   buildArchiveBytes,
   buildExportRecord,
   buildManifest,
@@ -12,6 +15,7 @@ import { buildPruneEvidence, buildRecoveryManifest } from "../../scripts/ops/chi
 import { verifyArchiveBytes } from "../../scripts/ops/chips-ledger-archive-store.mjs";
 import {
   assertTableBinding,
+  parseTableReference,
   parseTableIdempotencyKey,
 } from "../../scripts/ops/_shared/chips-table-idempotency.mjs";
 import { validateStageEnvironment } from "../../scripts/ops/chips-ledger-stage-automation.mjs";
@@ -102,6 +106,15 @@ function historicalKeyAndEntryBindingContract() {
     reference: `BOT_SEED_BUY_IN:${TABLE_ID}:1`,
   }).tableId, TABLE_ID);
   assertThrowsMessage(() => parseTableIdempotencyKey("deleted-key"), /supported/);
+  assertThrowsMessage(() => parseTableReference(`legacy-funding:${TABLE_ID}`), /supported/);
+  assertThrowsMessage(() => assertTableBinding({
+    idempotencyKey: KEY,
+    metadata: { tableId: null },
+  }), /metadata\.tableId/);
+  assertThrowsMessage(() => assertTableBinding({
+    idempotencyKey: KEY,
+    reference: `legacy-funding:${TABLE_ID}`,
+  }), /reference format/);
   assertThrowsMessage(() => assertTableBinding({
     idempotencyKey: KEY,
     metadata: { tableId: "00000000-0000-4000-8000-000000000099" },
@@ -224,9 +237,418 @@ function retryAndAccountingContract() {
   assert.doesNotMatch(operator.slice(0, operator.indexOf("grant select")), /update public\.chips_accounts/);
 }
 
+const POSTGRES_TEST_DB_URL = process.env.CHIPS_MIGRATIONS_TEST_DB_URL || null;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DB_ROLLBACK = new Error("bot-only-retention-test-rollback");
+
+async function enableTableFence(db, active) {
+  await db.unsafe("select public.chips_set_table_fence_active($1::boolean);", [active]);
+}
+
+async function expectDatabaseError(tx, savepoint, operation, code, pattern) {
+  await tx.unsafe(`savepoint ${savepoint};`);
+  let caught = null;
+  try {
+    await operation();
+  } catch (error) {
+    caught = error;
+  }
+  await tx.unsafe(`rollback to savepoint ${savepoint};`);
+  await tx.unsafe(`release savepoint ${savepoint};`);
+  assert.ok(caught, `${savepoint} must fail closed`);
+  assert.equal(caught.code, code, `${savepoint} error code`);
+  assert.match(caught.message || "", pattern, `${savepoint} error message`);
+}
+
+async function createDatabaseTable(tx, status = "OPEN") {
+  const tableId = randomUUID();
+  const escrowAccountId = randomUUID();
+  const systemRows = await tx.unsafe(`
+    select id
+      from public.chips_accounts
+     where account_type::text = 'SYSTEM'
+       and system_key = 'GENESIS'
+     limit 1;
+  `);
+  assert.ok(systemRows[0]?.id, "GENESIS fixture is required for PostgreSQL bot-only tests");
+  await tx.unsafe(`
+    insert into public.poker_tables (id, status, has_human_participant, bot_only_proof_eligible)
+    values ($1::uuid, $2, false, true);
+  `, [tableId, status]);
+  await tx.unsafe(`
+    insert into public.chips_accounts (id, account_type, system_key, status, balance)
+    values ($1::uuid, 'ESCROW', $2, 'active', 0);
+  `, [escrowAccountId, `POKER_TABLE:${tableId}`]);
+  return { tableId, systemAccountId: systemRows[0].id, escrowAccountId };
+}
+
+async function insertDatabaseTableTransaction(tx, fixture, {
+  kind = "buyin",
+  createdAt,
+  metadata = { tableId: fixture.tableId },
+  reference = null,
+  escrowAccountId = fixture.escrowAccountId,
+  keySuffix = null,
+} = {}) {
+  const transactionId = randomUUID();
+  const amount = 100;
+  const isBuyIn = kind === "buyin";
+  const transactionType = isBuyIn ? "TABLE_BUY_IN" : "TABLE_CASH_OUT";
+  const key = isBuyIn
+    ? `bot-seed-buyin:${fixture.tableId}:${keySuffix || transactionId}`
+    : `poker:bot-terminal-cashout:v1:${fixture.tableId}:${keySuffix || transactionId}`;
+  const transactionReference = reference || (isBuyIn
+    ? `BOT_SEED_BUY_IN:${fixture.tableId}:1`
+    : `table:${fixture.tableId}`);
+  const payloadHash = "a".repeat(64);
+  await tx.unsafe(`
+    insert into public.chips_transactions
+      (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id, created_at)
+    values ($1::uuid, $2, $3::jsonb, $4, $5, $6, null, $7::timestamptz);
+  `, [
+    transactionId,
+    transactionReference,
+    JSON.stringify(metadata),
+    key,
+    payloadHash,
+    transactionType,
+    createdAt || new Date().toISOString(),
+  ]);
+  const systemAmount = isBuyIn ? -amount : amount;
+  const escrowAmount = -systemAmount;
+  const entryRows = await tx.unsafe(`
+    insert into public.chips_entries (transaction_id, account_id, amount, metadata)
+    values
+      ($1::uuid, $2::uuid, $3::bigint, '{}'::jsonb),
+      ($1::uuid, $4::uuid, $5::bigint, '{}'::jsonb)
+    returning id;
+  `, [transactionId, fixture.systemAccountId, systemAmount, escrowAccountId, escrowAmount]);
+  return {
+    transactionId,
+    entryIds: entryRows.map((row) => String(row.id)).sort((left, right) => BigInt(left) < BigInt(right) ? -1 : 1),
+    key,
+    createdAt: createdAt || new Date().toISOString(),
+  };
+}
+
+async function historicalKeyAndEntryBindingPostgresContract(sql) {
+  await sql.begin(async (tx) => {
+    await enableTableFence(tx, true);
+    const fixture = await createDatabaseTable(tx);
+    const valid = await insertDatabaseTableTransaction(tx, fixture, { keySuffix: "valid" });
+    await tx.unsafe("set constraints all immediate;");
+    const registry = await tx.unsafe(`
+      select table_id::text, key_format_version, key_format
+        from public.chips_transaction_idempotency
+       where idempotency_key = $1;
+    `, [valid.key]);
+    assert.deepEqual(registry[0], {
+      table_id: fixture.tableId,
+      key_format_version: 1,
+      key_format: "bot-seed-buyin",
+    });
+
+    await expectDatabaseError(tx, "null_metadata_marker", async () => {
+      await tx.unsafe(`
+        insert into public.chips_transactions
+          (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
+        values ($1::uuid, $2, '{"tableId":null}'::jsonb, $3, $4, 'TABLE_BUY_IN', null);
+      `, [randomUUID(), `BOT_SEED_BUY_IN:${fixture.tableId}:1`, `bot-seed-buyin:${fixture.tableId}:bad-meta-${randomUUID()}`, "b".repeat(64)]);
+    }, "P8902", /metadata\.tableId|metadata/);
+
+    await expectDatabaseError(tx, "unknown_reference_marker", async () => {
+      await tx.unsafe(`
+        insert into public.chips_transactions
+          (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
+        values ($1::uuid, $2, $3::jsonb, $4, $5, 'TABLE_BUY_IN', null);
+      `, [
+        randomUUID(),
+        `legacy-funding:${fixture.tableId}`,
+        JSON.stringify({ tableId: fixture.tableId }),
+        `bot-seed-buyin:${fixture.tableId}:bad-reference-${randomUUID()}`,
+        "c".repeat(64),
+      ]);
+    }, "P8902", /reference/);
+
+    const wrongEscrowId = randomUUID();
+    await tx.unsafe(`
+      insert into public.chips_accounts (id, account_type, system_key, status, balance)
+      values ($1::uuid, 'ESCROW', $2, 'active', 0);
+    `, [wrongEscrowId, `POKER_TABLE:${randomUUID()}`]);
+    await expectDatabaseError(tx, "deferred_escrow_binding", async () => {
+      await tx.unsafe("set constraints all deferred;");
+      await insertDatabaseTableTransaction(tx, fixture, {
+        kind: "buyin",
+        escrowAccountId: wrongEscrowId,
+        keySuffix: "wrong-escrow",
+      });
+      await tx.unsafe("set constraints all immediate;");
+    }, "P8904", /ESCROW table|authoritative ESCROW/);
+
+    throw DB_ROLLBACK;
+  }).catch((error) => {
+    if (error !== DB_ROLLBACK) throw error;
+  });
+}
+
+async function concurrencyInsertVersusClosePostgresContract(dbUrl) {
+  const first = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  const second = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+  try {
+    await enableTableFence(first, true);
+    const fixture = await createDatabaseTable(first);
+    let releaseInsert;
+    const insertHeld = new Promise((resolve) => { releaseInsert = resolve; });
+    let inserted;
+    const insertedReady = new Promise((resolve, reject) => {
+      inserted = { resolve, reject };
+    });
+    const insertTransaction = first.begin(async (tx) => {
+      try {
+        await insertDatabaseTableTransaction(tx, fixture, { keySuffix: "race" });
+        await tx.unsafe("set constraints all immediate;");
+        inserted.resolve();
+        await insertHeld;
+      } catch (error) {
+        inserted.reject(error);
+        throw error;
+      }
+    });
+    await insertedReady;
+
+    const closeWhileInsertHolds = second.begin(async (tx) => {
+      await tx.unsafe("set local lock_timeout = '150ms';");
+      await tx.unsafe("update public.poker_tables set status = 'CLOSED' where id = $1::uuid;", [fixture.tableId]);
+    });
+    await assert.rejects(closeWhileInsertHolds, (error) => error?.code === "55P03", "close must not bypass the insert fence lock");
+    releaseInsert();
+    await insertTransaction;
+
+    await second.unsafe("update public.poker_tables set status = 'CLOSED' where id = $1::uuid;", [fixture.tableId]);
+    await assert.rejects(
+      () => first.begin(async (tx) => insertDatabaseTableTransaction(tx, fixture, { keySuffix: "after-close" })),
+      (error) => error?.code === "P8903",
+      "a TABLE insert after the committed close must fail closed",
+    );
+    await enableTableFence(first, false);
+  } finally {
+    await first.end({ timeout: 5 });
+    await second.end({ timeout: 5 });
+  }
+}
+
+async function createTimedBotTable(sql, createdAt) {
+  return sql.begin(async (tx) => {
+    const fixture = await createDatabaseTable(tx);
+    await insertDatabaseTableTransaction(tx, fixture, { kind: "buyin", createdAt, keySuffix: "buyin" });
+    await insertDatabaseTableTransaction(tx, fixture, { kind: "cashout", createdAt, keySuffix: "cashout" });
+    await tx.unsafe("set constraints all immediate;");
+    await tx.unsafe("update public.poker_tables set status = 'CLOSED' where id = $1::uuid;", [fixture.tableId]);
+    return fixture;
+  });
+}
+
+async function ageBoundaryPostgresContract(sql) {
+  await enableTableFence(sql, true);
+  const now = Date.now();
+  const cutoff = new Date(now - (7 * DAY_MS)).toISOString();
+  const oldTable = await createTimedBotTable(sql, new Date(now - (10 * DAY_MS)).toISOString());
+  const recentTable = await createTimedBotTable(sql, new Date(now - (6 * DAY_MS)).toISOString());
+  const rows = await sql.unsafe(BOT_ONLY_CANDIDATE_SQL, [cutoff, 5000, null, null]);
+  assert.equal(rows.length, 2, "the 10-day table should contribute its complete two-transaction batch");
+  assert.deepEqual(new Set(rows.map((row) => row.table_id)), new Set([oldTable.tableId]));
+  assert.equal(rows.some((row) => row.table_id === recentTable.tableId), false, "the 6-day table must remain untouched");
+}
+
+async function retryDestructiveOperatorPostgresContract(sql) {
+  const now = Date.now();
+  const cutoff = new Date(now - (7 * DAY_MS)).toISOString();
+  const createdAt = new Date(now - (10 * DAY_MS)).toISOString();
+  const fixture = await sql.begin(async (tx) => {
+    const value = await createDatabaseTable(tx);
+    const transaction = await insertDatabaseTableTransaction(tx, value, { createdAt, keySuffix: "retry" });
+    await tx.unsafe("set constraints all immediate;");
+    await tx.unsafe("update public.poker_tables set status = 'CLOSED' where id = $1::uuid;", [value.tableId]);
+    return { ...value, transaction };
+  });
+  const transactionIds = [fixture.transaction.transactionId];
+  const entryIds = fixture.transaction.entryIds;
+  const registryKeys = [fixture.transaction.key];
+  const hashes = await sql.unsafe(`
+    select
+      public.chips_archive_uuid_ids_sha256($1::uuid[]) as transaction_hash,
+      public.chips_archive_bigint_ids_sha256($2::bigint[]) as entry_hash,
+      public.chips_archive_text_ids_sha256($3::text[]) as registry_hash,
+      public.chips_archive_text_ids_sha256(array[]::text[]) as empty_hash;
+  `, [transactionIds, entryIds, registryKeys]);
+  const hash = hashes[0];
+  const compressedSha = "2".repeat(64);
+  const objectPath = `v1/sha256/${compressedSha}.jsonl.gz`;
+  const batchRows = await sql.unsafe(`
+    insert into public.chips_ledger_archive_batches (
+      object_path, project_ref, format_version, cutoff, cursor_end_created_at, cursor_end_id,
+      first_created_at, last_created_at, transaction_count, entry_count, tx_types,
+      raw_bytes, compressed_bytes, raw_sha256, compressed_sha256, credits, debits, net_amount,
+      source_policy_id, bot_only_table_id, bot_only_table_count, bot_only_newest_created_at,
+      bot_only_registry_keys_sha256, bot_only_out_of_scope_keys_sha256,
+      bot_only_identity_count, bot_only_eligible_count, status, committed_at
+    ) values (
+      $1, 'krydukthwdvccggbyjfw', 2, $2::timestamptz, $3::timestamptz, $4::uuid,
+      $3::timestamptz, $3::timestamptz, 1, 2, '{"TABLE_BUY_IN":1}'::jsonb,
+      100, 80, $5, $6, 100, 100, 0,
+      'stage-ledger-bot-only-retention-7d-v1', $7::uuid, 1, $3::timestamptz,
+      $8, $9, 1, 1, 'committed', timezone('utc', now())
+    ) returning batch_id::text;
+  `, [
+    objectPath,
+    cutoff,
+    createdAt,
+    fixture.transaction.transactionId,
+    "1".repeat(64),
+    compressedSha,
+    fixture.tableId,
+    hash.registry_hash,
+    hash.empty_hash,
+  ]);
+  const batchId = batchRows[0].batch_id;
+  const gateDefinitions = await sql.unsafe(`
+    select
+      pg_get_functiondef('public.chips_assert_archive_prune_stage()'::regprocedure) as stage_definition,
+      pg_get_functiondef('public.chips_assert_archive_prune_target(text,bigint)'::regprocedure) as target_definition;
+  `);
+  assert.ok(gateDefinitions[0]?.stage_definition && gateDefinitions[0]?.target_definition, "archive identity gates must exist");
+  try {
+    // The disposable database cannot have canonical Stage's physical identity.
+    // Keep the production gates unchanged and replace them only for this test,
+    // restoring both definitions in finally after exercising the operator.
+    await sql.unsafe(`
+      create or replace function public.chips_assert_archive_prune_stage()
+      returns text language sql security definer set search_path = ''
+      as $bot_only_test_stage$ select '7656985631720456337'::text $bot_only_test_stage$;
+    `);
+    await sql.unsafe(`
+      create or replace function public.chips_assert_archive_prune_target(p_project_ref text, p_transaction_count bigint)
+      returns text language plpgsql security definer set search_path = ''
+      as $bot_only_test_target$
+      begin
+        if p_project_ref = 'krydukthwdvccggbyjfw' and p_transaction_count between 1 and 5000 then
+          return '7656985631720456337';
+        end if;
+        raise exception 'test target gate rejected request';
+      end
+      $bot_only_test_target$;
+    `);
+
+    const proof = await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      return tx.unsafe(`
+        select public.chips_register_bot_only_archive_proof($1, $2::uuid[], $3::bigint[], $4::uuid, $5::text[]) as result;
+      `, [objectPath, transactionIds, entryIds, fixture.tableId, registryKeys]);
+    });
+    assert.equal(proof[0].result.state, "proof_registered");
+    const go = await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      return tx.unsafe(
+        "select public.chips_authorize_bot_only_archive_batch($1::bigint, $2) as result;",
+        [batchId, `GO ${batchId}`],
+      );
+    });
+    assert.equal(go[0].result.state, "authorized");
+
+    const dry = await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      return tx.unsafe(`
+        select public.chips_prune_and_cleanup_bot_only_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::text[], $5::uuid, false, null
+        ) as result;
+      `, [objectPath, transactionIds, entryIds, registryKeys, fixture.tableId]);
+    });
+    assert.equal(dry[0].result.state, "ready", "prepare-only cleanup must validate without deleting");
+
+    await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      const execute = await tx.unsafe(`
+        select public.chips_prune_and_cleanup_bot_only_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::text[], $5::uuid, true, $6::bigint
+        ) as result;
+      `, [objectPath, transactionIds, entryIds, registryKeys, fixture.tableId, batchId]);
+      assert.equal(execute[0].result.state, "cleaned");
+      const inTransaction = await tx.unsafe(`
+        select
+          (select count(*) from public.chips_transactions where id = $1::uuid) as hot_transactions,
+          (select count(*) from public.chips_entries where id = any($2::bigint[])) as hot_entries,
+          (select count(*) from public.chips_transaction_idempotency where idempotency_key = $3) as registry_rows,
+          (select registry_cleaned_at from public.chips_ledger_archive_batches where batch_id = $4::bigint) as receipt_at;
+      `, [transactionIds[0], entryIds, registryKeys[0], batchId]);
+      assert.equal(Number(inTransaction[0].hot_transactions), 0);
+      assert.equal(Number(inTransaction[0].hot_entries), 0);
+      assert.equal(Number(inTransaction[0].registry_rows), 0);
+      assert.ok(inTransaction[0].receipt_at);
+      throw DB_ROLLBACK;
+    }).catch((error) => {
+      if (error !== DB_ROLLBACK) throw error;
+    });
+
+    const afterRollback = await sql.unsafe(`
+      select
+        (select count(*) from public.chips_transactions where id = $1::uuid) as hot_transactions,
+        (select count(*) from public.chips_entries where id = any($2::bigint[])) as hot_entries,
+        (select count(*) from public.chips_transaction_idempotency where idempotency_key = $3) as registry_rows,
+        (select pruned_at from public.chips_ledger_archive_batches where batch_id = $4::bigint) as pruned_at,
+        (select registry_cleaned_at from public.chips_ledger_archive_batches where batch_id = $4::bigint) as cleaned_at;
+    `, [transactionIds[0], entryIds, registryKeys[0], batchId]);
+    assert.equal(Number(afterRollback[0].hot_transactions), 1, "rollback must restore the hot transaction");
+    assert.equal(Number(afterRollback[0].hot_entries), 2, "rollback must restore both hot entries");
+    assert.equal(Number(afterRollback[0].registry_rows), 1, "rollback must restore the registry row");
+    assert.equal(afterRollback[0].pruned_at, null, "rollback must restore the prune receipt");
+    assert.equal(afterRollback[0].cleaned_at, null, "rollback must restore the cleanup receipt");
+
+    const execute = await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      return tx.unsafe(`
+        select public.chips_prune_and_cleanup_bot_only_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::text[], $5::uuid, true, $6::bigint
+        ) as result;
+      `, [objectPath, transactionIds, entryIds, registryKeys, fixture.tableId, batchId]);
+    });
+    assert.equal(execute[0].result.state, "cleaned");
+    const retry = await sql.begin(async (tx) => {
+      await tx.unsafe("set transaction isolation level serializable;");
+      return tx.unsafe(`
+        select public.chips_prune_and_cleanup_bot_only_archive_batch(
+          $1, $2::uuid[], $3::bigint[], $4::text[], $5::uuid, true, $6::bigint
+        ) as result;
+      `, [objectPath, transactionIds, entryIds, registryKeys, fixture.tableId, batchId]);
+    });
+    assert.equal(retry[0].result.state, "already_cleaned", "a retry must be idempotent after cleanup receipt commit");
+  } finally {
+    await sql.unsafe(gateDefinitions[0].stage_definition);
+    await sql.unsafe(gateDefinitions[0].target_definition);
+  }
+}
+
+async function runPostgresFundamentalContracts() {
+  const sql = postgres(POSTGRES_TEST_DB_URL, { max: 1, idle_timeout: 5 });
+  try {
+    const databaseRows = await sql`select current_database() as name;`;
+    assert.ok(/(?:_test|reset_contract)$/i.test(databaseRows[0]?.name || ""), "bot-only PostgreSQL tests require a disposable database");
+    await historicalKeyAndEntryBindingPostgresContract(sql);
+    await concurrencyInsertVersusClosePostgresContract(POSTGRES_TEST_DB_URL);
+    await ageBoundaryPostgresContract(sql);
+    await retryDestructiveOperatorPostgresContract(sql);
+    process.stdout.write("chips-ledger-bot-only-retention PostgreSQL four fundamental contracts passed\n");
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
 historicalKeyAndEntryBindingContract();
 concurrencyAndScopeContract();
 failClosedLifecycleContract();
 retryAndAccountingContract();
+
+if (POSTGRES_TEST_DB_URL) {
+  await runPostgresFundamentalContracts();
+}
 
 process.stdout.write("chips-ledger-bot-only-retention four fundamental contracts passed\n");

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -745,34 +745,54 @@ async function retryDestructiveOperatorPostgresContract(sql) {
 
     await sql.begin(async (tx) => {
       const substituted = await createDatabaseTable(tx, "OPEN");
-      const reusedTransactionId = randomUUID();
       const beforeReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
-      await expectDatabaseError(tx, "deleted_key_reuse", async () => {
+      const assertNoReuseEffects = async (label, transactionId) => {
+        const reuseRows = await tx.unsafe(`
+          select
+            (select count(*) from public.chips_transactions where id = $1::uuid) as transactions,
+            (select count(*) from public.chips_transaction_idempotency where idempotency_key = $2) as registry_rows,
+            (select count(*) from public.chips_entries where transaction_id = $1::uuid) as entries;
+        `, [transactionId, fixture.transaction.key]);
+        assert.equal(Number(reuseRows[0].transactions), 0, `${label}: must not create a transaction`);
+        assert.equal(Number(reuseRows[0].entries), 0, `${label}: must not create entries`);
+        assert.equal(Number(reuseRows[0].registry_rows), 0, `${label}: must not recreate the registry identity`);
+        const afterReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
+        assert.deepEqual(afterReuse.accounts, beforeReuse.accounts, `${label}: must not change balances or next_entry_seq`);
+        assert.equal(afterReuse.accountBalanceTotal, beforeReuse.accountBalanceTotal, `${label}: account total must be unchanged`);
+        assert.equal(afterReuse.conservation, beforeReuse.conservation, `${label}: conservation must be unchanged`);
+      };
+
+      const replacementTableReuseId = randomUUID();
+      await expectDatabaseError(tx, "deleted_key_reuse_replacement", async () => {
         await tx.unsafe(`
           insert into public.chips_transactions
             (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
           values ($1::uuid, $2, $3::jsonb, $4, $5, 'TABLE_BUY_IN', null);
         `, [
-          reusedTransactionId,
+          replacementTableReuseId,
           `BOT_SEED_BUY_IN:${substituted.tableId}:reuse`,
           JSON.stringify({ tableId: substituted.tableId }),
           fixture.transaction.key,
           "e".repeat(64),
         ]);
       }, "P8902", /does not match the idempotency key/);
-      const afterReuse = await readAccountingSnapshot(tx, accountIds, transactionIds);
-      assert.deepEqual(afterReuse.accounts, beforeReuse.accounts, "failed key reuse must not change balances or next_entry_seq");
-      assert.equal(afterReuse.accountBalanceTotal, beforeReuse.accountBalanceTotal);
-      assert.equal(afterReuse.conservation, beforeReuse.conservation);
-      const reuseRows = await tx.unsafe(`
-        select
-          (select count(*) from public.chips_transactions where id = $1::uuid) as transactions,
-          (select count(*) from public.chips_transaction_idempotency where idempotency_key = $2) as registry_rows,
-          (select count(*) from public.chips_entries where transaction_id = $1::uuid) as entries;
-      `, [reusedTransactionId, fixture.transaction.key]);
-      assert.equal(Number(reuseRows[0].transactions), 0, "deleted key reuse must not create a transaction");
-      assert.equal(Number(reuseRows[0].entries), 0, "deleted key reuse must not create entries");
-      assert.equal(Number(reuseRows[0].registry_rows), 0, "deleted key reuse must not recreate the registry identity");
+      await assertNoReuseEffects("replacement table key reuse", replacementTableReuseId);
+
+      const closedTableReuseId = randomUUID();
+      await expectDatabaseError(tx, "deleted_key_reuse_closed", async () => {
+        await tx.unsafe(`
+          insert into public.chips_transactions
+            (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
+          values ($1::uuid, $2, $3::jsonb, $4, $5, 'TABLE_BUY_IN', null);
+        `, [
+          closedTableReuseId,
+          `BOT_SEED_BUY_IN:${fixture.tableId}:reuse-closed`,
+          JSON.stringify({ tableId: fixture.tableId }),
+          fixture.transaction.key,
+          "f".repeat(64),
+        ]);
+      }, "P8903", /closed or missing/);
+      await assertNoReuseEffects("closed table key reuse", closedTableReuseId);
       throw DB_ROLLBACK;
     }).catch((error) => {
       if (error !== DB_ROLLBACK) throw error;

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -488,10 +488,26 @@ async function ageBoundaryPostgresContract(sql) {
   );
   const rows = await sql.unsafe(BOT_ONLY_CANDIDATE_SQL, [cutoff, 5000, null, null]);
   assert.equal(rows.length, 0, "a table with 10-day and 6-day identities must remain untouched");
-  const blockers = await sql.unsafe(BOT_ONLY_BLOCKING_ANOMALY_SQL, [cutoff, 5000]);
+  const mixedIdentitySummary = await sql.unsafe(`
+    select
+      count(*)::text as identity_count,
+      count(*) filter (where transaction_created_at < $2::timestamptz)::text as eligible_count,
+      max(transaction_created_at)::text as newest_created_at
+      from public.chips_transaction_idempotency
+     where table_id = $1::uuid
+       and archive_batch_id is null;
+  `, [mixedTable.tableId, cutoff]);
+  assert.equal(Number(mixedIdentitySummary[0].identity_count), 2, "the mixed table must retain both registry identities");
+  assert.equal(Number(mixedIdentitySummary[0].eligible_count), 1, "only the older mixed-table identity is beyond the cutoff");
   assert.ok(
-    blockers.some((row) => row.blocker_code === "younger_table_identity" && Number(row.table_count) === 1),
-    "the mixed-age table must report the younger identity as a blocking anomaly",
+    new Date(mixedIdentitySummary[0].newest_created_at).getTime() >= new Date(cutoff).getTime(),
+    "the mixed table newest identity must remain at or after the cutoff",
+  );
+  const blockers = await sql.unsafe(BOT_ONLY_BLOCKING_ANOMALY_SQL, [cutoff, 5000]);
+  const youngerBlocker = blockers.find((row) => row.blocker_code === "younger_table_identity");
+  assert.ok(
+    youngerBlocker && Number(youngerBlocker.table_count) > 0 && Number(youngerBlocker.transaction_count) >= 2,
+    `the mixed-age table must report the younger identity as a blocking anomaly: ${JSON.stringify(blockers)}`,
   );
 
   const youngerCrossedCutoff = new Date(now - (5 * DAY_MS)).toISOString();

--- a/tests/chips/chips-ledger-bot-only-retention.test.mjs
+++ b/tests/chips/chips-ledger-bot-only-retention.test.mjs
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+import {
+  buildArchiveBytes,
+  buildExportRecord,
+  buildManifest,
+  evaluateTableEligibility,
+  validateBatch,
+} from "../../scripts/ops/chips-ledger-archive-export.mjs";
+import { buildPruneEvidence, buildRecoveryManifest } from "../../scripts/ops/chips-ledger-archive-prune.mjs";
+import { verifyArchiveBytes } from "../../scripts/ops/chips-ledger-archive-store.mjs";
+import {
+  assertTableBinding,
+  parseTableIdempotencyKey,
+} from "../../scripts/ops/_shared/chips-table-idempotency.mjs";
+import { validateStageEnvironment } from "../../scripts/ops/chips-ledger-stage-automation.mjs";
+
+const migration = fs.readFileSync("supabase/migrations/20260818100000_chips_ledger_bot_only_retention.sql", "utf8");
+const closedTableCleanup = fs.readFileSync("ws-server/poker/persistence/closed-table-cleanup.mjs", "utf8");
+
+const TABLE_ID = "00000000-0000-4000-8000-000000000020";
+const TX_ID = "00000000-0000-4000-8000-000000000021";
+const SYSTEM_ID = "00000000-0000-4000-8000-000000000022";
+const ESCROW_ID = "00000000-0000-4000-8000-000000000023";
+const KEY = `bot-seed-buyin:${TABLE_ID}:1`;
+
+function entry(id, amount, accountId, accountType, systemKey = null) {
+  return {
+    id: String(id),
+    transaction_id: TX_ID,
+    account_id: accountId,
+    entry_seq: String(id),
+    amount: String(amount),
+    metadata: {},
+    created_at: "2026-07-01T00:00:00.000000Z",
+    account_row_id: accountId,
+    account_type: accountType,
+    account_user_id: null,
+    account_system_key: systemKey,
+    account_status: "active",
+    account_label: null,
+  };
+}
+
+function botCandidate(overrides = {}) {
+  return {
+    id: TX_ID,
+    sequence: "1",
+    tx_type: "TABLE_BUY_IN",
+    idempotency_key: KEY,
+    payload_hash: "a".repeat(64),
+    user_id: null,
+    reference: `BOT_SEED_BUY_IN:${TABLE_ID}:1`,
+    description: null,
+    metadata: { tableId: TABLE_ID },
+    created_by: "00000000-0000-4000-8000-000000000024",
+    created_at: "2026-07-01T00:00:00.000000Z",
+    entry_count: "2",
+    table_related: true,
+    table_id: TABLE_ID,
+    table_exists: true,
+    table_status: "CLOSED",
+    escrow_account_id: ESCROW_ID,
+    escrow_status: "active",
+    escrow_balance: "0",
+    has_human_participant: false,
+    bot_only_proof_eligible: true,
+    key_table_id: TABLE_ID,
+    key_format_version: 1,
+    key_format: "bot-seed-buyin",
+    table_newest_created_at: "2026-07-01T00:00:00.000000Z",
+    table_identity_count: "1",
+    table_eligible_count: "1",
+    table_out_of_scope_keys_sha256: "b".repeat(64),
+    ...overrides,
+  };
+}
+
+function botRecord(candidate = botCandidate(), entries = [
+  entry(2, -100, SYSTEM_ID, "SYSTEM", "TREASURY"),
+  entry(1, 100, ESCROW_ID, "ESCROW", `POKER_TABLE:${TABLE_ID}`),
+]) {
+  return buildExportRecord(candidate, entries, { schemaVersion: 2 });
+}
+
+function assertThrowsMessage(fn, pattern) {
+  assert.throws(fn, pattern);
+}
+
+function historicalKeyAndEntryBindingContract() {
+  assert.deepEqual(parseTableIdempotencyKey(KEY), {
+    version: 1,
+    format: "bot-seed-buyin",
+    tableId: TABLE_ID,
+    key: KEY,
+  });
+  assert.equal(parseTableIdempotencyKey(`poker:inactive_cleanup:${TABLE_ID}:user`).format, "poker:inactive_cleanup");
+  assert.equal(assertTableBinding({
+    idempotencyKey: KEY,
+    metadata: { tableId: TABLE_ID },
+    reference: `BOT_SEED_BUY_IN:${TABLE_ID}:1`,
+  }).tableId, TABLE_ID);
+  assertThrowsMessage(() => parseTableIdempotencyKey("deleted-key"), /supported/);
+  assertThrowsMessage(() => assertTableBinding({
+    idempotencyKey: KEY,
+    metadata: { tableId: "00000000-0000-4000-8000-000000000099" },
+  }), /binding/);
+
+  const candidate = botCandidate();
+  const valid = botRecord(candidate);
+  assert.equal(validateBatch({ candidates: [candidate], records: [valid], cutoff: "2026-07-02T00:00:00Z", schemaVersion: 2 }).transactionCount, 1);
+  assertThrowsMessage(() => validateBatch({
+    candidates: [candidate],
+    records: [botRecord(candidate, [
+      entry(2, -100, SYSTEM_ID, "SYSTEM", "TREASURY"),
+      entry(1, 100, ESCROW_ID, "ESCROW", "POKER_TABLE:00000000-0000-4000-8000-000000000099"),
+    ])],
+    cutoff: "2026-07-02T00:00:00Z",
+    schemaVersion: 2,
+  }), /ESCROW binding/);
+}
+
+function concurrencyAndScopeContract() {
+  const immediate = migration.slice(
+    migration.indexOf("create or replace function public.chips_table_transaction_before_insert"),
+    migration.indexOf("$$;", migration.indexOf("create or replace function public.chips_table_transaction_before_insert")) + 3,
+  );
+  assert.match(migration, /create trigger chips_table_transaction_fence[\s\S]*?before insert on public\.chips_transactions/i);
+  assert.match(immediate, /for update/i);
+  assert.doesNotMatch(immediate, /chips_entries/);
+  assert.match(migration, /if tg_table_name = 'chips_transactions' then[\s\S]*?transaction_id := new\.id/);
+  assert.match(migration, /create constraint trigger chips_table_transaction_binding[\s\S]*?deferrable initially deferred/i);
+  assert.match(migration, /create constraint trigger chips_entries_table_transaction_binding[\s\S]*?deferrable initially deferred/i);
+  assert.equal(evaluateTableEligibility({ table_related: true, table_id: TABLE_ID, table_exists: true, table_status: "OPEN", escrow_account_id: ESCROW_ID, escrow_balance: "0" }).eligible, false);
+  assert.equal(evaluateTableEligibility({ table_related: true, table_id: TABLE_ID, table_exists: true, table_status: "CLOSED", escrow_account_id: ESCROW_ID, escrow_balance: "0" }).eligible, true);
+  assertThrowsMessage(() => validateBatch({
+    candidates: [botCandidate({ tx_type: "HAND_SETTLEMENT" })],
+    records: [botRecord(botCandidate({ tx_type: "HAND_SETTLEMENT" }))],
+    cutoff: "2026-07-02T00:00:00Z",
+    schemaVersion: 2,
+  }), /non-TABLE/);
+}
+
+function failClosedLifecycleContract() {
+  assert.match(migration, /enforcement_active boolean not null default false/);
+  assert.match(migration, /has_human_participant is true and new\.has_human_participant is not true/);
+  assert.match(migration, /new\.bot_only_proof_eligible is not true/);
+  assert.match(migration, /p_confirmation is distinct from \('GO ' \|\| p_batch_id::text\)/);
+  assert.match(migration, /source_policy_id <> 'stage-ledger-bot-only-retention-7d-v1'/);
+  assert.match(migration, /Production authorization|canonical Stage schema-v2 batch/);
+  assert.match(closedTableCleanup, /has_human_participant is true or t\.bot_only_retention_complete_at is not null/);
+  assertThrowsMessage(() => validateStageEnvironment({
+    SUPABASE_STAGE_DB_URL: "postgresql://postgres.krydukthwdvccggbyjfw@db.krydukthwdvccggbyjfw.supabase.co:5432/postgres",
+    SUPABASE_STAGE_URL: "https://krydukthwdvccggbyjfw.supabase.co",
+    SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test",
+    SUPABASE_PROD_DB_URL: "forbidden",
+  }), /Production credentials/);
+}
+
+function retryAndAccountingContract() {
+  const candidate = botCandidate();
+  const record = botRecord(candidate);
+  const localArchive = {
+    records: [record],
+    manifest: {
+      schema_version: 2,
+      batch: { tx_types: { TABLE_BUY_IN: 1 } },
+      bot_only: { out_of_scope_keys_sha256: "b".repeat(64) },
+    },
+    summary: { credits: "100", debits: "100", netAmount: "0" },
+  };
+  const first = buildPruneEvidence(localArchive);
+  const second = buildPruneEvidence(localArchive);
+  assert.deepEqual(second, first);
+  assert.equal(first.credits, "100");
+  assert.equal(first.debits, "100");
+  assert.equal(first.net, "0");
+  assert.deepEqual(first.registryKeys, [KEY]);
+  const archive = buildArchiveBytes([record]);
+  const manifest = buildManifest({
+    target: "stage",
+    cutoff: "2026-07-08T00:00:00Z",
+    batchSize: 5000,
+    cursor: null,
+    records: [record],
+    archive,
+    outputPath: "archive.jsonl.gz",
+    sourcePolicyId: "stage-ledger-bot-only-retention-7d-v1",
+    schemaVersion: 2,
+  });
+  const verified = verifyArchiveBytes({
+    compressedBytes: archive.compressedBytes,
+    manifest,
+    target: { target: "stage" },
+    artifactName: "archive.jsonl.gz",
+  });
+  assert.equal(verified.summary.transactionCount, 1);
+  const recovery = buildRecoveryManifest({
+    object_path: "v1/sha256/" + "c".repeat(64) + ".jsonl.gz",
+    project_ref: "krydukthwdvccggbyjfw",
+    source_policy_id: "stage-ledger-bot-only-retention-7d-v1",
+    format_version: 2,
+    cutoff: "2026-07-08T00:00:00Z",
+    transaction_count: 1,
+    entry_count: 2,
+    tx_types: { TABLE_BUY_IN: 1 },
+    raw_bytes: 1,
+    compressed_bytes: 1,
+    raw_sha256: "d".repeat(64),
+    compressed_sha256: "c".repeat(64),
+    credits: "100",
+    debits: "100",
+    net_amount: "0",
+  }, "7656985631720456337", first, { target: "stage" });
+  assert.equal(recovery.id_proof.transaction_ids_sha256, first.transactionIdsSha256);
+  assert.equal(recovery.bot_only.table_id, TABLE_ID);
+  assert.equal(recovery.bot_only.registry_keys_sha256, first.registryKeysSha256);
+  assert.equal(recovery.bot_only.registry_key_count, 1);
+  const operator = migration.slice(migration.indexOf("create or replace function public.chips_prune_and_cleanup_bot_only_archive_batch"));
+  assert.match(operator, /delete from public\.chips_transaction_idempotency/);
+  assert.match(operator, /registry_cleaned_keys_sha256/);
+  assert.match(operator, /update public\.poker_tables/);
+  assert.doesNotMatch(operator.slice(0, operator.indexOf("grant select")), /update public\.chips_accounts/);
+}
+
+historicalKeyAndEntryBindingContract();
+concurrencyAndScopeContract();
+failClosedLifecycleContract();
+retryAndAccountingContract();
+
+process.stdout.write("chips-ledger-bot-only-retention four fundamental contracts passed\n");

--- a/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.observability.behavior.test.mjs
@@ -25,6 +25,7 @@ function cleanEnv(overrides = {}) {
     ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !/^SUPABASE_PROD_|^PRODUCTION_/.test(key))),
     SUPABASE_STAGE_DB_URL: sampleDbUrl,
     SUPABASE_STAGE_SERVICE_ROLE_KEY: sampleSecret,
+    GITHUB_SHA: "f".repeat(40),
     ...overrides,
   };
 }
@@ -61,6 +62,7 @@ try {
   assert.equal(child.stderr, "");
   const { line, report } = parseSingleAggregate(child.stdout);
   assert.deepEqual(Object.keys(report).sort(), [
+    "deployed_commit_sha",
     "event",
     "project_ref",
     "reason",

--- a/tests/chips/chips-ledger-stage-automation.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.test.mjs
@@ -5,8 +5,11 @@ import { readSnapshot, STAGE_AUTOMATION_POLICY_ID } from "../../scripts/ops/chip
 import {
   assertDurableRecoveryReady,
   assertResumeRecoveryState,
+  botOnlyExportArgs,
+  botOnlyReport,
   findOwnCycle,
   persistDurableRecovery,
+  runBotOnlyStageAutomation,
   runStageAutomation,
   STAGE_PROJECT_REF,
   STAGE_SYSTEM_IDENTIFIER,
@@ -27,7 +30,11 @@ const ENV = {
 };
 
 const stageOrchestratorSource = fs.readFileSync("scripts/ops/chips-ledger-stage-automation.mjs", "utf8");
-assert.doesNotMatch(stageOrchestratorSource, /--after-(?:created-at|id)/);
+assert.match(stageOrchestratorSource, /resumePending[\s\S]*botOnlyExportArgs/);
+assert.doesNotMatch(
+  stageOrchestratorSource.slice(stageOrchestratorSource.indexOf("export async function runBotOnlyStageAutomation")),
+  /activeRows\[0\]\?\.status === "pending"\)\s*fail\(/,
+);
 
 function response(value, status = 200, headers = {}) {
   if (Buffer.isBuffer(value)) return new Response(value, { status, headers: { "content-type": "application/gzip", ...headers } });
@@ -189,6 +196,156 @@ assert.throws(
   /receipt is partial/,
 );
 assert.throws(() => findOwnCycle([{ ...completedRow, status: "pending" }]), /pending/);
+const pendingBotRow = {
+  status: "pending",
+  cutoff: "2026-08-12T00:00:00.000000Z",
+  cursor_start_created_at: "2026-07-01T00:00:00.000000Z",
+  cursor_start_id: "00000000-0000-4000-8000-000000000001",
+};
+assert.deepEqual(botOnlyExportArgs(pendingBotRow, "/tmp/bot.archive.gz", "/tmp/bot.manifest.json"), [
+  "--target", "stage",
+  "--cutoff", pendingBotRow.cutoff,
+  "--batch-size", "5000",
+  "--after-created-at", pendingBotRow.cursor_start_created_at,
+  "--after-id", pendingBotRow.cursor_start_id,
+  "--output", "/tmp/bot.archive.gz",
+  "--manifest", "/tmp/bot.manifest.json",
+]);
+const preparedBotReport = botOnlyReport({
+  row: {
+    ...pendingBotRow,
+    project_ref: STAGE_PROJECT_REF,
+    batch_id: "12",
+    object_path: "v1/sha256/" + "a".repeat(64) + ".jsonl.gz",
+    bot_only_table_id: "00000000-0000-4000-8000-000000000020",
+    bot_only_table_count: "1",
+    bot_only_identity_count: "2",
+    bot_only_eligible_count: "2",
+    bot_only_registry_keys_sha256: "b".repeat(64),
+    bot_only_out_of_scope_keys_sha256: "c".repeat(64),
+    compressed_sha256: "a".repeat(64),
+  },
+  identity: STAGE_SYSTEM_IDENTIFIER,
+  dry: { evidence: {
+    transactionCount: 2,
+    entryCount: 4,
+    txTypes: { TABLE_BUY_IN: 2 },
+    credits: "200",
+    debits: "200",
+    net: "0",
+    registryKeys: ["one", "two"],
+  } },
+  durable: {
+    recoveryArchive: { sha256: "d".repeat(64) },
+    recoveryManifest: { sha256: "e".repeat(64) },
+  },
+  state: "prepared",
+  mode: "prepare-only",
+});
+assert.deepEqual({
+  batchId: preparedBotReport.batchId,
+  objectPath: preparedBotReport.objectPath,
+  tableId: preparedBotReport.tableId,
+  registryKeyCount: preparedBotReport.registryKeyCount,
+  registryKeysSha256: preparedBotReport.registryKeysSha256,
+  stageSystemIdentifier: preparedBotReport.stageSystemIdentifier,
+  recoveryArchiveSha256: preparedBotReport.recoveryArchiveSha256,
+  recoveryManifestSha256: preparedBotReport.recoveryManifestSha256,
+}, {
+  batchId: "12",
+  objectPath: "v1/sha256/" + "a".repeat(64) + ".jsonl.gz",
+  tableId: "00000000-0000-4000-8000-000000000020",
+  registryKeyCount: 2,
+  registryKeysSha256: "b".repeat(64),
+  stageSystemIdentifier: STAGE_SYSTEM_IDENTIFIER,
+  recoveryArchiveSha256: "d".repeat(64),
+  recoveryManifestSha256: "e".repeat(64),
+});
+const storageTarget = {
+  target: "stage",
+  projectRef: STAGE_PROJECT_REF,
+  baseUrl: STAGE_URL,
+  serviceKey: "stage-test-key",
+};
+const pendingAutomationRow = {
+  status: "pending",
+  project_ref: STAGE_PROJECT_REF,
+  source_policy_id: "stage-ledger-bot-only-retention-7d-v1",
+  batch_id: "13",
+  object_path: "v1/sha256/" + "f".repeat(64) + ".jsonl.gz",
+  cutoff: "2026-08-12T00:00:00.000000Z",
+  cursor_start_created_at: "2026-07-01T00:00:00.000000Z",
+  cursor_start_id: "00000000-0000-4000-8000-000000000001",
+  bot_only_table_id: "00000000-0000-4000-8000-000000000020",
+  bot_only_table_count: "1",
+  bot_only_identity_count: "1",
+  bot_only_eligible_count: "1",
+  bot_only_registry_keys_sha256: "1".repeat(64),
+  bot_only_out_of_scope_keys_sha256: "2".repeat(64),
+  compressed_sha256: "f".repeat(64),
+  archive_proof_verified_at: "2026-08-13T00:00:00.000000Z",
+};
+const committedPendingRow = {
+  ...pendingAutomationRow,
+  status: "committed",
+  registry_cleaned_at: "2026-08-13T00:01:00.000000Z",
+};
+const botOnlySqlCalls = [];
+const botOnlySql = {
+  unsafe: async (query, values = []) => {
+    botOnlySqlCalls.push({ query, values });
+    if (query.includes("pg_try_advisory_lock")) return [{ acquired: true, backend_pid: "bot-only-session" }];
+    if (query.includes("pg_backend_pid")) return [{ backend_pid: "bot-only-session" }];
+    if (query.includes("pg_advisory_unlock")) return [{ pg_advisory_unlock: true }];
+    if (query.includes("pg_control_system")) return [{ system_identifier: STAGE_SYSTEM_IDENTIFIER }];
+    if (query.includes("from public.chips_ledger_archive_batches")) return [pendingAutomationRow];
+    throw new Error(`unexpected bot-only SQL: ${query}`);
+  },
+};
+const pendingExportCalls = [];
+const pendingStoreCalls = [];
+const pendingPruneCalls = [];
+const pendingAutomationResult = await runBotOnlyStageAutomation({
+  env: ENV,
+  deps: {
+    sql: botOnlySql,
+    storageTarget,
+    tempRoot: fs.mkdtempSync("/tmp/chips-ledger-stage-bot-only-pending-"),
+    pruneStore: { getManifest: async () => committedPendingRow },
+    verifyBucket: async () => {},
+    exportArchive: async ({ argv }) => {
+      pendingExportCalls.push(argv);
+      return { noCandidate: false };
+    },
+    storeArchive: async (args) => {
+      pendingStoreCalls.push(args);
+      return { objectPath: pendingAutomationRow.object_path };
+    },
+    pruneArchive: async ({ argv }) => {
+      pendingPruneCalls.push(argv);
+      return {
+        state: "already_cleaned",
+        evidence: {
+          transactionCount: 1,
+          entryCount: 2,
+          txTypes: { TABLE_BUY_IN: 1 },
+          credits: "100",
+          debits: "100",
+          net: "0",
+        },
+      };
+    },
+  },
+});
+assert.equal(pendingAutomationResult.state, "already_cleaned");
+const expectedPendingArgs = botOnlyExportArgs(pendingAutomationRow, "artifact", "manifest");
+assert.deepEqual(pendingExportCalls[0].slice(0, 10), expectedPendingArgs.slice(0, 10));
+assert.equal(pendingExportCalls[0][10], "--output");
+assert.equal(pendingExportCalls[0][12], "--manifest");
+assert.equal(pendingStoreCalls.length, 1, "a pending bot-only batch must be retried through Storage");
+assert.equal(pendingStoreCalls[0].argv.includes("--artifact"), true);
+assert.equal(pendingPruneCalls.length, 1, "the retried committed batch must continue through the existing prune runner");
+assert.equal(botOnlySqlCalls.some(({ query }) => query.includes("pg_try_advisory_lock")), true);
 assert.throws(() => assertDurableRecoveryReady({ archiveBytes: Buffer.from("archive") }), /both durable recovery copies/);
 assert.throws(
   () => assertResumeRecoveryState({ archive_proof_verified_at: "now", pruned_at: null }, null),
@@ -239,12 +396,6 @@ const evidence = {
 };
 const durableObjects = new Map();
 const storageCalls = [];
-const storageTarget = {
-  target: "stage",
-  projectRef: STAGE_PROJECT_REF,
-  baseUrl: STAGE_URL,
-  serviceKey: "stage-test-key",
-};
 const fetch = async (url, init = {}) => {
   const requestUrl = new URL(url);
   const objectPath = decodeURIComponent(requestUrl.pathname.split(`/storage/v1/object/authenticated/${ARCHIVE_BUCKET}/`)[1] || requestUrl.pathname.split(`/storage/v1/object/${ARCHIVE_BUCKET}/`)[1] || "");

--- a/tests/chips/chips-ledger-stage-automation.test.mjs
+++ b/tests/chips/chips-ledger-stage-automation.test.mjs
@@ -27,6 +27,7 @@ const ENV = {
   SUPABASE_STAGE_DB_URL: STAGE_DB_URL,
   SUPABASE_STAGE_URL: STAGE_URL,
   SUPABASE_STAGE_SERVICE_ROLE_KEY: "stage-test-key",
+  GITHUB_SHA: "f".repeat(40),
 };
 
 const stageOrchestratorSource = fs.readFileSync("scripts/ops/chips-ledger-stage-automation.mjs", "utf8");
@@ -241,6 +242,7 @@ const preparedBotReport = botOnlyReport({
   },
   state: "prepared",
   mode: "prepare-only",
+  deployedCommitSha: "f".repeat(40),
 });
 assert.deepEqual({
   batchId: preparedBotReport.batchId,
@@ -251,6 +253,7 @@ assert.deepEqual({
   stageSystemIdentifier: preparedBotReport.stageSystemIdentifier,
   recoveryArchiveSha256: preparedBotReport.recoveryArchiveSha256,
   recoveryManifestSha256: preparedBotReport.recoveryManifestSha256,
+  deployedCommitSha: preparedBotReport.deployedCommitSha,
 }, {
   batchId: "12",
   objectPath: "v1/sha256/" + "a".repeat(64) + ".jsonl.gz",
@@ -260,6 +263,7 @@ assert.deepEqual({
   stageSystemIdentifier: STAGE_SYSTEM_IDENTIFIER,
   recoveryArchiveSha256: "d".repeat(64),
   recoveryManifestSha256: "e".repeat(64),
+  deployedCommitSha: "f".repeat(40),
 });
 const storageTarget = {
   target: "stage",
@@ -346,6 +350,30 @@ assert.equal(pendingStoreCalls.length, 1, "a pending bot-only batch must be retr
 assert.equal(pendingStoreCalls[0].argv.includes("--artifact"), true);
 assert.equal(pendingPruneCalls.length, 1, "the retried committed batch must continue through the existing prune runner");
 assert.equal(botOnlySqlCalls.some(({ query }) => query.includes("pg_try_advisory_lock")), true);
+
+const noCandidateBotSql = fakeSql();
+const noCandidateBotOnly = await runBotOnlyStageAutomation({
+  env: ENV,
+  deps: {
+    sql: noCandidateBotSql,
+    storageTarget,
+    tempRoot: fs.mkdtempSync("/tmp/chips-ledger-stage-bot-only-no-candidate-"),
+    verifyBucket: async () => {},
+    exportArchive: async () => ({
+      noCandidate: true,
+      options: {
+        projectRef: STAGE_PROJECT_REF,
+        cutoff: "2026-08-14T00:00:00.000Z",
+        cursor: null,
+      },
+      blockingAnomalies: [{ code: "younger_table_identity", transaction_count: "2", table_count: "1" }],
+    }),
+  },
+});
+assert.equal(noCandidateBotOnly.reason, "blocking_anomalies");
+assert.deepEqual(noCandidateBotOnly.blockingAnomalies, [{ code: "younger_table_identity", transaction_count: "2", table_count: "1" }]);
+assert.equal(noCandidateBotOnly.cutoff, "2026-08-14T00:00:00.000Z");
+assert.equal(noCandidateBotOnly.deployedCommitSha, "f".repeat(40));
 assert.throws(() => assertDurableRecoveryReady({ archiveBytes: Buffer.from("archive") }), /both durable recovery copies/);
 assert.throws(
   () => assertResumeRecoveryState({ archive_proof_verified_at: "now", pruned_at: null }, null),

--- a/tests/chips/chips-ledger-table-metadata-fence.test.mjs
+++ b/tests/chips/chips-ledger-table-metadata-fence.test.mjs
@@ -330,15 +330,16 @@ async function main() {
   const databaseRows = await db`select current_database() as name;`;
   assert.ok(/(?:_test|reset_contract)$/i.test(databaseRows[0]?.name || ""), "metadata fence tests require a disposable database");
 
-  await setFence(false);
+  const fenceRows = await db`select public.chips_table_fence_is_active() as active;`;
+  const fenceWasActive = Boolean(fenceRows[0]?.active);
   const fixture = await createFixture();
-  await setFence(true);
+  if (!fenceWasActive) await setFence(true);
   try {
     await validProducerContract(fixture);
     await netlifyWrongMetadataContract(fixture);
     await directSqlMetadataContracts(fixture);
   } finally {
-    await setFence(false);
+    if (!fenceWasActive) await setFence(false);
     await db.end({ timeout: 5 });
     const adminModule = await import("../../netlify/functions/_shared/supabase-admin.mjs");
     if (adminModule?.closeSql) await adminModule.closeSql();

--- a/tests/chips/chips-ledger-table-metadata-fence.test.mjs
+++ b/tests/chips/chips-ledger-table-metadata-fence.test.mjs
@@ -1,0 +1,353 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import postgres from "postgres";
+
+const dbUrl = process.env.CHIPS_MIGRATIONS_TEST_DB_URL;
+
+if (!dbUrl) {
+  console.log("Skipping TABLE metadata fence regression tests: CHIPS_MIGRATIONS_TEST_DB_URL not set.");
+  process.exit(0);
+}
+
+process.env.SUPABASE_DB_URL = dbUrl;
+
+const ROLLBACK = new Error("table-metadata-fence-test-rollback");
+
+const netlifyLedger = await import("../../netlify/functions/_shared/chips-ledger.mjs");
+const wsLedger = await import("../../ws-server/poker/persistence/chips-ledger.mjs");
+const db = postgres(dbUrl, { max: 1, idle_timeout: 5 });
+
+function legacyMetadata(tableId) {
+  return JSON.stringify({ tableId });
+}
+
+function keyFor(kind, tableId, suffix) {
+  if (kind === "cashout") return `poker:bot-terminal-cashout:v1:${tableId}:${suffix}`;
+  return `bot-seed-buyin:${tableId}:${suffix}`;
+}
+
+function referenceFor(kind, tableId) {
+  if (kind === "cashout") return `table:${tableId}`;
+  return `BOT_SEED_BUY_IN:${tableId}:1`;
+}
+
+function tableEntries(fixture, kind, metadata) {
+  const buyIn = kind === "buyin";
+  return [
+    {
+      accountType: "SYSTEM",
+      systemKey: fixture.fundingKey,
+      amount: buyIn ? -100 : 100,
+      metadata,
+    },
+    {
+      accountType: "ESCROW",
+      systemKey: fixture.escrowKey,
+      amount: buyIn ? 100 : -100,
+      metadata,
+    },
+  ];
+}
+
+function tablePayload(fixture, kind, metadata, suffix) {
+  const txType = kind === "cashout" ? "TABLE_CASH_OUT" : "TABLE_BUY_IN";
+  return {
+    userId: null,
+    txType,
+    idempotencyKey: keyFor(kind, fixture.tableId, suffix),
+    reference: referenceFor(kind, fixture.tableId),
+    metadata,
+    entries: tableEntries(fixture, kind, metadata),
+    createdBy: fixture.createdBy,
+  };
+}
+
+async function setFence(active) {
+  await db.unsafe("select public.chips_set_table_fence_active($1::boolean);", [active]);
+}
+
+async function createFixture() {
+  const tableId = randomUUID();
+  const fundingAccountId = randomUUID();
+  const escrowAccountId = randomUUID();
+  const fundingKey = `TABLE_METADATA_TEST:${tableId}`;
+  const escrowKey = `POKER_TABLE:${tableId}`;
+  const createdBy = randomUUID();
+  await db.unsafe(`
+    insert into public.poker_tables (id, status, has_human_participant, bot_only_proof_eligible)
+    values ($1::uuid, 'OPEN', false, true);
+  `, [tableId]);
+  await db.unsafe(`
+    insert into public.chips_accounts (id, account_type, system_key, status, balance)
+    values ($1::uuid, 'SYSTEM', $2, 'active', 1000);
+  `, [fundingAccountId, fundingKey]);
+  await db.unsafe(`
+    insert into public.chips_accounts (id, account_type, system_key, status, balance)
+    values ($1::uuid, 'ESCROW', $2, 'active', 0);
+  `, [escrowAccountId, escrowKey]);
+  return {
+    tableId,
+    fundingAccountId,
+    fundingKey,
+    escrowAccountId,
+    escrowKey,
+    createdBy,
+  };
+}
+
+async function snapshot(tx, fixture, idempotencyKey) {
+  const accounts = await tx.unsafe(`
+    select id::text, balance::text, next_entry_seq::text
+      from public.chips_accounts
+     where id = any($1::uuid[])
+     order by id;
+  `, [[fixture.fundingAccountId, fixture.escrowAccountId]]);
+  const rows = await tx.unsafe(`
+    select
+      (select count(*) from public.chips_transactions where idempotency_key = $1) as transactions,
+      (select count(*) from public.chips_entries where transaction_id in (
+        select id from public.chips_transactions where idempotency_key = $1
+      )) as entries,
+      (select count(*) from public.chips_transaction_idempotency where idempotency_key = $1) as registry_rows;
+  `, [idempotencyKey]);
+  return {
+    accounts,
+    transactions: Number(rows[0].transactions),
+    entries: Number(rows[0].entries),
+    registryRows: Number(rows[0].registry_rows),
+  };
+}
+
+async function expectRejectedWithoutEffects(fixture, label, operation, {
+  idempotencyKey,
+  code,
+  message,
+}) {
+  let observed = null;
+  await db.begin(async (tx) => {
+    const before = await snapshot(tx, fixture, idempotencyKey);
+    await tx.unsafe("savepoint table_metadata_fence_attempt;");
+    let caught = null;
+    try {
+      await operation(tx);
+      await tx.unsafe("set constraints all immediate;");
+    } catch (error) {
+      caught = error;
+    }
+    observed = caught;
+    await tx.unsafe("rollback to savepoint table_metadata_fence_attempt;");
+    await tx.unsafe("release savepoint table_metadata_fence_attempt;");
+
+    assert.ok(caught, `${label}: operation must fail closed`);
+    assert.equal(caught.code, code, `${label}: error code`);
+    if (message) assert.match(caught.message || "", message, `${label}: error message`);
+
+    const after = await snapshot(tx, fixture, idempotencyKey);
+    assert.deepEqual(after, before, `${label}: transaction, entries, registry and account state must be unchanged`);
+    throw ROLLBACK;
+  }).catch((error) => {
+    if (error !== ROLLBACK) throw error;
+  });
+  return observed;
+}
+
+async function insertDirectTransaction(tx, fixture, {
+  transactionId,
+  idempotencyKey,
+  metadataSql,
+  metadataValue,
+  entryMetadataSql = "'{}'::jsonb",
+  entryMetadataValue = null,
+}) {
+  const reference = referenceFor("buyin", fixture.tableId);
+  await tx.unsafe(`
+    insert into public.chips_transactions
+      (id, reference, metadata, idempotency_key, payload_hash, tx_type, user_id)
+    values ($1::uuid, $2, ${metadataSql}, $4, $5, 'TABLE_BUY_IN', null);
+  `, [transactionId, reference, metadataValue, idempotencyKey, "a".repeat(64)]);
+
+  await tx.unsafe(`
+    insert into public.chips_entries (transaction_id, account_id, amount, metadata)
+    values
+      ($1::uuid, $2::uuid, -100, ${entryMetadataSql}),
+      ($1::uuid, $3::uuid, 100, ${entryMetadataSql});
+  `, [transactionId, fixture.fundingAccountId, fixture.escrowAccountId, entryMetadataValue]);
+}
+
+async function assertObjectMetadata(transactionId, tableId) {
+  const rows = await db.unsafe(`
+    select
+      jsonb_typeof(t.metadata) as transaction_metadata_type,
+      t.metadata as transaction_metadata,
+      jsonb_agg(jsonb_typeof(e.metadata) order by e.id) as entry_metadata_types
+      from public.chips_transactions t
+      join public.chips_entries e on e.transaction_id = t.id
+     where t.id = $1::uuid
+     group by t.metadata;
+  `, [transactionId]);
+  assert.equal(rows.length, 1, "metadata regression transaction must exist");
+  assert.equal(rows[0].transaction_metadata_type, "object", "transaction metadata must be JSONB object");
+  assert.deepEqual(rows[0].transaction_metadata, { tableId });
+  assert.deepEqual(rows[0].entry_metadata_types, ["object", "object"], "entry metadata must be JSONB objects");
+}
+
+async function validProducerContract(fixture) {
+  const netlifyBuy = tablePayload(fixture, "buyin", { tableId: fixture.tableId }, `netlify-${randomUUID()}`);
+  const netlifyResult = await db.begin((tx) => netlifyLedger.postTransaction({ ...netlifyBuy, tx }));
+  assert.equal(netlifyResult.transaction.tx_type, "TABLE_BUY_IN", "Netlify TABLE_BUY_IN should pass");
+  await assertObjectMetadata(netlifyResult.transaction.id, fixture.tableId);
+
+  const wsBuy = tablePayload(fixture, "buyin", { tableId: fixture.tableId }, `ws-${randomUUID()}`);
+  const wsResult = await db.begin((tx) => wsLedger.postTransaction({ ...wsBuy, tx }));
+  assert.equal(wsResult.transaction.tx_type, "TABLE_BUY_IN", "WS TABLE_BUY_IN should pass");
+  await assertObjectMetadata(wsResult.transaction.id, fixture.tableId);
+
+  const netlifyCashout = tablePayload(fixture, "cashout", { tableId: fixture.tableId }, `netlify-${randomUUID()}`);
+  const cashoutResult = await db.begin((tx) => netlifyLedger.postTransaction({ ...netlifyCashout, tx }));
+  assert.equal(cashoutResult.transaction.tx_type, "TABLE_CASH_OUT", "Netlify TABLE_CASH_OUT should pass");
+  await assertObjectMetadata(cashoutResult.transaction.id, fixture.tableId);
+
+  const balances = await db.unsafe(`
+    select system_key, balance::text
+      from public.chips_accounts
+     where id = any($1::uuid[])
+     order by id;
+  `, [[fixture.fundingAccountId, fixture.escrowAccountId]]);
+  assert.deepEqual(
+    Object.fromEntries(balances.map((row) => [row.system_key, row.balance])),
+    { [fixture.fundingKey]: "900", [fixture.escrowKey]: "100" },
+    "valid buy-in and cash-out producers must apply their balanced fixture deltas",
+  );
+}
+
+async function netlifyWrongMetadataContract(fixture) {
+  const payload = tablePayload(
+    fixture,
+    "buyin",
+    { tableId: randomUUID() },
+    `netlify-wrong-${randomUUID()}`,
+  );
+  const caught = await expectRejectedWithoutEffects(fixture, "Netlify substituted metadata.tableId", async (tx) => {
+    await netlifyLedger.postTransaction({ ...payload, tx });
+  }, {
+    idempotencyKey: payload.idempotencyKey,
+    code: "invalid_table_binding",
+    message: /TABLE idempotency key or binding is invalid/,
+  });
+  assert.equal(caught?.cause?.code, "P8902", "Netlify must preserve the database P8902 cause");
+}
+
+async function directSqlMetadataContracts(fixture) {
+  const wrongTableId = randomUUID();
+  const wrongTransactionId = randomUUID();
+  const wrongKey = keyFor("buyin", fixture.tableId, `legacy-wrong-${randomUUID()}`);
+  await expectRejectedWithoutEffects(fixture, "legacy JSONB string with substituted tableId", async (tx) => {
+    await insertDirectTransaction(tx, fixture, {
+      transactionId: wrongTransactionId,
+      idempotencyKey: wrongKey,
+      metadataSql: "to_jsonb($3::text)",
+      metadataValue: legacyMetadata(wrongTableId),
+    });
+  }, {
+    transactionId: wrongTransactionId,
+    idempotencyKey: wrongKey,
+    code: "P8902",
+    message: /metadata\.tableId/,
+  });
+
+  const wrongEntryTransactionId = randomUUID();
+  const wrongEntryKey = keyFor("buyin", fixture.tableId, `entry-legacy-wrong-${randomUUID()}`);
+  await expectRejectedWithoutEffects(fixture, "entry JSONB string with substituted tableId", async (tx) => {
+    await insertDirectTransaction(tx, fixture, {
+      transactionId: wrongEntryTransactionId,
+      idempotencyKey: wrongEntryKey,
+      metadataSql: "$3::jsonb",
+      metadataValue: JSON.stringify({ tableId: fixture.tableId }),
+      entryMetadataSql: "to_jsonb($4::text)",
+      entryMetadataValue: legacyMetadata(wrongTableId),
+    });
+  }, {
+    transactionId: wrongEntryTransactionId,
+    idempotencyKey: wrongEntryKey,
+    code: "P8904",
+    message: /authoritative ESCROW table/,
+  });
+
+  const invalidMetadataCases = [
+    ["malformed legacy string", "to_jsonb($3::text)", "{\"tableId\":"],
+    ["legacy scalar", "to_jsonb($3::text)", "42"],
+    ["legacy array", "to_jsonb($3::text)", "[]"],
+    ["native scalar", "$3::jsonb", "42"],
+    ["native array", "$3::jsonb", "[]"],
+  ];
+  for (const [label, metadataSql, metadataValue] of invalidMetadataCases) {
+    const transactionId = randomUUID();
+    const idempotencyKey = keyFor("buyin", fixture.tableId, `${label.replaceAll(" ", "-")}-${randomUUID()}`);
+    await expectRejectedWithoutEffects(fixture, label, async (tx) => {
+      await insertDirectTransaction(tx, fixture, {
+        transactionId,
+        idempotencyKey,
+        metadataSql,
+        metadataValue,
+      });
+    }, {
+      transactionId,
+      idempotencyKey,
+      code: "P8902",
+      message: /TABLE metadata/,
+    });
+  }
+
+  const validLegacyTransactionId = randomUUID();
+  const validLegacyKey = keyFor("buyin", fixture.tableId, `legacy-valid-${randomUUID()}`);
+  await db.begin(async (tx) => {
+    await insertDirectTransaction(tx, fixture, {
+      transactionId: validLegacyTransactionId,
+      idempotencyKey: validLegacyKey,
+      metadataSql: "to_jsonb($3::text)",
+      metadataValue: legacyMetadata(fixture.tableId),
+      entryMetadataSql: "to_jsonb($4::text)",
+      entryMetadataValue: legacyMetadata(fixture.tableId),
+    });
+    await tx.unsafe("set constraints all immediate;");
+  });
+  const legacyRows = await db.unsafe(`
+    select
+      jsonb_typeof(t.metadata) as transaction_metadata_type,
+      jsonb_agg(jsonb_typeof(e.metadata) order by e.id) as entry_metadata_types
+      from public.chips_transactions t
+      join public.chips_entries e on e.transaction_id = t.id
+     where t.id = $1::uuid
+     group by t.metadata;
+  `, [validLegacyTransactionId]);
+  assert.deepEqual(legacyRows[0], {
+    transaction_metadata_type: "string",
+    entry_metadata_types: ["string", "string"],
+  }, "a valid legacy JSONB string must remain accepted for both tables");
+}
+
+async function main() {
+  const databaseRows = await db`select current_database() as name;`;
+  assert.ok(/(?:_test|reset_contract)$/i.test(databaseRows[0]?.name || ""), "metadata fence tests require a disposable database");
+
+  await setFence(false);
+  const fixture = await createFixture();
+  await setFence(true);
+  try {
+    await validProducerContract(fixture);
+    await netlifyWrongMetadataContract(fixture);
+    await directSqlMetadataContracts(fixture);
+  } finally {
+    await setFence(false);
+    await db.end({ timeout: 5 });
+    const adminModule = await import("../../netlify/functions/_shared/supabase-admin.mjs");
+    if (adminModule?.closeSql) await adminModule.closeSql();
+  }
+  console.log("TABLE metadata fence regression tests passed");
+}
+
+main().catch(async (error) => {
+  console.error("TABLE metadata fence regression tests failed", error);
+  await db.end({ timeout: 5 }).catch(() => {});
+  process.exit(1);
+});

--- a/ws-server/poker/persistence/chips-ledger.mjs
+++ b/ws-server/poker/persistence/chips-ledger.mjs
@@ -11,6 +11,22 @@ function badRequest(code, message = code) {
   return error;
 }
 
+function mapTableLifecycleError(error) {
+  if (error?.code === "P8901" || error?.code === "P8902") {
+    const mapped = new Error("TABLE idempotency key or binding is invalid");
+    mapped.code = "invalid_table_binding";
+    mapped.status = 400;
+    mapped.cause = error;
+    return mapped;
+  }
+  if (error?.code !== "P8903" && error?.code !== "P8904") return error;
+  const mapped = new Error(error.code === "P8903" ? "TABLE table is closed" : "TABLE idempotency binding is retired");
+  mapped.code = error.code === "P8903" ? "table_closed" : "idempotency_retired";
+  mapped.status = 409;
+  mapped.cause = error;
+  return mapped;
+}
+
 function hashPayload(input) {
   return crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
@@ -427,8 +443,12 @@ limit 1;
 
 export async function postTransaction(payload) {
   const sqlTx = payload?.tx;
-  if (sqlTx) {
-    return runTableBuyIn(sqlTx, payload);
+  try {
+    if (sqlTx) {
+      return await runTableBuyIn(sqlTx, payload);
+    }
+    return await beginSql((tx) => runTableBuyIn(tx, payload));
+  } catch (error) {
+    throw mapTableLifecycleError(error);
   }
-  return beginSql((tx) => runTableBuyIn(tx, payload));
 }

--- a/ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs
+++ b/ws-server/poker/persistence/closed-table-cleanup.integration.test.mjs
@@ -37,10 +37,14 @@ async function ensureSchema(db) {
     create table if not exists public.poker_tables (
       id uuid primary key,
       status text not null default 'OPEN',
-      updated_at timestamptz not null default now()
+      updated_at timestamptz not null default now(),
+      has_human_participant boolean not null default true,
+      bot_only_retention_complete_at timestamptz
     );
     alter table public.poker_tables
-      add column if not exists updated_at timestamptz not null default now();
+      add column if not exists updated_at timestamptz not null default now(),
+      add column if not exists has_human_participant boolean not null default true,
+      add column if not exists bot_only_retention_complete_at timestamptz;
     create table if not exists public.poker_state (
       table_id uuid primary key,
       version bigint not null default 0,

--- a/ws-server/poker/persistence/closed-table-cleanup.mjs
+++ b/ws-server/poker/persistence/closed-table-cleanup.mjs
@@ -64,6 +64,7 @@ async function discoverCandidates({ tx, cutoff, batchSize, statementTimeoutMs })
        from public.poker_tables t
       where t.status = 'CLOSED'
         and t.updated_at < $1::timestamptz
+        and (t.has_human_participant is true or t.bot_only_retention_complete_at is not null)
         and exists (
               select 1 from public.poker_state ps
                where ps.table_id = t.id
@@ -113,6 +114,7 @@ async function deleteClaimed({ tx, cutoff, claimedIds, batchSize }) {
    where t.id = any($3::uuid[])
      and t.status = 'CLOSED'
      and t.updated_at < $1::timestamptz
+     and (t.has_human_participant is true or t.bot_only_retention_complete_at is not null)
      and exists (
            select 1 from public.poker_state ps
             where ps.table_id = t.id
@@ -363,6 +365,7 @@ export function createClosedTableCleanup({
              from public.poker_tables t
             where t.status = 'CLOSED'
               and t.updated_at < $1::timestamptz
+              and (t.has_human_participant is true or t.bot_only_retention_complete_at is not null)
               and exists (
                     select 1 from public.poker_state ps
                      where ps.table_id = t.id


### PR DESCRIPTION
## Summary

Implements the complete fail-closed bot-only TABLE_* retention lifecycle from #890.

- Adds the separate 7-day Stage bot-only policy and schema v2 evidence.
- Reuses the existing exporter, Storage manifest/proof, pruner, recovery bundle, and Stage automation runner.
- Adds the immediate OPEN-table fence, deferred atomic entry binding, immutable key/table evidence, one-way human guard, lifecycle gate, cleanup receipt, and exact-batch GO latch.
- Makes registry deletion, cleanup receipt, and table lifecycle marker one atomic restart-safe transition.
- Keeps the existing 30-day policy unchanged and leaves historical uncertain `has_human_participant=false` tables unqualified.
- Updates TABLE producers with server-verifiable metadata/reference bindings and maps fence errors at existing ledger boundaries.
- Bot-only Stage automation is prepare-only by default; no destructive batch, exact-batch GO, or Production migration/action was executed.

## Verification

- `node scripts/syntax-check.mjs`
- `node scripts/check-db-migrations.mjs`
- Four issue-level fundamental contracts
- Existing archive exporter, Storage, pruner, Stage automation, producer, and persistence tests
- `git diff --check`

Refs #890